### PR TITLE
feat(components/modals): remove public export of confirm button

### DIFF
--- a/libs/components/indicators/src/lib/modules/key-info/key-info.component.ts
+++ b/libs/components/indicators/src/lib/modules/key-info/key-info.component.ts
@@ -13,7 +13,6 @@ export class SkyKeyInfoComponent {
    * value or in a horizontal layout with the label beside the value.
    * @default "vertical"
    */
-  // TODO: More strongly type this in a future breaking change.
   @Input()
   public layout: SkyKeyInfoLayoutType | undefined = 'vertical';
 }

--- a/libs/components/modals/src/index.ts
+++ b/libs/components/modals/src/index.ts
@@ -1,5 +1,3 @@
-// TODO: confirm-button is internal and should be removed in a future version
-export * from './lib/modules/confirm/confirm-button';
 export * from './lib/modules/confirm/confirm-button-action';
 export * from './lib/modules/confirm/confirm-button-config';
 export * from './lib/modules/confirm/confirm-button-style-type';


### PR DESCRIPTION
BREAKING CHANGE: The `SkyConfirmButton` component is intended for internal use only and is removed from the exported API. To address this, remove any usages of the `SkyConfirmButton` component.