### PR TITLE
fix(components/ag-grid): use functions instead of expressions

### DIFF
--- a/libs/components/ag-grid/src/lib/modules/ag-grid/ag-grid.service.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/ag-grid.service.ts
@@ -206,7 +206,7 @@ export class SkyAgGridService implements OnDestroy {
 
   private getDefaultGridOptions(args: SkyGetGridOptionsArgs): GridOptions {
     // cellClassRules can be functions or string expressions
-    const cellClassRuleTrueExpression = 'true';
+    const cellClassRuleTrueExpression = () => true;
 
     function getEditableFn(
       isUneditable?: boolean


### PR DESCRIPTION
Ag-grid documentation says that it's [necessary](https://www.ag-grid.com/javascript-data-grid/security/#:~:text=If%20you%20are%20working%20with%20expressions%20/%20code%20parsing%20inside%20of%20the%20grid%20instead%20of%20functions%2c%20it%20will%20be%20necessary%20to%20add%20the%20unsafe-eval%20rule%20to%20your%20policy) to add unsafe-eval if you're using expressions inside the grid but that could be avoided if we use functions instead of expressions. Using unsafe-eval is a security risk so we want to avoid using it.

https://dev.azure.com/blackbaud/Products/_workitems/edit/2187168