### PR TITLE
chore: add .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Must use lf for Prettier to work consistently on all platforms.
+* text=auto eol=lf


### PR DESCRIPTION
Enforce consistent line endings for all platforms.