### PR TITLE
fix(components/forms): form controls on radio groups now properly disable radio buttons on initialization and do not mark the form as dirty on programatic changes

### DIFF
--- a/libs/components/forms/src/lib/modules/radio/fixtures/radio-group-reactive.component.fixture.ts
+++ b/libs/components/forms/src/lib/modules/radio/fixtures/radio-group-reactive.component.fixture.ts
@@ -1,4 +1,4 @@
-import { Component, ViewChild } from '@angular/core';
+import { Component, OnInit, ViewChild } from '@angular/core';
 import { FormBuilder, FormControl, FormGroup } from '@angular/forms';
 
 import { SkyRadioGroupComponent } from '../radio-group.component';
@@ -6,10 +6,14 @@ import { SkyRadioGroupComponent } from '../radio-group.component';
 @Component({
   templateUrl: './radio-group-reactive.component.fixture.html',
 })
-export class SkyRadioGroupReactiveFixtureComponent {
+export class SkyRadioGroupReactiveFixtureComponent implements OnInit {
   public ariaLabel: string;
 
   public ariaLabelledBy = 'radio-group-label';
+
+  public initialDisabled = false;
+
+  public initialValue: unknown = null;
 
   public options = [
     { name: 'Lillith Corharvest', disabled: false },
@@ -17,8 +21,7 @@ export class SkyRadioGroupReactiveFixtureComponent {
     { name: 'Harry Mckenzie', disabled: false },
   ];
 
-  public radioControl = new FormControl();
-
+  public radioControl: FormControl;
   public radioForm: FormGroup;
 
   public required = false;
@@ -30,7 +33,14 @@ export class SkyRadioGroupReactiveFixtureComponent {
   @ViewChild(SkyRadioGroupComponent)
   public radioGroupComponent: SkyRadioGroupComponent;
 
-  constructor(private fb: FormBuilder) {
+  constructor(private fb: FormBuilder) {}
+
+  public ngOnInit(): void {
+    this.radioControl = new FormControl({
+      value: this.initialValue,
+      disabled: this.initialDisabled,
+    });
+
     this.radioForm = this.fb.group({
       radioGroup: this.radioControl,
     });

--- a/libs/components/forms/src/lib/modules/radio/radio-group.component.spec.ts
+++ b/libs/components/forms/src/lib/modules/radio/radio-group.component.spec.ts
@@ -55,7 +55,7 @@ describe('Radio group component (reactive)', function () {
     fixture.destroy();
   });
 
-  it('should update ngModel properly when nothing is selected on init', fakeAsync(function () {
+  it('should update the form properly when nothing is selected on init', fakeAsync(function () {
     fixture.detectChanges();
 
     expect(componentInstance.radioForm.value).toEqual({ radioGroup: null });
@@ -73,7 +73,31 @@ describe('Radio group component (reactive)', function () {
     expect(componentInstance.radioForm.dirty).toEqual(true);
   }));
 
-  it('should update ngModel properly when form is initialized with values', fakeAsync(function () {
+  it('should update the form properly when form is initialized with values', fakeAsync(function () {
+    componentInstance.initialValue = componentInstance.options[0];
+
+    fixture.detectChanges();
+
+    expect(componentInstance.radioForm.value).toEqual({
+      radioGroup: { name: 'Lillith Corharvest', disabled: false },
+    });
+    expect(componentInstance.radioForm.touched).toEqual(false);
+    expect(componentInstance.radioForm.pristine).toEqual(true);
+    expect(componentInstance.radioForm.dirty).toEqual(false);
+
+    clickCheckbox(fixture, 1);
+
+    expect(componentInstance.radioForm.value).toEqual({
+      radioGroup: { name: 'Harima Kenji', disabled: false },
+    });
+    expect(componentInstance.radioForm.touched).toEqual(true);
+    expect(componentInstance.radioForm.pristine).toEqual(false);
+    expect(componentInstance.radioForm.dirty).toEqual(true);
+  }));
+
+  it('should not update dirty state when form value is updated programatically', fakeAsync(function () {
+    fixture.detectChanges();
+
     componentInstance.radioForm.patchValue({
       radioGroup: componentInstance.options[0],
     });
@@ -97,7 +121,7 @@ describe('Radio group component (reactive)', function () {
     expect(componentInstance.radioForm.dirty).toEqual(true);
   }));
 
-  it('should mark as touched after losing focus', fakeAsync(function () {
+  it('should mark the form as touched after losing focus', fakeAsync(function () {
     fixture.detectChanges();
     tick();
 
@@ -113,7 +137,7 @@ describe('Radio group component (reactive)', function () {
     expect(componentInstance.radioForm.touched).toEqual(true);
   }));
 
-  it('should update the ngModel properly when radio button is changed', fakeAsync(function () {
+  it('should update the the form properly when radio button is changed', fakeAsync(function () {
     fixture.detectChanges();
 
     const radios = getRadios(fixture);
@@ -126,7 +150,7 @@ describe('Radio group component (reactive)', function () {
     expect(componentInstance.radioGroupComponent.value).toEqual(value);
   }));
 
-  it('should update the radio buttons properly when ngModel is changed', fakeAsync(function () {
+  it('should update the radio buttons properly when the form is changed', fakeAsync(function () {
     fixture.detectChanges();
     clickCheckbox(fixture, 0);
     expect(componentInstance.radioGroupComponent.value.name).toEqual(
@@ -164,7 +188,7 @@ describe('Radio group component (reactive)', function () {
     expect(radioGroupDiv.getAttribute('aria-required')).toBe('true');
   }));
 
-  it('should update the ngModel properly when radio button is required and changed', fakeAsync(() => {
+  it('should update the form properly when radio button is required and changed', fakeAsync(() => {
     componentInstance.required = true;
     fixture.detectChanges();
 
@@ -355,6 +379,8 @@ describe('Radio group component (reactive)', function () {
   }));
 
   it('should support resetting form control when fields are added dynamically', fakeAsync(function () {
+    fixture.detectChanges();
+
     componentInstance.radioForm.patchValue({
       radioGroup: componentInstance.options[0],
     });
@@ -392,7 +418,46 @@ describe('Radio group component (reactive)', function () {
     });
   }));
 
+  it('should disable the radio buttons when the form is disabled on init', fakeAsync(function () {
+    componentInstance.initialDisabled = true;
+    fixture.detectChanges();
+    tick();
+
+    fixture.detectChanges();
+    tick();
+
+    expect(componentInstance.radioForm.value).toEqual({ radioGroup: null });
+    expect(componentInstance.radioForm.touched).toEqual(false);
+    expect(componentInstance.radioForm.pristine).toEqual(true);
+    expect(componentInstance.radioForm.dirty).toEqual(false);
+    expect(componentInstance.radioForm.disabled).toEqual(true);
+
+    const inputArray = Array.from(getRadios(fixture));
+    const labelArray = Array.from(getRadioLabels(fixture));
+
+    for (const input of inputArray) {
+      expect(input.getAttribute('disabled')).not.toBeNull();
+    }
+    for (const label of labelArray) {
+      expect(label).toHaveCssClass('sky-switch-disabled');
+    }
+
+    // Call form control's enable method. Expect form to be enabled.
+    componentInstance.radioForm.get('radioGroup').enable();
+    fixture.detectChanges();
+    tick();
+
+    for (const input of inputArray) {
+      expect(input.getAttribute('disabled')).toBeNull();
+    }
+    for (const label of labelArray) {
+      expect(label).not.toHaveCssClass('sky-switch-disabled');
+    }
+  }));
+
   it(`should update disabled attribute and disabled class when form control's disable method is called`, fakeAsync(() => {
+    fixture.detectChanges();
+
     const inputArray = Array.from(getRadios(fixture));
     const labelArray = Array.from(getRadioLabels(fixture));
 

--- a/libs/components/forms/src/lib/modules/radio/radio-group.component.ts
+++ b/libs/components/forms/src/lib/modules/radio/radio-group.component.ts
@@ -102,14 +102,7 @@ export class SkyRadioGroupComponent
    */
   @Input()
   public set value(value: any) {
-    const isNewValue = value !== this._value;
-
-    /* istanbul ignore else */
-    if (isNewValue) {
-      this._value = value;
-      this.onChange(this._value);
-      this.updateCheckedRadioFromValue();
-    }
+    this.#updateValue(value, true);
   }
   public get value(): any {
     return this._value;
@@ -192,7 +185,7 @@ export class SkyRadioGroupComponent
         .pipe(takeUntil(this.ngUnsubscribe))
         .subscribe((change: SkyRadioChange) => {
           this.onTouched();
-          this.writeValue(change.value);
+          this.value = change.value;
         });
       radio.blur.pipe(takeUntil(this.ngUnsubscribe)).subscribe(() => {
         this.onTouched();
@@ -207,7 +200,7 @@ export class SkyRadioGroupComponent
   }
 
   public writeValue(value: any): void {
-    this.value = value;
+    this.#updateValue(value, false);
   }
 
   /**
@@ -269,5 +262,19 @@ export class SkyRadioGroupComponent
     this.updateCheckedRadioFromValue();
     this.updateRadioButtonNames();
     this.updateRadioButtonTabIndexes();
+    this.updateRadioButtonDisabled();
+  }
+
+  #updateValue(value: any, markDirty: boolean): void {
+    const isNewValue = value !== this._value;
+
+    /* istanbul ignore else */
+    if (isNewValue) {
+      this._value = value;
+      if (markDirty) {
+        this.onChange(this._value);
+      }
+      this.updateCheckedRadioFromValue();
+    }
   }
 }


### PR DESCRIPTION
[AB#2235949](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/2235949)

Also fixed programmatic changes to not mark the form as dirty. This matches what we have found is default for Angular and Material. Here is an example of Material's radio buttons: https://stackblitz.com/edit/angular-nnyi5q?file=src%2Fapp%2Fradio-ng-model-example.html,src%2Fapp%2Fradio-ng-model-example.ts,src%2Fapp%2Fradio-ng-model-example.css 