### PR TITLE
fix(components/flyout): revert breaking change to `SkyFlyoutService` injectors

### DIFF
--- a/libs/components/flyout/src/lib/modules/flyout/flyout.service.ts
+++ b/libs/components/flyout/src/lib/modules/flyout/flyout.service.ts
@@ -1,8 +1,10 @@
 import {
+  ApplicationRef,
   ComponentRef,
   Injectable,
   NgZone,
   OnDestroy,
+  Optional,
   Type,
 } from '@angular/core';
 import { NavigationStart, Router } from '@angular/router';
@@ -41,8 +43,16 @@ export class SkyFlyoutService implements OnDestroy {
     private windowRef: SkyAppWindowRef,
     private dynamicComponentService: SkyDynamicComponentService,
     private router: Router,
-    private readonly _ngZone: NgZone
-  ) {}
+    private readonly _ngZone: NgZone,
+    // NOTE: This used to be used for an `applicationRef.tick` which has since been removed.
+    // We can not remove this due to it being a breaking change for those manually constructing the service.
+    @Optional() private readonly _applicationRef?: ApplicationRef
+  ) {
+    /*istanbul ignore if*/
+    /*eslint-disable-next-line no-empty*/
+    if (this._applicationRef) {
+    }
+  }
 
   public ngOnDestroy(): void {
     this.removeListners();


### PR DESCRIPTION
We have several consumers mocking out `SkyFlyoutService` and receive the following error in their unit tests:
```
SkyFlyoutService: Expected 5 arguments, but got 6.
```