### PR TITLE
feat(components/tabs): wizard keyboard nav and roles

### DIFF
--- a/libs/components/modals/src/lib/modules/modal/modal.component.html
+++ b/libs/components/modals/src/lib/modules/modal/modal.component.html
@@ -59,7 +59,7 @@
     <div
       class="sky-modal-content sky-padding-even-large"
       role="region"
-      tabindex="0"
+      tabindex="-1"
       [attr.aria-labelledby]="modalHeaderId"
       [attr.id]="modalContentId"
       (skyModalScrollShadow)="scrollShadowChange($event)"

--- a/libs/components/tabs/src/lib/modules/tabs/fixtures/tabset.component.fixture.html
+++ b/libs/components/tabs/src/lib/modules/tabs/fixtures/tabset.component.fixture.html
@@ -1,5 +1,9 @@
 <div [ngStyle]="{'max-width.px': tabMaxWidth}">
-  <sky-tabset [ariaLabel]="ariaLabel" [ariaLabelledBy]="ariaLabelledBy">
+  <sky-tabset
+    [ariaLabel]="ariaLabel"
+    [ariaLabelledBy]="ariaLabelledBy"
+    tabStyle="tabs"
+  >
     <sky-tab [tabHeading]="tab1Heading" [active]="activeTab === 0">
       <div class="tabset-test-content-1">{{tab1Content}}</div>
     </sky-tab>

--- a/libs/components/tabs/src/lib/modules/tabs/tab-button-adapter.service.ts
+++ b/libs/components/tabs/src/lib/modules/tabs/tab-button-adapter.service.ts
@@ -1,0 +1,11 @@
+import { ElementRef, Injectable } from '@angular/core';
+
+/**
+ * @internal
+ */
+@Injectable()
+export class SkyTabButtonAdapterService {
+  public focusButtonLink(buttonEl: ElementRef): void {
+    buttonEl.nativeElement.querySelector('a').focus();
+  }
+}

--- a/libs/components/tabs/src/lib/modules/tabs/tab-button-view-model.ts
+++ b/libs/components/tabs/src/lib/modules/tabs/tab-button-view-model.ts
@@ -1,0 +1,16 @@
+import { SkyTabIndex } from './tab-index';
+
+/**
+ * @internal
+ */
+export type TabButtonViewModel = {
+  active: boolean;
+  ariaControls: string;
+  buttonHref: string;
+  buttonId: string;
+  buttonText: string;
+  buttonTextCount: string;
+  closeable: boolean;
+  disabled: boolean;
+  tabIndex: SkyTabIndex;
+};

--- a/libs/components/tabs/src/lib/modules/tabs/tab-button.component.html
+++ b/libs/components/tabs/src/lib/modules/tabs/tab-button.component.html
@@ -7,7 +7,7 @@
 >
   <a
     class="sky-btn-tab"
-    role="tab"
+    [attr.role]="elementRole"
     [attr.aria-controls]="ariaControls"
     [attr.aria-disabled]="disabled"
     [attr.aria-selected]="active"

--- a/libs/components/tabs/src/lib/modules/tabs/tab-button.component.html
+++ b/libs/components/tabs/src/lib/modules/tabs/tab-button.component.html
@@ -6,6 +6,7 @@
   }"
 >
   <a
+    #tabButtonEl
     class="sky-btn-tab"
     [attr.role]="elementRole"
     [attr.aria-controls]="ariaControls"
@@ -19,9 +20,10 @@
       'sky-btn-tab-disabled': disabled,
       'sky-tab-btn-closeable': closeable
     }"
-    [tabindex]="disabled ? '-1' : '0'"
+    [tabindex]="active ? '0' : '-1'"
     (click)="onButtonClick($event)"
     (keydown)="onTabButtonKeyDown($event)"
+    (focus)="onFocus()"
   >
     <span class="sky-tab-heading">
       {{ buttonText }}
@@ -34,6 +36,7 @@
   <button
     *ngIf="closeable"
     class="sky-btn-tab-close"
+    [tabindex]="closeBtnTabIndex"
     type="button"
     [attr.aria-label]="'skyux_tab_close' | skyLibResources: buttonText"
     [disabled]="disabled"

--- a/libs/components/tabs/src/lib/modules/tabs/tab-button.component.ts
+++ b/libs/components/tabs/src/lib/modules/tabs/tab-button.component.ts
@@ -19,6 +19,8 @@ import { SkyTabIndex } from './tab-index';
 import { SkyTabsetStyle } from './tabset-style';
 import { SkyTabsetService } from './tabset.service';
 
+const DEFAULT_ELEMENT_ROLE = 'tab';
+
 /**
  * @internal
  */
@@ -63,9 +65,9 @@ export class SkyTabButtonComponent implements AfterViewInit, OnDestroy {
     return this.#_tabStyle;
   }
 
-  public set tabStyle(style: SkyTabsetStyle) {
+  public set tabStyle(style: SkyTabsetStyle | undefined) {
     this.#_tabStyle = style;
-    this.elementRole = style === 'tabs' ? 'tab' : undefined;
+    this.elementRole = style === 'tabs' ? DEFAULT_ELEMENT_ROLE : undefined;
   }
 
   @Output()
@@ -86,7 +88,7 @@ export class SkyTabButtonComponent implements AfterViewInit, OnDestroy {
     this.#tabsetService = tabsetService;
   }
 
-  public elementRole: string | undefined = 'tab';
+  public elementRole: string | undefined = DEFAULT_ELEMENT_ROLE;
   public closeBtnTabIndex = '-1';
 
   #_tabStyle: SkyTabsetStyle;

--- a/libs/components/tabs/src/lib/modules/tabs/tab-button.component.ts
+++ b/libs/components/tabs/src/lib/modules/tabs/tab-button.component.ts
@@ -1,13 +1,23 @@
 import {
+  AfterViewInit,
   ChangeDetectionStrategy,
+  ChangeDetectorRef,
   Component,
+  ElementRef,
   EventEmitter,
   Input,
+  OnDestroy,
   Output,
   ViewEncapsulation,
 } from '@angular/core';
 
+import { Subject } from 'rxjs';
+import { distinctUntilChanged, takeUntil } from 'rxjs/operators';
+
+import { SkyTabButtonAdapterService } from './tab-button-adapter.service';
+import { SkyTabIndex } from './tab-index';
 import { SkyTabsetStyle } from './tabset-style';
+import { SkyTabsetService } from './tabset.service';
 
 /**
  * @internal
@@ -16,10 +26,11 @@ import { SkyTabsetStyle } from './tabset-style';
   selector: 'sky-tab-button',
   templateUrl: './tab-button.component.html',
   styleUrls: ['./tab-button.component.scss'],
+  providers: [SkyTabButtonAdapterService],
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
 })
-export class SkyTabButtonComponent {
+export class SkyTabButtonComponent implements AfterViewInit, OnDestroy {
   @Input()
   public active: boolean;
 
@@ -45,13 +56,16 @@ export class SkyTabButtonComponent {
   public disabled: boolean;
 
   @Input()
+  public tabIndex: SkyTabIndex;
+
+  @Input()
   public get tabStyle(): SkyTabsetStyle {
     return this.#_tabStyle;
   }
 
   public set tabStyle(style: SkyTabsetStyle) {
     this.#_tabStyle = style;
-    this.elementRole = style === 'tabs' ? 'tab' : 'link';
+    this.elementRole = style === 'tabs' ? 'tab' : undefined;
   }
 
   @Output()
@@ -60,10 +74,46 @@ export class SkyTabButtonComponent {
   @Output()
   public closeClick = new EventEmitter<void>();
 
+  constructor(
+    elementRef: ElementRef,
+    adapterService: SkyTabButtonAdapterService,
+    changeDetectorRef: ChangeDetectorRef,
+    tabsetService: SkyTabsetService
+  ) {
+    this.#adapterService = adapterService;
+    this.#changeDetectorRef = changeDetectorRef;
+    this.#elementRef = elementRef;
+    this.#tabsetService = tabsetService;
+  }
 
-  public elementRole = 'tab';
+  public elementRole: string | undefined = 'tab';
+  public closeBtnTabIndex = '-1';
+
   #_tabStyle: SkyTabsetStyle;
+  #adapterService: SkyTabButtonAdapterService;
+  #changeDetectorRef: ChangeDetectorRef;
+  #elementRef: ElementRef;
+  #tabsetService: SkyTabsetService;
+  #ngUnsubscribe = new Subject<void>();
 
+  public ngAfterViewInit(): void {
+    this.#tabsetService.focusedTabBtnIndex
+      .pipe(distinctUntilChanged(), takeUntil(this.#ngUnsubscribe))
+      .subscribe((focusedIndex) => {
+        if (focusedIndex === this.tabIndex) {
+          this.closeBtnTabIndex = '0';
+          this.focusBtn();
+        } else {
+          this.closeBtnTabIndex = '-1';
+        }
+        this.#changeDetectorRef.markForCheck();
+      });
+  }
+
+  public ngOnDestroy(): void {
+    this.#ngUnsubscribe.next();
+    this.#ngUnsubscribe.complete();
+  }
 
   public onButtonClick(event: any): void {
     if (!this.disabled) {
@@ -94,5 +144,13 @@ export class SkyTabButtonComponent {
     // otherwise it will trigger a page refresh.
     event.stopPropagation();
     event.preventDefault();
+  }
+
+  public focusBtn(): void {
+    this.#adapterService.focusButtonLink(this.#elementRef);
+  }
+
+  public onFocus(): void {
+    this.#tabsetService.setFocusedTabBtnIndex(this.tabIndex);
   }
 }

--- a/libs/components/tabs/src/lib/modules/tabs/tab-button.component.ts
+++ b/libs/components/tabs/src/lib/modules/tabs/tab-button.component.ts
@@ -45,13 +45,25 @@ export class SkyTabButtonComponent {
   public disabled: boolean;
 
   @Input()
-  public tabStyle: SkyTabsetStyle;
+  public get tabStyle(): SkyTabsetStyle {
+    return this.#_tabStyle;
+  }
+
+  public set tabStyle(style: SkyTabsetStyle) {
+    this.#_tabStyle = style;
+    this.elementRole = style === 'tabs' ? 'tab' : 'link';
+  }
 
   @Output()
   public buttonClick = new EventEmitter<void>();
 
   @Output()
   public closeClick = new EventEmitter<void>();
+
+
+  public elementRole = 'tab';
+  #_tabStyle: SkyTabsetStyle;
+
 
   public onButtonClick(event: any): void {
     if (!this.disabled) {

--- a/libs/components/tabs/src/lib/modules/tabs/tabset-nav-button.component.spec.ts
+++ b/libs/components/tabs/src/lib/modules/tabs/tabset-nav-button.component.spec.ts
@@ -1,4 +1,4 @@
-import { TestBed, async, fakeAsync, tick } from '@angular/core/testing';
+import { TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { expect, expectAsync } from '@skyux-sdk/testing';
 import { SkyLogService } from '@skyux/core';
 
@@ -64,13 +64,13 @@ describe('Tabset navigation button', () => {
 
   describe('wizard style', () => {
     describe('without finish button', () => {
-      it('should be accessible', async(async () => {
+      it('should be accessible', async () => {
         const fixture = TestBed.createComponent(SkyWizardTestFormComponent);
         fixture.detectChanges();
         await fixture.whenStable();
         fixture.detectChanges();
         await expectAsync(fixture.nativeElement).toBeAccessible();
-      }));
+      });
 
       describe('previous button', () => {
         it('should navigate to the previous tab when clicked', fakeAsync(() => {

--- a/libs/components/tabs/src/lib/modules/tabs/tabset.component.html
+++ b/libs/components/tabs/src/lib/modules/tabs/tabset.component.html
@@ -1,12 +1,16 @@
 <div
   class="sky-tabset"
-  role="tablist"
+  [attr.role]="elementRole"
   [attr.aria-label]="ariaLabel"
   [attr.aria-labelledby]="ariaLabelledBy"
   [ngClass]="
     'sky-tabset-mode-' + tabDisplayMode + ' sky-tabset-style-' + tabStyle
   "
   (window:resize)="onWindowResize()"
+  (keydown.arrowright)="onRightKeyDown()"
+  (keydown.arrowleft)="onLeftKeyDown()"
+  (keydown.home)="onHomeKeyDown()"
+  (keydown.end)="onEndKeyDown()"
 >
   <span class="sky-tabset-dropdown">
     <sky-dropdown *ngIf="tabDisplayMode === 'dropdown'" buttonType="tab">
@@ -88,6 +92,7 @@
     [buttonTextCount]="tabButton.buttonTextCount"
     [closeable]="tabButton.closeable"
     [disabled]="tabButton.disabled"
+    [tabIndex]="tabButton.tabIndex"
     [tabStyle]="tabStyle"
     (buttonClick)="onTabButtonClick(tabButton)"
     (closeClick)="onTabCloseClick(tabButton)"

--- a/libs/components/tabs/src/lib/modules/tabs/tabset.component.ts
+++ b/libs/components/tabs/src/lib/modules/tabs/tabset.component.ts
@@ -16,6 +16,7 @@ import {
 import { Subject, combineLatest, race } from 'rxjs';
 import { distinctUntilChanged, takeUntil } from 'rxjs/operators';
 
+import { TabButtonViewModel } from './tab-button-view-model';
 import { SkyTabIndex } from './tab-index';
 import { SkyTabComponent } from './tab.component';
 import { SkyTabsetAdapterService } from './tabset-adapter.service';
@@ -24,21 +25,6 @@ import { SkyTabsetPermalinkService } from './tabset-permalink.service';
 import { SkyTabsetStyle } from './tabset-style';
 import { SkyTabsetTabIndexesChange } from './tabset-tab-indexes-change';
 import { SkyTabsetService } from './tabset.service';
-
-/**
- * @internal
- */
-interface TabButtonViewModel {
-  active: boolean;
-  ariaControls: string;
-  buttonHref: string;
-  buttonId: string;
-  buttonText: string;
-  buttonTextCount: string;
-  closeable: boolean;
-  disabled: boolean;
-  tabIndex: SkyTabIndex;
-}
 
 @Component({
   selector: 'sky-tabset',
@@ -134,6 +120,7 @@ export class SkyTabsetComponent implements AfterViewInit, OnDestroy {
   @Input()
   public set tabStyle(value: SkyTabsetStyle) {
     this._tabStyle = value;
+    this.elementRole = value === 'tabs' ? 'tablist' : undefined;
   }
 
   public get tabStyle(): SkyTabsetStyle {
@@ -198,6 +185,8 @@ export class SkyTabsetComponent implements AfterViewInit, OnDestroy {
   public lastActiveTabIndex: SkyTabIndex;
 
   public tabButtons: TabButtonViewModel[] = [];
+
+  public elementRole: string | undefined = 'tablist';
 
   private ngUnsubscribe = new Subject<void>();
 
@@ -280,6 +269,22 @@ export class SkyTabsetComponent implements AfterViewInit, OnDestroy {
 
   public onOpenTabClick(): void {
     this.openTab.emit();
+  }
+
+  public onRightKeyDown(): void {
+    this.tabsetService.focusNextTabBtn(this.tabButtons);
+  }
+
+  public onLeftKeyDown(): void {
+    this.tabsetService.focusPrevTabBtn(this.tabButtons);
+  }
+
+  public onHomeKeyDown(): void {
+    this.tabsetService.focusFirstTabBtn(this.tabButtons);
+  }
+
+  public onEndKeyDown(): void {
+    this.tabsetService.focusLastTabBtn(this.tabButtons);
   }
 
   /**

--- a/libs/components/tabs/src/lib/modules/tabs/tabset.component.ts
+++ b/libs/components/tabs/src/lib/modules/tabs/tabset.component.ts
@@ -26,6 +26,8 @@ import { SkyTabsetStyle } from './tabset-style';
 import { SkyTabsetTabIndexesChange } from './tabset-tab-indexes-change';
 import { SkyTabsetService } from './tabset.service';
 
+const DEFAULT_ELEMENT_ROLE = 'tablist';
+
 @Component({
   selector: 'sky-tabset',
   styleUrls: ['./tabset.component.scss'],
@@ -120,7 +122,7 @@ export class SkyTabsetComponent implements AfterViewInit, OnDestroy {
   @Input()
   public set tabStyle(value: SkyTabsetStyle) {
     this._tabStyle = value;
-    this.elementRole = value === 'tabs' ? 'tablist' : undefined;
+    this.elementRole = value === 'tabs' ? DEFAULT_ELEMENT_ROLE : undefined;
   }
 
   public get tabStyle(): SkyTabsetStyle {
@@ -186,7 +188,7 @@ export class SkyTabsetComponent implements AfterViewInit, OnDestroy {
 
   public tabButtons: TabButtonViewModel[] = [];
 
-  public elementRole: string | undefined = 'tablist';
+  public elementRole: string | undefined = DEFAULT_ELEMENT_ROLE;
 
   private ngUnsubscribe = new Subject<void>();
 

--- a/libs/components/tabs/src/lib/modules/tabs/tabset.component.ts
+++ b/libs/components/tabs/src/lib/modules/tabs/tabset.component.ts
@@ -280,11 +280,11 @@ export class SkyTabsetComponent implements AfterViewInit, OnDestroy {
   }
 
   public onHomeKeyDown(): void {
-    this.tabsetService.focusFirstTabBtn(this.tabButtons);
+    this.tabsetService.focusFirstOrNearestTabBtn(this.tabButtons);
   }
 
   public onEndKeyDown(): void {
-    this.tabsetService.focusLastTabBtn(this.tabButtons);
+    this.tabsetService.focusLastOrNearestTabBtn(this.tabButtons);
   }
 
   /**

--- a/libs/components/tabs/src/lib/modules/tabs/tabset.service.ts
+++ b/libs/components/tabs/src/lib/modules/tabs/tabset.service.ts
@@ -100,7 +100,7 @@ export class SkyTabsetService {
     }
   }
 
-  public focusFirstTabBtn(tabButtons: TabButtonViewModel[]): void {
+  public focusFirstOrNearestTabBtn(tabButtons: TabButtonViewModel[]): void {
     for (let i = 0; i < tabButtons.length; i++) {
       const tabBtn = tabButtons[i];
 
@@ -111,7 +111,7 @@ export class SkyTabsetService {
     }
   }
 
-  public focusLastTabBtn(tabButtons: TabButtonViewModel[]): void {
+  public focusLastOrNearestTabBtn(tabButtons: TabButtonViewModel[]): void {
     for (let i = tabButtons.length - 1; i >= 0; i--) {
       const tabBtn = tabButtons[i];
 

--- a/libs/components/tabs/src/lib/modules/tabs/tabset.service.ts
+++ b/libs/components/tabs/src/lib/modules/tabs/tabset.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@angular/core';
 
 import { BehaviorSubject, Observable, Subject } from 'rxjs';
 
+import { TabButtonViewModel } from './tab-button-view-model';
 import { SkyTabIndex } from './tab-index';
 import { SkyTabsetActiveTabUnregisteredArgs } from './tabset-active-tab-unregistered-args';
 
@@ -18,9 +19,17 @@ export class SkyTabsetService {
     return this._activeTabIndex.asObservable();
   }
 
+  public get focusedTabBtnIndex(): Observable<SkyTabIndex> {
+    return this._focusedTabBtnIndex.asObservable();
+  }
+
   public currentActiveTabIndex: SkyTabIndex = 0;
 
+  public currentFocusedTabBtnIndex: SkyTabIndex = 0;
+
   private _activeTabIndex = new BehaviorSubject<SkyTabIndex>(0);
+
+  private _focusedTabBtnIndex = new Subject<SkyTabIndex>();
 
   private _activeTabUnregistered =
     new Subject<SkyTabsetActiveTabUnregisteredArgs>();
@@ -45,11 +54,77 @@ export class SkyTabsetService {
       !this.tabIndexesEqual(value, this.currentActiveTabIndex)
     ) {
       this.currentActiveTabIndex = value;
+
       /* istanbul ignore else */
       if (config.emitChange) {
         this._activeTabIndex.next(value);
       }
+
+      this.setFocusedTabBtnIndex(value);
     }
+  }
+
+  public focusNextTabBtn(tabButtons: TabButtonViewModel[]): void {
+    const currentTabArrayIndex = this.tabs.findIndex((tab) =>
+      this.tabIndexesEqual(tab.tabIndex, this.currentFocusedTabBtnIndex)
+    );
+
+    for (
+      let i = this.getNextTabArrayIndex(currentTabArrayIndex);
+      i !== currentTabArrayIndex;
+      i = this.getNextTabArrayIndex(i)
+    ) {
+      const tabBtn = tabButtons[i];
+      if (!tabBtn.disabled) {
+        this.setFocusedTabBtnIndex(tabBtn.tabIndex);
+        return;
+      }
+    }
+  }
+
+  public focusPrevTabBtn(tabButtons: TabButtonViewModel[]): void {
+    const currentTabArrayIndex = this.tabs.findIndex((tab) =>
+      this.tabIndexesEqual(tab.tabIndex, this.currentFocusedTabBtnIndex)
+    );
+
+    for (
+      let i = this.getPrevTabArrayIndex(currentTabArrayIndex);
+      i !== currentTabArrayIndex;
+      i = this.getPrevTabArrayIndex(i)
+    ) {
+      const tabBtn = tabButtons[i];
+      if (!tabBtn.disabled) {
+        this.setFocusedTabBtnIndex(tabBtn.tabIndex);
+        return;
+      }
+    }
+  }
+
+  public focusFirstTabBtn(tabButtons: TabButtonViewModel[]): void {
+    for (let i = 0; i < tabButtons.length; i++) {
+      const tabBtn = tabButtons[i];
+
+      if (!tabBtn.disabled) {
+        this.setFocusedTabBtnIndex(tabBtn.tabIndex);
+        return;
+      }
+    }
+  }
+
+  public focusLastTabBtn(tabButtons: TabButtonViewModel[]): void {
+    for (let i = tabButtons.length - 1; i >= 0; i--) {
+      const tabBtn = tabButtons[i];
+
+      if (!tabBtn.disabled) {
+        this.setFocusedTabBtnIndex(tabBtn.tabIndex);
+        return;
+      }
+    }
+  }
+
+  public setFocusedTabBtnIndex(tabIndex: SkyTabIndex): void {
+    this.currentFocusedTabBtnIndex = tabIndex;
+    this._focusedTabBtnIndex.next(tabIndex);
   }
 
   /**
@@ -143,5 +218,25 @@ export class SkyTabsetService {
 
   private isTabIndexActive(tabIndex: SkyTabIndex): boolean {
     return this.tabIndexesEqual(tabIndex, this.currentActiveTabIndex);
+  }
+
+  private getNextTabArrayIndex(currentIndex: number): number {
+    let nextIndex = currentIndex + 1;
+
+    if (nextIndex === this.tabs.length) {
+      nextIndex = 0;
+    }
+
+    return nextIndex;
+  }
+
+  private getPrevTabArrayIndex(currentIndex: number): number {
+    let prevIndex = currentIndex - 1;
+
+    if (prevIndex < 0) {
+      prevIndex = this.tabs.length - 1;
+    }
+
+    return prevIndex;
   }
 }


### PR DESCRIPTION
Updates include:
- not setting tab roles (tab, tablist) when the tabset is in wizard mode
- updating keyboard nav
  - clicking tab on a tab button (or wizard button) now goes immediately to the tab content (or whatever is next if nothing in the tab content) instead of needing to click through _all_ tabs to get to the content
  - left/right arrow keys are used to navigate the tab buttons
  - hitting left on the first tab goes to the last, hitting right on the last goes to the first (so they loop)
  - disabled tabs are skipped
  - home key goes to the first tab (or nearest one that is not disabled)
  - end key goes to the last tab (or nearest one that is not disabled)