### PR TITLE
refactor: implement various updates found during the Nx 14 migration

### DIFF
--- a/libs/components/data-manager/src/lib/modules/data-manager/data-manager.service.spec.ts
+++ b/libs/components/data-manager/src/lib/modules/data-manager/data-manager.service.spec.ts
@@ -1,21 +1,19 @@
-import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { expect } from '@skyux-sdk/testing';
 import { SkyUIConfigService } from '@skyux/core';
 
-import {
-  SkyDataManagerConfig,
-  SkyDataManagerInitArgs,
-  SkyDataManagerService,
-  SkyDataManagerState,
-  SkyDataViewConfig,
-  SkyDataViewState,
-} from 'libs/components/data-manager/src/index';
 import { Observable, Subject } from 'rxjs';
 
+import { SkyDataManagerService } from './data-manager.service';
 import { DataViewCardFixtureComponent } from './fixtures/data-manager-card-view.component.fixture';
 import { DataViewRepeaterFixtureComponent } from './fixtures/data-manager-repeater-view.component.fixture';
 import { DataManagerFixtureComponent } from './fixtures/data-manager.component.fixture';
 import { DataManagerFixtureModule } from './fixtures/data-manager.module.fixture';
+import { SkyDataManagerConfig } from './models/data-manager-config';
+import { SkyDataManagerInitArgs } from './models/data-manager-init-args';
+import { SkyDataManagerState } from './models/data-manager-state';
+import { SkyDataViewConfig } from './models/data-view-config';
+import { SkyDataViewState } from './models/data-view-state';
 
 describe('SkyDataManagerService', () => {
   let dataManagerFixture: ComponentFixture<DataManagerFixtureComponent>;
@@ -104,22 +102,22 @@ describe('SkyDataManagerService', () => {
         uiConfigServiceSetObservable = new Subject<any>();
       });
 
-      it('should request a data state from the ui config service', waitForAsync(() => {
+      it('should request a data state from the ui config service', async () => {
         spyOn(uiConfigService, 'getConfig').and.returnValue(
           uiConfigServiceGetObservable
         );
 
         dataManagerService.initDataManager(initArgs);
 
-        dataManagerFixture.whenStable().then(() => {
-          expect(uiConfigService.getConfig).toHaveBeenCalledWith(
-            key,
-            initialDataState.getStateOptions()
-          );
-        });
-      }));
+        await dataManagerFixture.whenStable();
 
-      it('should update the data state via the data manager service when the ui config service returns a data state', waitForAsync(() => {
+        expect(uiConfigService.getConfig).toHaveBeenCalledWith(
+          key,
+          initialDataState.getStateOptions()
+        );
+      });
+
+      it('should update the data state via the data manager service when the ui config service returns a data state', async () => {
         spyOn(uiConfigService, 'getConfig').and.returnValue(
           uiConfigServiceGetObservable
         );
@@ -127,20 +125,19 @@ describe('SkyDataManagerService', () => {
 
         dataManagerService.initDataManager(initArgs);
 
-        dataManagerFixture.whenStable().then(() => {
-          uiConfigServiceGetObservable.next(initialDataState.getStateOptions());
-          expect(uiConfigService.getConfig).toHaveBeenCalledWith(
-            key,
-            initialDataState.getStateOptions()
-          );
-          expect(dataManagerService.updateDataState).toHaveBeenCalledWith(
-            initialDataState,
-            'dataManagerServiceInit'
-          );
-        });
-      }));
+        await dataManagerFixture.whenStable();
+        uiConfigServiceGetObservable.next(initialDataState.getStateOptions());
+        expect(uiConfigService.getConfig).toHaveBeenCalledWith(
+          key,
+          initialDataState.getStateOptions()
+        );
+        expect(dataManagerService.updateDataState).toHaveBeenCalledWith(
+          initialDataState,
+          'dataManagerServiceInit'
+        );
+      });
 
-      it('should update the ui config service when the data state changes', waitForAsync(() => {
+      it('should update the ui config service when the data state changes', async () => {
         const newDataState = new SkyDataManagerState({ searchText: 'test' });
         spyOn(uiConfigService, 'getConfig').and.returnValue(
           uiConfigServiceGetObservable
@@ -148,18 +145,17 @@ describe('SkyDataManagerService', () => {
 
         dataManagerService.initDataManager(initArgs);
 
-        dataManagerFixture.whenStable().then(() => {
-          spyOn(uiConfigService, 'setConfig').and.returnValue(
-            uiConfigServiceSetObservable
-          );
-          dataManagerService.updateDataState(newDataState, sourceId);
+        await dataManagerFixture.whenStable();
+        spyOn(uiConfigService, 'setConfig').and.returnValue(
+          uiConfigServiceSetObservable
+        );
+        dataManagerService.updateDataState(newDataState, sourceId);
 
-          uiConfigServiceSetObservable.next('');
-          expect(uiConfigService.setConfig).toHaveBeenCalled();
-        });
-      }));
+        uiConfigServiceSetObservable.next('');
+        expect(uiConfigService.setConfig).toHaveBeenCalled();
+      });
 
-      it('should log an error when unable to update the ui config service when the data state changes', waitForAsync(() => {
+      it('should log an error when unable to update the ui config service when the data state changes', async () => {
         const newDataState = new SkyDataManagerState({ searchText: 'test' });
         const errorMessage = 'something went wrong';
         spyOn(uiConfigService, 'getConfig').and.returnValue(
@@ -168,18 +164,17 @@ describe('SkyDataManagerService', () => {
 
         dataManagerService.initDataManager(initArgs);
 
-        dataManagerFixture.whenStable().then(() => {
-          spyOn(uiConfigService, 'setConfig').and.returnValue(
-            uiConfigServiceSetObservable
-          );
-          spyOn(console, 'warn');
-          dataManagerService.updateDataState(newDataState, sourceId);
+        await dataManagerFixture.whenStable();
+        spyOn(uiConfigService, 'setConfig').and.returnValue(
+          uiConfigServiceSetObservable
+        );
+        spyOn(console, 'warn');
+        dataManagerService.updateDataState(newDataState, sourceId);
 
-          uiConfigServiceSetObservable.error(errorMessage);
-          expect(uiConfigService.setConfig).toHaveBeenCalled();
-          expect(console.warn).toHaveBeenCalledWith(errorMessage);
-        });
-      }));
+        uiConfigServiceSetObservable.error(errorMessage);
+        expect(uiConfigService.setConfig).toHaveBeenCalled();
+        expect(console.warn).toHaveBeenCalledWith(errorMessage);
+      });
     });
   });
 
@@ -409,7 +404,7 @@ describe('SkyDataManagerService', () => {
   });
 
   describe('initDataView', () => {
-    it('should create a new view config and view state when a data state has been set', waitForAsync(() => {
+    it('should create a new view config and view state when a data state has been set', async () => {
       let currentDataState: SkyDataManagerState;
 
       dataManagerService
@@ -419,20 +414,19 @@ describe('SkyDataManagerService', () => {
 
       dataManagerFixture.detectChanges();
 
-      dataManagerFixture.whenStable().then(() => {
-        const newView = { id: 'newView', name: 'newView' };
-        let viewState = currentDataState.getViewStateById(newView.id);
+      await dataManagerFixture.whenStable();
+      const newView = { id: 'newView', name: 'newView' };
+      let viewState = currentDataState.getViewStateById(newView.id);
 
-        expect(dataManagerService.getViewById(newView.id)).toBeUndefined();
-        expect(viewState).toBeUndefined();
+      expect(dataManagerService.getViewById(newView.id)).toBeUndefined();
+      expect(viewState).toBeUndefined();
 
-        dataManagerService.initDataView(newView);
-        viewState = currentDataState.getViewStateById(newView.id);
+      dataManagerService.initDataView(newView);
+      viewState = currentDataState.getViewStateById(newView.id);
 
-        expect(dataManagerService.getViewById(newView.id)).toEqual(newView);
-        expect(viewState).toBeDefined();
-      });
-    }));
+      expect(dataManagerService.getViewById(newView.id)).toEqual(newView);
+      expect(viewState).toBeDefined();
+    });
 
     it('should not create a new view and update the data state if a view with that ID is already defined', () => {
       const view = { id: 'view', name: 'View' };
@@ -449,7 +443,7 @@ describe('SkyDataManagerService', () => {
     });
 
     it(`should create a new view and update the data state if a view with the ID exists in the
-     state but has not been initialized`, waitForAsync(() => {
+     state but has not been initialized`, async () => {
       let currentDataState: SkyDataManagerState;
 
       dataManagerService
@@ -468,99 +462,35 @@ describe('SkyDataManagerService', () => {
 
       dataManagerFixture.detectChanges();
 
-      dataManagerFixture.whenStable().then(() => {
-        const newView = { id: 'newView', name: 'newView' };
-        let viewState = currentDataState.getViewStateById(newView.id);
+      await dataManagerFixture.whenStable();
+      const newView = { id: 'newView', name: 'newView' };
+      let viewState = currentDataState.getViewStateById(newView.id);
 
-        expect(dataManagerService.getViewById(newView.id)).toBeUndefined();
-        expect(viewState).toEqual(
-          new SkyDataViewState({
-            viewId: 'newView',
-            columnIds: [],
-            displayedColumnIds: [],
-            additionalData: undefined,
-          })
-        );
-
-        dataManagerService.initDataView(newView);
-        viewState = currentDataState.getViewStateById(newView.id);
-
-        expect(dataManagerService.getViewById(newView.id)).toEqual(newView);
-        expect(viewState).toEqual(
-          new SkyDataViewState({
-            viewId: 'newView',
-            columnIds: [],
-            displayedColumnIds: [],
-            additionalData: undefined,
-          })
-        );
-      });
-    }));
-
-    it(`should not update available or displayed column IDs on an exisitng view state if current columns match`, waitForAsync(() => {
-      let currentDataState: SkyDataManagerState;
-
-      dataManagerService
-        .getDataStateUpdates(sourceId)
-        .subscribe((state) => (currentDataState = state));
-      dataManagerService.updateDataState(
-        new SkyDataManagerState({
-          views: [
-            {
-              viewId: 'newView',
-              columnIds: ['1', '2'],
-              displayedColumnIds: ['2'],
-            },
-          ],
-        }),
-        'test'
+      expect(dataManagerService.getViewById(newView.id)).toBeUndefined();
+      expect(viewState).toEqual(
+        new SkyDataViewState({
+          viewId: 'newView',
+          columnIds: [],
+          displayedColumnIds: [],
+          additionalData: undefined,
+        })
       );
 
-      dataManagerFixture.detectChanges();
+      dataManagerService.initDataView(newView);
+      viewState = currentDataState.getViewStateById(newView.id);
 
-      dataManagerFixture.whenStable().then(() => {
-        const newView: SkyDataViewConfig = {
-          id: 'newView',
-          name: 'newView',
-          columnOptions: [
-            {
-              id: '1',
-              label: 'Column 1',
-            },
-            {
-              id: '2',
-              label: 'Column 2',
-            },
-          ],
-        };
-        let viewState = currentDataState.getViewStateById(newView.id);
+      expect(dataManagerService.getViewById(newView.id)).toEqual(newView);
+      expect(viewState).toEqual(
+        new SkyDataViewState({
+          viewId: 'newView',
+          columnIds: [],
+          displayedColumnIds: [],
+          additionalData: undefined,
+        })
+      );
+    });
 
-        expect(dataManagerService.getViewById(newView.id)).toBeUndefined();
-        expect(viewState).toEqual(
-          new SkyDataViewState({
-            viewId: 'newView',
-            columnIds: ['1', '2'],
-            displayedColumnIds: ['2'],
-            additionalData: undefined,
-          })
-        );
-
-        dataManagerService.initDataView(newView);
-        viewState = currentDataState.getViewStateById(newView.id);
-
-        expect(dataManagerService.getViewById(newView.id)).toEqual(newView);
-        expect(viewState).toEqual(
-          new SkyDataViewState({
-            viewId: 'newView',
-            columnIds: ['1', '2'],
-            displayedColumnIds: ['2'],
-            additionalData: undefined,
-          })
-        );
-      });
-    }));
-
-    it(`should update available or displayed column IDs on an exisitng view state if a new column exists`, waitForAsync(() => {
+    it(`should not update available or displayed column IDs on an exisitng view state if current columns match`, async () => {
       let currentDataState: SkyDataManagerState;
 
       dataManagerService
@@ -581,54 +511,115 @@ describe('SkyDataManagerService', () => {
 
       dataManagerFixture.detectChanges();
 
-      dataManagerFixture.whenStable().then(() => {
-        const newView: SkyDataViewConfig = {
-          id: 'newView',
-          name: 'newView',
-          columnOptions: [
+      await dataManagerFixture.whenStable();
+      const newView: SkyDataViewConfig = {
+        id: 'newView',
+        name: 'newView',
+        columnOptions: [
+          {
+            id: '1',
+            label: 'Column 1',
+          },
+          {
+            id: '2',
+            label: 'Column 2',
+          },
+        ],
+      };
+      let viewState = currentDataState.getViewStateById(newView.id);
+
+      expect(dataManagerService.getViewById(newView.id)).toBeUndefined();
+      expect(viewState).toEqual(
+        new SkyDataViewState({
+          viewId: 'newView',
+          columnIds: ['1', '2'],
+          displayedColumnIds: ['2'],
+          additionalData: undefined,
+        })
+      );
+
+      dataManagerService.initDataView(newView);
+      viewState = currentDataState.getViewStateById(newView.id);
+
+      expect(dataManagerService.getViewById(newView.id)).toEqual(newView);
+      expect(viewState).toEqual(
+        new SkyDataViewState({
+          viewId: 'newView',
+          columnIds: ['1', '2'],
+          displayedColumnIds: ['2'],
+          additionalData: undefined,
+        })
+      );
+    });
+
+    it(`should update available or displayed column IDs on an exisitng view state if a new column exists`, async () => {
+      let currentDataState: SkyDataManagerState;
+
+      dataManagerService
+        .getDataStateUpdates(sourceId)
+        .subscribe((state) => (currentDataState = state));
+      dataManagerService.updateDataState(
+        new SkyDataManagerState({
+          views: [
             {
-              id: '1',
-              label: 'Column 1',
-            },
-            {
-              id: '2',
-              label: 'Column 2',
-            },
-            {
-              id: '3',
-              label: 'Column 3',
+              viewId: 'newView',
+              columnIds: ['1', '2'],
+              displayedColumnIds: ['2'],
             },
           ],
-        };
-        let viewState = currentDataState.getViewStateById(newView.id);
+        }),
+        'test'
+      );
 
-        expect(dataManagerService.getViewById(newView.id)).toBeUndefined();
-        expect(viewState).toEqual(
-          new SkyDataViewState({
-            viewId: 'newView',
-            columnIds: ['1', '2'],
-            displayedColumnIds: ['2'],
-            additionalData: undefined,
-          })
-        );
+      dataManagerFixture.detectChanges();
 
-        dataManagerService.initDataView(newView);
-        viewState = currentDataState.getViewStateById(newView.id);
+      await dataManagerFixture.whenStable();
+      const newView: SkyDataViewConfig = {
+        id: 'newView',
+        name: 'newView',
+        columnOptions: [
+          {
+            id: '1',
+            label: 'Column 1',
+          },
+          {
+            id: '2',
+            label: 'Column 2',
+          },
+          {
+            id: '3',
+            label: 'Column 3',
+          },
+        ],
+      };
+      let viewState = currentDataState.getViewStateById(newView.id);
 
-        expect(dataManagerService.getViewById(newView.id)).toEqual(newView);
-        expect(viewState).toEqual(
-          new SkyDataViewState({
-            viewId: 'newView',
-            columnIds: ['1', '2', '3'],
-            displayedColumnIds: ['2', '3'],
-            additionalData: undefined,
-          })
-        );
-      });
-    }));
+      expect(dataManagerService.getViewById(newView.id)).toBeUndefined();
+      expect(viewState).toEqual(
+        new SkyDataViewState({
+          viewId: 'newView',
+          columnIds: ['1', '2'],
+          displayedColumnIds: ['2'],
+          additionalData: undefined,
+        })
+      );
+
+      dataManagerService.initDataView(newView);
+      viewState = currentDataState.getViewStateById(newView.id);
+
+      expect(dataManagerService.getViewById(newView.id)).toEqual(newView);
+      expect(viewState).toEqual(
+        new SkyDataViewState({
+          viewId: 'newView',
+          columnIds: ['1', '2', '3'],
+          displayedColumnIds: ['2', '3'],
+          additionalData: undefined,
+        })
+      );
+    });
 
     it(`should update available but not displayed column IDs on an exisitng view state if a new
-    column exists with 'initialHide'`, waitForAsync(() => {
+    column exists with 'initialHide'`, async () => {
       let currentDataState: SkyDataManagerState;
 
       dataManagerService
@@ -649,55 +640,54 @@ describe('SkyDataManagerService', () => {
 
       dataManagerFixture.detectChanges();
 
-      dataManagerFixture.whenStable().then(() => {
-        const newView: SkyDataViewConfig = {
-          id: 'newView',
-          name: 'newView',
-          columnOptions: [
-            {
-              id: '1',
-              label: 'Column 1',
-            },
-            {
-              id: '2',
-              label: 'Column 2',
-            },
-            {
-              id: '3',
-              label: 'Column 3',
-              initialHide: true,
-            },
-          ],
-        };
-        let viewState = currentDataState.getViewStateById(newView.id);
+      await dataManagerFixture.whenStable();
+      const newView: SkyDataViewConfig = {
+        id: 'newView',
+        name: 'newView',
+        columnOptions: [
+          {
+            id: '1',
+            label: 'Column 1',
+          },
+          {
+            id: '2',
+            label: 'Column 2',
+          },
+          {
+            id: '3',
+            label: 'Column 3',
+            initialHide: true,
+          },
+        ],
+      };
+      let viewState = currentDataState.getViewStateById(newView.id);
 
-        expect(dataManagerService.getViewById(newView.id)).toBeUndefined();
-        expect(viewState).toEqual(
-          new SkyDataViewState({
-            viewId: 'newView',
-            columnIds: ['1', '2'],
-            displayedColumnIds: ['2'],
-            additionalData: undefined,
-          })
-        );
+      expect(dataManagerService.getViewById(newView.id)).toBeUndefined();
+      expect(viewState).toEqual(
+        new SkyDataViewState({
+          viewId: 'newView',
+          columnIds: ['1', '2'],
+          displayedColumnIds: ['2'],
+          additionalData: undefined,
+        })
+      );
 
-        dataManagerService.initDataView(newView);
-        viewState = currentDataState.getViewStateById(newView.id);
+      dataManagerService.initDataView(newView);
+      viewState = currentDataState.getViewStateById(newView.id);
 
-        expect(dataManagerService.getViewById(newView.id)).toEqual(newView);
-        expect(viewState).toEqual(
-          new SkyDataViewState({
-            viewId: 'newView',
-            columnIds: ['1', '2', '3'],
-            displayedColumnIds: ['2'],
-            additionalData: undefined,
-          })
-        );
-      });
-    }));
+      expect(dataManagerService.getViewById(newView.id)).toEqual(newView);
+      expect(viewState).toEqual(
+        new SkyDataViewState({
+          viewId: 'newView',
+          columnIds: ['1', '2', '3'],
+          displayedColumnIds: ['2'],
+          additionalData: undefined,
+        })
+      );
+    });
 
     it(`should update available but not displayed column IDs on an exisitng view state if available
-     columns weren't previously given`, waitForAsync(() => {
+     columns weren't previously given`, async () => {
       let currentDataState: SkyDataManagerState;
 
       dataManagerService
@@ -718,54 +708,53 @@ describe('SkyDataManagerService', () => {
 
       dataManagerFixture.detectChanges();
 
-      dataManagerFixture.whenStable().then(() => {
-        const newView: SkyDataViewConfig = {
-          id: 'newView',
-          name: 'newView',
-          columnOptions: [
-            {
-              id: '1',
-              label: 'Column 1',
-            },
-            {
-              id: '2',
-              label: 'Column 2',
-            },
-            {
-              id: '3',
-              label: 'Column 3',
-              initialHide: true,
-            },
-          ],
-        };
-        let viewState = currentDataState.getViewStateById(newView.id);
+      await dataManagerFixture.whenStable();
+      const newView: SkyDataViewConfig = {
+        id: 'newView',
+        name: 'newView',
+        columnOptions: [
+          {
+            id: '1',
+            label: 'Column 1',
+          },
+          {
+            id: '2',
+            label: 'Column 2',
+          },
+          {
+            id: '3',
+            label: 'Column 3',
+            initialHide: true,
+          },
+        ],
+      };
+      let viewState = currentDataState.getViewStateById(newView.id);
 
-        expect(dataManagerService.getViewById(newView.id)).toBeUndefined();
-        expect(viewState).toEqual(
-          new SkyDataViewState({
-            viewId: 'newView',
-            columnIds: [],
-            displayedColumnIds: ['2'],
-            additionalData: undefined,
-          })
-        );
+      expect(dataManagerService.getViewById(newView.id)).toBeUndefined();
+      expect(viewState).toEqual(
+        new SkyDataViewState({
+          viewId: 'newView',
+          columnIds: [],
+          displayedColumnIds: ['2'],
+          additionalData: undefined,
+        })
+      );
 
-        dataManagerService.initDataView(newView);
-        viewState = currentDataState.getViewStateById(newView.id);
+      dataManagerService.initDataView(newView);
+      viewState = currentDataState.getViewStateById(newView.id);
 
-        expect(dataManagerService.getViewById(newView.id)).toEqual(newView);
-        expect(viewState).toEqual(
-          new SkyDataViewState({
-            viewId: 'newView',
-            columnIds: ['1', '2', '3'],
-            displayedColumnIds: ['2'],
-            additionalData: undefined,
-          })
-        );
-      });
-    }));
+      expect(dataManagerService.getViewById(newView.id)).toEqual(newView);
+      expect(viewState).toEqual(
+        new SkyDataViewState({
+          viewId: 'newView',
+          columnIds: ['1', '2', '3'],
+          displayedColumnIds: ['2'],
+          additionalData: undefined,
+        })
+      );
+    });
 
-    it(`should update available and displayed column ids on a new view`, waitForAsync(() => {
+    it(`should update available and displayed column ids on a new view`, async () => {
       let currentDataState: SkyDataManagerState;
 
       dataManagerService
@@ -775,96 +764,91 @@ describe('SkyDataManagerService', () => {
 
       dataManagerFixture.detectChanges();
 
-      dataManagerFixture.whenStable().then(() => {
-        const newView: SkyDataViewConfig = {
-          id: 'newView',
-          name: 'newView',
-          columnOptions: [
-            {
-              id: '1',
-              label: 'Column 1',
-            },
-            {
-              id: '2',
-              label: 'Column 2',
-            },
-            {
-              id: '3',
-              label: 'Column 3',
-              initialHide: true,
-            },
-          ],
-        };
-        let viewState = currentDataState.getViewStateById(newView.id);
+      await dataManagerFixture.whenStable();
+      const newView: SkyDataViewConfig = {
+        id: 'newView',
+        name: 'newView',
+        columnOptions: [
+          {
+            id: '1',
+            label: 'Column 1',
+          },
+          {
+            id: '2',
+            label: 'Column 2',
+          },
+          {
+            id: '3',
+            label: 'Column 3',
+            initialHide: true,
+          },
+        ],
+      };
+      let viewState = currentDataState.getViewStateById(newView.id);
 
-        expect(dataManagerService.getViewById(newView.id)).toBeUndefined();
-        expect(viewState).toBeUndefined();
+      expect(dataManagerService.getViewById(newView.id)).toBeUndefined();
+      expect(viewState).toBeUndefined();
 
-        dataManagerService.initDataView(newView);
-        viewState = currentDataState.getViewStateById(newView.id);
+      dataManagerService.initDataView(newView);
+      viewState = currentDataState.getViewStateById(newView.id);
 
-        expect(dataManagerService.getViewById(newView.id)).toEqual(newView);
-        expect(viewState).toEqual(
-          new SkyDataViewState({
-            viewId: 'newView',
-            columnIds: ['1', '2', '3'],
-            displayedColumnIds: ['1', '2'],
-            additionalData: undefined,
-          })
-        );
-      });
-    }));
+      expect(dataManagerService.getViewById(newView.id)).toEqual(newView);
+      expect(viewState).toEqual(
+        new SkyDataViewState({
+          viewId: 'newView',
+          columnIds: ['1', '2', '3'],
+          displayedColumnIds: ['1', '2'],
+          additionalData: undefined,
+        })
+      );
+    });
   });
 
   describe('views', () => {
-    it('getViewById should return the SkyDataViewConfig with the given id', waitForAsync(() => {
-      dataManagerFixture.whenStable().then(() => {
-        const repeaterViewConfig = dataManagerComponent.repeaterView.viewConfig;
+    it('getViewById should return the SkyDataViewConfig with the given id', async () => {
+      await dataManagerFixture.whenStable();
+      const repeaterViewConfig = dataManagerComponent.repeaterView.viewConfig;
 
-        expect(dataManagerService.getViewById(repeaterViewConfig.id)).toEqual(
-          repeaterViewConfig
-        );
-      });
-    }));
+      expect(dataManagerService.getViewById(repeaterViewConfig.id)).toEqual(
+        repeaterViewConfig
+      );
+    });
 
     describe('updateViewConfig', () => {
-      it('returns undefined when trying to update a view that it is not registered', waitForAsync(() => {
-        dataManagerFixture.whenStable().then(() => {
-          const newView = { id: 'newView', name: 'newView' };
+      it('returns undefined when trying to update a view that it is not registered', async () => {
+        await dataManagerFixture.whenStable();
+        const newView = { id: 'newView', name: 'newView' };
 
-          expect(dataManagerService.getViewById(newView.id)).toBeUndefined();
+        expect(dataManagerService.getViewById(newView.id)).toBeUndefined();
 
-          dataManagerService.updateViewConfig(newView);
+        dataManagerService.updateViewConfig(newView);
 
-          expect(dataManagerService.getViewById(newView.id)).toBeUndefined();
-        });
-      }));
+        expect(dataManagerService.getViewById(newView.id)).toBeUndefined();
+      });
 
-      it('updates a view config when it is already registered', waitForAsync(() => {
-        dataManagerFixture.whenStable().then(() => {
-          const repeaterViewConfig =
-            dataManagerComponent.repeaterView.viewConfig;
-          const modifiedConfig = {
-            id: repeaterViewConfig.id,
-            name: 'new name',
-          };
+      it('updates a view config when it is already registered', async () => {
+        await dataManagerFixture.whenStable();
+        const repeaterViewConfig = dataManagerComponent.repeaterView.viewConfig;
+        const modifiedConfig = {
+          id: repeaterViewConfig.id,
+          name: 'new name',
+        };
 
-          let registeredConfig = dataManagerService.getViewById(
-            repeaterViewConfig.id
-          );
+        let registeredConfig = dataManagerService.getViewById(
+          repeaterViewConfig.id
+        );
 
-          expect(registeredConfig).toEqual(repeaterViewConfig);
-          expect(registeredConfig).not.toEqual(modifiedConfig);
+        expect(registeredConfig).toEqual(repeaterViewConfig);
+        expect(registeredConfig).not.toEqual(modifiedConfig);
 
-          dataManagerService.updateViewConfig(modifiedConfig);
-          registeredConfig = dataManagerService.getViewById(
-            repeaterViewConfig.id
-          );
+        dataManagerService.updateViewConfig(modifiedConfig);
+        registeredConfig = dataManagerService.getViewById(
+          repeaterViewConfig.id
+        );
 
-          expect(registeredConfig).not.toEqual(repeaterViewConfig);
-          expect(registeredConfig).toEqual(modifiedConfig);
-        });
-      }));
+        expect(registeredConfig).not.toEqual(repeaterViewConfig);
+        expect(registeredConfig).toEqual(modifiedConfig);
+      });
     });
   });
 

--- a/libs/components/forms/src/lib/modules/character-counter/character-counter.component.spec.ts
+++ b/libs/components/forms/src/lib/modules/character-counter/character-counter.component.spec.ts
@@ -1,11 +1,10 @@
 import {
   ComponentFixture,
   TestBed,
-  async,
   fakeAsync,
   tick,
 } from '@angular/core/testing';
-import { expect } from '@skyux-sdk/testing';
+import { expect, expectAsync } from '@skyux-sdk/testing';
 
 import { SkyCharacterCounterIndicatorComponent } from './character-counter-indicator.component';
 import { CharacterCountNoIndicatorTestComponent } from './fixtures/character-count-no-indicator.component.fixture';
@@ -113,7 +112,7 @@ describe('Character Counter component', () => {
       ).toBeFalsy();
     }));
 
-    it('should only update the limit if different', async(() => {
+    it('should only update the limit if different', () => {
       const spy = spyOnProperty(
         characterCountComponent,
         'characterCountLimit',
@@ -133,7 +132,7 @@ describe('Character Counter component', () => {
       component.setCharacterCountLimit(10);
       fixture.detectChanges();
       expect(spy).toHaveBeenCalledWith(10);
-    }));
+    });
 
     it('should default the limit to zero', fakeAsync(() => {
       component.setCharacterCountLimit(5);
@@ -147,12 +146,11 @@ describe('Character Counter component', () => {
       expect(characterCountComponent.characterCountLimit).toEqual(0);
     }));
 
-    it('should pass accessibility', async(() => {
+    it('should pass accessibility', async () => {
       fixture.detectChanges();
-      fixture.whenStable().then(() => {
-        expect(fixture.nativeElement).toBeAccessible();
-      });
-    }));
+      await fixture.whenStable();
+      await expectAsync(fixture.nativeElement).toBeAccessible();
+    });
   });
 
   describe('without count indicator', () => {
@@ -190,11 +188,10 @@ describe('Character Counter component', () => {
       expect(component.firstName.valid).toBeTruthy();
     }));
 
-    it('should pass accessibility', async(() => {
+    it('should pass accessibility', async () => {
       fixture.detectChanges();
-      fixture.whenStable().then(() => {
-        expect(fixture.nativeElement).toBeAccessible();
-      });
-    }));
+      await fixture.whenStable();
+      await expectAsync(fixture.nativeElement).toBeAccessible();
+    });
   });
 });

--- a/libs/components/forms/src/lib/modules/file-attachment/file-item.component.spec.ts
+++ b/libs/components/forms/src/lib/modules/file-attachment/file-item.component.spec.ts
@@ -1,6 +1,6 @@
-import { ComponentFixture, TestBed, async } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { expect } from '@skyux-sdk/testing';
+import { expect, expectAsync } from '@skyux-sdk/testing';
 
 import { SkyFileAttachmentsModule } from './file-attachments.module';
 import { SkyFileItem } from './file-item';
@@ -131,7 +131,7 @@ describe('File item component', () => {
     expect(sizeEl.nativeElement.textContent).toContain('(1 KB)');
   });
 
-  it('shows the url if the item is a link', async(() => {
+  it('shows the url if the item is a link', async () => {
     componentInstance.fileItem = {
       url: '$/myFile.txt',
     };
@@ -146,10 +146,9 @@ describe('File item component', () => {
     expect(sizeEl).toBeFalsy();
 
     // Test Accessibility
-    fixture.whenStable().then(() => {
-      expect(fixture.nativeElement).toBeAccessible();
-    });
-  }));
+    await fixture.whenStable();
+    await expectAsync(fixture.nativeElement).toBeAccessible();
+  });
 
   it('emits the delete event when the delete button is clicked', () => {
     componentInstance.fileItem = {
@@ -187,14 +186,14 @@ describe('File item component', () => {
     expect(deletedFile.file.size).toBe(1000);
   });
 
-  it('shows an image if the item is an image', async(() => {
+  it('shows an image if the item is an image', () => {
     testImage('png');
     testImage('bmp');
     testImage('jpeg');
     testImage('gif');
-  }));
+  });
 
-  it('shows a file icon with the proper extension if it is not an image', async(() => {
+  it('shows a file icon with the proper extension if it is not an image', () => {
     testOtherPreview('pdf', 'pdf');
     testOtherPreview('gz', 'gz');
     testOtherPreview('rar', 'rar');
@@ -213,9 +212,9 @@ describe('File item component', () => {
     testOtherPreview('tiff', 'image');
     testOtherPreview('other', 'text');
     testOtherPreview('mp4', 'video');
-  }));
+  });
 
-  it('should pass accessibility', async(() => {
+  it('should pass accessibility', async () => {
     componentInstance.fileItem = {
       file: {
         name: 'myFile.txt',
@@ -223,8 +222,7 @@ describe('File item component', () => {
       },
     } as SkyFileItem;
     fixture.detectChanges();
-    fixture.whenStable().then(() => {
-      expect(fixture.nativeElement).toBeAccessible();
-    });
-  }));
+    await fixture.whenStable();
+    await expectAsync(fixture.nativeElement).toBeAccessible();
+  });
 });

--- a/libs/components/forms/src/lib/modules/toggle-switch/toggle-switch.component.spec.ts
+++ b/libs/components/forms/src/lib/modules/toggle-switch/toggle-switch.component.spec.ts
@@ -295,14 +295,6 @@ describe('Toggle switch component', () => {
     });
   });
 
-  describe('with multiple toggles', () => {
-    beforeEach(() => {
-      fixture = TestBed.createComponent(SkyToggleSwitchFixtureComponent);
-      fixture.debugElement.componentInstance.multiple = true;
-      fixture.detectChanges();
-    });
-  });
-
   describe('with ngModel and an initial value', () => {
     let toggleElement: DebugElement;
     let testComponent: SkyToggleSwitchFormDirectivesFixtureComponent;

--- a/libs/components/layout/src/lib/modules/back-to-top/back-to-top.component.spec.ts
+++ b/libs/components/layout/src/lib/modules/back-to-top/back-to-top.component.spec.ts
@@ -1,9 +1,4 @@
-import {
-  ComponentFixture,
-  TestBed,
-  async,
-  fakeAsync,
-} from '@angular/core/testing';
+import { ComponentFixture, TestBed, fakeAsync } from '@angular/core/testing';
 import { SkyAppTestUtility, expect } from '@skyux-sdk/testing';
 
 import { Subject } from 'rxjs';
@@ -208,7 +203,7 @@ describe('back to top component', () => {
       expect(backToTopElement).toBeNull();
     }));
 
-    it('should scroll to target element when back to top button is clicked', async(() => {
+    it('should scroll to target element when back to top button is clicked', () => {
       scrollElement(parentElement, 999, fixture);
       const backToTopTarget = getBackToTopTarget();
 
@@ -217,7 +212,7 @@ describe('back to top component', () => {
       clickBackToTopButton(fixture);
 
       expect(isElementInView(backToTopTarget)).toBe(true);
-    }));
+    });
   });
 
   describe('when the message stream is used', () => {

--- a/libs/components/modals/src/lib/modules/modal/modal-host.component.ts
+++ b/libs/components/modals/src/lib/modules/modal/modal-host.component.ts
@@ -157,7 +157,7 @@ export class SkyModalHostComponent implements OnDestroy {
       modalComponentRef.destroy();
     }
 
-    hostService.openHelp.subscribe((helpKey?: string) => {
+    hostService.openHelp.subscribe((helpKey) => {
       modalInstance.openHelp(helpKey);
     });
 

--- a/libs/components/modals/src/lib/modules/modal/modal-host.service.ts
+++ b/libs/components/modals/src/lib/modules/modal/modal-host.service.ts
@@ -1,4 +1,6 @@
-import { EventEmitter, Injectable } from '@angular/core';
+import { Injectable } from '@angular/core';
+
+import { Subject } from 'rxjs';
 
 const BASE_Z_INDEX = 1040;
 const modalHosts: SkyModalHostService[] = [];
@@ -28,9 +30,9 @@ export class SkyModalHostService {
     return modalHosts[modalHosts.length - 1];
   }
 
-  public close = new EventEmitter<void>();
+  public close = new Subject<void>();
   public fullPage = false;
-  public openHelp = new EventEmitter<any>();
+  public openHelp = new Subject<string>();
   public zIndex: number;
 
   constructor() {
@@ -43,11 +45,11 @@ export class SkyModalHostService {
   }
 
   public onClose(): void {
-    this.close.emit();
+    this.close.next();
   }
 
-  public onOpenHelp(helpKey?: string) {
-    this.openHelp.emit(helpKey);
+  public onOpenHelp(helpKey: string) {
+    this.openHelp.next(helpKey);
   }
 
   public destroy(): void {

--- a/libs/components/modals/src/lib/modules/modal/modal-instance.spec.ts
+++ b/libs/components/modals/src/lib/modules/modal/modal-instance.spec.ts
@@ -71,7 +71,7 @@ describe('Modal instance', () => {
       helpOpened = true;
     });
 
-    modalInstance.openHelp();
+    modalInstance.openHelp('foobar');
 
     expect(helpOpened).toEqual(true);
   });

--- a/libs/components/modals/src/lib/modules/modal/modal-instance.ts
+++ b/libs/components/modals/src/lib/modules/modal/modal-instance.ts
@@ -93,7 +93,7 @@ export class SkyModalInstance {
    * the modal instance's `helpOpened` event. Consumers can inject the `SkyModalInstance` provider
    * into a component's constructor to call the `openHelp` function in the modal template.
    */
-  public openHelp(helpKey?: string): void {
+  public openHelp(helpKey: string): void {
     this.#_helpOpened.next(helpKey);
   }
 

--- a/libs/components/modals/src/lib/modules/modal/modal.component.ts
+++ b/libs/components/modals/src/lib/modules/modal/modal.component.ts
@@ -219,7 +219,9 @@ export class SkyModalComponent implements AfterViewInit, OnDestroy {
   }
 
   public helpButtonClick() {
-    this.#hostService.onOpenHelp(this.helpKey);
+    if (this.helpKey) {
+      this.#hostService.onOpenHelp(this.helpKey);
+    }
   }
 
   public closeButtonClick() {

--- a/libs/components/packages/src/schematics/ng-add/ng-add.schematic.spec.ts
+++ b/libs/components/packages/src/schematics/ng-add/ng-add.schematic.spec.ts
@@ -37,6 +37,21 @@ describe('ng-add.schematic', () => {
     ).toEqual(1);
   });
 
+  it('should not apply the crossvent fix if it already exists', async () => {
+    tree.overwrite(
+      'projects/my-lib/src/test.ts',
+      '(window as any).global = window;'
+    );
+
+    const updatedTree = await runSchematic();
+
+    expect(
+      updatedTree
+        .readContent('projects/my-lib/src/test.ts')
+        .match(/\(window as any\)\.global = window/)?.length
+    ).toEqual(1);
+  });
+
   it('should install @angular/cdk', async () => {
     const updatedTree = await runSchematic();
 

--- a/libs/components/popovers/testing/src/dropdown/dropdown-fixture.spec.ts
+++ b/libs/components/popovers/testing/src/dropdown/dropdown-fixture.spec.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { ComponentFixture, TestBed, async } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { expect } from '@skyux-sdk/testing';
 import { SkyDropdownMenuChange } from '@skyux/popovers';
 import {
@@ -125,7 +125,7 @@ describe('Dropdown fixture', () => {
     dropdownFixture = new SkyDropdownFixture(fixture, DATA_SKY_ID);
   });
 
-  it('should expose the properties for the dropdown button', async(() => {
+  it('should expose the properties for the dropdown button', () => {
     // Give properties non-default values.
     testComponent.buttonStyle = 'primary';
     testComponent.buttonType = 'context-menu';
@@ -147,13 +147,13 @@ describe('Dropdown fixture', () => {
     expect(dropdownFixture.dropdown.buttonType).toEqual(
       testComponent.buttonType
     );
-  }));
+  });
 
-  it('should expose the inner text of the dropdown button', async(() => {
+  it('should expose the inner text of the dropdown button', () => {
     expect(dropdownFixture.dropdownButtonText).toEqual(
       testComponent.dropdownButtonText
     );
-  }));
+  });
 
   it('should open and close the dropdown menu when the dropdown button is clicked', async () => {
     await dropdownFixture.clickDropdownButton();

--- a/libs/components/progress-indicator/src/lib/modules/progress-indicator/progress-indicator.component.spec.ts
+++ b/libs/components/progress-indicator/src/lib/modules/progress-indicator/progress-indicator.component.spec.ts
@@ -3,7 +3,6 @@ import {
   TestBed,
   fakeAsync,
   tick,
-  waitForAsync,
 } from '@angular/core/testing';
 import { expect, expectAsync } from '@skyux-sdk/testing';
 import {
@@ -196,88 +195,83 @@ describe('Progress indicator component', function () {
     expect(componentInstance.emptyProgressIndicator.itemStatuses).toEqual([]);
   }));
 
-  it('should handle dynamic steps being added and removed', waitForAsync(function () {
+  it('should handle dynamic steps being added and removed', async () => {
     componentInstance.startingIndex = 2;
 
     fixture.detectChanges();
-    fixture.whenStable().then(() => {
-      // Verify that the desired index is set to Active,
-      // and all previous steps are set to Complete.
-      verifyActiveIndex(2);
-      verifyItemStatuses([
-        SkyProgressIndicatorItemStatus.Complete,
-        SkyProgressIndicatorItemStatus.Complete,
-        SkyProgressIndicatorItemStatus.Active,
-      ]);
+    await fixture.whenStable();
+    // Verify that the desired index is set to Active,
+    // and all previous steps are set to Complete.
+    verifyActiveIndex(2);
+    verifyItemStatuses([
+      SkyProgressIndicatorItemStatus.Complete,
+      SkyProgressIndicatorItemStatus.Complete,
+      SkyProgressIndicatorItemStatus.Active,
+    ]);
 
-      componentInstance.displayFourthItem();
+    componentInstance.displayFourthItem();
 
-      fixture.detectChanges();
-      fixture.whenStable().then(() => {
-        fixture.detectChanges();
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
 
-        // Verify that the desired index is set to Active,
-        // and all previous steps are set to Complete.
-        verifyActiveIndex(2);
-        verifyItemStatuses([
-          SkyProgressIndicatorItemStatus.Complete,
-          SkyProgressIndicatorItemStatus.Complete,
-          SkyProgressIndicatorItemStatus.Active,
-          SkyProgressIndicatorItemStatus.Incomplete,
-        ]);
+    // Verify that the desired index is set to Active,
+    // and all previous steps are set to Complete.
+    verifyActiveIndex(2);
+    verifyItemStatuses([
+      SkyProgressIndicatorItemStatus.Complete,
+      SkyProgressIndicatorItemStatus.Complete,
+      SkyProgressIndicatorItemStatus.Active,
+      SkyProgressIndicatorItemStatus.Incomplete,
+    ]);
 
-        componentInstance.sendMessage({
-          type: SkyProgressIndicatorMessageType.Progress,
-        });
-
-        fixture.detectChanges();
-        fixture.whenStable().then(() => {
-          // Verify that the desired index is set to Active,
-          // and all previous steps are set to Complete.
-          verifyActiveIndex(3);
-          verifyItemStatuses([
-            SkyProgressIndicatorItemStatus.Complete,
-            SkyProgressIndicatorItemStatus.Complete,
-            SkyProgressIndicatorItemStatus.Complete,
-            SkyProgressIndicatorItemStatus.Active,
-          ]);
-        });
-      });
+    componentInstance.sendMessage({
+      type: SkyProgressIndicatorMessageType.Progress,
     });
-  }));
 
-  it('should handle an index which is past the number of items', waitForAsync(function () {
+    fixture.detectChanges();
+    await fixture.whenStable();
+    // Verify that the desired index is set to Active,
+    // and all previous steps are set to Complete.
+    verifyActiveIndex(3);
+    verifyItemStatuses([
+      SkyProgressIndicatorItemStatus.Complete,
+      SkyProgressIndicatorItemStatus.Complete,
+      SkyProgressIndicatorItemStatus.Complete,
+      SkyProgressIndicatorItemStatus.Active,
+    ]);
+  });
+
+  it('should handle an index which is past the number of items', async () => {
     componentInstance.startingIndex = 3;
     componentInstance.displayFourthItem();
 
     fixture.detectChanges();
-    fixture.whenStable().then(() => {
-      fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
 
-      // Verify that the desired index is set to Active,
-      // and all previous steps are set to Complete.
-      verifyActiveIndex(3);
-      verifyItemStatuses([
-        SkyProgressIndicatorItemStatus.Complete,
-        SkyProgressIndicatorItemStatus.Complete,
-        SkyProgressIndicatorItemStatus.Complete,
-        SkyProgressIndicatorItemStatus.Active,
-      ]);
+    // Verify that the desired index is set to Active,
+    // and all previous steps are set to Complete.
+    verifyActiveIndex(3);
+    verifyItemStatuses([
+      SkyProgressIndicatorItemStatus.Complete,
+      SkyProgressIndicatorItemStatus.Complete,
+      SkyProgressIndicatorItemStatus.Complete,
+      SkyProgressIndicatorItemStatus.Active,
+    ]);
 
-      componentInstance.hideFourthItem();
-      fixture.detectChanges();
-      fixture.whenStable().then(() => {
-        // Verify that the desired index is set to Active,
-        // and all previous steps are set to Complete.
-        verifyActiveIndex(2);
-        verifyItemStatuses([
-          SkyProgressIndicatorItemStatus.Complete,
-          SkyProgressIndicatorItemStatus.Complete,
-          SkyProgressIndicatorItemStatus.Active,
-        ]);
-      });
-    });
-  }));
+    componentInstance.hideFourthItem();
+    fixture.detectChanges();
+    await fixture.whenStable();
+    // Verify that the desired index is set to Active,
+    // and all previous steps are set to Complete.
+    verifyActiveIndex(2);
+    verifyItemStatuses([
+      SkyProgressIndicatorItemStatus.Complete,
+      SkyProgressIndicatorItemStatus.Complete,
+      SkyProgressIndicatorItemStatus.Active,
+    ]);
+  });
 
   describe('Passive mode', function () {
     beforeEach(function () {

--- a/libs/sdk/e2e-schematics/src/utils/ast-utils.spec.ts
+++ b/libs/sdk/e2e-schematics/src/utils/ast-utils.spec.ts
@@ -3,10 +3,10 @@ import {
   componentGenerator,
 } from '@nrwl/angular/generators';
 import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import * as ts from '@schematics/angular/third_party/github.com/Microsoft/TypeScript/lib/typescript';
 
 import { wrapAngularDevkitSchematic } from 'nx/src/adapter/ngcli-adapter';
 import { createTree } from 'nx/src/generators/testing-utils/create-tree';
-import * as ts from 'typescript';
 
 import { angularModuleGenerator } from './angular-module-generator';
 import {

--- a/libs/sdk/e2e-schematics/src/utils/ast-utils.ts
+++ b/libs/sdk/e2e-schematics/src/utils/ast-utils.ts
@@ -1,7 +1,6 @@
 import { getSourceNodes } from '@angular/cdk/schematics';
 import { Tree } from '@nrwl/devkit';
-
-import * as ts from 'typescript';
+import * as ts from '@schematics/angular/third_party/github.com/Microsoft/TypeScript/lib/typescript';
 
 export type DecoratedClass = {
   classDeclaration: ts.ClassDeclaration;

--- a/libs/sdk/e2e-schematics/src/utils/find-module.ts
+++ b/libs/sdk/e2e-schematics/src/utils/find-module.ts
@@ -1,7 +1,7 @@
 import { Tree, normalizePath, visitNotIgnoredFiles } from '@nrwl/devkit';
+import * as ts from '@schematics/angular/third_party/github.com/Microsoft/TypeScript/lib/typescript';
 
 import { relative } from 'path';
-import * as ts from 'typescript';
 
 import {
   DecoratedClass,

--- a/libs/sdk/testing/src/lib/matchers/matchers.ts
+++ b/libs/sdk/testing/src/lib/matchers/matchers.ts
@@ -2,6 +2,7 @@ import { TestBed } from '@angular/core/testing';
 import { SkyAppResourcesService, SkyLibResourcesService } from '@skyux/i18n';
 
 import { Observable } from 'rxjs';
+import { take } from 'rxjs/operators';
 
 import { SkyA11yAnalyzer } from '../a11y/a11y-analyzer';
 import { SkyA11yAnalyzerConfig } from '../a11y/a11y-analyzer-config';
@@ -335,8 +336,8 @@ const matchers: jasmine.CustomMatcherFactories = {
         const actual = el.textContent;
 
         getResourcesObservable(name)
-          .toPromise()
-          .then((message) => {
+          .pipe(take(1))
+          .subscribe((message) => {
             if (!isTemplateMatch(actual, message)) {
               windowRef.fail(
                 `Expected element's text "${actual}" to match "${message}"`
@@ -519,8 +520,8 @@ const asyncMatchers: jasmine.CustomAsyncMatcherFactories = {
           const actual = element.textContent;
 
           getResourcesObservable(name)
-            .toPromise()
-            .then((message) => {
+            .pipe(take(1))
+            .subscribe((message) => {
               if (isTemplateMatch(actual, message)) {
                 resolve({
                   pass: true,
@@ -546,9 +547,9 @@ const asyncMatchers: jasmine.CustomAsyncMatcherFactories = {
         return new Promise((resolve) => {
           const actual = element.textContent;
 
-          getLibResourcesObservable(name)
-            .toPromise()
-            .then((message) => {
+          getResourcesObservable(name)
+            .pipe(take(1))
+            .subscribe((message) => {
               if (isTemplateMatch(actual, message)) {
                 resolve({
                   pass: true,

--- a/libs/sdk/testing/src/lib/matchers/matchers.ts
+++ b/libs/sdk/testing/src/lib/matchers/matchers.ts
@@ -547,7 +547,7 @@ const asyncMatchers: jasmine.CustomAsyncMatcherFactories = {
         return new Promise((resolve) => {
           const actual = element.textContent;
 
-          getResourcesObservable(name)
+          getLibResourcesObservable(name)
             .pipe(take(1))
             .subscribe((message) => {
               if (isTemplateMatch(actual, message)) {

--- a/libs/sdk/testing/src/lib/test-utility/test-utility.spec.ts
+++ b/libs/sdk/testing/src/lib/test-utility/test-utility.spec.ts
@@ -14,7 +14,7 @@ import { SkyAppTestUtility } from './test-utility';
 //#region test components
 
 @Component({
-  selector: 'sky-test-parent-cmp',
+  selector: 'test-parent-cmp',
   template: `
     <test-cmp [attr.data-sky-id]="'my-id'"> My component. </test-cmp>
   `,
@@ -22,7 +22,7 @@ import { SkyAppTestUtility } from './test-utility';
 class TestParentComponent {}
 
 @Component({
-  selector: 'sky-test-cmp',
+  selector: 'test-cmp',
   template: `<ng-content></ng-content>`,
 })
 class TestComponent {}

--- a/workspace.json
+++ b/workspace.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "./node_modules/nx/schemas/workspace-schema.json",
   "version": 2,
   "projects": {
     "a11y": "libs/components/a11y",


### PR DESCRIPTION
- Some of our async tests that were using the deprecated `async()` function were timing out.
- Fixed the modals strict mode implementation.
- Various changes.