### PR TITLE
fix(components/modals): hide non modal elements from screen readers

### DIFF
--- a/apps/playground/src/app/components/components.module.ts
+++ b/apps/playground/src/app/components/components.module.ts
@@ -58,6 +58,11 @@ export const componentRoutes: Routes = [
       import('./lookup/lookup.module').then((m) => m.LookupModule),
   },
   {
+    path: 'modal',
+    loadChildren: () =>
+      import('./modal/modal-visual.module').then((m) => m.ModalVisualModule),
+  },
+  {
     path: 'pages',
     loadChildren: () =>
       import('./pages/pages.module').then((m) => m.PagesModule),

--- a/apps/playground/src/app/components/modal/modal-close-confirm.component.html
+++ b/apps/playground/src/app/components/modal/modal-close-confirm.component.html
@@ -1,0 +1,13 @@
+<sky-modal>
+  <sky-modal-header> Title </sky-modal-header>
+  <sky-modal-content>
+    <label for="unsaved-work-checkbox">
+      Is there unsaved work?
+      <input
+        id="unsaved-work-checkbox"
+        type="checkbox"
+        [(ngModel)]="hasUnsavedWork"
+      />
+    </label>
+  </sky-modal-content>
+</sky-modal>

--- a/apps/playground/src/app/components/modal/modal-close-confirm.component.ts
+++ b/apps/playground/src/app/components/modal/modal-close-confirm.component.ts
@@ -1,0 +1,46 @@
+import { Component } from '@angular/core';
+import {
+  SkyConfirmCloseEventArgs,
+  SkyConfirmService,
+  SkyConfirmType,
+  SkyModalBeforeCloseHandler,
+  SkyModalInstance,
+} from '@skyux/modals';
+
+@Component({
+  selector: 'app-test-cmp-modal-close-confirm',
+  templateUrl: './modal-close-confirm.component.html',
+})
+export class ModalCloseConfirmComponent {
+  public hasUnsavedWork = true;
+  public confirmationConfig = true;
+
+  constructor(
+    public instance: SkyModalInstance,
+    public confirmService: SkyConfirmService
+  ) {
+    this.instance.beforeClose.subscribe(
+      (closeHandler: SkyModalBeforeCloseHandler) => {
+        this.onClose(closeHandler);
+      }
+    );
+  }
+
+  public onClose(closeHandler: SkyModalBeforeCloseHandler) {
+    if (this.hasUnsavedWork) {
+      this.confirmService
+        .open({
+          message:
+            'You have unsaved work. Are you sure you want to close this dialog?',
+          type: SkyConfirmType.YesCancel,
+        })
+        .closed.subscribe((closeArgs: SkyConfirmCloseEventArgs) => {
+          if (closeArgs.action.toLowerCase() === 'yes') {
+            closeHandler.closeModal();
+          }
+        });
+    } else {
+      closeHandler.closeModal();
+    }
+  }
+}

--- a/apps/playground/src/app/components/modal/modal-content-autofocus.component.html
+++ b/apps/playground/src/app/components/modal/modal-content-autofocus.component.html
@@ -1,0 +1,21 @@
+<sky-modal>
+  <sky-modal-content>
+    Content
+    <button
+      type="button"
+      class="sky-btn sky-btn-primary sky-test-close sky-margin-inline-compact"
+      (click)="instance.cancel()"
+    >
+      Close
+    </button>
+
+    <button
+      type="button"
+      class="sky-btn sky-btn-link"
+      autofocus="autofocus"
+      (click)="instance.cancel()"
+    >
+      Focused button
+    </button>
+  </sky-modal-content>
+</sky-modal>

--- a/apps/playground/src/app/components/modal/modal-content-autofocus.component.ts
+++ b/apps/playground/src/app/components/modal/modal-content-autofocus.component.ts
@@ -1,0 +1,10 @@
+import { Component } from '@angular/core';
+import { SkyModalInstance } from '@skyux/modals';
+
+@Component({
+  selector: 'app-test-cmp-modal-autofocus',
+  templateUrl: './modal-content-autofocus.component.html',
+})
+export class ModalContentAutofocusComponent {
+  constructor(public instance: SkyModalInstance) {}
+}

--- a/apps/playground/src/app/components/modal/modal-content-demo.component.html
+++ b/apps/playground/src/app/components/modal/modal-content-demo.component.html
@@ -1,0 +1,12 @@
+<sky-modal>
+  <sky-modal-content>
+    Content
+    <button
+      type="button"
+      class="sky-btn sky-btn-primary sky-test-close"
+      (click)="instance.cancel()"
+    >
+      Close
+    </button>
+  </sky-modal-content>
+</sky-modal>

--- a/apps/playground/src/app/components/modal/modal-content-demo.component.ts
+++ b/apps/playground/src/app/components/modal/modal-content-demo.component.ts
@@ -1,0 +1,10 @@
+import { Component } from '@angular/core';
+import { SkyModalInstance } from '@skyux/modals';
+
+@Component({
+  selector: 'app-test-cmp-modal-content',
+  templateUrl: './modal-content-demo.component.html',
+})
+export class ModalContentDemoComponent {
+  constructor(public instance: SkyModalInstance) {}
+}

--- a/apps/playground/src/app/components/modal/modal-demo.component.html
+++ b/apps/playground/src/app/components/modal/modal-demo.component.html
@@ -1,0 +1,9 @@
+<sky-modal>
+  <sky-modal-header>
+    {{ title }}
+  </sky-modal-header>
+  <sky-modal-content>
+    <div>Content A</div>
+  </sky-modal-content>
+  <sky-modal-footer> Footer </sky-modal-footer>
+</sky-modal>

--- a/apps/playground/src/app/components/modal/modal-demo.component.ts
+++ b/apps/playground/src/app/components/modal/modal-demo.component.ts
@@ -1,0 +1,11 @@
+import { Component } from '@angular/core';
+import { SkyModalService } from '@skyux/modals';
+
+@Component({
+  selector: 'app-test-cmp-modal',
+  templateUrl: './modal-demo.component.html',
+  providers: [SkyModalService],
+})
+export class ModalDemoComponent {
+  public title = 'Hello world';
+}

--- a/apps/playground/src/app/components/modal/modal-form-demo.component.html
+++ b/apps/playground/src/app/components/modal/modal-form-demo.component.html
@@ -1,0 +1,79 @@
+<sky-modal>
+  <sky-modal-header>
+    {{ title }}
+  </sky-modal-header>
+  <sky-modal-content>
+    <sky-input-box class="sky-margin-stacked-lg">
+      <label class="sky-control-label"> Field label </label>
+      <input class="sky-form-control" type="text" value="Text value" />
+    </sky-input-box>
+    <sky-input-box class="sky-margin-stacked-lg">
+      <label class="sky-control-label"> Field label </label>
+      <input class="sky-form-control" type="text" value="Text value" />
+    </sky-input-box>
+    <sky-input-box class="sky-margin-stacked-lg">
+      <label class="sky-control-label"> Field label </label>
+      <input class="sky-form-control" type="text" value="Text value" />
+    </sky-input-box>
+    <sky-input-box class="sky-margin-stacked-lg">
+      <label class="sky-control-label"> Field label </label>
+      <input class="sky-form-control" type="text" value="Text value" />
+    </sky-input-box>
+    <sky-input-box class="sky-margin-stacked-lg">
+      <label class="sky-control-label"> Field label </label>
+      <input class="sky-form-control" type="text" value="Text value" />
+    </sky-input-box>
+    <sky-input-box class="sky-margin-stacked-lg">
+      <label class="sky-control-label"> Field label </label>
+      <input class="sky-form-control" type="text" value="Text value" />
+    </sky-input-box>
+    <sky-input-box class="sky-margin-stacked-lg">
+      <label class="sky-control-label"> Field label </label>
+      <input class="sky-form-control" type="text" value="Text value" />
+    </sky-input-box>
+    <sky-input-box class="sky-margin-stacked-lg">
+      <label class="sky-control-label"> Field label </label>
+      <input class="sky-form-control" type="text" value="Text value" />
+    </sky-input-box>
+    <sky-input-box class="sky-margin-stacked-lg">
+      <label class="sky-control-label"> Field label </label>
+      <input class="sky-form-control" type="text" value="Text value" />
+    </sky-input-box>
+    <sky-input-box class="sky-margin-stacked-lg">
+      <label class="sky-control-label"> Field label </label>
+      <input class="sky-form-control" type="text" value="Text value" />
+    </sky-input-box>
+    <sky-input-box class="sky-margin-stacked-lg">
+      <label class="sky-control-label"> Field label </label>
+      <input class="sky-form-control" type="text" value="Text value" />
+    </sky-input-box>
+    <sky-input-box class="sky-margin-stacked-lg">
+      <label class="sky-control-label"> Field label </label>
+      <input class="sky-form-control" type="text" value="Text value" />
+    </sky-input-box>
+    <sky-input-box class="sky-margin-stacked-lg">
+      <label class="sky-control-label"> Field label </label>
+      <input class="sky-form-control" type="text" value="Text value" />
+    </sky-input-box>
+    <sky-input-box>
+      <label class="sky-control-label"> Field label </label>
+      <input class="sky-form-control" type="text" value="Text value" />
+    </sky-input-box>
+  </sky-modal-content>
+  <sky-modal-footer>
+    <button
+      class="sky-btn sky-btn-primary sky-margin-inline-sm"
+      type="button"
+      (click)="instance.cancel()"
+    >
+      Save
+    </button>
+    <button
+      class="sky-btn sky-btn-link"
+      type="button"
+      (click)="instance.cancel()"
+    >
+      Cancel
+    </button>
+  </sky-modal-footer>
+</sky-modal>

--- a/apps/playground/src/app/components/modal/modal-form-demo.component.ts
+++ b/apps/playground/src/app/components/modal/modal-form-demo.component.ts
@@ -1,0 +1,13 @@
+import { Component } from '@angular/core';
+import { SkyModalInstance, SkyModalService } from '@skyux/modals';
+
+@Component({
+  selector: 'app-test-cmp-modal',
+  templateUrl: './modal-form-demo.component.html',
+  providers: [SkyModalService],
+})
+export class ModalFormDemoComponent {
+  public title = 'Modal form with scroll';
+
+  constructor(public instance: SkyModalInstance) {}
+}

--- a/apps/playground/src/app/components/modal/modal-fullpage-demo.component.html
+++ b/apps/playground/src/app/components/modal/modal-fullpage-demo.component.html
@@ -1,0 +1,7 @@
+<sky-modal>
+  <sky-modal-header>
+    {{ title }}
+  </sky-modal-header>
+  <sky-modal-content> Content for Full Screen </sky-modal-content>
+  <sky-modal-footer> Footer </sky-modal-footer>
+</sky-modal>

--- a/apps/playground/src/app/components/modal/modal-fullpage-demo.component.ts
+++ b/apps/playground/src/app/components/modal/modal-fullpage-demo.component.ts
@@ -1,0 +1,11 @@
+import { Component } from '@angular/core';
+import { SkyModalService } from '@skyux/modals';
+
+@Component({
+  selector: 'app-test-cmp-modal-fullpage',
+  templateUrl: './modal-fullpage-demo.component.html',
+  providers: [SkyModalService],
+})
+export class ModalFullPageDemoComponent {
+  public title = 'Hello world';
+}

--- a/apps/playground/src/app/components/modal/modal-large-demo.component.html
+++ b/apps/playground/src/app/components/modal/modal-large-demo.component.html
@@ -1,0 +1,7 @@
+<sky-modal>
+  <sky-modal-header>
+    {{ title }}
+  </sky-modal-header>
+  <sky-modal-content> Content A </sky-modal-content>
+  <sky-modal-footer> Footer </sky-modal-footer>
+</sky-modal>

--- a/apps/playground/src/app/components/modal/modal-large-demo.component.ts
+++ b/apps/playground/src/app/components/modal/modal-large-demo.component.ts
@@ -1,0 +1,11 @@
+import { Component } from '@angular/core';
+import { SkyModalService } from '@skyux/modals';
+
+@Component({
+  selector: 'app-test-cmp-modal-large',
+  templateUrl: './modal-large-demo.component.html',
+  providers: [SkyModalService],
+})
+export class ModalLargeDemoComponent {
+  public title = 'Hello world';
+}

--- a/apps/playground/src/app/components/modal/modal-tiled-demo.component.html
+++ b/apps/playground/src/app/components/modal/modal-tiled-demo.component.html
@@ -1,0 +1,20 @@
+<sky-modal [tiledBody]="true">
+  <sky-modal-header>
+    {{ title }}
+  </sky-modal-header>
+  <sky-modal-content>
+    <sky-tile>
+      <sky-tile-title>Section 1</sky-tile-title>
+      <sky-tile-content>
+        <sky-tile-content-section> Content 1 </sky-tile-content-section>
+      </sky-tile-content>
+    </sky-tile>
+    <sky-tile>
+      <sky-tile-title>Section 2</sky-tile-title>
+      <sky-tile-content>
+        <sky-tile-content-section> Content 2 </sky-tile-content-section>
+      </sky-tile-content>
+    </sky-tile>
+  </sky-modal-content>
+  <sky-modal-footer> Footer </sky-modal-footer>
+</sky-modal>

--- a/apps/playground/src/app/components/modal/modal-tiled-demo.component.ts
+++ b/apps/playground/src/app/components/modal/modal-tiled-demo.component.ts
@@ -1,0 +1,11 @@
+import { Component } from '@angular/core';
+import { SkyModalService } from '@skyux/modals';
+
+@Component({
+  selector: 'app-test-cmp-modal-tiled',
+  templateUrl: './modal-tiled-demo.component.html',
+  providers: [SkyModalService],
+})
+export class ModalTiledDemoComponent {
+  public title = 'Hello world';
+}

--- a/apps/playground/src/app/components/modal/modal-visual-routing.module.ts
+++ b/apps/playground/src/app/components/modal/modal-visual-routing.module.ts
@@ -1,0 +1,25 @@
+import { NgModule } from '@angular/core';
+import { RouterModule } from '@angular/router';
+
+import { ComponentRouteInfo } from '../../shared/component-info/component-route-info';
+
+import { ModalVisualComponent } from './modal-visual.component';
+
+const routes: ComponentRouteInfo[] = [
+  {
+    path: '',
+    component: ModalVisualComponent,
+    data: {
+      name: 'Modal',
+      library: 'modal',
+      icon: 'universal-access',
+    },
+  },
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+})
+export class ModalVisualRoutingModule {
+  public static routes = routes;
+}

--- a/apps/playground/src/app/components/modal/modal-visual.component.html
+++ b/apps/playground/src/app/components/modal/modal-visual.component.html
@@ -1,0 +1,92 @@
+<div>
+  <button class="sky-btn sky-btn-primary" type="button" (click)="openModal()">
+    Open modal
+  </button>
+
+  <button
+    type="button"
+    class="sky-btn sky-btn-primary sky-modal-with-help"
+    (click)="openModalWithHelp()"
+  >
+    Open modal with Help
+  </button>
+
+  <button
+    type="button"
+    class="sky-btn sky-btn-primary sky-modal-with-extended-title"
+    (click)="openModalWithExtendedTitle()"
+  >
+    Open modal with extended title
+  </button>
+
+  <button
+    type="button"
+    class="sky-btn sky-btn-primary sky-test-large-modal"
+    (click)="openFullScreenModal()"
+  >
+    Open large modal
+  </button>
+
+  <button
+    type="button"
+    class="sky-btn sky-btn-primary sky-test-content-only"
+    (click)="openContentModal()"
+  >
+    Open content modal
+  </button>
+
+  <button
+    type="button"
+    class="sky-btn sky-btn-primary sky-test-small-size-modal"
+    (click)="openSmallSizeModal()"
+  >
+    Open small modal
+  </button>
+
+  <button
+    type="button"
+    class="sky-btn sky-btn-primary sky-test-medium-size-modal"
+    (click)="openMediumSizeModal()"
+  >
+    Open medium size modal
+  </button>
+
+  <button
+    type="button"
+    class="sky-btn sky-btn-primary sky-test-large-size-modal"
+    (click)="openLargeSizeModal()"
+  >
+    Open large size modal
+  </button>
+  <button
+    type="button"
+    class="sky-btn sky-btn-primary sky-test-tiled-modal"
+    (click)="openTiledModal()"
+  >
+    Open tiled modal
+  </button>
+
+  <button
+    type="button"
+    class="sky-btn sky-btn-primary sky-test-large-modal-autofocus"
+    (click)="openAutofocusModal()"
+  >
+    Open autofocus modal
+  </button>
+
+  <button
+    type="button"
+    class="sky-btn sky-btn-primary sky-test-large-modal-close-confirmation"
+    (click)="openCloseConfirmationModal()"
+  >
+    Open modal with close confirmation
+  </button>
+
+  <button
+    type="button"
+    class="sky-btn sky-btn-primary sky-test-modal-form"
+    (click)="openFormModal()"
+  >
+    Open form modal with scroll
+  </button>
+</div>

--- a/apps/playground/src/app/components/modal/modal-visual.component.scss
+++ b/apps/playground/src/app/components/modal/modal-visual.component.scss
@@ -1,0 +1,17 @@
+#modal-screenshot {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+}
+
+.modal-screenshot-buttons {
+  height: 10000px;
+  position: relative;
+  z-index: 1;
+}
+
+.modal-screenshot-buttons-hidden {
+  visibility: hidden;
+}

--- a/apps/playground/src/app/components/modal/modal-visual.component.ts
+++ b/apps/playground/src/app/components/modal/modal-visual.component.ts
@@ -1,0 +1,132 @@
+import { Component } from '@angular/core';
+import {
+  SkyModalConfigurationInterface,
+  SkyModalInstance,
+  SkyModalService,
+} from '@skyux/modals';
+
+import { ModalCloseConfirmComponent } from './modal-close-confirm.component';
+import { ModalContentAutofocusComponent } from './modal-content-autofocus.component';
+import { ModalContentDemoComponent } from './modal-content-demo.component';
+import { ModalDemoComponent } from './modal-demo.component';
+import { ModalFormDemoComponent } from './modal-form-demo.component';
+import { ModalFullPageDemoComponent } from './modal-fullpage-demo.component';
+import { ModalLargeDemoComponent } from './modal-large-demo.component';
+import { ModalTiledDemoComponent } from './modal-tiled-demo.component';
+
+@Component({
+  selector: 'app-modal-visual',
+  templateUrl: './modal-visual.component.html',
+  styleUrls: ['./modal-visual.component.scss'],
+})
+export class ModalVisualComponent {
+  public buttonsHidden: boolean;
+
+  constructor(private modal: SkyModalService) {}
+
+  public openModal(): void {
+    this.openModalInstance(ModalDemoComponent, { providers: [] });
+  }
+
+  public openModalWithHelp(): void {
+    this.openModalInstance(ModalDemoComponent, {
+      providers: [],
+      helpKey: 'demo-key.html',
+    });
+  }
+
+  public openModalWithExtendedTitle(): void {
+    const instance = this.openModalInstance(ModalDemoComponent, {
+      providers: [],
+      helpKey: 'demo-key.html',
+    });
+    instance.componentInstance.title =
+      'This is a modal title with an extended header text that must wrap by default';
+  }
+
+  public openLargeModal(): void {
+    this.openModalInstance(ModalLargeDemoComponent, { providers: [] });
+  }
+
+  public openFullScreenModal(): void {
+    this.openModalInstance(ModalFullPageDemoComponent, {
+      providers: [],
+      fullPage: true,
+    });
+  }
+
+  public openContentModal(): void {
+    this.openModalInstance(ModalContentDemoComponent);
+  }
+
+  public openSmallSizeModal(): void {
+    this.openModalInstance(ModalDemoComponent, {
+      providers: [],
+      fullPage: false,
+      size: 'small',
+    });
+  }
+
+  public openMediumSizeModal(): void {
+    this.openModalInstance(ModalDemoComponent, {
+      providers: [],
+      fullPage: false,
+      size: 'medium',
+    });
+  }
+
+  public openLargeSizeModal(): void {
+    this.openModalInstance(ModalDemoComponent, {
+      providers: [],
+      fullPage: false,
+      size: 'large',
+    });
+  }
+
+  public openTiledModal(): void {
+    this.openModalInstance(ModalTiledDemoComponent, { providers: [] });
+  }
+
+  public openAutofocusModal(): void {
+    this.openModalInstance(ModalContentAutofocusComponent, {
+      providers: [],
+      fullPage: false,
+      size: 'large',
+    });
+  }
+
+  public openCloseConfirmationModal(): void {
+    this.openModalInstance(ModalCloseConfirmComponent, {
+      providers: [],
+      fullPage: false,
+      size: 'large',
+    });
+  }
+
+  public openFormModal(): void {
+    this.openModalInstance(ModalFormDemoComponent);
+  }
+
+  public hideButtons(): void {
+    this.buttonsHidden = true;
+  }
+
+  public showButtons(): void {
+    this.buttonsHidden = false;
+  }
+
+  private openModalInstance(
+    modalType: any,
+    options?: SkyModalConfigurationInterface
+  ): SkyModalInstance {
+    this.hideButtons();
+
+    const instance = this.modal.open(modalType, options);
+
+    instance.closed.subscribe(() => {
+      this.showButtons();
+    });
+
+    return instance;
+  }
+}

--- a/apps/playground/src/app/components/modal/modal-visual.module.ts
+++ b/apps/playground/src/app/components/modal/modal-visual.module.ts
@@ -1,0 +1,42 @@
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { SkyInputBoxModule } from '@skyux/forms';
+import { SkyModalModule } from '@skyux/modals';
+import { SkyTilesModule } from '@skyux/tiles';
+
+import { ModalCloseConfirmComponent } from './modal-close-confirm.component';
+import { ModalContentAutofocusComponent } from './modal-content-autofocus.component';
+import { ModalContentDemoComponent } from './modal-content-demo.component';
+import { ModalDemoComponent } from './modal-demo.component';
+import { ModalFormDemoComponent } from './modal-form-demo.component';
+import { ModalFullPageDemoComponent } from './modal-fullpage-demo.component';
+import { ModalLargeDemoComponent } from './modal-large-demo.component';
+import { ModalTiledDemoComponent } from './modal-tiled-demo.component';
+import { ModalVisualRoutingModule } from './modal-visual-routing.module';
+import { ModalVisualComponent } from './modal-visual.component';
+
+@NgModule({
+  declarations: [
+    ModalCloseConfirmComponent,
+    ModalContentAutofocusComponent,
+    ModalContentDemoComponent,
+    ModalDemoComponent,
+    ModalFormDemoComponent,
+    ModalFullPageDemoComponent,
+    ModalLargeDemoComponent,
+    ModalTiledDemoComponent,
+    ModalVisualComponent,
+  ],
+  imports: [
+    CommonModule,
+    FormsModule,
+    SkyInputBoxModule,
+    SkyTilesModule,
+    SkyModalModule,
+    ModalVisualRoutingModule,
+  ],
+})
+export class ModalVisualModule {
+  public static routes = ModalVisualRoutingModule.routes;
+}

--- a/libs/components/modals/src/lib/modules/modal/modal-adapter.service.ts
+++ b/libs/components/modals/src/lib/modules/modal/modal-adapter.service.ts
@@ -13,7 +13,7 @@ export class SkyModalAdapterService {
   #bodyEl: HTMLElement;
 
   #windowRef: SkyAppWindowRef;
-  #hostSiblingPreviousValue = new Map<Element, string | null>();
+  #hostSiblingAriaHiddenCache = new Map<Element, string | null>();
 
   constructor(windowRef: SkyAppWindowRef) {
     this.#windowRef = windowRef;
@@ -49,7 +49,11 @@ export class SkyModalAdapterService {
     this.#bodyEl.classList.remove(className);
   }
 
-  public hideHostSiblings(hostElRef: ElementRef): void {
+  /**
+   * Hides siblings of modal-host from screen readers
+   * @param hostElRef reference to modal-host element
+   */
+  public hideHostSiblingsFromScreenReaders(hostElRef: ElementRef): void {
     const hostElement = hostElRef.nativeElement;
     const hostSiblings = hostElement.parentElement.children;
 
@@ -62,7 +66,7 @@ export class SkyModalAdapterService {
         element.nodeName.toLowerCase() !== 'style'
       ) {
         // preserve previous aria-hidden status of elements outside of modal host
-        this.#hostSiblingPreviousValue.set(
+        this.#hostSiblingAriaHiddenCache.set(
           element,
           element.getAttribute('aria-hidden')
         );
@@ -71,8 +75,11 @@ export class SkyModalAdapterService {
     }
   }
 
-  public unhideOrRestoreHostSiblings(): void {
-    this.#hostSiblingPreviousValue.forEach((previousValue, element) => {
+  /**
+   * Restores modal-host siblings to screenreader status prior to modals being opened
+   */
+  public unhideOrRestoreHostSiblingsFromScreenReaders(): void {
+    this.#hostSiblingAriaHiddenCache.forEach((previousValue, element) => {
       // if element had aria-hidden status prior, restore status
       if (element.parentElement) {
         if (previousValue) {
@@ -82,16 +89,16 @@ export class SkyModalAdapterService {
         }
       }
     });
-    this.#hostSiblingPreviousValue.clear();
+    this.#hostSiblingAriaHiddenCache.clear();
   }
 
-  public hidePreviousModal(topModal: Element): void {
+  public hidePreviousModalFromScreenReaders(topModal: Element): void {
     if (topModal && topModal.previousElementSibling) {
       topModal.previousElementSibling.setAttribute('aria-hidden', 'true');
     }
   }
 
-  public unhidePreviousModal(topModal: Element): void {
+  public unhidePreviousModalFromScreenReaders(topModal: Element): void {
     if (topModal && topModal.previousElementSibling) {
       topModal.previousElementSibling.removeAttribute('aria-hidden');
     }

--- a/libs/components/modals/src/lib/modules/modal/modal-adapter.service.ts
+++ b/libs/components/modals/src/lib/modules/modal/modal-adapter.service.ts
@@ -13,7 +13,7 @@ export class SkyModalAdapterService {
   #bodyEl: HTMLElement;
 
   #windowRef: SkyAppWindowRef;
-  #hiddenElements = new Map<Element, string | null>();
+  #hostSiblingPreviousValue = new Map<Element, string | null>();
 
   constructor(windowRef: SkyAppWindowRef) {
     this.#windowRef = windowRef;
@@ -49,8 +49,8 @@ export class SkyModalAdapterService {
     this.#bodyEl.classList.remove(className);
   }
 
-  public hideHostSiblings(elRef: ElementRef): void {
-    const hostElement = elRef.nativeElement;
+  public hideHostSiblings(hostElRef: ElementRef): void {
+    const hostElement = hostElRef.nativeElement;
     const hostSiblings = hostElement.parentElement.children;
 
     for (let i = 0; i < hostSiblings.length; i++) {
@@ -62,14 +62,17 @@ export class SkyModalAdapterService {
         element.nodeName.toLowerCase() !== 'style'
       ) {
         // preserve previous aria-hidden status of elements outside of modal host
-        this.#hiddenElements.set(element, element.getAttribute('aria-hidden'));
+        this.#hostSiblingPreviousValue.set(
+          element,
+          element.getAttribute('aria-hidden')
+        );
         element.setAttribute('aria-hidden', 'true');
       }
     }
   }
 
-  public unhideHostSiblings(): void {
-    this.#hiddenElements.forEach((previousValue, element) => {
+  public unhideOrRestoreHostSiblings(): void {
+    this.#hostSiblingPreviousValue.forEach((previousValue, element) => {
       // if element had aria-hidden status prior, restore status
       if (previousValue) {
         element.setAttribute('aria-hidden', previousValue);
@@ -77,18 +80,18 @@ export class SkyModalAdapterService {
         element.removeAttribute('aria-hidden');
       }
     });
-    this.#hiddenElements.clear();
+    this.#hostSiblingPreviousValue.clear();
   }
 
-  public hidePreviousModal(modal: Element): void {
-    if (modal && modal.previousElementSibling) {
-      modal.previousElementSibling.setAttribute('aria-hidden', 'true');
+  public hidePreviousModal(topModal: Element): void {
+    if (topModal && topModal.previousElementSibling) {
+      topModal.previousElementSibling.setAttribute('aria-hidden', 'true');
     }
   }
 
-  public unhidePreviousModal(modal: Element): void {
-    if (modal && modal.previousElementSibling) {
-      modal.previousElementSibling.removeAttribute('aria-hidden');
+  public unhidePreviousModal(topModal: Element): void {
+    if (topModal && topModal.previousElementSibling) {
+      topModal.previousElementSibling.removeAttribute('aria-hidden');
     }
   }
 }

--- a/libs/components/modals/src/lib/modules/modal/modal-adapter.service.ts
+++ b/libs/components/modals/src/lib/modules/modal/modal-adapter.service.ts
@@ -74,10 +74,12 @@ export class SkyModalAdapterService {
   public unhideOrRestoreHostSiblings(): void {
     this.#hostSiblingPreviousValue.forEach((previousValue, element) => {
       // if element had aria-hidden status prior, restore status
-      if (previousValue) {
-        element.setAttribute('aria-hidden', previousValue);
-      } else {
-        element.removeAttribute('aria-hidden');
+      if (element.parentElement) {
+        if (previousValue) {
+          element.setAttribute('aria-hidden', previousValue);
+        } else {
+          element.removeAttribute('aria-hidden');
+        }
       }
     });
     this.#hostSiblingPreviousValue.clear();

--- a/libs/components/modals/src/lib/modules/modal/modal-adapter.service.ts
+++ b/libs/components/modals/src/lib/modules/modal/modal-adapter.service.ts
@@ -47,4 +47,36 @@ export class SkyModalAdapterService {
   #removeClassFromBody(className: string): void {
     this.#bodyEl.classList.remove(className);
   }
+
+  public addAriaHidden(
+    elementsToHide: HTMLCollection,
+    self: Element | unknown
+  ): Map<Element, string | null> {
+    const hiddenElements = new Map<Element, string | null>();
+
+    for (let i = 0; i < elementsToHide.length; i++) {
+      const element = elementsToHide[i];
+      if (
+        element !== self &&
+        !element.hasAttribute('aria-live') &&
+        element.nodeName.toLowerCase() !== 'script' &&
+        element.nodeName.toLowerCase() !== 'style'
+      ) {
+        hiddenElements.set(element, element.getAttribute('aria-hidden'));
+        element.setAttribute('aria-hidden', 'true');
+      }
+    }
+
+    return hiddenElements;
+  }
+
+  public removeAriaHidden(hiddenElements: Map<Element, string | null>): void {
+    hiddenElements.forEach((previousValue, element) => {
+      if (previousValue) {
+        element.setAttribute('aria-hidden', previousValue);
+      } else {
+        element.removeAttribute('aria-hidden');
+      }
+    });
+  }
 }

--- a/libs/components/modals/src/lib/modules/modal/modal-adapter.service.ts
+++ b/libs/components/modals/src/lib/modules/modal/modal-adapter.service.ts
@@ -92,15 +92,20 @@ export class SkyModalAdapterService {
     this.#hostSiblingAriaHiddenCache.clear();
   }
 
-  public hidePreviousModalFromScreenReaders(topModal: Element): void {
-    if (topModal && topModal.previousElementSibling) {
-      topModal.previousElementSibling.setAttribute('aria-hidden', 'true');
+  public hidePreviousModalFromScreenReaders(topModal: ElementRef): void {
+    if (topModal && topModal.nativeElement.previousElementSibling) {
+      topModal.nativeElement.previousElementSibling.setAttribute(
+        'aria-hidden',
+        'true'
+      );
     }
   }
 
-  public unhidePreviousModalFromScreenReaders(topModal: Element): void {
-    if (topModal && topModal.previousElementSibling) {
-      topModal.previousElementSibling.removeAttribute('aria-hidden');
+  public unhidePreviousModalFromScreenReaders(topModal: ElementRef): void {
+    if (topModal && topModal.nativeElement.previousElementSibling) {
+      topModal.nativeElement.previousElementSibling.removeAttribute(
+        'aria-hidden'
+      );
     }
   }
 }

--- a/libs/components/modals/src/lib/modules/modal/modal-adapter.service.ts
+++ b/libs/components/modals/src/lib/modules/modal/modal-adapter.service.ts
@@ -62,6 +62,7 @@ export class SkyModalAdapterService {
         element.nodeName.toLowerCase() !== 'script' &&
         element.nodeName.toLowerCase() !== 'style'
       ) {
+        // preserve previous aria-hidden status of elements outside of modal host
         hiddenElements.set(element, element.getAttribute('aria-hidden'));
         element.setAttribute('aria-hidden', 'true');
       }
@@ -72,6 +73,7 @@ export class SkyModalAdapterService {
 
   public removeAriaHidden(hiddenElements: Map<Element, string | null>): void {
     hiddenElements.forEach((previousValue, element) => {
+      // if element had aria-hidden status prior, restore status
       if (previousValue) {
         element.setAttribute('aria-hidden', previousValue);
       } else {

--- a/libs/components/modals/src/lib/modules/modal/modal-host.component.ts
+++ b/libs/components/modals/src/lib/modules/modal/modal-host.component.ts
@@ -143,7 +143,7 @@ export class SkyModalHostComponent implements OnDestroy {
     );
 
     // modal element that was just opened
-    const modalElement = modalComponentRef.location.nativeElement;
+    const modalElement = modalComponentRef.location;
 
     modalInstance.componentInstance = modalComponentRef.instance;
 

--- a/libs/components/modals/src/lib/modules/modal/modal-host.component.ts
+++ b/libs/components/modals/src/lib/modules/modal/modal-host.component.ts
@@ -160,18 +160,17 @@ export class SkyModalHostComponent implements OnDestroy {
     modalInstance.componentInstance = modalComponentRef.instance;
 
     this.#registerModalInstance(modalInstance);
-    // hidding all elements at the modal-host level from screenreaders
-    const hostElement = this.#elRef.nativeElement;
-    let allModals = hostElement.children;
 
     if (SkyModalHostService.openModalCount == 1) {
+      // hidding all elements at the modal-host level from screenreaders when the first modal is opened
       this.hideModalHostSiblings();
     }
     if (
       SkyModalHostService.openModalCount > 1 &&
-      allModals[allModals.length - 1] == modalElement
+      SkyModalHostService.topModal == hostService
     ) {
-      allModals[allModals.length - 2].setAttribute('aria-hidden', true);
+      // hiding the lower modals when more than one modal is opened
+      modalElement.previousElementSibling.setAttribute('aria-hidden', true);
     }
 
     const closeModal = () => {
@@ -181,8 +180,8 @@ export class SkyModalHostComponent implements OnDestroy {
         this.#ariaPreviousValueSiblings.clear();
       } else if (SkyModalHostService.topModal == hostService) {
         // if there are more than 1 modal then unhide the one behind this one before closing it
-        allModals = hostElement.children;
-        allModals[allModals.length - 2].removeAttribute('aria-hidden');
+        // allModals = hostElement.children;
+        modalElement.previousElementSibling.removeAttribute('aria-hidden');
       }
 
       hostService.destroy();

--- a/libs/components/modals/src/lib/modules/modal/modal-host.component.ts
+++ b/libs/components/modals/src/lib/modules/modal/modal-host.component.ts
@@ -150,22 +150,22 @@ export class SkyModalHostComponent implements OnDestroy {
     this.#registerModalInstance(modalInstance);
 
     // hidding all elements at the modal-host level from screenreaders when the a modal is opened
-    this.#adapter.hideHostSiblings(this.#elRef);
+    this.#adapter.hideHostSiblingsFromScreenReaders(this.#elRef);
     if (
       SkyModalHostService.openModalCount > 1 &&
-      SkyModalHostService.topModal == hostService
+      SkyModalHostService.topModal === hostService
     ) {
       // hiding the lower modals when more than one modal is opened
-      this.#adapter.hidePreviousModal(modalElement);
+      this.#adapter.hidePreviousModalFromScreenReaders(modalElement);
     }
 
     const closeModal = () => {
       // unhide siblings if last modal is closing
-      if (SkyModalHostService.openModalCount == 1) {
-        this.#adapter.unhideOrRestoreHostSiblings();
-      } else if (SkyModalHostService.topModal == hostService) {
+      if (SkyModalHostService.openModalCount === 1) {
+        this.#adapter.unhideOrRestoreHostSiblingsFromScreenReaders();
+      } else if (SkyModalHostService.topModal === hostService) {
         // if there are more than 1 modal then unhide the one behind this one before closing it
-        this.#adapter.unhidePreviousModal(modalElement);
+        this.#adapter.unhidePreviousModalFromScreenReaders(modalElement);
       }
 
       hostService.destroy();

--- a/libs/components/modals/src/lib/modules/modal/modal-host.component.ts
+++ b/libs/components/modals/src/lib/modules/modal/modal-host.component.ts
@@ -119,7 +119,6 @@ export class SkyModalHostComponent implements OnDestroy {
 
     const adapter = this.#adapter;
     const modalOpener: HTMLElement = adapter.getModalOpener();
-    let ariaPreviousValueSiblings = this.#ariaPreviousValueSiblings;
 
     let isOpen = true;
 
@@ -167,7 +166,6 @@ export class SkyModalHostComponent implements OnDestroy {
 
     if (SkyModalHostService.openModalCount == 1) {
       this.hideModalHostSiblings();
-      ariaPreviousValueSiblings = this.#ariaPreviousValueSiblings;
     }
     if (
       SkyModalHostService.openModalCount > 1 &&
@@ -176,11 +174,11 @@ export class SkyModalHostComponent implements OnDestroy {
       allModals[allModals.length - 2].setAttribute('aria-hidden', true);
     }
 
-    function closeModal() {
+    const closeModal = () => {
       // unhide siblings if last modal is closing
       if (SkyModalHostService.openModalCount == 1) {
-        adapter.removeAriaHidden(ariaPreviousValueSiblings);
-        ariaPreviousValueSiblings.clear();
+        adapter.removeAriaHidden(this.#ariaPreviousValueSiblings);
+        this.#ariaPreviousValueSiblings.clear();
       } else if (SkyModalHostService.topModal == hostService) {
         // if there are more than 1 modal then unhide the one behind this one before closing it
         allModals = hostElement.children;
@@ -198,7 +196,7 @@ export class SkyModalHostComponent implements OnDestroy {
         modalOpener.focus();
       }
       modalComponentRef.destroy();
-    }
+    };
 
     hostService.openHelp.subscribe((helpKey?: string) => {
       modalInstance.openHelp(helpKey);

--- a/libs/components/modals/src/lib/modules/modal/modal-host.component.ts
+++ b/libs/components/modals/src/lib/modules/modal/modal-host.component.ts
@@ -149,10 +149,8 @@ export class SkyModalHostComponent implements OnDestroy {
 
     this.#registerModalInstance(modalInstance);
 
-    if (SkyModalHostService.openModalCount == 1) {
-      // hidding all elements at the modal-host level from screenreaders when the first modal is opened
-      this.#adapter.hideHostSiblings(this.#elRef);
-    }
+    // hidding all elements at the modal-host level from screenreaders when the a modal is opened
+    this.#adapter.hideHostSiblings(this.#elRef);
     if (
       SkyModalHostService.openModalCount > 1 &&
       SkyModalHostService.topModal == hostService

--- a/libs/components/modals/src/lib/modules/modal/modal-host.component.ts
+++ b/libs/components/modals/src/lib/modules/modal/modal-host.component.ts
@@ -164,7 +164,7 @@ export class SkyModalHostComponent implements OnDestroy {
     const closeModal = () => {
       // unhide siblings if last modal is closing
       if (SkyModalHostService.openModalCount == 1) {
-        this.#adapter.unhideHostSiblings();
+        this.#adapter.unhideOrRestoreHostSiblings();
       } else if (SkyModalHostService.topModal == hostService) {
         // if there are more than 1 modal then unhide the one behind this one before closing it
         this.#adapter.unhidePreviousModal(modalElement);

--- a/libs/components/modals/src/lib/modules/modal/modal.service.spec.ts
+++ b/libs/components/modals/src/lib/modules/modal/modal.service.spec.ts
@@ -237,6 +237,23 @@ describe('Modal service', () => {
       closeModal(modal);
     }));
 
+    it('should not modify siblings if they have been removed from the DOM before the modal closes', fakeAsync(() => {
+      const div = document.createElement('div');
+      document.body.appendChild(div);
+      const previousAriaHidden = 'bingbong';
+
+      div.setAttribute('aria-hidden', previousAriaHidden);
+
+      const modal = openModal(ModalTestComponent, { fullPage: false });
+
+      expect(div.getAttribute('aria-hidden')).toBeTruthy();
+
+      div.remove();
+
+      closeModal(modal);
+      expect(div.getAttribute('aria-hidden')).not.toBe(previousAriaHidden);
+    }));
+
     it('should keep sibling modals hidden when non top modal closes', fakeAsync(() => {
       const firstModal = openModal(ModalTestComponent, { fullPage: false });
       const secondModal = openModal(ModalTestComponent, { fullPage: false });

--- a/libs/components/modals/src/lib/modules/modal/modal.service.spec.ts
+++ b/libs/components/modals/src/lib/modules/modal/modal.service.spec.ts
@@ -196,125 +196,125 @@ describe('Modal service', () => {
     closeModal(modal);
   }));
 
-  it('should hide and unhide elements at the host level from screen readers', fakeAsync(() => {
-    const div = document.createElement('div');
-    document.body.appendChild(div);
-    const modal = openModal(ModalTestComponent, { fullPage: false });
+  describe('accessibility', () => {
+    it('should hide and unhide elements at the host level from screen readers', fakeAsync(() => {
+      const div = document.createElement('div');
+      document.body.appendChild(div);
+      const modal = openModal(ModalTestComponent, { fullPage: false });
 
-    expect(div.getAttribute('aria-hidden')).toBe('true');
+      expect(div.getAttribute('aria-hidden')).toBe('true');
 
-    closeModal(modal);
+      closeModal(modal);
 
-    expect(div.getAttribute('aria-hidden')).toBe(null);
-    div.remove();
-  }));
+      expect(div.getAttribute('aria-hidden')).toBe(null);
+      div.remove();
+    }));
 
-  it('should keep hidden status elements at the host level consistent', fakeAsync(() => {
-    const div = document.createElement('div');
-    document.body.appendChild(div);
-    div.setAttribute('aria-hidden', 'true');
+    it('should keep hidden status elements at the host level consistent', fakeAsync(() => {
+      const div = document.createElement('div');
+      document.body.appendChild(div);
+      div.setAttribute('aria-hidden', 'true');
 
-    const modal = openModal(ModalTestComponent, { fullPage: false });
+      const modal = openModal(ModalTestComponent, { fullPage: false });
 
-    expect(div.getAttribute('aria-hidden')).toBe('true');
+      expect(div.getAttribute('aria-hidden')).toBe('true');
 
-    closeModal(modal);
+      closeModal(modal);
 
-    expect(div.getAttribute('aria-hidden')).toBe('true');
-    div.remove();
-  }));
+      expect(div.getAttribute('aria-hidden')).toBe('true');
+      div.remove();
+    }));
 
-  it('should not hide host siblings that are live', fakeAsync(() => {
-    const div = document.createElement('div');
-    document.body.appendChild(div);
-    div.setAttribute('aria-live', 'true');
+    it('should not hide host siblings that are live', fakeAsync(() => {
+      const div = document.createElement('div');
+      document.body.appendChild(div);
+      div.setAttribute('aria-live', 'true');
 
-    const modal = openModal(ModalTestComponent, { fullPage: false });
+      const modal = openModal(ModalTestComponent, { fullPage: false });
 
-    expect(div.getAttribute('aria-hidden')).toBe(null);
-    div.remove();
-    closeModal(modal);
-  }));
+      expect(div.getAttribute('aria-hidden')).toBe(null);
+      div.remove();
+      closeModal(modal);
+    }));
 
-  it('should keep sibling modals hidden when non top modal closes', fakeAsync(() => {
-    const firstModal = openModal(ModalTestComponent, { fullPage: false });
-    const secondModal = openModal(ModalTestComponent, { fullPage: false });
-    const modalsList = getModalEls();
-    modalsList.item(0).id = 'firstModal';
-    modalsList.item(1).id = 'secondModal';
+    it('should keep sibling modals hidden when non top modal closes', fakeAsync(() => {
+      const firstModal = openModal(ModalTestComponent, { fullPage: false });
+      const secondModal = openModal(ModalTestComponent, { fullPage: false });
+      const modalsList = getModalEls();
+      modalsList.item(0).id = 'firstModal';
+      modalsList.item(1).id = 'secondModal';
 
-    const topModal = openModal(ModalTestComponent, { fullPage: false });
+      const topModal = openModal(ModalTestComponent, { fullPage: false });
 
-    expect(
-      document.getElementById('firstModal').getAttribute('aria-hidden')
-    ).toBe('true');
+      expect(
+        document.getElementById('firstModal').getAttribute('aria-hidden')
+      ).toBe('true');
 
-    closeModal(secondModal);
+      closeModal(secondModal);
 
-    expect(
-      document.getElementById('firstModal').getAttribute('aria-hidden')
-    ).toBe('true');
+      expect(
+        document.getElementById('firstModal').getAttribute('aria-hidden')
+      ).toBe('true');
 
-    closeModal(firstModal);
-    closeModal(topModal);
-  }));
+      closeModal(firstModal);
+      closeModal(topModal);
+    }));
 
-  it('should unhide the correct modal when the top modal closes', fakeAsync(() => {
-    const lowerModal = openModal(ModalTestComponent, { fullPage: false });
-    const middleModal = openModal(ModalTestComponent, { fullPage: false });
-    const topModal = openModal(ModalTestComponent, { fullPage: false });
-    const modalsList = getModalEls();
-    modalsList.item(0).id = 'lowerModal';
+    it('should unhide the correct modal when the top modal closes', fakeAsync(() => {
+      const lowerModal = openModal(ModalTestComponent, { fullPage: false });
+      const middleModal = openModal(ModalTestComponent, { fullPage: false });
+      const topModal = openModal(ModalTestComponent, { fullPage: false });
+      const modalsList = getModalEls();
+      modalsList.item(0).id = 'lowerModal';
 
-    closeModal(middleModal);
-    closeModal(topModal);
+      closeModal(middleModal);
+      closeModal(topModal);
 
-    expect(
-      document.getElementById('lowerModal').getAttribute('aria-hidden')
-    ).toBe(null);
+      expect(
+        document.getElementById('lowerModal').getAttribute('aria-hidden')
+      ).toBe(null);
 
-    closeModal(lowerModal);
-  }));
+      closeModal(lowerModal);
+    }));
 
-  // modal siblings
+    it('should hide and unhide modal siblings from screen readers', fakeAsync(() => {
+      const siblingModal = openModal(ModalTestComponent, { fullPage: false });
+      const modal = openModal(ModalTestComponent, { fullPage: false });
+      const modalsList = getModalEls();
+      modalsList.item(0).id = 'sibling';
 
-  it('should hide and unhide modal siblings from screen readers', fakeAsync(() => {
-    const siblingModal = openModal(ModalTestComponent, { fullPage: false });
-    const modal = openModal(ModalTestComponent, { fullPage: false });
-    const modalsList = getModalEls();
-    modalsList.item(0).id = 'sibling';
+      expect(
+        document.getElementById('sibling').getAttribute('aria-hidden')
+      ).toBe('true');
 
-    expect(document.getElementById('sibling').getAttribute('aria-hidden')).toBe(
-      'true'
-    );
+      closeModal(modal);
+      expect(
+        document.getElementById('sibling').getAttribute('aria-hidden')
+      ).toBe(null);
+      closeModal(siblingModal);
+    }));
 
-    closeModal(modal);
-    expect(document.getElementById('sibling').getAttribute('aria-hidden')).toBe(
-      null
-    );
-    closeModal(siblingModal);
-  }));
+    it('should not hide live elements from screen readers', fakeAsync(() => {
+      const div = document.createElement('div');
+      document.body.appendChild(div);
+      div.setAttribute('aria-live', 'true');
+      const modal = openModal(ModalTestComponent, { fullPage: false });
 
-  it('should not hide live elements from screen readers', fakeAsync(() => {
-    const div = document.createElement('div');
-    document.body.appendChild(div);
-    div.setAttribute('aria-live', 'true');
-    const modal = openModal(ModalTestComponent, { fullPage: false });
+      expect(div.getAttribute('aria-hidden')).toBe(null);
 
-    expect(div.getAttribute('aria-hidden')).toBe(null);
+      closeModal(modal);
+      expect(div.getAttribute('aria-hidden')).toBe(null);
+      div.remove();
+    }));
 
-    closeModal(modal);
-    expect(div.getAttribute('aria-hidden')).toBe(null);
-    div.remove();
-  }));
+    it('should not hide current modal from screen readers', fakeAsync(() => {
+      const modal = openModal(ModalTestComponent, { fullPage: false });
 
-  it('should not hide current modal from screen readers', fakeAsync(() => {
-    const modal = openModal(ModalTestComponent, { fullPage: false });
+      expect(
+        document.querySelector('sky-test-cmp').getAttribute('aria-hidden')
+      ).toBe(null);
 
-    expect(
-      document.querySelector('sky-test-cmp').getAttribute('aria-hidden')
-    ).toBe(null);
-
-    closeModal(modal);
-  }));
+      closeModal(modal);
+    }));
+  });
 });

--- a/libs/components/modals/src/lib/modules/modal/modal.service.spec.ts
+++ b/libs/components/modals/src/lib/modules/modal/modal.service.spec.ts
@@ -28,6 +28,10 @@ describe('Modal service', () => {
     applicationRef.tick();
   }
 
+  function getModalEls() {
+    return document.querySelectorAll('sky-test-cmp');
+  }
+
   beforeEach(() => {
     // Confirm that each test starts without a modal host component.
     const modalHosts = document.querySelectorAll('sky-modal-host');
@@ -225,42 +229,43 @@ describe('Modal service', () => {
     document.body.appendChild(div);
     div.setAttribute('aria-live', 'true');
 
-    openModal(ModalTestComponent, { fullPage: false });
+    const modal = openModal(ModalTestComponent, { fullPage: false });
 
     expect(div.getAttribute('aria-hidden')).toBe(null);
     div.remove();
+    closeModal(modal);
   }));
 
   it('should keep sibling modals hidden when non top modal closes', fakeAsync(() => {
-    openModal(ModalTestComponent, { fullPage: false });
-    document.querySelector('sky-test-cmp').id = 'sibling';
-    const host = document.querySelector('sky-modal-host');
+    const firstModal = openModal(ModalTestComponent, { fullPage: false });
+    document.querySelector('sky-test-cmp').id = 'firstModal';
 
-    const lowerModal = openModal(ModalTestComponent, { fullPage: false });
-    const list = host.children;
-    list[3].id = 'lowerModal';
+    const secondModal = openModal(ModalTestComponent, { fullPage: false });
+    const modalsList = getModalEls();
+    modalsList.item(1).id = 'secondModal';
 
-    openModal(ModalTestComponent, { fullPage: false });
+    const topModal = openModal(ModalTestComponent, { fullPage: false });
 
-    expect(document.getElementById('sibling').getAttribute('aria-hidden')).toBe(
-      'true'
-    );
+    expect(
+      document.getElementById('firstModal').getAttribute('aria-hidden')
+    ).toBe('true');
 
-    closeModal(lowerModal);
+    closeModal(secondModal);
 
-    expect(document.getElementById('sibling').getAttribute('aria-hidden')).toBe(
-      'true'
-    );
+    expect(
+      document.getElementById('firstModal').getAttribute('aria-hidden')
+    ).toBe('true');
+
+    closeModal(firstModal);
+    closeModal(topModal);
   }));
 
-  it('should unhide modal behind top modal when top modal is closed even when the layering of modals has changed', fakeAsync(() => {
-    openModal(ModalTestComponent, { fullPage: false });
-    openModal(ModalTestComponent, { fullPage: false });
+  it('should unhide the correct modal when the top modal closes', fakeAsync(() => {
+    const lowerModal = openModal(ModalTestComponent, { fullPage: false });
     const middleModal = openModal(ModalTestComponent, { fullPage: false });
     const topModal = openModal(ModalTestComponent, { fullPage: false });
-    const host = document.querySelector('sky-modal-host');
-    const list = host.children;
-    list[3].id = 'lowerModal';
+    const modalsList = getModalEls();
+    modalsList.item(0).id = 'lowerModal';
 
     closeModal(middleModal);
     closeModal(topModal);
@@ -268,12 +273,14 @@ describe('Modal service', () => {
     expect(
       document.getElementById('lowerModal').getAttribute('aria-hidden')
     ).toBe(null);
+
+    closeModal(lowerModal);
   }));
 
   // modal siblings
 
   it('should hide and unhide modal siblings from screen readers', fakeAsync(() => {
-    openModal(ModalTestComponent, { fullPage: false });
+    const siblingModal = openModal(ModalTestComponent, { fullPage: false });
     document.querySelector('sky-test-cmp').id = 'sibling';
     const modal = openModal(ModalTestComponent, { fullPage: false });
 
@@ -285,6 +292,7 @@ describe('Modal service', () => {
     expect(document.getElementById('sibling').getAttribute('aria-hidden')).toBe(
       null
     );
+    closeModal(siblingModal);
   }));
 
   it('should not hide live elements from screen readers', fakeAsync(() => {

--- a/libs/components/modals/src/lib/modules/modal/modal.service.spec.ts
+++ b/libs/components/modals/src/lib/modules/modal/modal.service.spec.ts
@@ -176,9 +176,137 @@ describe('Modal service', () => {
 
   it('should show a modal with a wrapper class', fakeAsync(() => {
     const wrapperClass = 'custom-wrapper-class';
-    openModal(ModalTestComponent, { wrapperClass });
+    const modal = openModal(ModalTestComponent, { wrapperClass });
     applicationRef.tick();
 
     expect(document.body.querySelector(`sky-modal.${wrapperClass}`)).toExist();
+    closeModal(modal);
+  }));
+
+  it('should not hide modal host from screen readers when opening a modal', fakeAsync(() => {
+    const modal = openModal(ModalTestComponent, { fullPage: false });
+
+    expect(
+      document.querySelector('sky-modal-host').getAttribute('aria-hidden')
+    ).toBe(null);
+    closeModal(modal);
+  }));
+
+  it('should hide and unhide elements at the host level from screen readers', fakeAsync(() => {
+    const div = document.createElement('div');
+    document.body.appendChild(div);
+    const modal = openModal(ModalTestComponent, { fullPage: false });
+
+    expect(div.getAttribute('aria-hidden')).toBe('true');
+
+    closeModal(modal);
+
+    expect(div.getAttribute('aria-hidden')).toBe(null);
+    div.remove();
+  }));
+
+  it('should keep hidden status elements at the host level consistent', fakeAsync(() => {
+    const div = document.createElement('div');
+    document.body.appendChild(div);
+    div.setAttribute('aria-hidden', 'true');
+
+    const modal = openModal(ModalTestComponent, { fullPage: false });
+
+    expect(div.getAttribute('aria-hidden')).toBe('true');
+
+    closeModal(modal);
+
+    expect(div.getAttribute('aria-hidden')).toBe('true');
+    div.remove();
+  }));
+
+  it('should not hide host siblings that are live', fakeAsync(() => {
+    const div = document.createElement('div');
+    document.body.appendChild(div);
+    div.setAttribute('aria-live', 'true');
+
+    openModal(ModalTestComponent, { fullPage: false });
+
+    expect(div.getAttribute('aria-hidden')).toBe(null);
+    div.remove();
+  }));
+
+  it('what does it do with layered modals', fakeAsync(() => {
+    openModal(ModalTestComponent, { fullPage: false });
+    document.querySelector('sky-test-cmp').id = 'sibling';
+    const host = document.querySelector('sky-modal-host');
+
+    const lowerModal = openModal(ModalTestComponent, { fullPage: false });
+    const list = host.children;
+    list[3].id = 'lowerModal';
+
+    openModal(ModalTestComponent, { fullPage: false });
+
+    expect(document.getElementById('sibling').getAttribute('aria-hidden')).toBe(
+      'true'
+    );
+
+    closeModal(lowerModal);
+
+    expect(document.getElementById('sibling').getAttribute('aria-hidden')).toBe(
+      'true'
+    );
+  }));
+
+  it('what does it do with layered modals', fakeAsync(() => {
+    openModal(ModalTestComponent, { fullPage: false });
+    openModal(ModalTestComponent, { fullPage: false });
+    const middleModal = openModal(ModalTestComponent, { fullPage: false });
+    const topModal = openModal(ModalTestComponent, { fullPage: false });
+    const host = document.querySelector('sky-modal-host');
+    const list = host.children;
+    list[3].id = 'lowerModal';
+
+    closeModal(middleModal);
+    closeModal(topModal);
+
+    expect(
+      document.getElementById('lowerModal').getAttribute('aria-hidden')
+    ).toBe(null);
+  }));
+
+  // modal siblings
+
+  it('should hide and unhide modal siblings from screen readers', fakeAsync(() => {
+    openModal(ModalTestComponent, { fullPage: false });
+    document.querySelector('sky-test-cmp').id = 'sibling';
+    const modal = openModal(ModalTestComponent, { fullPage: false });
+
+    expect(document.getElementById('sibling').getAttribute('aria-hidden')).toBe(
+      'true'
+    );
+
+    closeModal(modal);
+    expect(document.getElementById('sibling').getAttribute('aria-hidden')).toBe(
+      null
+    );
+  }));
+
+  it('should not hide live elements from screen readers', fakeAsync(() => {
+    const div = document.createElement('div');
+    document.body.appendChild(div);
+    div.setAttribute('aria-live', 'true');
+    const modal = openModal(ModalTestComponent, { fullPage: false });
+
+    expect(div.getAttribute('aria-hidden')).toBe(null);
+
+    closeModal(modal);
+    expect(div.getAttribute('aria-hidden')).toBe(null);
+    div.remove();
+  }));
+
+  it('should not hide current modal from screen readers', fakeAsync(() => {
+    const modal = openModal(ModalTestComponent, { fullPage: false });
+
+    expect(
+      document.querySelector('sky-test-cmp').getAttribute('aria-hidden')
+    ).toBe(null);
+
+    closeModal(modal);
   }));
 });

--- a/libs/components/modals/src/lib/modules/modal/modal.service.spec.ts
+++ b/libs/components/modals/src/lib/modules/modal/modal.service.spec.ts
@@ -238,10 +238,9 @@ describe('Modal service', () => {
 
   it('should keep sibling modals hidden when non top modal closes', fakeAsync(() => {
     const firstModal = openModal(ModalTestComponent, { fullPage: false });
-    document.querySelector('sky-test-cmp').id = 'firstModal';
-
     const secondModal = openModal(ModalTestComponent, { fullPage: false });
     const modalsList = getModalEls();
+    modalsList.item(0).id = 'firstModal';
     modalsList.item(1).id = 'secondModal';
 
     const topModal = openModal(ModalTestComponent, { fullPage: false });
@@ -281,8 +280,9 @@ describe('Modal service', () => {
 
   it('should hide and unhide modal siblings from screen readers', fakeAsync(() => {
     const siblingModal = openModal(ModalTestComponent, { fullPage: false });
-    document.querySelector('sky-test-cmp').id = 'sibling';
     const modal = openModal(ModalTestComponent, { fullPage: false });
+    const modalsList = getModalEls();
+    modalsList.item(0).id = 'sibling';
 
     expect(document.getElementById('sibling').getAttribute('aria-hidden')).toBe(
       'true'

--- a/libs/components/modals/src/lib/modules/modal/modal.service.spec.ts
+++ b/libs/components/modals/src/lib/modules/modal/modal.service.spec.ts
@@ -187,16 +187,16 @@ describe('Modal service', () => {
     closeModal(modal);
   }));
 
-  it('should not hide modal host from screen readers when opening a modal', fakeAsync(() => {
-    const modal = openModal(ModalTestComponent, { fullPage: false });
-
-    expect(
-      document.querySelector('sky-modal-host').getAttribute('aria-hidden')
-    ).toBe(null);
-    closeModal(modal);
-  }));
-
   describe('accessibility', () => {
+    it('should not hide modal host from screen readers when opening a modal', fakeAsync(() => {
+      const modal = openModal(ModalTestComponent, { fullPage: false });
+
+      expect(
+        document.querySelector('sky-modal-host').getAttribute('aria-hidden')
+      ).toBe(null);
+      closeModal(modal);
+    }));
+
     it('should hide and unhide elements at the host level from screen readers', fakeAsync(() => {
       const div = document.createElement('div');
       document.body.appendChild(div);

--- a/libs/components/modals/src/lib/modules/modal/modal.service.spec.ts
+++ b/libs/components/modals/src/lib/modules/modal/modal.service.spec.ts
@@ -231,7 +231,7 @@ describe('Modal service', () => {
     div.remove();
   }));
 
-  it('what does it do with layered modals', fakeAsync(() => {
+  it('should keep sibling modals hidden when non top modal closes', fakeAsync(() => {
     openModal(ModalTestComponent, { fullPage: false });
     document.querySelector('sky-test-cmp').id = 'sibling';
     const host = document.querySelector('sky-modal-host');
@@ -253,7 +253,7 @@ describe('Modal service', () => {
     );
   }));
 
-  it('what does it do with layered modals', fakeAsync(() => {
+  it('should unhide modal behind top modal when top modal is closed even when the layering of modals has changed', fakeAsync(() => {
     openModal(ModalTestComponent, { fullPage: false });
     openModal(ModalTestComponent, { fullPage: false });
     const middleModal = openModal(ModalTestComponent, { fullPage: false });


### PR DESCRIPTION
add aria-hidden to siblings of the current modal and modal host so that screen readers cannot
navigate outside the modal while it is open