### PR TITLE
feat(components/datetime):  date-picker shortcut functionality

### DIFF
--- a/libs/components/datetime/src/lib/modules/datepicker/date-formatter.ts
+++ b/libs/components/datetime/src/lib/modules/datepicker/date-formatter.ts
@@ -43,6 +43,7 @@ export class SkyDateFormatter {
   }
 
   public dateIsValid(date: Date): boolean {
+    // test
     return (
       date &&
       date instanceof Date &&

--- a/libs/components/datetime/src/lib/modules/datepicker/date-formatter.ts
+++ b/libs/components/datetime/src/lib/modules/datepicker/date-formatter.ts
@@ -43,12 +43,97 @@ export class SkyDateFormatter {
   }
 
   public dateIsValid(date: Date): boolean {
-    // test
     return (
       date &&
       date instanceof Date &&
       !isNaN(date.valueOf()) &&
       !isNaN(new Date(date).getDate())
     );
+  }
+  public dateFromUserInput(inputValue: string, format: string, strict: boolean): Date {
+    const sep = '/';
+    const pattern = format.toUpperCase();
+    let date = undefined;
+    if (!inputValue) {
+      return undefined;
+    }
+    inputValue = (`${inputValue}`).replace(/[^\d]/g, sep);
+    if (inputValue && inputValue.replace(/[^\d]/g, '').length === 0) {
+      inputValue = '';
+    }
+    if (inputValue) {
+      let valueParts = inputValue.split(sep, 3);
+      date = this.getDateFromString(inputValue, pattern, strict);
+      if (!date || valueParts.length !== 3) {
+        const today = new Date(),
+          thisYear = today.getUTCFullYear(),
+          patternParts = pattern.split(sep),
+          dayIdx = patternParts.findIndex(item => item.indexOf('D') > -1),
+          monthIdx = patternParts.findIndex(item => item.indexOf('M') > -1),
+          yearIdx = patternParts.findIndex(item => item.indexOf('Y') > -1);
+        let month = today.getUTCMonth() + 1, //months are 0 based, but we need to process as 1 based
+          day = today.getUTCDate(),
+          year = thisYear,
+          tmp = 0;
+
+        const fixYearText = (yearText) => {
+          const thisYearText = `${thisYear}`;
+          if (yearText !== undefined && yearText !== '') {
+            yearText = `${yearText}`;
+            if (yearText.length < 4 && thisYearText.length > yearText.length) {
+              yearText = thisYearText.substring(0, thisYearText.length - yearText.length) + yearText;
+            }
+            return yearText;
+          }
+          return thisYearText;
+        };
+        if (valueParts.length === 1) {
+          if (valueParts[0].length === 8) {
+            //assume full date with no separators
+            valueParts = ['', '', ''];
+            valueParts[monthIdx] = inputValue.substr((((dayIdx < monthIdx) ? 2 : 0) + ((yearIdx < monthIdx) ? 4 : 0)), 2);
+            valueParts[dayIdx] = inputValue.substr((((monthIdx < dayIdx) ? 2 : 0) + ((yearIdx < dayIdx) ? 4 : 0)), 2);
+            valueParts[yearIdx] = inputValue.substr((((monthIdx < yearIdx) ? 2 : 0) + ((dayIdx < yearIdx) ? 2 : 0)), 4);
+          } else if (valueParts[0].length === 6) {
+            //assume full date with two digit year with no separators
+            valueParts = ['', '', ''];
+            valueParts[monthIdx] = inputValue.substr((((dayIdx < monthIdx) ? 2 : 0) + ((yearIdx < monthIdx) ? 2 : 0)), 2);
+            valueParts[dayIdx] = inputValue.substr((((monthIdx < dayIdx) ? 2 : 0) + ((yearIdx < dayIdx) ? 2 : 0)), 2);
+            valueParts[yearIdx] = inputValue.substr((((monthIdx < yearIdx) ? 2 : 0) + ((dayIdx < yearIdx) ? 2 : 0)), 2);
+          } else if (valueParts[0].length === 4) {
+            //assume day month
+            valueParts = ['', '', ''];
+            valueParts[monthIdx] = inputValue.substr(((dayIdx < monthIdx) ? 2 : 0), 2);
+            valueParts[dayIdx] = inputValue.substr(((monthIdx < dayIdx) ? 2 : 0), 2);
+            valueParts[yearIdx] = `${thisYear}`;
+          }
+        }
+        switch (valueParts.length) {
+          case 1:
+            //only a single value was entered - treat it like a day unless it couldn't be, then treat it like a year
+            tmp = parseInt(inputValue);
+            if (tmp > 31) {
+              year = tmp;
+            } else {
+              day = tmp;
+            }
+            date = new Date(year, month - 1, day);
+            break;
+          case 2:
+            month = parseInt(valueParts[monthIdx]);
+            day = parseInt(valueParts[dayIdx]);
+            year = parseInt(fixYearText(valueParts[yearIdx]));
+            date = new Date(year, month - 1, day);
+            break;
+          case 3:
+            month = parseInt(valueParts[monthIdx]);
+            day = parseInt(valueParts[dayIdx]);
+            year = parseInt(fixYearText(valueParts[yearIdx]));
+            date = new Date(year, month - 1, day);
+            break;
+        }
+      }
+    }
+    return date;
   }
 }

--- a/libs/components/datetime/src/lib/modules/datepicker/datepicker-input.directive.ts
+++ b/libs/components/datetime/src/lib/modules/datepicker/datepicker-input.directive.ts
@@ -55,13 +55,12 @@ const SKY_DATEPICKER_VALIDATOR = {
 })
 export class SkyDatepickerInputDirective
   implements
-    OnInit,
-    OnDestroy,
-    AfterViewInit,
-    AfterContentInit,
-    ControlValueAccessor,
-    Validator
-{
+  OnInit,
+  OnDestroy,
+  AfterViewInit,
+  AfterContentInit,
+  ControlValueAccessor,
+  Validator {
   /**
    * Specifies the date format for the input. Place this attribute on the `input` element
    * to override the default in the `SkyDatepickerConfigService`.
@@ -152,10 +151,10 @@ export class SkyDatepickerInputDirective
     if (value) {
       console.warn(
         '[Deprecation warning] You no longer need to provide a template reference variable ' +
-          'to the `skyDatepickerInput` attribute (this will be a breaking change in the next ' +
-          'major version release).\n' +
-          'Do this instead:\n' +
-          '<sky-datepicker>\n  <input skyDatepickerInput />\n</sky-datepicker>'
+        'to the `skyDatepickerInput` attribute (this will be a breaking change in the next ' +
+        'major version release).\n' +
+        'Do this instead:\n' +
+        '<sky-datepicker>\n  <input skyDatepickerInput />\n</sky-datepicker>'
       );
     }
   }
@@ -252,7 +251,7 @@ export class SkyDatepickerInputDirective
     if (!this.datepickerComponent) {
       throw new Error(
         'You must wrap the `skyDatepickerInput` directive within a ' +
-          '`<sky-datepicker>` component!'
+        '`<sky-datepicker>` component!'
       );
     }
 
@@ -447,7 +446,7 @@ export class SkyDatepickerInputDirective
     if (value instanceof Date) {
       dateValue = value;
     } else if (typeof value === 'string') {
-      const date = this.dateFormatter.getDateFromString(
+      const date = this.dateFormatter.dateFromUserInput(
         value,
         this.dateFormat,
         this.strict
@@ -483,11 +482,11 @@ export class SkyDatepickerInputDirective
   }
 
   // eslint-disable-next-line @typescript-eslint/no-empty-function
-  private onChange = (_: any) => {};
+  private onChange = (_: any) => { };
   // eslint-disable-next-line @typescript-eslint/no-empty-function
-  private onTouched = () => {};
+  private onTouched = () => { };
   // eslint-disable-next-line @typescript-eslint/no-empty-function
-  private onValidatorChange = () => {};
+  private onValidatorChange = () => { };
 
   private updatePlaceholder(): void {
     if (!this.initialPlaceholder) {

--- a/libs/components/datetime/src/lib/modules/datepicker/datepicker.component.spec.ts
+++ b/libs/components/datetime/src/lib/modules/datepicker/datepicker.component.spec.ts
@@ -615,7 +615,82 @@ describe('datepicker', () => {
         const inputElement = fixture.debugElement.query(By.css('input'));
         ngModel = inputElement.injector.get(NgModel);
       });
+      it('should attempt to convert the date from 02022024 by appending separator', fakeAsync(() => {
+        fixture.detectChanges();
+        const date = '02022024'
+        setInputProperty(date, component, fixture);
+        expect(getInputElementValue(fixture)).toBe('02/02/2024');
+        expect(component.selectedDate).toEqual(new Date('02/02/2024'));
+        expect(ngModel.valid).toEqual(true);
+      }));
 
+      it('should attempt to convert the date from 0202 by appending the current year', fakeAsync(() => {
+        fixture.detectChanges();
+        const date = '0202'
+        setInputProperty(date, component, fixture);
+        expect(getInputElementValue(fixture)).toBe('02/02/2022');
+        expect(component.selectedDate).toEqual(new Date('02/02/2022'));
+        expect(ngModel.valid).toEqual(true);
+      }));
+      it('should attempt to convert the date from 020224 by appending separator', fakeAsync(() => {
+        fixture.detectChanges();
+        const date = '020224'
+        setInputProperty(date, component, fixture);
+        expect(getInputElementValue(fixture)).toBe('02/02/2024');
+        expect(component.selectedDate).toEqual(new Date('02/02/2024'));
+        expect(ngModel.valid).toEqual(true);
+      }));
+      it('should attempt to convert the date from 20 to 04/20/2022', fakeAsync(() => {
+        fixture.detectChanges();
+        setInputProperty('5/12/98', component, fixture);
+        const date = '20'
+        setInputProperty(date, component, fixture);
+        expect(getInputElementValue(fixture)).toBe('04/20/2022');
+        expect(component.selectedDate).toEqual(new Date('04/20/2022'));
+        expect(ngModel.valid).toEqual(true);
+      }));
+      it('should attempt to convert the date from 0202 by appending the current year', fakeAsync(() => {
+        component.dateFormat = 'DD/MM/YYYY';
+        fixture.detectChanges();
+        const date = '02/02'
+        setInputProperty(date, component, fixture);
+        expect(getInputElementValue(fixture)).toBe('02/02/2022');
+        expect(component.selectedDate).toEqual(new Date('02/02/2022'));
+        expect(ngModel.valid).toEqual(true);
+      }));
+      it('should attempt to convert the date from 02022024 by appending separator', fakeAsync(() => {
+        component.dateFormat = 'YYYY/DD/MM';
+        fixture.detectChanges();
+        const date = '02022024'
+        setInputProperty(date, component, fixture);
+        expect(getInputElementValue(fixture)).toBe('0203/20/12');
+        expect(ngModel.valid).toEqual(true);
+      }));
+      it('should attempt to convert the date from 020224 by appending separator', fakeAsync(() => {
+        component.dateFormat = 'YYYY/DD/MM';
+        fixture.detectChanges();
+        const date = '020224'
+        setInputProperty(date, component, fixture);
+        expect(getInputElementValue(fixture)).toBe('2003/02/12');
+        expect(ngModel.valid).toEqual(true);
+      }));
+      it('should attempt to convert the date from 020224 by appending separator', fakeAsync(() => {
+        component.dateFormat = 'YYYY/DD/MM';
+        fixture.detectChanges();
+        const date = '0202'
+        setInputProperty(date, component, fixture);
+        expect(getInputElementValue(fixture)).toBe('2022/02/02');
+        expect(ngModel.valid).toEqual(true);
+      }));
+      it('should attempt to convert the date from 32 to 1932/04/04', fakeAsync(() => {
+        component.dateFormat = 'YYYY/DD/MM';
+        fixture.detectChanges();
+        const todaysDate = new Date();
+        const date = '1932/' + '0' + todaysDate.getUTCDate() + '/' + ('0' + (todaysDate.getUTCMonth() + 1))
+        setInputProperty('32', component, fixture);
+        expect(getInputElementValue(fixture)).toBe(date);
+        expect(ngModel.valid).toEqual(true);
+      }));
       it('should handle model change with a Date object', fakeAsync(() => {
         fixture.detectChanges();
         setInputProperty(new Date('5/12/2017'), component, fixture);
@@ -626,7 +701,6 @@ describe('datepicker', () => {
       it('should handle model change with a string with the expected format', fakeAsync(() => {
         fixture.detectChanges();
         setInputProperty('5/12/2017', component, fixture);
-
         expect(getInputElementValue(fixture)).toBe('05/12/2017');
         expect(component.selectedDate).toEqual(new Date('5/12/2017'));
       }));
@@ -634,7 +708,6 @@ describe('datepicker', () => {
       it('should handle model change with a ISO string', fakeAsync(() => {
         fixture.detectChanges();
         setInputProperty('2009-06-15T00:00:01', component, fixture);
-
         expect(getInputElementValue(fixture)).toBe('06/15/2009');
         expect(component.selectedDate).toEqual(
           moment('2009-06-15T00:00:01', isoFormat).toDate()
@@ -644,7 +717,6 @@ describe('datepicker', () => {
       it('should handle model change with an ISO string with offset', fakeAsync(() => {
         fixture.detectChanges();
         setInputProperty('1994-11-05T08:15:30-05:00', component, fixture);
-
         expect(getInputElementValue(fixture)).toBe('11/05/1994');
         expect(component.selectedDate).toEqual(
           moment('1994-11-05T08:15:30-05:00', isoFormatWithOffset).toDate()
@@ -731,41 +803,6 @@ describe('datepicker', () => {
 
         expect(getInputElementValue(fixture)).toBe('abcdebf');
         expect(component.selectedDate).toBe('abcdebf');
-        expect(ngModel.valid).toBe(false);
-      }));
-
-      it('should validate properly when a non-convertable date is passed through input change', fakeAsync(() => {
-        detectChanges(fixture);
-        setInputElementValue(nativeElement, '133320', fixture);
-
-        expect(getInputElementValue(fixture)).toBe('133320');
-        expect(component.selectedDate).toBe('133320');
-        expect(ngModel.valid).toBe(false);
-        expect(ngModel.pristine).toBe(false);
-        expect(ngModel.touched).toBe(true);
-      }));
-
-      it('should validate properly when a non-convertable date on initialization', fakeAsync(() => {
-        setInputProperty('133320', component, fixture);
-
-        expect(getInputElementValue(fixture)).toBe('133320');
-        expect(component.selectedDate).toBe('133320');
-        expect(ngModel.valid).toBe(false);
-        expect(ngModel.touched).toBe(true);
-
-        blurInput(fixture.nativeElement, fixture);
-
-        expect(ngModel.valid).toBe(false);
-        expect(ngModel.touched).toBe(true);
-      }));
-
-      it('should validate properly when a non-convertable date on model change', fakeAsync(() => {
-        detectChanges(fixture);
-
-        setInputProperty('133320', component, fixture);
-
-        expect(getInputElementValue(fixture)).toBe('133320');
-        expect(component.selectedDate).toBe('133320');
         expect(ngModel.valid).toBe(false);
       }));
 
@@ -969,7 +1006,7 @@ describe('datepicker', () => {
     describe('disabled state', () => {
       it(
         'should disable the input and trigger button when disabled is set to true ' +
-          'and enable them when disabled is changed to false',
+        'and enable them when disabled is changed to false',
         fakeAsync(() => {
           component.isDisabled = true;
           detectChanges(fixture);
@@ -1504,7 +1541,7 @@ describe('datepicker', () => {
     describe('disabled state', () => {
       it(
         'should disable the input and trigger button when disabled is set to true ' +
-          'and enable them when disabled is changed to false',
+        'and enable them when disabled is changed to false',
         () => {
           fixture.detectChanges();
           component.isDisabled = true;


### PR DESCRIPTION
If you are entering a date into a charge (this also happens in single contributions), and you clear the date field and enter "28," you would expect it to be smart enough to render that as 04/28/2021. It does not, it renders it as 01/01/2028.
If you enter "0201" it will render it as 02/01/2021 (which is correct). FE NXT renders the "28" as 04/28/2021, saving users keystrokes.
If you enter a nonsensical date (such as "0332" - clearly there is no March 32nd), it renders it as 01/01/0332. FE NXT renders that as 04/01/2021. This is a bit of an edge case, granted.