### PR TITLE
feat(components/indicators): remove support for key info layout string type

### DIFF
--- a/libs/components/indicators/src/lib/modules/key-info/fixtures/key-info.component.fixture.ts
+++ b/libs/components/indicators/src/lib/modules/key-info/fixtures/key-info.component.fixture.ts
@@ -1,9 +1,11 @@
 import { Component } from '@angular/core';
 
+import { SkyKeyInfoLayoutType } from '../key-info-layout-type';
+
 @Component({
   selector: 'sky-test-cmp',
   templateUrl: './key-info.component.fixture.html',
 })
 export class KeyInfoTestComponent {
-  public layout: string | undefined = 'vertical';
+  public layout: SkyKeyInfoLayoutType | undefined = 'vertical';
 }

--- a/libs/components/indicators/src/lib/modules/key-info/key-info.component.ts
+++ b/libs/components/indicators/src/lib/modules/key-info/key-info.component.ts
@@ -15,5 +15,5 @@ export class SkyKeyInfoComponent {
    */
   // TODO: More strongly type this in a future breaking change.
   @Input()
-  public layout: SkyKeyInfoLayoutType | string | undefined = 'vertical';
+  public layout: SkyKeyInfoLayoutType | undefined = 'vertical';
 }


### PR DESCRIPTION

BREAKING CHANGE: This change updates the types accepted by the key info component's layout property. To address this change, only pass 'horizontal' or 'vertical' to the property, and use the
 type `SkyKeyInfoLayoutType` if typing variables.