### PR TITLE
fix(components/flyout): navigating when a flyout is open does not throw an error

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -2274,7 +2274,6 @@
             ],
             "styles": [
               "libs/components/theme/src/lib/styles/sky.scss",
-              "libs/components/theme/src/lib/styles/_mixins.scss",
               "libs/components/theme/src/lib/styles/themes/modern/styles.scss",
               "libs/components/ag-grid/src/lib/styles/ag-grid-styles.scss",
               "apps/playground/src/styles.scss"

--- a/angular.json
+++ b/angular.json
@@ -2274,6 +2274,7 @@
             ],
             "styles": [
               "libs/components/theme/src/lib/styles/sky.scss",
+              "libs/components/theme/src/lib/styles/_mixins.scss",
               "libs/components/theme/src/lib/styles/themes/modern/styles.scss",
               "libs/components/ag-grid/src/lib/styles/ag-grid-styles.scss",
               "apps/playground/src/styles.scss"

--- a/apps/playground/src/app/components/components.module.ts
+++ b/apps/playground/src/app/components/components.module.ts
@@ -8,6 +8,11 @@ const routes: Routes = [
       import('./datetime/datetime.module').then((m) => m.DatetimeModule),
   },
   {
+    path: 'flyout',
+    loadChildren: () =>
+      import('./flyout/flyout.module').then((m) => m.FlyoutModule),
+  },
+  {
     path: 'layout',
     loadChildren: () =>
       import('./layout/layout.module').then((m) => m.LayoutModule),

--- a/apps/playground/src/app/components/flyout/flyout.module.ts
+++ b/apps/playground/src/app/components/flyout/flyout.module.ts
@@ -1,0 +1,21 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+
+const routes: Routes = [
+  {
+    path: 'flyout',
+    loadChildren: () =>
+      import('./flyout/flyout.module').then((m) => m.FlyoutModule),
+  },
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule],
+})
+export class FlyoutRoutingModule {}
+
+@NgModule({
+  imports: [FlyoutRoutingModule],
+})
+export class FlyoutModule {}

--- a/apps/playground/src/app/components/flyout/flyout/flyout-demo-context.ts
+++ b/apps/playground/src/app/components/flyout/flyout/flyout-demo-context.ts
@@ -1,0 +1,4 @@
+export class FlyoutDemoContext {
+  public id: string;
+  public name: string;
+}

--- a/apps/playground/src/app/components/flyout/flyout/flyout-demo.component.html
+++ b/apps/playground/src/app/components/flyout/flyout/flyout-demo.component.html
@@ -1,0 +1,36 @@
+<h1>{{ context.name }}: {{ context.id }}</h1>
+
+<sky-dropdown buttonType="context-menu">
+  <sky-dropdown-menu>
+    <sky-dropdown-item>
+      <button type="button">Option 1</button>
+    </sky-dropdown-item>
+    <sky-dropdown-item>
+      <button type="button">Option 2</button>
+    </sky-dropdown-item>
+  </sky-dropdown-menu>
+</sky-dropdown>
+
+<p>
+  <button class="sky-btn sky-btn-default" type="button" (click)="openModal()">
+    Open modal
+  </button>
+
+  <button class="sky-btn sky-btn-default" type="button" (click)="openMessage()">
+    Open toast
+  </button>
+
+  <button class="sky-btn sky-btn-default" type="button" (click)="goToPage()">
+    Navigate to new page
+  </button>
+</p>
+
+<h3>Infinite scroll</h3>
+
+<ul>
+  <li *ngFor="let item of infiniteScrollData">
+    {{ item.name }}
+  </li>
+</ul>
+<sky-infinite-scroll [enabled]="enableInfiniteScroll" (scrollEnd)="addData()">
+</sky-infinite-scroll>

--- a/apps/playground/src/app/components/flyout/flyout/flyout-demo.component.ts
+++ b/apps/playground/src/app/components/flyout/flyout/flyout-demo.component.ts
@@ -1,0 +1,83 @@
+import { ChangeDetectorRef, Component, OnInit } from '@angular/core';
+import { Router } from '@angular/router';
+import { SkyFlyoutService } from '@skyux/flyout';
+import { SkyModalService } from '@skyux/modals';
+import { SkyToastService, SkyToastType } from '@skyux/toast';
+
+import { FlyoutDemoContext } from './flyout-demo-context';
+import { FlyoutModalDemoComponent } from './flyout-modal.component';
+
+@Component({
+  selector: 'app-flyout-demo',
+  templateUrl: './flyout-demo.component.html',
+  providers: [SkyFlyoutService],
+})
+export class FlyoutDemoComponent implements OnInit {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  public infiniteScrollData: any[] = [];
+
+  public enableInfiniteScroll = true;
+
+  private nextId = 0;
+
+  constructor(
+    public context: FlyoutDemoContext,
+    private modalService: SkyModalService,
+    private toastService: SkyToastService,
+    private router: Router,
+    private changeDetector: ChangeDetectorRef
+  ) {}
+
+  public ngOnInit(): void {
+    this.addData(false);
+  }
+
+  public openModal(): void {
+    this.modalService.open(FlyoutModalDemoComponent);
+  }
+
+  public openMessage(): void {
+    this.toastService.openMessage(`This is a sample toast message.`, {
+      type: SkyToastType.Info,
+    });
+  }
+
+  public goToPage(): void {
+    this.router.navigate(['/']);
+  }
+
+  public addData(delay = true): void {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    this.mockRemote(delay).then((result: any) => {
+      this.infiniteScrollData = this.infiniteScrollData.concat(result.data);
+      this.enableInfiniteScroll = result.hasMore;
+      this.changeDetector.markForCheck();
+    });
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private mockRemote(delay: boolean): Promise<any> {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const data: any[] = [];
+
+    for (let i = 0; i < 8; i++) {
+      data.push({
+        name: `Item #${++this.nextId}`,
+      });
+    }
+
+    // Simulate async request.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return new Promise((resolve: any) => {
+      setTimeout(
+        () => {
+          resolve({
+            data,
+            hasMore: this.nextId < 24,
+          });
+        },
+        delay ? 1000 : 0
+      );
+    });
+  }
+}

--- a/apps/playground/src/app/components/flyout/flyout/flyout-modal.component.ts
+++ b/apps/playground/src/app/components/flyout/flyout/flyout-modal.component.ts
@@ -1,0 +1,33 @@
+import { Component } from '@angular/core';
+
+import { SkyModalInstance } from '@skyux/modals';
+
+@Component({
+  selector: 'app-flyout-modal-demo',
+  template: `
+    <sky-modal>
+      <sky-modal-content> Modal content... </sky-modal-content>
+      <sky-modal-footer>
+        <button
+          *ngIf="visible"
+          class="sky-btn-default"
+          type="button"
+          (click)="visible = false"
+        >
+          Click to delete
+        </button>
+        <button class="sky-btn sky-btn-primary" type="button" (click)="close()">
+          Close
+        </button>
+      </sky-modal-footer>
+    </sky-modal>
+  `,
+})
+export class FlyoutModalDemoComponent {
+  public visible = true;
+  constructor(private instance: SkyModalInstance) {}
+
+  public close(): void {
+    this.instance.close();
+  }
+}

--- a/apps/playground/src/app/components/flyout/flyout/flyout-modal.component.ts
+++ b/apps/playground/src/app/components/flyout/flyout/flyout-modal.component.ts
@@ -1,5 +1,4 @@
 import { Component } from '@angular/core';
-
 import { SkyModalInstance } from '@skyux/modals';
 
 @Component({

--- a/apps/playground/src/app/components/flyout/flyout/flyout-responsive-demo-content.component.html
+++ b/apps/playground/src/app/components/flyout/flyout/flyout-responsive-demo-content.component.html
@@ -1,0 +1,10 @@
+<div class="flyout-reponsive-wrapper">
+  <div class="flyout-responsive-box box-1"></div>
+  <div class="flyout-responsive-box box-2"></div>
+</div>
+<div
+  [class]="'flyout-reponsive-wrapper flyout-media-' + currentMediaBreakpoint"
+>
+  <div class="flyout-responsive-box box-3"></div>
+  <div class="flyout-responsive-box box-4"></div>
+</div>

--- a/apps/playground/src/app/components/flyout/flyout/flyout-responsive-demo-content.component.scss
+++ b/apps/playground/src/app/components/flyout/flyout/flyout-responsive-demo-content.component.scss
@@ -1,0 +1,111 @@
+@import 'libs/components/theme/src/lib/styles/_mixins.scss';
+
+.flyout-reponsive-wrapper {
+  width: 100%;
+  display: flex;
+  border: 3px black solid;
+}
+
+.flyout-reponsive-wrapper:not(:last-of-type) {
+  border-bottom: none;
+}
+
+.flyout-responsive-box {
+  height: 200px;
+}
+
+.box-1 {
+  background-color: aqua;
+}
+
+.box-2 {
+  background-color: plum;
+}
+
+.box-3 {
+  background-color: rgb(255, 102, 0);
+}
+
+.box-4 {
+  background-color: rgb(65, 141, 2);
+}
+
+.flyout-media-xs {
+  .box-3 {
+    flex-basis: 25%;
+  }
+
+  .box-4 {
+    flex-basis: 75%;
+  }
+}
+
+.flyout-media-sm {
+  .box-3 {
+    flex-basis: 40%;
+  }
+
+  .box-4 {
+    flex-basis: 60%;
+  }
+}
+
+.flyout-media-md {
+  .box-3 {
+    flex-basis: 50%;
+  }
+
+  .box-4 {
+    flex-basis: 50%;
+  }
+}
+
+.flyout-media-lg {
+  .box-3 {
+    flex-basis: 75%;
+  }
+
+  .box-4 {
+    flex-basis: 25%;
+  }
+}
+
+@include sky-host-responsive-container-xs-min() {
+  .box-1 {
+    flex-basis: 25%;
+  }
+
+  .box-2 {
+    flex-basis: 75%;
+  }
+}
+
+@include sky-host-responsive-container-sm-min() {
+  .box-1 {
+    flex-basis: 40%;
+  }
+
+  .box-2 {
+    flex-basis: 60%;
+  }
+}
+
+@include sky-host-responsive-container-md-min() {
+  .box-1 {
+    flex-basis: 50%;
+  }
+
+  .box-2 {
+    flex-basis: 50%;
+  }
+}
+
+@include sky-host-responsive-container-lg-min() {
+  .box-1 {
+    flex-basis: 75%;
+  }
+
+  .box-2 {
+    flex-basis: 25%;
+  }
+}

--- a/apps/playground/src/app/components/flyout/flyout/flyout-responsive-demo-content.component.ts
+++ b/apps/playground/src/app/components/flyout/flyout/flyout-responsive-demo-content.component.ts
@@ -1,0 +1,35 @@
+import { Component } from '@angular/core';
+
+import { SkyMediaBreakpoints, SkyMediaQueryService } from '@skyux/core';
+
+@Component({
+  selector: 'app-flyout-responsive-demo-content',
+  templateUrl: './flyout-responsive-demo-content.component.html',
+  styleUrls: ['./flyout-responsive-demo-content.component.scss'],
+})
+export class FlyoutResponsiveDemoContentComponent {
+  public currentMediaBreakpoint: string;
+
+  constructor(private mediaQueryService: SkyMediaQueryService) {
+    this.mediaQueryService.subscribe((breakpoint) => {
+      switch (breakpoint) {
+        case SkyMediaBreakpoints.xs: {
+          this.currentMediaBreakpoint = 'xs';
+          break;
+        }
+        case SkyMediaBreakpoints.sm: {
+          this.currentMediaBreakpoint = 'sm';
+          break;
+        }
+        case SkyMediaBreakpoints.md: {
+          this.currentMediaBreakpoint = 'md';
+          break;
+        }
+        default: {
+          this.currentMediaBreakpoint = 'lg';
+          break;
+        }
+      }
+    });
+  }
+}

--- a/apps/playground/src/app/components/flyout/flyout/flyout-responsive-demo-content.component.ts
+++ b/apps/playground/src/app/components/flyout/flyout/flyout-responsive-demo-content.component.ts
@@ -1,5 +1,4 @@
 import { Component } from '@angular/core';
-
 import { SkyMediaBreakpoints, SkyMediaQueryService } from '@skyux/core';
 
 @Component({

--- a/apps/playground/src/app/components/flyout/flyout/flyout-responsive-demo.component.html
+++ b/apps/playground/src/app/components/flyout/flyout/flyout-responsive-demo.component.html
@@ -1,0 +1,2 @@
+<h1>Responsive content</h1>
+<app-flyout-responsive-demo-content></app-flyout-responsive-demo-content>

--- a/apps/playground/src/app/components/flyout/flyout/flyout-responsive-demo.component.ts
+++ b/apps/playground/src/app/components/flyout/flyout/flyout-responsive-demo.component.ts
@@ -1,0 +1,9 @@
+import { Component } from '@angular/core';
+import { SkyFlyoutService } from '@skyux/flyout';
+
+@Component({
+  selector: 'app-flyout-responsive-demo',
+  templateUrl: './flyout-responsive-demo.component.html',
+  providers: [SkyFlyoutService],
+})
+export class FlyoutResponsiveDemoComponent {}

--- a/apps/playground/src/app/components/flyout/flyout/flyout-routing.module.ts
+++ b/apps/playground/src/app/components/flyout/flyout/flyout-routing.module.ts
@@ -1,0 +1,16 @@
+import { NgModule } from '@angular/core';
+import { RouterModule } from '@angular/router';
+
+import { FlyoutComponent } from './flyout.component';
+
+@NgModule({
+  imports: [
+    RouterModule.forChild([
+      {
+        path: '',
+        component: FlyoutComponent,
+      },
+    ]),
+  ],
+})
+export class FlyoutRoutingModule {}

--- a/apps/playground/src/app/components/flyout/flyout/flyout.component.html
+++ b/apps/playground/src/app/components/flyout/flyout/flyout.component.html
@@ -1,0 +1,87 @@
+<div id="screenshot-flyout" style="height: 500px">
+  <div *ngFor="let user of users" class="sky-flyout-demo-item">
+    <button
+      class="sky-btn sky-btn-primary"
+      type="button"
+      (click)="openFlyout(user)"
+    >
+      {{ user.name }}
+    </button>
+  </div>
+
+  <div class="sky-flyout-demo-item">
+    <button
+      class="sky-btn sky-btn-primary"
+      id="open-flyout-fullscreen"
+      type="button"
+      (click)="openFlyoutWithFullscreenAvailable(users[0])"
+    >
+      Open flyout which can go full screen
+    </button>
+  </div>
+
+  <div class="sky-flyout-demo-item">
+    <button
+      class="sky-btn sky-btn-primary"
+      id="open-flyout-permalink"
+      type="button"
+      (click)="openFlyoutWithPermalink(users[0])"
+    >
+      Open flyout with permalink
+    </button>
+  </div>
+
+  <div class="sky-flyout-demo-item">
+    <button
+      class="sky-btn sky-btn-primary"
+      id="open-flyout-with-iterators"
+      type="button"
+      (click)="openFlyoutWithIterators(users[0], false, false)"
+    >
+      Open flyout with row iterators enabled
+    </button>
+    <button
+      class="sky-btn sky-btn-primary"
+      id="open-flyout-with-iterators-disabled"
+      type="button"
+      (click)="openFlyoutWithIterators(users[0], true, true)"
+    >
+      Open flyout with row iterators disabled
+    </button>
+  </div>
+
+  <div class="sky-flyout-demo-item">
+    <button
+      class="sky-btn sky-btn-primary"
+      id="open-responsive-flyout-xs"
+      type="button"
+      (click)="openResponsiveFlyout(700)"
+    >
+      Open flyout with xs responsive content
+    </button>
+    <button
+      class="sky-btn sky-btn-primary"
+      id="open-responsive-flyout-sm"
+      type="button"
+      (click)="openResponsiveFlyout(768)"
+    >
+      Open flyout with sm responsive content
+    </button>
+    <button
+      class="sky-btn sky-btn-primary"
+      id="open-responsive-flyout-md"
+      type="button"
+      (click)="openResponsiveFlyout(992)"
+    >
+      Open flyout with md responsive content
+    </button>
+    <button
+      class="sky-btn sky-btn-primary"
+      id="open-responsive-flyout-lg"
+      type="button"
+      (click)="openResponsiveFlyout(1200)"
+    >
+      Open flyout with lg responsive content
+    </button>
+  </div>
+</div>

--- a/apps/playground/src/app/components/flyout/flyout/flyout.component.scss
+++ b/apps/playground/src/app/components/flyout/flyout/flyout.component.scss
@@ -1,0 +1,10 @@
+.sky-flyout-demo-item {
+  padding: 8px 12px;
+}
+::ng-deep {
+  .sky-flyout-content {
+    h1 {
+      margin: 0.75em 0;
+    }
+  }
+}

--- a/apps/playground/src/app/components/flyout/flyout/flyout.component.ts
+++ b/apps/playground/src/app/components/flyout/flyout/flyout.component.ts
@@ -1,0 +1,120 @@
+import { Component, OnDestroy } from '@angular/core';
+import { SkyFlyoutInstance, SkyFlyoutService } from '@skyux/flyout';
+
+import { Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
+
+import { FlyoutDemoContext } from './flyout-demo-context';
+import { FlyoutDemoComponent } from './flyout-demo.component';
+import { FlyoutResponsiveDemoComponent } from './flyout-responsive-demo.component';
+
+@Component({
+  selector: 'app-flyout',
+  templateUrl: './flyout.component.html',
+  styleUrls: ['./flyout.component.scss'],
+})
+export class FlyoutComponent implements OnDestroy {
+  public users: { id: string; name: string }[] = [
+    { id: '1', name: 'Sally' },
+    { id: '2', name: 'John' },
+    { id: '3', name: 'David' },
+    { id: '4', name: 'Janet' },
+  ];
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  public flyout: SkyFlyoutInstance<any>;
+
+  private ngUnsubscribe = new Subject();
+
+  constructor(private flyoutService: SkyFlyoutService) {}
+
+  public ngOnDestroy(): void {
+    this.ngUnsubscribe.next();
+    this.ngUnsubscribe.complete();
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  public openFlyout(record: any): void {
+    this.flyout = this.flyoutService.open(FlyoutDemoComponent, {
+      providers: [
+        {
+          provide: FlyoutDemoContext,
+          useValue: record,
+        },
+      ],
+      ariaLabel: 'User details',
+      defaultWidth: 500,
+    });
+  }
+
+  public openFlyoutWithIterators(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    record: any,
+    previousButtonDisabled: boolean,
+    nextButtonDisabled: boolean
+  ): void {
+    this.flyout = this.flyoutService.open(FlyoutDemoComponent, {
+      providers: [
+        {
+          provide: FlyoutDemoContext,
+          useValue: record,
+        },
+      ],
+      defaultWidth: 500,
+      showIterator: true,
+      iteratorPreviousButtonDisabled: previousButtonDisabled,
+      iteratorNextButtonDisabled: nextButtonDisabled,
+    });
+
+    this.flyout.iteratorPreviousButtonClick
+      .pipe(takeUntil(this.ngUnsubscribe))
+      .subscribe(() => {
+        console.log('previous clicked');
+      });
+
+    this.flyout.iteratorNextButtonClick
+      .pipe(takeUntil(this.ngUnsubscribe))
+      .subscribe(() => {
+        console.log('next clicked');
+      });
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  public openFlyoutWithFullscreenAvailable(record: any): void {
+    this.flyout = this.flyoutService.open(FlyoutDemoComponent, {
+      providers: [
+        {
+          provide: FlyoutDemoContext,
+          useValue: record,
+        },
+      ],
+      minWidth: 600,
+      defaultWidth: 800,
+    });
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  public openFlyoutWithPermalink(record: any): void {
+    this.flyout = this.flyoutService.open(FlyoutDemoComponent, {
+      providers: [
+        {
+          provide: FlyoutDemoContext,
+          useValue: record,
+        },
+      ],
+      minWidth: 600,
+      defaultWidth: 800,
+      permalink: {
+        label: 'Go home',
+        url: '/',
+      },
+    });
+  }
+
+  public openResponsiveFlyout(width: number): void {
+    this.flyout = this.flyoutService.open(FlyoutResponsiveDemoComponent, {
+      defaultWidth: width,
+      maxWidth: 5000,
+    });
+  }
+}

--- a/apps/playground/src/app/components/flyout/flyout/flyout.module.ts
+++ b/apps/playground/src/app/components/flyout/flyout/flyout.module.ts
@@ -1,0 +1,34 @@
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { RouterModule } from '@angular/router';
+import { SkyFlyoutModule } from '@skyux/flyout';
+import { SkyInfiniteScrollModule } from '@skyux/lists';
+import { SkyModalModule } from '@skyux/modals';
+import { SkyDropdownModule } from '@skyux/popovers';
+
+import { FlyoutDemoComponent } from './flyout-demo.component';
+import { FlyoutModalDemoComponent } from './flyout-modal.component';
+import { FlyoutResponsiveDemoContentComponent } from './flyout-responsive-demo-content.component';
+import { FlyoutResponsiveDemoComponent } from './flyout-responsive-demo.component';
+import { FlyoutRoutingModule } from './flyout-routing.module';
+import { FlyoutComponent } from './flyout.component';
+
+@NgModule({
+  declarations: [
+    FlyoutComponent,
+    FlyoutDemoComponent,
+    FlyoutModalDemoComponent,
+    FlyoutResponsiveDemoComponent,
+    FlyoutResponsiveDemoContentComponent,
+  ],
+  imports: [
+    CommonModule,
+    FlyoutRoutingModule,
+    SkyDropdownModule,
+    SkyFlyoutModule,
+    SkyInfiniteScrollModule,
+    SkyModalModule,
+    RouterModule,
+  ],
+})
+export class FlyoutModule {}

--- a/apps/playground/src/app/home/home.component.html
+++ b/apps/playground/src/app/home/home.component.html
@@ -40,4 +40,10 @@
       </li>
     </ul>
   </li>
+  <li>
+    Flyout
+    <ul>
+      <li><a routerLink="components/flyout/flyout">Flyout</a></li>
+    </ul>
+  </li>
 </ul>

--- a/libs/components/flyout/src/lib/modules/flyout/flyout.service.ts
+++ b/libs/components/flyout/src/lib/modules/flyout/flyout.service.ts
@@ -1,8 +1,10 @@
 import {
+  ApplicationRef,
   ComponentRef,
   Injectable,
   NgZone,
   OnDestroy,
+  Optional,
   Type,
 } from '@angular/core';
 import { NavigationStart, Router } from '@angular/router';
@@ -41,7 +43,10 @@ export class SkyFlyoutService implements OnDestroy {
     private windowRef: SkyAppWindowRef,
     private dynamicComponentService: SkyDynamicComponentService,
     private router: Router,
-    private readonly _ngZone: NgZone
+    private readonly _ngZone: NgZone,
+    // NOTE: This used to be used for an `applicationRef.tick` which has since been removed.
+    // We can not remove this due to it being a breaking change for those manually constructing the service.
+    @Optional() private readonly applicationRef?: ApplicationRef
   ) {}
 
   public ngOnDestroy(): void {

--- a/libs/components/flyout/src/lib/modules/flyout/flyout.service.ts
+++ b/libs/components/flyout/src/lib/modules/flyout/flyout.service.ts
@@ -1,5 +1,4 @@
 import {
-  ApplicationRef,
   ComponentRef,
   Injectable,
   NgZone,
@@ -42,8 +41,7 @@ export class SkyFlyoutService implements OnDestroy {
     private windowRef: SkyAppWindowRef,
     private dynamicComponentService: SkyDynamicComponentService,
     private router: Router,
-    private readonly _ngZone: NgZone,
-    private readonly applicationRef: ApplicationRef
+    private readonly _ngZone: NgZone
   ) {}
 
   public ngOnDestroy(): void {
@@ -59,7 +57,6 @@ export class SkyFlyoutService implements OnDestroy {
    */
   public close(args?: SkyFlyoutCloseArgs): void {
     if (this.host && !this.isOpening) {
-      this.removeAfterClosed = true;
       this.host.instance.messageStream.next({
         type: SkyFlyoutMessageType.Close,
         data: {
@@ -97,8 +94,6 @@ export class SkyFlyoutService implements OnDestroy {
             this._ngZone.onStable.pipe(take(1)).subscribe(() => {
               if (this.host) {
                 this.removeHostComponent();
-                // Without this tick - the host does not actually get removed on initial navigation in this case.
-                this.applicationRef.tick();
               }
             });
           }


### PR DESCRIPTION
I'm removing that `applicationRef` `tick` call here as it was causing consumers to receive "Application ref was called recursively" errors. I did some manual testing using the playground page that I added and found that it wasn't necessary. I'm honestly not 100% sure why I felt that the `tick` was needed (and even put a comment in) but could not reproduce the scenario when testing for this change. 