### PR TITLE
fix(components/a11y): skip link button shows proper localized strings

### DIFF
--- a/apps/playground/src/app/components/a11y/a11y.module.ts
+++ b/apps/playground/src/app/components/a11y/a11y.module.ts
@@ -1,0 +1,22 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+
+import { SkipLinkComponent } from './skip-link/skip-link.component';
+
+const routes: Routes = [
+  {
+    path: 'skip-link',
+    loadChildren: () =>
+      import('./skip-link/skip-link.module').then((m) => m.SkipLinkModule),
+  },
+];
+@NgModule({
+  declarations: [],
+  imports: [RouterModule.forChild(routes)],
+})
+export class A11yRoutingModule {}
+
+@NgModule({
+  imports: [A11yRoutingModule],
+})
+export class A11yModule {}

--- a/apps/playground/src/app/components/a11y/skip-link/skip-link-routing.module.ts
+++ b/apps/playground/src/app/components/a11y/skip-link/skip-link-routing.module.ts
@@ -1,0 +1,16 @@
+import { NgModule } from '@angular/core';
+import { RouterModule } from '@angular/router';
+
+import { SkipLinkComponent } from './skip-link.component';
+
+@NgModule({
+  imports: [
+    RouterModule.forChild([
+      {
+        path: '',
+        component: SkipLinkComponent,
+      },
+    ]),
+  ],
+})
+export class SkipLinkRoutingModule {}

--- a/apps/playground/src/app/components/a11y/skip-link/skip-link.component.html
+++ b/apps/playground/src/app/components/a11y/skip-link/skip-link.component.html
@@ -1,0 +1,57 @@
+<div class="sky-container">
+  <p>Press [tab] to see the links.</p>
+
+  <div tabindex="-1" #skipLink1>
+    <h2>Area 1</h2>
+    <p>
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi egestas,
+      tellus sed placerat gravida, sapien nisi auctor justo, et mattis nisi eros
+      sed purus. Pellentesque sodales nunc tortor, ullamcorper ornare est
+      blandit non. Suspendisse sed orci posuere, vestibulum purus gravida,
+      auctor ex. Suspendisse lectus velit, euismod commodo tempor ac, semper ut
+      metus. Aliquam tincidunt neque sed erat blandit, id pulvinar orci
+      tristique. Phasellus maximus efficitur scelerisque. In at sapien eu lectus
+      placerat pellentesque. Praesent auctor porttitor arcu quis blandit. Nulla
+      cursus lacus eu dictum sollicitudin.
+    </p>
+    <p>
+      Sed tristique purus id augue egestas, sit amet congue eros tempor.
+      Vestibulum blandit nisi eu massa congue iaculis dictum eget nunc. Nam
+      tincidunt quam vel bibendum lacinia. Fusce sed leo arcu. Ut ut erat lacus.
+      In id ultrices nunc. Fusce vitae finibus est. Donec auctor mattis egestas.
+      Nulla luctus magna et eleifend fermentum. Maecenas sagittis sapien at
+      metus vestibulum consequat. Pellentesque lobortis nulla sed nibh
+      consectetur varius. Etiam suscipit est vitae dui fermentum, accumsan
+      dignissim turpis luctus. Maecenas eu orci ipsum. In tincidunt elementum
+      nisi vel consectetur. Quisque a lacus vehicula, sodales velit vitae,
+      condimentum ligula.
+    </p>
+  </div>
+
+  <div tabindex="-1" #skipLink2>
+    <h2>Area 2</h2>
+    <p>
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi egestas,
+      tellus sed placerat gravida, sapien nisi auctor justo, et mattis nisi eros
+      sed purus. Pellentesque sodales nunc tortor, ullamcorper ornare est
+      blandit non. Suspendisse sed orci posuere, vestibulum purus gravida,
+      auctor ex. Suspendisse lectus velit, euismod commodo tempor ac, semper ut
+      metus. Aliquam tincidunt neque sed erat blandit, id pulvinar orci
+      tristique. Phasellus maximus efficitur scelerisque. In at sapien eu lectus
+      placerat pellentesque. Praesent auctor porttitor arcu quis blandit. Nulla
+      cursus lacus eu dictum sollicitudin.
+    </p>
+    <p>
+      Sed tristique purus id augue egestas, sit amet congue eros tempor.
+      Vestibulum blandit nisi eu massa congue iaculis dictum eget nunc. Nam
+      tincidunt quam vel bibendum lacinia. Fusce sed leo arcu. Ut ut erat lacus.
+      In id ultrices nunc. Fusce vitae finibus est. Donec auctor mattis egestas.
+      Nulla luctus magna et eleifend fermentum. Maecenas sagittis sapien at
+      metus vestibulum consequat. Pellentesque lobortis nulla sed nibh
+      consectetur varius. Etiam suscipit est vitae dui fermentum, accumsan
+      dignissim turpis luctus. Maecenas eu orci ipsum. In tincidunt elementum
+      nisi vel consectetur. Quisque a lacus vehicula, sodales velit vitae,
+      condimentum ligula.
+    </p>
+  </div>
+</div>

--- a/apps/playground/src/app/components/a11y/skip-link/skip-link.component.scss
+++ b/apps/playground/src/app/components/a11y/skip-link/skip-link.component.scss
@@ -1,0 +1,4 @@
+#skip-link-screenshot {
+  height: 100px;
+  width: 200px;
+}

--- a/apps/playground/src/app/components/a11y/skip-link/skip-link.component.ts
+++ b/apps/playground/src/app/components/a11y/skip-link/skip-link.component.ts
@@ -1,0 +1,39 @@
+//#region imports
+import { AfterViewInit, Component, ElementRef, ViewChild } from '@angular/core';
+import { SkySkipLinkService } from '@skyux/a11y';
+
+//#endregion
+
+@Component({
+  selector: 'app-skip-link',
+  templateUrl: './skip-link.component.html',
+  styleUrls: ['./skip-link.component.scss'],
+})
+export class SkipLinkComponent implements AfterViewInit {
+  @ViewChild('skipLink1', { read: ElementRef })
+  private skipLink1: ElementRef;
+
+  @ViewChild('skipLink2', { read: ElementRef })
+  private skipLink2: ElementRef;
+
+  constructor(private skipLinkService: SkySkipLinkService) {}
+
+  public ngAfterViewInit(): void {
+    this.skipLinkService.setSkipLinks({
+      links: [
+        {
+          title: 'Area 1',
+          elementRef: this.skipLink1,
+        },
+        {
+          title: 'Area 2',
+          elementRef: this.skipLink2,
+        },
+        {
+          title: 'Invalid area',
+          elementRef: undefined,
+        },
+      ],
+    });
+  }
+}

--- a/apps/playground/src/app/components/a11y/skip-link/skip-link.module.ts
+++ b/apps/playground/src/app/components/a11y/skip-link/skip-link.module.ts
@@ -1,0 +1,18 @@
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { SkySkipLinkModule } from '@skyux/a11y';
+import { SkyAppLinkModule } from '@skyux/router';
+
+import { SkipLinkRoutingModule } from './skip-link-routing.module';
+import { SkipLinkComponent } from './skip-link.component';
+
+@NgModule({
+  declarations: [SkipLinkComponent],
+  imports: [
+    CommonModule,
+    SkyAppLinkModule,
+    SkySkipLinkModule,
+    SkipLinkRoutingModule,
+  ],
+})
+export class SkipLinkModule {}

--- a/apps/playground/src/app/components/components.module.ts
+++ b/apps/playground/src/app/components/components.module.ts
@@ -3,6 +3,10 @@ import { RouterModule, Routes } from '@angular/router';
 
 const routes: Routes = [
   {
+    path: 'a11y',
+    loadChildren: () => import('./a11y/a11y.module').then((m) => m.A11yModule),
+  },
+  {
     path: 'action-bars',
     loadChildren: () =>
       import('./action-bars/action-bars.module').then(

--- a/apps/playground/src/app/home/home.component.html
+++ b/apps/playground/src/app/home/home.component.html
@@ -1,5 +1,13 @@
 <ul>
   <li>
+    A11y
+    <ul>
+      <li>
+        <a routerLink="components/a11y/skip-link">Skip link</a>
+      </li>
+    </ul>
+  </li>
+  <li>
     Action bars
     <ul>
       <li>

--- a/libs/components/a11y/src/lib/modules/skip-link/skip-link.service.ts
+++ b/libs/components/a11y/src/lib/modules/skip-link/skip-link.service.ts
@@ -17,7 +17,10 @@ import { SkySkipLinkHostComponent } from './skip-link-host.component';
  * @dynamic
  */
 @Injectable({
-  providedIn: 'root',
+  // Must be 'any' so that the skip link component is created in the context of its module's injector.
+  // If set to 'root', the component's dependency injections would only be derived from the root
+  // injector and may loose context if the skip link was created from within a lazy-loaded module.
+  providedIn: 'any',
 })
 export class SkySkipLinkService {
   private static host: ComponentRef<SkySkipLinkHostComponent>;


### PR DESCRIPTION
- injects a11y/skip-links at component module level instead of root level
- adds a11y/skip-links to playground