### PR TITLE
fix(migrations): install `@angular/cdk` if relevant packages installed

### DIFF
--- a/libs/components/packages/src/schematics/migrations/migration-collection.json
+++ b/libs/components/packages/src/schematics/migrations/migration-collection.json
@@ -9,6 +9,11 @@
       "version": "6.0.0-0",
       "factory": "./update-6/fix-scss-tilde-imports.schematic",
       "description": "Remove tilde character from SCSS imports"
+    },
+    "add-cdk": {
+      "version": "6.0.0-0",
+      "factory": "./update-6/add-cdk.schematic",
+      "description": "Add @angular/cdk if applicable"
     }
   }
 }

--- a/libs/components/packages/src/schematics/migrations/update-6/add-cdk.schematic.spec.ts
+++ b/libs/components/packages/src/schematics/migrations/update-6/add-cdk.schematic.spec.ts
@@ -1,0 +1,72 @@
+import {
+  SchematicTestRunner,
+  UnitTestTree,
+} from '@angular-devkit/schematics/testing';
+
+import path from 'path';
+
+import { createTestLibrary } from '../../testing/scaffold';
+
+describe('Migrations > Add cdk', () => {
+  const collectionPath = path.join(__dirname, '../migration-collection.json');
+  const defaultProjectName = 'my-lib';
+  const schematicName = 'add-cdk';
+
+  const runner = new SchematicTestRunner('migrations', collectionPath);
+
+  let tree: UnitTestTree;
+
+  beforeEach(async () => {
+    tree = await createTestLibrary(runner, {
+      name: defaultProjectName,
+    });
+  });
+
+  function runSchematic(name?: string): Promise<UnitTestTree> {
+    return runner
+      .runSchematicAsync(
+        schematicName,
+        {
+          defaultProjectName: name || defaultProjectName,
+        },
+        tree
+      )
+      .toPromise();
+  }
+
+  it('should add the cdk if a relevant package installed', async () => {
+    tree.overwrite(
+      'package.json',
+      `{
+  "dependencies": {
+    "@skyux/flyout": "5.0.0"
+  },
+  "devDependencies": {}
+}`
+    );
+
+    const updatedTree = await runSchematic();
+
+    const libraryPackageJson = JSON.parse(
+      updatedTree.readContent('package.json')
+    );
+
+    expect(libraryPackageJson.dependencies['@angular/cdk']).toEqual('^13.0.0');
+  });
+
+  it('should not add the cdk if relevant package not installed', async () => {
+    tree.overwrite(
+      'package.json',
+      `{
+}`
+    );
+
+    const updatedTree = await runSchematic();
+
+    const packageJson = JSON.parse(updatedTree.readContent('package.json'));
+
+    expect(
+      packageJson.dependencies && packageJson.dependencies['@angular/cdk']
+    ).toBeUndefined();
+  });
+});

--- a/libs/components/packages/src/schematics/migrations/update-6/add-cdk.schematic.ts
+++ b/libs/components/packages/src/schematics/migrations/update-6/add-cdk.schematic.ts
@@ -1,0 +1,40 @@
+import { Rule } from '@angular-devkit/schematics';
+import { NodePackageInstallTask } from '@angular-devkit/schematics/tasks';
+import {
+  NodeDependencyType,
+  addPackageJsonDependency,
+} from '@schematics/angular/utility/dependencies';
+
+import { readRequiredFile } from '../../utility/tree';
+
+export default function (): Rule {
+  return async (tree, context) => {
+    const packageJson = JSON.parse(readRequiredFile(tree, 'package.json'));
+
+    const packagesThatDependOnCdk = ['@skyux/flyout'];
+
+    const dependencies = {
+      ...(packageJson.dependencies || {}),
+      ...(packageJson.devDependencies || {}),
+    };
+
+    let packageFound = false;
+    for (const packageName of packagesThatDependOnCdk) {
+      if (dependencies[packageName]) {
+        packageFound = true;
+        break;
+      }
+    }
+
+    if (packageFound) {
+      context.addTask(new NodePackageInstallTask());
+
+      addPackageJsonDependency(tree, {
+        type: NodeDependencyType.Default,
+        name: '@angular/cdk',
+        version: '^13.0.0',
+        overwrite: true,
+      });
+    }
+  };
+}


### PR DESCRIPTION
`@skyux/flyout` needs `@angular/cdk`, adding this step to make sure it gets installed during the migration.