### PR TITLE
fix(components/data-manager): assign specific types to properties of `SkyDataViewConfig`

### DIFF
--- a/libs/components/data-manager/src/lib/modules/data-manager/models/data-view-config.ts
+++ b/libs/components/data-manager/src/lib/modules/data-manager/models/data-view-config.ts
@@ -10,7 +10,7 @@ export interface SkyDataViewConfig {
    * An untyped property that can track any view config information relevant to a
    * data view that the existing options do not include.
    */
-  additionalOptions?: Object;
+  additionalOptions?: Record<string, unknown>;
   /**
    * The column data to pass to the column picker. Columns that are always displayed should be
    * passed in addition to the optional columns. See SkyDataManagerColumnPickerOption.
@@ -50,12 +50,12 @@ export interface SkyDataViewConfig {
    * The function called when a user selects the "Clear all" button on the multi-select toolbar.
    * Update your displayed data to indicate it is not selected in this function.
    */
-  onClearAllClick?: Function;
+  onClearAllClick?: () => void;
   /**
    * The function called when a user selects the "Select all" button on the multi-select toolbar.
    * Update your displayed data to indicate it is selected in this function.
    */
-  onSelectAllClick?: Function;
+  onSelectAllClick?: () => void;
   /**
    * Indicates whether to display the search box for this view.
    */


### PR DESCRIPTION
Assign more specific types for the properties `additionalOptions`, `onClearAllClick`, and
`onSelectAllClick` of `SkyDataViewConfig`. This was done to address the
`@typescript-eslint/ban-types` ESLint rule. Marking as a breaking change, but this will likely not
cause any downstream effects.

BREAKING CHANGE: The properties `additionalOptions`, `onClearAllClick`, and `onSelectAllClick` of
`SkyDataViewConfig` are assigned more specific types.