### PR TITLE
fix(components/ag-grid): use functions instead of expressions

### DIFF
--- a/libs/components/ag-grid/src/lib/modules/ag-grid/ag-grid.service.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/ag-grid.service.ts
@@ -268,7 +268,7 @@ export class SkyAgGridService implements OnDestroy {
       columnTypes: {
         [SkyCellType.Autocomplete]: {
           cellClassRules: {
-            [SkyCellClass.Autocomplete]: cellClassRuleTrueExpression,
+            [SkyCellClass.Autocomplete]: () => cellClassRuleTrueExpression,
             ...editableCellClassRules,
           },
           cellEditor: SkyAgGridCellEditorAutocompleteComponent,
@@ -278,7 +278,7 @@ export class SkyAgGridService implements OnDestroy {
         },
         [SkyCellType.Currency]: {
           cellClassRules: {
-            [SkyCellClass.Currency]: cellClassRuleTrueExpression,
+            [SkyCellClass.Currency]: () => cellClassRuleTrueExpression,
             ...validatorCellClassRules,
             ...editableCellClassRules,
           },
@@ -292,7 +292,7 @@ export class SkyAgGridService implements OnDestroy {
         },
         [SkyCellType.Date]: {
           cellClassRules: {
-            [SkyCellClass.Date]: cellClassRuleTrueExpression,
+            [SkyCellClass.Date]: () => cellClassRuleTrueExpression,
             ...editableCellClassRules,
           },
           cellEditor: SkyAgGridCellEditorDatepickerComponent,
@@ -303,7 +303,7 @@ export class SkyAgGridService implements OnDestroy {
         },
         [SkyCellType.Lookup]: {
           cellClassRules: {
-            [SkyCellClass.Lookup]: cellClassRuleTrueExpression,
+            [SkyCellClass.Lookup]: () => cellClassRuleTrueExpression,
             ...editableCellClassRules,
           },
           cellEditor: SkyAgGridCellEditorLookupComponent,
@@ -321,7 +321,7 @@ export class SkyAgGridService implements OnDestroy {
         },
         [SkyCellType.Number]: {
           cellClassRules: {
-            [SkyCellClass.Number]: cellClassRuleTrueExpression,
+            [SkyCellClass.Number]: () => cellClassRuleTrueExpression,
             ...validatorCellClassRules,
             ...editableCellClassRules,
           },
@@ -333,8 +333,8 @@ export class SkyAgGridService implements OnDestroy {
         },
         [SkyCellType.RowSelector]: {
           cellClassRules: {
-            [SkyCellClass.RowSelector]: cellClassRuleTrueExpression,
-            [SkyCellClass.Uneditable]: cellClassRuleTrueExpression,
+            [SkyCellClass.RowSelector]: () => cellClassRuleTrueExpression,
+            [SkyCellClass.Uneditable]: () => cellClassRuleTrueExpression,
           },
           cellRenderer: SkyAgGridCellRendererRowSelectorComponent,
           headerName: '',
@@ -345,7 +345,7 @@ export class SkyAgGridService implements OnDestroy {
         },
         [SkyCellType.Text]: {
           cellClassRules: {
-            [SkyCellClass.Text]: cellClassRuleTrueExpression,
+            [SkyCellClass.Text]: () => cellClassRuleTrueExpression,
             ...validatorCellClassRules,
             ...editableCellClassRules,
           },

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/ag-grid.service.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/ag-grid.service.ts
@@ -218,7 +218,7 @@ export class SkyAgGridService implements OnDestroy {
 
   private getDefaultGridOptions(args: SkyGetGridOptionsArgs): GridOptions {
     // cellClassRules can be functions or string expressions
-    const cellClassRuleTrueExpression = 'true';
+    const cellClassRuleTrueExpression = true;
 
     function getEditableFn(
       isUneditable?: boolean

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/ag-grid.service.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/ag-grid.service.ts
@@ -218,7 +218,7 @@ export class SkyAgGridService implements OnDestroy {
 
   private getDefaultGridOptions(args: SkyGetGridOptionsArgs): GridOptions {
     // cellClassRules can be functions or string expressions
-    const cellClassRuleTrueExpression = true;
+    const cellClassRuleTrueExpression = () => true;
 
     function getEditableFn(
       isUneditable?: boolean
@@ -268,7 +268,7 @@ export class SkyAgGridService implements OnDestroy {
       columnTypes: {
         [SkyCellType.Autocomplete]: {
           cellClassRules: {
-            [SkyCellClass.Autocomplete]: () => cellClassRuleTrueExpression,
+            [SkyCellClass.Autocomplete]: cellClassRuleTrueExpression,
             ...editableCellClassRules,
           },
           cellEditor: SkyAgGridCellEditorAutocompleteComponent,
@@ -278,7 +278,7 @@ export class SkyAgGridService implements OnDestroy {
         },
         [SkyCellType.Currency]: {
           cellClassRules: {
-            [SkyCellClass.Currency]: () => cellClassRuleTrueExpression,
+            [SkyCellClass.Currency]: cellClassRuleTrueExpression,
             ...validatorCellClassRules,
             ...editableCellClassRules,
           },
@@ -292,7 +292,7 @@ export class SkyAgGridService implements OnDestroy {
         },
         [SkyCellType.Date]: {
           cellClassRules: {
-            [SkyCellClass.Date]: () => cellClassRuleTrueExpression,
+            [SkyCellClass.Date]: cellClassRuleTrueExpression,
             ...editableCellClassRules,
           },
           cellEditor: SkyAgGridCellEditorDatepickerComponent,
@@ -303,7 +303,7 @@ export class SkyAgGridService implements OnDestroy {
         },
         [SkyCellType.Lookup]: {
           cellClassRules: {
-            [SkyCellClass.Lookup]: () => cellClassRuleTrueExpression,
+            [SkyCellClass.Lookup]: cellClassRuleTrueExpression,
             ...editableCellClassRules,
           },
           cellEditor: SkyAgGridCellEditorLookupComponent,
@@ -321,7 +321,7 @@ export class SkyAgGridService implements OnDestroy {
         },
         [SkyCellType.Number]: {
           cellClassRules: {
-            [SkyCellClass.Number]: () => cellClassRuleTrueExpression,
+            [SkyCellClass.Number]: cellClassRuleTrueExpression,
             ...validatorCellClassRules,
             ...editableCellClassRules,
           },
@@ -333,8 +333,8 @@ export class SkyAgGridService implements OnDestroy {
         },
         [SkyCellType.RowSelector]: {
           cellClassRules: {
-            [SkyCellClass.RowSelector]: () => cellClassRuleTrueExpression,
-            [SkyCellClass.Uneditable]: () => cellClassRuleTrueExpression,
+            [SkyCellClass.RowSelector]: cellClassRuleTrueExpression,
+            [SkyCellClass.Uneditable]: cellClassRuleTrueExpression,
           },
           cellRenderer: SkyAgGridCellRendererRowSelectorComponent,
           headerName: '',
@@ -345,7 +345,7 @@ export class SkyAgGridService implements OnDestroy {
         },
         [SkyCellType.Text]: {
           cellClassRules: {
-            [SkyCellClass.Text]: () => cellClassRuleTrueExpression,
+            [SkyCellClass.Text]: cellClassRuleTrueExpression,
             ...validatorCellClassRules,
             ...editableCellClassRules,
           },


### PR DESCRIPTION
Ag-grid documentation says that it's [necessary](https://www.ag-grid.com/javascript-data-grid/security/#:~:text=If%20you%20are%20working%20with%20expressions%20/%20code%20parsing%20inside%20of%20the%20grid%20instead%20of%20functions%2c%20it%20will%20be%20necessary%20to%20add%20the%20unsafe-eval%20rule%20to%20your%20policy) to add unsafe-eval if you're using expressions inside the grid but that could be avoided if we use functions instead of expressions. Using unsafe-eval is a security risk so we want to avoid using it.

https://dev.azure.com/blackbaud/Products/_workitems/edit/2187168