### PR TITLE
feat(components/tabs): remove support for not using a finish nav button

### DIFF
--- a/apps/e2e/tabs-storybook/src/app/wizard/wizard-modal.component.html
+++ b/apps/e2e/tabs-storybook/src/app/wizard/wizard-modal.component.html
@@ -56,13 +56,11 @@
         buttonType="next"
         [tabset]="wizardDemo"
       ></sky-tabset-nav-button>
-      <button
-        class="sky-btn sky-btn-primary sky-inline-margin-sm"
-        type="submit"
+      <sky-tabset-nav-button
+        buttonType="finish"
+        [tabset]="wizardDemo"
         [disabled]="saveDisabled"
-      >
-        Save
-      </button>
+      ></sky-tabset-nav-button>
       <button
         class="sky-btn sky-btn-link"
         type="button"

--- a/apps/playground/src/app/components/tabs/wizard/wizard-dropdown-demo-modal.component.html
+++ b/apps/playground/src/app/components/tabs/wizard/wizard-dropdown-demo-modal.component.html
@@ -62,13 +62,11 @@
         buttonType="next"
         [tabset]="wizardDemo"
       ></sky-tabset-nav-button>
-      <button
-        class="sky-btn sky-btn-primary sky-inline-margin-sm"
-        type="submit"
+      <sky-tabset-nav-button
+        buttonType="finish"
+        [tabset]="wizardDemo"
         [disabled]="saveDisabled"
-      >
-        Save
-      </button>
+      ></sky-tabset-nav-button>
       <button
         class="sky-btn sky-btn-link"
         type="button"

--- a/apps/playground/src/app/components/tabs/wizard/wizard-dropdown-demo-modal.component.ts
+++ b/apps/playground/src/app/components/tabs/wizard/wizard-dropdown-demo-modal.component.ts
@@ -33,7 +33,7 @@ export class WizardDropdownDemoModalComponent implements OnInit {
   public checkRequirementsMet(): void {
     this.step2Disabled = !this.myForm.get('requiredValue1')?.value;
     this.step3Disabled = !this.myForm.get('requiredValue2')?.value;
-    this.saveDisabled = this.myForm.get('requiredValue3')?.value;
+    this.saveDisabled = !this.myForm.get('requiredValue3')?.value;
   }
 
   public onNextClick(): void {

--- a/libs/components/tabs/src/lib/modules/tabs/fixtures/tabset-wizard.component.fixture.ts
+++ b/libs/components/tabs/src/lib/modules/tabs/fixtures/tabset-wizard.component.fixture.ts
@@ -17,8 +17,6 @@ export class SkyWizardTestFormComponent {
 
   public finishDisabled = undefined;
 
-  public renderFinishButton = false;
-
   public passTabset = true;
 
   public onSave: () => void;

--- a/libs/components/tabs/src/lib/modules/tabs/tabset-nav-button.component.spec.ts
+++ b/libs/components/tabs/src/lib/modules/tabs/tabset-nav-button.component.spec.ts
@@ -63,277 +63,253 @@ describe('Tabset navigation button', () => {
   });
 
   describe('wizard style', () => {
-    describe('without finish button', () => {
-      it('should be accessible', async () => {
+    it('should be accessible', async () => {
+      const fixture = TestBed.createComponent(SkyWizardTestFormComponent);
+      fixture.detectChanges();
+      await fixture.whenStable();
+      fixture.detectChanges();
+      await expectAsync(fixture.nativeElement).toBeAccessible();
+    });
+
+    describe('previous button', () => {
+      it('should navigate to the previous tab when clicked', fakeAsync(() => {
         const fixture = TestBed.createComponent(SkyWizardTestFormComponent);
+
         fixture.detectChanges();
-        await fixture.whenStable();
+        tick();
         fixture.detectChanges();
-        await expectAsync(fixture.nativeElement).toBeAccessible();
-      });
+        tick();
 
-      describe('previous button', () => {
-        it('should navigate to the previous tab when clicked', fakeAsync(() => {
-          const fixture = TestBed.createComponent(SkyWizardTestFormComponent);
+        fixture.componentInstance.selectedTab = 1;
 
-          fixture.detectChanges();
-          tick();
-          fixture.detectChanges();
-          tick();
+        fixture.detectChanges();
+        tick();
+        fixture.detectChanges();
+        tick();
 
-          fixture.componentInstance.selectedTab = 1;
+        const tabBtns = document.querySelectorAll('.sky-btn-tab-wizard');
 
-          fixture.detectChanges();
-          tick();
-          fixture.detectChanges();
-          tick();
+        expect(tabBtns[1]).toHaveCssClass('sky-btn-tab-selected');
 
-          const tabBtns = document.querySelectorAll('.sky-btn-tab-wizard');
+        const previousBtn = getPreviousBtn();
 
-          expect(tabBtns[1]).toHaveCssClass('sky-btn-tab-selected');
+        previousBtn.click();
+        fixture.detectChanges();
+        tick();
+        fixture.detectChanges();
+        tick();
 
-          const previousBtn = getPreviousBtn();
+        expect(tabBtns[0]).toHaveCssClass('sky-btn-tab-selected');
+      }));
 
-          previousBtn.click();
-          fixture.detectChanges();
-          tick();
-          fixture.detectChanges();
-          tick();
-
-          expect(tabBtns[0]).toHaveCssClass('sky-btn-tab-selected');
-        }));
-
-        it('should be disabled if the first tab is selected', () => {
-          const fixture = TestBed.createComponent(SkyWizardTestFormComponent);
-
-          fixture.detectChanges();
-
-          const previousBtn = getPreviousBtn();
-
-          expect(previousBtn.disabled).toBe(true);
-        });
-
-        it('should have aria-controls set', fakeAsync(() => {
-          const fixture = TestBed.createComponent(SkyWizardTestFormComponent);
-          fixture.componentInstance.selectedTab = 1;
-
-          fixture.detectChanges();
-          tick();
-          fixture.detectChanges();
-          tick();
-
-          const previousBtn = getPreviousBtn();
-
-          expect(previousBtn.getAttribute('aria-controls')).toBeDefined();
-        }));
-      });
-
-      describe('next button', () => {
-        it('should navigate to the next tab when clicked', fakeAsync(() => {
-          const fixture = TestBed.createComponent(SkyWizardTestFormComponent);
-
-          fixture.detectChanges();
-          tick();
-          fixture.detectChanges();
-          tick();
-
-          const tabBtns = document.querySelectorAll('.sky-btn-tab-wizard');
-
-          expect(tabBtns[0]).toHaveCssClass('sky-btn-tab-selected');
-
-          const nextBtn = getNextBtn();
-
-          nextBtn.click();
-          fixture.detectChanges();
-          tick();
-          fixture.detectChanges();
-          tick();
-
-          expect(tabBtns[1]).toHaveCssClass('sky-btn-tab-selected');
-        }));
-
-        it('should be disabled if the next tab is disabled', fakeAsync(() => {
-          const fixture = TestBed.createComponent(SkyWizardTestFormComponent);
-
-          fixture.componentInstance.step2Disabled = true;
-
-          fixture.detectChanges();
-          tick();
-
-          const nextBtn = getNextBtn();
-
-          expect(nextBtn.disabled).toBe(true);
-
-          fixture.componentInstance.step2Disabled = false;
-
-          fixture.detectChanges();
-          tick();
-
-          expect(nextBtn.disabled).toBe(false);
-        }));
-
-        it('should be disabled if the last tab is selected', () => {
-          const fixture = TestBed.createComponent(SkyWizardTestFormComponent);
-
-          fixture.componentInstance.selectedTab = 2;
-
-          fixture.detectChanges();
-
-          const nextBtn = getNextBtn();
-
-          expect(nextBtn.disabled).toBe(true);
-        });
-
-        it('should have aria-controls set', () => {
-          const fixture = TestBed.createComponent(SkyWizardTestFormComponent);
-
-          fixture.detectChanges();
-
-          const nextBtn = getNextBtn();
-
-          expect(nextBtn.getAttribute('aria-controls')).toBeDefined();
-        });
-      });
-
-      it('should log an error if the tabset is removed', () => {
+      it('should be disabled if the first tab is selected', () => {
         const fixture = TestBed.createComponent(SkyWizardTestFormComponent);
-        const logService = TestBed.inject(SkyLogService);
-        const errorLogSpy = spyOn(logService, 'error').and.stub();
 
         fixture.detectChanges();
 
-        fixture.componentInstance.passTabset = false;
+        const previousBtn = getPreviousBtn();
+
+        expect(previousBtn.disabled).toBe(true);
+      });
+
+      it('should have aria-controls set', fakeAsync(() => {
+        const fixture = TestBed.createComponent(SkyWizardTestFormComponent);
+        fixture.componentInstance.selectedTab = 1;
+
+        fixture.detectChanges();
+        tick();
+        fixture.detectChanges();
+        tick();
+
+        const previousBtn = getPreviousBtn();
+
+        expect(previousBtn.getAttribute('aria-controls')).toBeDefined();
+      }));
+    });
+
+    describe('next button', () => {
+      it('should navigate to the next tab when clicked', fakeAsync(() => {
+        const fixture = TestBed.createComponent(SkyWizardTestFormComponent);
+
+        fixture.detectChanges();
+        tick();
+        fixture.detectChanges();
+        tick();
+
+        const tabBtns = document.querySelectorAll('.sky-btn-tab-wizard');
+
+        expect(tabBtns[0]).toHaveCssClass('sky-btn-tab-selected');
+
+        const nextBtn = getNextBtn();
+
+        nextBtn.click();
+        fixture.detectChanges();
+        tick();
+        fixture.detectChanges();
+        tick();
+
+        expect(tabBtns[1]).toHaveCssClass('sky-btn-tab-selected');
+      }));
+
+      it('should be disabled if the next tab is disabled', fakeAsync(() => {
+        const fixture = TestBed.createComponent(SkyWizardTestFormComponent);
+
+        fixture.componentInstance.step2Disabled = true;
+
+        fixture.detectChanges();
+        tick();
+
+        const nextBtn = getNextBtn();
+
+        expect(nextBtn.disabled).toBe(true);
+
+        fixture.componentInstance.step2Disabled = false;
+
+        fixture.detectChanges();
+        tick();
+
+        expect(nextBtn.disabled).toBe(false);
+      }));
+
+      it('should not be present if the last tab is selected', fakeAsync(() => {
+        const fixture = TestBed.createComponent(SkyWizardTestFormComponent);
+
+        fixture.componentInstance.selectedTab = 2;
+
+        fixture.detectChanges();
+        tick();
+
+        fixture.detectChanges();
+        tick();
+
+        const nextBtn = getNextBtn();
+
+        expect(nextBtn).toBeNull();
+      }));
+
+      it('should have aria-controls set', () => {
+        const fixture = TestBed.createComponent(SkyWizardTestFormComponent);
 
         fixture.detectChanges();
 
-        expect(errorLogSpy).toHaveBeenCalledWith(
-          'The SkyTabsetNavButtonComponent requires a reference to the SkyTabsetComponent it controls.'
-        );
+        const nextBtn = getNextBtn();
+
+        expect(nextBtn.getAttribute('aria-controls')).toBeDefined();
       });
     });
-    describe('with finish button', () => {
-      describe('next button', () => {
-        it('should not be present if the last tab is selected', fakeAsync(() => {
-          const fixture = TestBed.createComponent(SkyWizardTestFormComponent);
 
-          fixture.componentInstance.renderFinishButton = true;
-          fixture.componentInstance.selectedTab = 2;
+    describe('finish button', () => {
+      it('should set default text based on the button type', fakeAsync(() => {
+        const fixture = TestBed.createComponent(SkyWizardTestFormComponent);
 
-          fixture.detectChanges();
-          tick();
+        fixture.componentInstance.selectedTab = 2;
 
-          fixture.detectChanges();
-          tick();
+        fixture.detectChanges();
+        tick();
 
-          const nextBtn = getNextBtn();
+        fixture.detectChanges();
+        tick();
 
-          expect(nextBtn).toBeNull();
-        }));
+        const finishBtn = getFinishBtn();
+
+        expect(finishBtn).toHaveText('Finish');
+      }));
+
+      it('should not be present if the last tab is not selected', () => {
+        const fixture = TestBed.createComponent(SkyWizardTestFormComponent);
+
+        fixture.componentInstance.selectedTab = 0;
+
+        fixture.detectChanges();
+
+        const finishBtn = getFinishBtn();
+
+        expect(finishBtn).toBeNull();
       });
 
-      describe('finish button', () => {
-        it('should set default text based on the button type', fakeAsync(() => {
-          const fixture = TestBed.createComponent(SkyWizardTestFormComponent);
+      it('should be present if the last tab is selected', fakeAsync(() => {
+        const fixture = TestBed.createComponent(SkyWizardTestFormComponent);
 
-          fixture.componentInstance.renderFinishButton = true;
-          fixture.componentInstance.selectedTab = 2;
+        fixture.componentInstance.selectedTab = 2;
 
-          fixture.detectChanges();
-          tick();
+        fixture.detectChanges();
+        tick();
 
-          fixture.detectChanges();
-          tick();
+        fixture.detectChanges();
+        tick();
 
-          const finishBtn = getFinishBtn();
+        const finishBtn = getFinishBtn();
 
-          expect(finishBtn).toHaveText('Finish');
-        }));
+        expect(finishBtn).toBeVisible();
+      }));
 
-        it('should not be present if the last tab is not selected', () => {
-          const fixture = TestBed.createComponent(SkyWizardTestFormComponent);
+      it('should default to not being disabled', fakeAsync(() => {
+        const fixture = TestBed.createComponent(SkyWizardTestFormComponent);
 
-          fixture.componentInstance.renderFinishButton = true;
-          fixture.componentInstance.selectedTab = 0;
+        fixture.componentInstance.selectedTab = 2;
 
-          fixture.detectChanges();
+        fixture.detectChanges();
+        tick();
 
-          const finishBtn = getFinishBtn();
+        fixture.detectChanges();
+        tick();
 
-          expect(finishBtn).toBeNull();
-        });
+        const finishBtn = getFinishBtn();
 
-        it('should be present if the last tab is selected', fakeAsync(() => {
-          const fixture = TestBed.createComponent(SkyWizardTestFormComponent);
+        expect(finishBtn.disabled).toBe(false);
+      }));
 
-          fixture.componentInstance.renderFinishButton = true;
-          fixture.componentInstance.selectedTab = 2;
+      it('should reflect disabled input if passed', fakeAsync(() => {
+        const fixture = TestBed.createComponent(SkyWizardTestFormComponent);
 
-          fixture.detectChanges();
-          tick();
+        fixture.componentInstance.selectedTab = 2;
+        fixture.componentInstance.finishDisabled = true;
 
-          fixture.detectChanges();
-          tick();
+        fixture.detectChanges();
+        tick();
 
-          const finishBtn = getFinishBtn();
+        fixture.detectChanges();
+        tick();
 
-          expect(finishBtn).toBeVisible();
-        }));
+        const finishBtn = getFinishBtn();
 
-        it('should default to not being disabled', fakeAsync(() => {
-          const fixture = TestBed.createComponent(SkyWizardTestFormComponent);
+        expect(finishBtn.disabled).toBe(true);
+      }));
 
-          fixture.componentInstance.renderFinishButton = true;
-          fixture.componentInstance.selectedTab = 2;
+      it('should submit the form on click', fakeAsync(() => {
+        const fixture = TestBed.createComponent(SkyWizardTestFormComponent);
+        const saveSpy = jasmine.createSpy().and.stub();
 
-          fixture.detectChanges();
-          tick();
+        fixture.componentInstance.selectedTab = 2;
+        fixture.componentInstance.onSave = saveSpy;
 
-          fixture.detectChanges();
-          tick();
+        fixture.detectChanges();
+        tick();
+        fixture.detectChanges();
+        tick();
 
-          const finishBtn = getFinishBtn();
+        const finishBtn = getFinishBtn();
 
-          expect(finishBtn.disabled).toBe(false);
-        }));
+        finishBtn.click();
 
-        it('should reflect disabled input if passed', fakeAsync(() => {
-          const fixture = TestBed.createComponent(SkyWizardTestFormComponent);
+        expect(saveSpy).toHaveBeenCalled();
+      }));
+    });
 
-          fixture.componentInstance.renderFinishButton = true;
-          fixture.componentInstance.selectedTab = 2;
-          fixture.componentInstance.finishDisabled = true;
+    it('should log an error if the tabset is removed', () => {
+      const fixture = TestBed.createComponent(SkyWizardTestFormComponent);
+      const logService = TestBed.inject(SkyLogService);
+      const errorLogSpy = spyOn(logService, 'error').and.stub();
 
-          fixture.detectChanges();
-          tick();
+      fixture.detectChanges();
 
-          fixture.detectChanges();
-          tick();
+      fixture.componentInstance.passTabset = false;
 
-          const finishBtn = getFinishBtn();
+      fixture.detectChanges();
 
-          expect(finishBtn.disabled).toBe(true);
-        }));
-
-        it('should submit the form on click', fakeAsync(() => {
-          const fixture = TestBed.createComponent(SkyWizardTestFormComponent);
-          const saveSpy = jasmine.createSpy().and.stub();
-
-          fixture.componentInstance.renderFinishButton = true;
-          fixture.componentInstance.selectedTab = 2;
-          fixture.componentInstance.onSave = saveSpy;
-
-          fixture.detectChanges();
-          tick();
-          fixture.detectChanges();
-          tick();
-
-          const finishBtn = getFinishBtn();
-
-          finishBtn.click();
-
-          expect(saveSpy).toHaveBeenCalled();
-        }));
-      });
+      expect(errorLogSpy).toHaveBeenCalledWith(
+        'The SkyTabsetNavButtonComponent requires a reference to the SkyTabsetComponent it controls.'
+      );
     });
   });
 });

--- a/libs/components/tabs/src/lib/modules/tabs/tabset-nav-button.component.ts
+++ b/libs/components/tabs/src/lib/modules/tabs/tabset-nav-button.component.ts
@@ -31,10 +31,6 @@ export class SkyTabsetNavButtonComponent implements OnDestroy {
     }
 
     if (value) {
-      if (this.#_buttonType === buttonTypeFinish) {
-        this.#_tabset.hasFinishButton = true;
-      }
-
       this.#currentTabsetSub = this.#_tabset.activeChange
         .pipe(distinctUntilChanged(), takeUntil(this.#ngUnsubscribe))
         .subscribe((index: SkyTabIndex) => {
@@ -135,29 +131,19 @@ export class SkyTabsetNavButtonComponent implements OnDestroy {
   #updateButtonVisibility(): void {
     const isLastStep = this.#activeIndexNumber === this.#tabCount - 1;
 
-    if (this.#_buttonType === buttonTypeFinish) {
+    if (this.buttonType === buttonTypeFinish) {
       this.isVisible = isLastStep;
-      return;
+    } else if (this.buttonType === buttonTypeNext) {
+      this.isVisible = !isLastStep;
+    } else {
+      this.isVisible = true;
     }
-
-    // Hide the next button on the last step only if a finish button exists.
-    if (
-      this.#_buttonType === buttonTypeNext &&
-      isLastStep &&
-      this.#_tabset.hasFinishButton
-    ) {
-      this.isVisible = false;
-      return;
-    }
-
-    this.isVisible = true;
   }
 
   #updateButtonProperties(): void {
     if (
-      (this.#_buttonType === buttonTypeNext ||
-        this.#_buttonType === buttonTypeFinish) &&
-      this.#_tabset?.hasFinishButton
+      this.#_buttonType === buttonTypeNext ||
+      this.#_buttonType === buttonTypeFinish
     ) {
       this.buttonClassName = 'sky-btn-primary';
     } else {

--- a/libs/components/tabs/src/lib/modules/tabs/tabset-nav-button.component.ts
+++ b/libs/components/tabs/src/lib/modules/tabs/tabset-nav-button.component.ts
@@ -23,6 +23,10 @@ export class SkyTabsetNavButtonComponent implements OnDestroy {
    * @required
    */
   @Input()
+  public get tabset(): SkyTabsetComponent {
+    return this.#_tabset;
+  }
+
   public set tabset(value: SkyTabsetComponent) {
     this.#_tabset = value;
 

--- a/libs/components/tabs/src/lib/modules/tabs/tabset-nav-button.component.ts
+++ b/libs/components/tabs/src/lib/modules/tabs/tabset-nav-button.component.ts
@@ -89,7 +89,7 @@ export class SkyTabsetNavButtonComponent implements OnDestroy {
   public get disabled(): boolean {
     if (this.#_disabled !== undefined) {
       return this.#_disabled;
-    } else if (this.#_buttonType === buttonTypeFinish) {
+    } else if (this.buttonType === buttonTypeFinish) {
       return false;
     }
 
@@ -124,7 +124,7 @@ export class SkyTabsetNavButtonComponent implements OnDestroy {
   public buttonClick() {
     /* istanbul ignore else */
     if (this.#tabToSelect && !this.#tabToSelect.disabled) {
-      this.#_tabset.active = this.#tabToSelect.tabIndex;
+      this.tabset.active = this.#tabToSelect.tabIndex;
     }
   }
 
@@ -142,8 +142,8 @@ export class SkyTabsetNavButtonComponent implements OnDestroy {
 
   #updateButtonProperties(): void {
     if (
-      this.#_buttonType === buttonTypeNext ||
-      this.#_buttonType === buttonTypeFinish
+      this.buttonType === buttonTypeNext ||
+      this.buttonType === buttonTypeFinish
     ) {
       this.buttonClassName = 'sky-btn-primary';
     } else {
@@ -154,8 +154,8 @@ export class SkyTabsetNavButtonComponent implements OnDestroy {
   }
 
   #updateTabToSelect(): void {
-    if (this.#_tabset?.tabs) {
-      const tabs = this.#_tabset.tabs.toArray();
+    if (this.tabset?.tabs) {
+      const tabs = this.tabset.tabs.toArray();
       this.#tabToSelect = undefined;
 
       // tab index can be a number or a string, but we need the actual number index
@@ -165,9 +165,9 @@ export class SkyTabsetNavButtonComponent implements OnDestroy {
 
       /* istanbul ignore else */
       if (this.#activeIndexNumber !== undefined) {
-        if (this.#_buttonType === buttonTypeNext) {
+        if (this.buttonType === buttonTypeNext) {
           this.#tabToSelect = tabs[this.#activeIndexNumber + 1];
-        } else if (this.#_buttonType === buttonTypePrevious) {
+        } else if (this.buttonType === buttonTypePrevious) {
           this.#tabToSelect = tabs[this.#activeIndexNumber - 1];
         }
       }

--- a/libs/components/tabs/src/lib/modules/tabs/tabset.component.ts
+++ b/libs/components/tabs/src/lib/modules/tabs/tabset.component.ts
@@ -167,14 +167,6 @@ export class SkyTabsetComponent implements AfterViewInit, OnDestroy {
     return this._tabDisplayMode || 'tabs';
   }
 
-  public get hasFinishButton(): boolean {
-    return this.#_hasFinishButton;
-  }
-
-  public set hasFinishButton(value: boolean) {
-    this.#_hasFinishButton = value;
-  }
-
   @ContentChildren(SkyTabComponent)
   public tabs: QueryList<SkyTabComponent>;
 
@@ -201,8 +193,6 @@ export class SkyTabsetComponent implements AfterViewInit, OnDestroy {
   private _tabDisplayMode: SkyTabsetButtonsDisplayMode;
 
   private _tabStyle: SkyTabsetStyle;
-
-  #_hasFinishButton = false;
 
   constructor(
     private changeDetector: ChangeDetectorRef,


### PR DESCRIPTION
The nav buttons no longer check for the presence of a finish button when determining styling classes and button visibility.

BREAKING CHANGE: This change removes support for not using a finish navigation button with the previous and next wizard navigation buttons. To address this change, remove other save or finish buttons and use the `sky-tabset-nav-button` of type `finish` instead.