### PR TITLE
fix(components/ag-grid): remove internal types from public API

### DIFF
--- a/libs/components/ag-grid/src/index.ts
+++ b/libs/components/ag-grid/src/index.ts
@@ -1,19 +1,8 @@
 // Export any types that should be included in the root.
 export * from './lib/modules/ag-grid/ag-grid.module';
 export * from './lib/modules/ag-grid/ag-grid.service';
-export * from './lib/modules/ag-grid/types/ag-grid-row-delete-cancel-args';
-export * from './lib/modules/ag-grid/types/ag-grid-row-delete-confirm-args';
-export * from './lib/modules/ag-grid/types/autocomplete-properties';
-export * from './lib/modules/ag-grid/types/cell-class';
 export * from './lib/modules/ag-grid/types/cell-type';
-export * from './lib/modules/ag-grid/types/currency-properties';
-export * from './lib/modules/ag-grid/types/datepicker-properties';
-export * from './lib/modules/ag-grid/types/header-class';
-export * from './lib/modules/ag-grid/types/lookup-properties';
-export * from './lib/modules/ag-grid/types/number-properties';
 export * from './lib/modules/ag-grid/types/sky-grid-options';
-export * from './lib/modules/ag-grid/types/text-properties';
-export * from './lib/modules/ag-grid/types/validator-options';
 
 // Components and directives must be exported to support Angular's "partial" Ivy compiler.
 // Obscure names are used to indicate types are not part of the public API.

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/types/cell-editor-autocomplete-params.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/types/cell-editor-autocomplete-params.ts
@@ -2,6 +2,9 @@ import { ICellEditorParams } from 'ag-grid-community';
 
 import { SkyAutocompleteProperties } from './autocomplete-properties';
 
+/**
+ * @internal
+ */
 export interface SkyCellEditorAutocompleteParams extends ICellEditorParams {
   skyComponentProperties?: SkyAutocompleteProperties;
 }

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/types/cell-editor-currency-params.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/types/cell-editor-currency-params.ts
@@ -2,6 +2,9 @@ import { ICellEditorParams } from 'ag-grid-community';
 
 import { SkyCurrencyProperties } from './currency-properties';
 
+/**
+ * @internal
+ */
 export interface SkyCellEditorCurrencyParams extends ICellEditorParams {
   skyComponentProperties?: SkyCurrencyProperties;
 }

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/types/cell-editor-datepicker-params.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/types/cell-editor-datepicker-params.ts
@@ -2,6 +2,9 @@ import { ICellEditorParams } from 'ag-grid-community';
 
 import { SkyDatepickerProperties } from './datepicker-properties';
 
+/**
+ * @internal
+ */
 export interface SkyCellEditorDatepickerParams extends ICellEditorParams {
   skyComponentProperties?: SkyDatepickerProperties;
 }

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/types/cell-editor-lookup-params.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/types/cell-editor-lookup-params.ts
@@ -2,6 +2,9 @@ import { ICellEditorParams } from 'ag-grid-community';
 
 import { SkyLookupProperties } from './lookup-properties';
 
+/**
+ * @internal
+ */
 export interface SkyCellEditorLookupParams extends ICellEditorParams {
   skyComponentProperties?: SkyLookupProperties;
 }

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/types/cell-editor-number-params.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/types/cell-editor-number-params.ts
@@ -2,6 +2,9 @@ import { ICellEditorParams } from 'ag-grid-community';
 
 import { SkyNumberProperties } from './number-properties';
 
+/**
+ * @internal
+ */
 export interface SkyCellEditorNumberParams extends ICellEditorParams {
   skyComponentProperties?: SkyNumberProperties;
 }

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/types/cell-editor-text-params.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/types/cell-editor-text-params.ts
@@ -2,6 +2,9 @@ import { ICellEditorParams } from 'ag-grid-community';
 
 import { SkyTextProperties } from './text-properties';
 
+/**
+ * @internal
+ */
 export interface SkyCellEditorTextParams extends ICellEditorParams {
   skyComponentProperties?: SkyTextProperties;
 }

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/types/cell-renderer-currency-params.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/types/cell-renderer-currency-params.ts
@@ -4,6 +4,9 @@ import { ICellRendererParams } from 'ag-grid-community';
 
 import { ValidatorOptions } from './validator-options';
 
+/**
+ * @internal
+ */
 export interface SkyCellRendererCurrencyParams extends ICellRendererParams {
   skyComponentProperties?: NumericOptions & ValidatorOptions;
 }

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/types/cell-renderer-lookup-params.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/types/cell-renderer-lookup-params.ts
@@ -2,6 +2,9 @@ import { ICellRendererParams } from 'ag-grid-community';
 
 import { SkyLookupProperties } from './lookup-properties';
 
+/**
+ * @internal
+ */
 export interface SkyCellRendererLookupParams extends ICellRendererParams {
   skyComponentProperties?: SkyLookupProperties;
 }

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/types/cell-renderer-validator-params.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/types/cell-renderer-validator-params.ts
@@ -2,6 +2,9 @@ import { ICellRendererParams } from 'ag-grid-community';
 
 import { ValidatorOptions } from './validator-options';
 
+/**
+ * @internal
+ */
 export interface SkyCellRendererValidatorParams extends ICellRendererParams {
   skyComponentProperties: ValidatorOptions;
 }

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/types/currency-properties.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/types/currency-properties.ts
@@ -1,3 +1,6 @@
+/**
+ * @internal
+ */
 export interface SkyCurrencyProperties {
   currencySymbol?: string;
   decimalPlaces?: number;

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/types/lookup-properties.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/types/lookup-properties.ts
@@ -1,4 +1,4 @@
-import { EventEmitter, TemplateRef } from '@angular/core';
+import { TemplateRef } from '@angular/core';
 import {
   SkyAutocompleteSearchAsyncArgs,
   SkyAutocompleteSearchFunction,
@@ -8,6 +8,9 @@ import {
   SkyLookupShowMoreConfig,
 } from '@skyux/lookup';
 
+/**
+ * @internal
+ */
 export interface SkyLookupProperties {
   addClick?: (args: SkyLookupAddClickEventArgs) => {};
   ariaLabel?: string;

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/types/validator-options.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/types/validator-options.ts
@@ -1,3 +1,6 @@
+/**
+ * @internal
+ */
 export interface ValidatorOptions {
   validator?: (value: any, data?: any, rowIndex?: number) => boolean;
   validatorMessage?:


### PR DESCRIPTION
Remove internal-only types from the public API.

BREAKING CHANGE: Removed several internal-only types from the public API.