### PR TITLE
fix(components/lookup): remove ARIA label from non-functional search icon

### DIFF
--- a/libs/components/lookup/src/assets/locales/resources_en_US.json
+++ b/libs/components/lookup/src/assets/locales/resources_en_US.json
@@ -23,10 +23,6 @@
     "_description": "Placeholder for country search autocomplete",
     "message": "Search for a country"
   },
-  "skyux_lookup_search_icon": {
-    "_description": "Label for lookup's search icon",
-    "message": "Search"
-  },
   "skyux_lookup_search_button_show_more": {
     "_description": "Label for lookup's search button that opens superselect modal",
     "message": "Show all search results"

--- a/libs/components/lookup/src/lib/modules/lookup/lookup.component.html
+++ b/libs/components/lookup/src/lib/modules/lookup/lookup.component.html
@@ -130,16 +130,7 @@
     class="sky-input-group-icon sky-input-box-icon-inset"
     [ngClass]="{ 'sky-lookup-disabled': disabled }"
   >
-    <sky-icon
-      *skyThemeIf="'default'"
-      icon="search"
-      [attr.aria-label]="'skyux_lookup_search_icon' | skyLibResources"
-    ></sky-icon>
-    <sky-icon
-      *skyThemeIf="'modern'"
-      iconType="skyux"
-      icon="search"
-      [attr.aria-label]="'skyux_lookup_search_icon' | skyLibResources"
-    ></sky-icon>
+    <sky-icon *skyThemeIf="'default'" icon="search"></sky-icon>
+    <sky-icon *skyThemeIf="'modern'" iconType="skyux" icon="search"></sky-icon>
   </div>
 </ng-template>

--- a/libs/components/lookup/src/lib/modules/shared/sky-lookup-resources.module.ts
+++ b/libs/components/lookup/src/lib/modules/shared/sky-lookup-resources.module.ts
@@ -22,7 +22,6 @@ const RESOURCES: { [locale: string]: SkyLibResources } = {
     skyux_autocomplete_show_all_count: { message: 'Show all {0}' },
     skyux_autocomplete_show_matches_count: { message: 'Show matches ({0})' },
     skyux_country_field_search_placeholder: { message: 'Search for a country' },
-    skyux_lookup_search_icon: { message: 'Search' },
     skyux_lookup_search_button_show_more: {
       message: 'Show all search results',
     },


### PR DESCRIPTION
Remove the `aria-label` from the icon because the icon is only a visual indicator and not needed by screen readers.