### PR TITLE
feat(components/modals): remove 'string' from `SkyConfirmButton`'s `styleType` type

### DIFF
--- a/libs/components/modals/src/lib/modules/confirm/confirm-button.ts
+++ b/libs/components/modals/src/lib/modules/confirm/confirm-button.ts
@@ -7,8 +7,7 @@ import { SkyConfirmButtonStyleType } from './confirm-button-style-type';
  */
 export interface SkyConfirmButton {
   action: SkyConfirmButtonAction;
-  // TODO: Remove 'string' in a breaking change.
-  styleType: SkyConfirmButtonStyleType | string;
+  styleType: SkyConfirmButtonStyleType;
   text: string;
   autofocus?: boolean;
 }


### PR DESCRIPTION
BREAKING CHANGE: `SkyConfirmButton`'s `styleType` will only accept predefined strings of type `SkyConfirmButtonStyleType`. To address this, ensure `styleType` is only being set to a supported value.