### PR TITLE
revert: feat(components/indicators): replace `string` alert types with dedicated `SkyAlertType` type

### DIFF
--- a/libs/components/indicators/src/index.ts
+++ b/libs/components/indicators/src/index.ts
@@ -1,4 +1,3 @@
-export * from './lib/modules/alert/alert-type';
 export * from './lib/modules/alert/alert.module';
 
 export * from './lib/modules/chevron/chevron.module';

--- a/libs/components/indicators/src/lib/modules/alert/alert-type.ts
+++ b/libs/components/indicators/src/lib/modules/alert/alert-type.ts
@@ -1,4 +1,0 @@
-/**
- * Specifies a style for the alert to determine the icon and background color.
- */
-export type SkyAlertType = 'danger' | 'info' | 'success' | 'warning';

--- a/libs/components/indicators/src/lib/modules/alert/alert.component.ts
+++ b/libs/components/indicators/src/lib/modules/alert/alert.component.ts
@@ -4,8 +4,6 @@ import { SkyIconStackItem } from '../icon/icon-stack-item';
 import { SkyIndicatorIconType } from '../shared/indicator-icon-type';
 import { SkyIndicatorIconUtility } from '../shared/indicator-icon-utility';
 
-import { SkyAlertType } from './alert-type';
-
 const ALERT_TYPE_DEFAULT = 'warning';
 
 @Component({
@@ -16,15 +14,16 @@ const ALERT_TYPE_DEFAULT = 'warning';
 export class SkyAlertComponent implements OnInit {
   /**
    * Specifies a style for the alert to determine the icon and background color.
+   * The valid options are `danger`, `info`, `success`, and `warning`.
    * @default "warning"
    */
   @Input()
-  public set alertType(value: SkyAlertType | undefined) {
+  public set alertType(value: string) {
     this._alertType = value;
     this.updateAlertIcon();
   }
 
-  public get alertType(): SkyAlertType {
+  public get alertType(): string {
     return this._alertType || ALERT_TYPE_DEFAULT;
   }
 
@@ -52,7 +51,7 @@ export class SkyAlertComponent implements OnInit {
 
   public alertTopIcon: SkyIconStackItem;
 
-  private _alertType: SkyAlertType;
+  private _alertType: string;
 
   public ngOnInit(): void {
     this.updateAlertIcon();


### PR DESCRIPTION
Reverts blackbaud/skyux#164