### PR TITLE
fix(components/popovers): respect alignment and placement values supplied to the popover component (#139)

### DIFF
--- a/libs/components/popovers/src/lib/modules/popover/popover.component.ts
+++ b/libs/components/popovers/src/lib/modules/popover/popover.component.ts
@@ -161,8 +161,8 @@ export class SkyPopoverComponent implements OnDestroy {
       this.setupOverlay();
     }
 
-    this.placement = placement;
-    this.alignment = alignment;
+    this.placement = placement ?? this.placement;
+    this.alignment = alignment ?? this.alignment;
     this.isActive = true;
 
     this.contentRef.open(caller, {

--- a/libs/components/popovers/src/lib/modules/popover/popover.directive.spec.ts
+++ b/libs/components/popovers/src/lib/modules/popover/popover.directive.spec.ts
@@ -102,6 +102,32 @@ describe('Popover directive', () => {
     expect(popoverRef.popoverTitle).toBeUndefined();
   }));
 
+  it('should use placement and alignment values of the popover component', fakeAsync(() => {
+    // Ensure alignment/placement are undefined for directive.
+    fixture.componentInstance.alignment = undefined;
+    fixture.componentInstance.placement = undefined;
+
+    // Set alignment/placement for component.
+    fixture.componentInstance.popoverAlignment = 'left';
+    fixture.componentInstance.popoverPlacement = 'left';
+    detectChangesFakeAsync();
+
+    // Launch popover.
+    const button = getCallerElement();
+    button.click();
+    detectChangesFakeAsync();
+
+    // Confirm popover class properties.
+    const popoverRef = fixture.componentInstance.popoverRef;
+    expect(popoverRef.alignment).toEqual('left');
+    expect(popoverRef.placement).toEqual('left');
+
+    // Confirm popover CSS classes.
+    const popover = getPopoverElement();
+    expect(popover).toHaveCssClass('sky-popover-placement-left');
+    expect(popover).toHaveCssClass('sky-popover-alignment-left');
+  }));
+
   it('should place the popover on all four sides of the caller', fakeAsync(() => {
     fixture.componentInstance.placement = 'above';
     detectChangesFakeAsync();


### PR DESCRIPTION
If alignment/placement values are not defined by the popover directive, the same values provided to
the component should be respected. Before this change, the values on the component were reset to
their default values.