### PR TITLE
fix(components/lists): adding aria label to pagination link button

### DIFF
--- a/libs/components/lists/src/assets/locales/resources_en_US.json
+++ b/libs/components/lists/src/assets/locales/resources_en_US.json
@@ -23,6 +23,10 @@
     "_description": "Text for the label for the next button on the pagination component",
     "message": "Next"
   },
+  "skyux_paging_page_link_aria_label": {
+    "_description": "Aria label used for pagination link label",
+    "message": "Page {0}"
+  },
   "skyux_paging_previous": {
     "_description": "Text for the label for the previous button on the pagination component",
     "message": "Previous"

--- a/libs/components/lists/src/lib/modules/paging/paging.component.html
+++ b/libs/components/lists/src/lib/modules/paging/paging.component.html
@@ -27,6 +27,9 @@
         type="button"
         [attr.aria-current]="currentPage === pageNumber ? 'page' : null"
         [attr.sky-cmp-id]="pageNumber"
+        [attr.aria-label]="
+          'skyux_paging_page_link_aria_label' | skyLibResources: pageNumber
+        "
         [disabled]="currentPage === pageNumber"
         [ngClass]="{ 'sky-paging-current': currentPage === pageNumber }"
         (click)="setPage(pageNumber)"

--- a/libs/components/lists/src/lib/modules/paging/paging.component.spec.ts
+++ b/libs/components/lists/src/lib/modules/paging/paging.component.spec.ts
@@ -346,6 +346,17 @@ describe('Paging component', () => {
         expect(pageNumbers).toEqual([1, 2, 3, 4, 5, 6]);
       });
 
+      it('should have an aria label for page number link', () => {
+        component.currentPage = 1;
+        component.maxPages = 8;
+        fixture.detectChanges();
+
+        const pageElement = element.query(By.css(getPagingSelector('2')))
+          .nativeElement as HTMLButtonElement;
+
+        expect(pageElement.ariaLabel).toBe('Page 2');
+      });
+
       it('should be accessible', async () => {
         fixture.detectChanges();
         await fixture.whenStable();

--- a/libs/components/lists/src/lib/modules/shared/sky-lists-resources.module.ts
+++ b/libs/components/lists/src/lib/modules/shared/sky-lists-resources.module.ts
@@ -22,6 +22,7 @@ const RESOURCES: { [locale: string]: SkyLibResources } = {
     skyux_infinite_scroll_load_more_button: { message: 'Load more' },
     skyux_paging_label: { message: 'Pagination' },
     skyux_paging_next: { message: 'Next' },
+    skyux_paging_page_link_aria_label: { message: 'Page {0}' },
     skyux_paging_previous: { message: 'Previous' },
     skyux_repeater_label: { message: 'List of items' },
     skyux_repeater_item_expand: { message: 'Expand or collapse {0}' },


### PR DESCRIPTION
Adding an aria label used for the pagination button to navigate to a specific page in order to
improve accessibility

ADO User Story [AB#1904895](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/1904895)