### PR TITLE
fix(components/popovers): address accessor type validation for `SkyPopoverDirective.skyPopoverMessageStream`

### DIFF
--- a/libs/components/popovers/src/lib/modules/popover/popover.directive.spec.ts
+++ b/libs/components/popovers/src/lib/modules/popover/popover.directive.spec.ts
@@ -747,7 +747,7 @@ describe('Popover directive', () => {
       detectChangesFakeAsync();
 
       expect(
-        fixture.componentInstance.noArgsDirectiveRef.messageStream
+        fixture.componentInstance.noArgsDirectiveRef.skyPopoverMessageStream
       ).toBeDefined();
     }));
 
@@ -755,7 +755,7 @@ describe('Popover directive', () => {
       detectChangesFakeAsync();
 
       expect(fixture.componentInstance.messageStream).toEqual(
-        fixture.componentInstance.directiveRef.messageStream
+        fixture.componentInstance.directiveRef.skyPopoverMessageStream
       );
 
       fixture.componentInstance.messageStream = undefined;
@@ -763,7 +763,7 @@ describe('Popover directive', () => {
       detectChangesFakeAsync();
 
       expect(
-        fixture.componentInstance.directiveRef.messageStream
+        fixture.componentInstance.directiveRef.skyPopoverMessageStream
       ).toBeDefined();
     }));
 

--- a/libs/components/popovers/src/lib/modules/popover/popover.directive.spec.ts
+++ b/libs/components/popovers/src/lib/modules/popover/popover.directive.spec.ts
@@ -747,7 +747,7 @@ describe('Popover directive', () => {
       detectChangesFakeAsync();
 
       expect(
-        fixture.componentInstance.noArgsDirectiveRef.skyPopoverMessageStream
+        fixture.componentInstance.noArgsDirectiveRef.messageStream
       ).toBeDefined();
     }));
 
@@ -755,7 +755,7 @@ describe('Popover directive', () => {
       detectChangesFakeAsync();
 
       expect(fixture.componentInstance.messageStream).toEqual(
-        fixture.componentInstance.directiveRef.skyPopoverMessageStream
+        fixture.componentInstance.directiveRef.messageStream
       );
 
       fixture.componentInstance.messageStream = undefined;
@@ -763,7 +763,7 @@ describe('Popover directive', () => {
       detectChangesFakeAsync();
 
       expect(
-        fixture.componentInstance.directiveRef.skyPopoverMessageStream
+        fixture.componentInstance.directiveRef.messageStream
       ).toBeDefined();
     }));
 

--- a/libs/components/popovers/src/lib/modules/popover/popover.directive.ts
+++ b/libs/components/popovers/src/lib/modules/popover/popover.directive.ts
@@ -39,7 +39,7 @@ export class SkyPopoverDirective implements OnInit, OnDestroy {
     this.subscribeMessageStream();
   }
 
-  public get skyPopoverMessageStream(): Subject<SkyPopoverMessage> {
+  public get messageStream(): Subject<SkyPopoverMessage> {
     return this._skyPopoverMessageStream;
   }
 
@@ -228,17 +228,15 @@ export class SkyPopoverDirective implements OnInit, OnDestroy {
   }
 
   private sendMessage(messageType: SkyPopoverMessageType): void {
-    this.skyPopoverMessageStream.next({ type: messageType });
+    this.messageStream.next({ type: messageType });
   }
 
   private subscribeMessageStream(): void {
     this.unsubscribeMessageStream();
 
-    this.#messageStreamSub = this.skyPopoverMessageStream.subscribe(
-      (message) => {
-        this.handleIncomingMessages(message);
-      }
-    );
+    this.#messageStreamSub = this.messageStream.subscribe((message) => {
+      this.handleIncomingMessages(message);
+    });
   }
 
   private unsubscribeMessageStream(): void {

--- a/libs/components/popovers/src/lib/modules/popover/popover.directive.ts
+++ b/libs/components/popovers/src/lib/modules/popover/popover.directive.ts
@@ -39,13 +39,11 @@ export class SkyPopoverDirective implements OnInit, OnDestroy {
     this.subscribeMessageStream();
   }
 
-  public get messageStream(): Subject<SkyPopoverMessage> {
+  public get skyPopoverMessageStream(): Subject<SkyPopoverMessage> | undefined {
     return this._skyPopoverMessageStream;
   }
 
   private _skyPopoverMessageStream = new Subject<SkyPopoverMessage>();
-
-  #messageStreamSub: Subscription | undefined;
 
   /**
    * Specifies the placement of the popover in relation to the trigger element.
@@ -69,6 +67,13 @@ export class SkyPopoverDirective implements OnInit, OnDestroy {
   private ngUnsubscribe = new Subject<void>();
 
   private _trigger: SkyPopoverTrigger;
+
+  // Used internally to avoid non-null assertions when accessing the message stream.
+  get #messageStream(): Subject<SkyPopoverMessage> {
+    return this._skyPopoverMessageStream;
+  }
+
+  #messageStreamSub: Subscription | undefined;
 
   constructor(private elementRef: ElementRef) {
     this.subscribeMessageStream();
@@ -228,13 +233,13 @@ export class SkyPopoverDirective implements OnInit, OnDestroy {
   }
 
   private sendMessage(messageType: SkyPopoverMessageType): void {
-    this.messageStream.next({ type: messageType });
+    this.#messageStream.next({ type: messageType });
   }
 
   private subscribeMessageStream(): void {
     this.unsubscribeMessageStream();
 
-    this.#messageStreamSub = this.messageStream.subscribe((message) => {
+    this.#messageStreamSub = this.#messageStream.subscribe((message) => {
       this.handleIncomingMessages(message);
     });
   }


### PR DESCRIPTION
Strict-mode apps were throwing this error:
```
Error: node_modules/@skyux/popovers/lib/modules/popover/popover.directive.d.ts:25:9 - error TS2380: 'get' and 'set' accessor must have the same type.
25     set skyPopoverMessageStream(value: Subject<SkyPopoverMessage> | undefined);
```