### PR TITLE
feat(components/config): add more specific typing to config params function return types

### DIFF
--- a/libs/components/config/src/lib/params.spec.ts
+++ b/libs/components/config/src/lib/params.spec.ts
@@ -137,12 +137,11 @@ describe('SkyAppRuntimeConfigParams', () => {
       }
     );
 
-    // TODO: In a breaking change, remove the `as unknown` declarations.
     expect(params.get('a1')).toBe('b');
-    expect(params.get('a2') as unknown).toBe(undefined);
+    expect(params.get('a2')).toBe(undefined);
     expect(params.get('a3')).toBe('d');
     expect(params.get('a4')).toBe('x');
-    expect(params.get('a5') as unknown).toBe(undefined);
+    expect(params.get('a5')).toBe(undefined);
   });
 
   it('should allow default values to be overridden by the query string', () => {

--- a/libs/components/config/src/lib/params.ts
+++ b/libs/components/config/src/lib/params.ts
@@ -20,9 +20,9 @@ function getUrlSearchParams(url: string): HttpParams {
 }
 
 export class SkyAppRuntimeConfigParams {
-  #params: { [key: string]: string } = {};
+  #params: Record<string, string> = {};
 
-  #defaultParamValues: { [key: string]: string } = {};
+  #defaultParamValues: Record<string, string> = {};
 
   #requiredParams: string[] = [];
 
@@ -121,22 +121,20 @@ export class SkyAppRuntimeConfigParams {
    * Returns the decoded value of the requested param.
    * @param key The parameter's key.
    */
-  public get(key: string): string {
+  public get(key: string): string | undefined {
     if (this.has(key)) {
       return decodeURIComponent(this.#params[key]);
     }
 
-    // TODO: Return `string | undefined` in a breaking change.
-    return undefined as unknown as string;
+    return;
   }
 
   /**
    * Returns the params object.
    * @param excludeDefaults Exclude params that have default values
    */
-  // TODO: Return a more specific type in a breaking change.
-  public getAll(excludeDefaults?: boolean): Object {
-    const filteredParams: { [key: string]: string } = {};
+  public getAll(excludeDefaults?: boolean): Record<string, string> {
+    const filteredParams: Record<string, string> = {};
 
     this.getAllKeys().forEach((key) => {
       if (


### PR DESCRIPTION
BREAKING CHANGE: The config params `get` function was updated to accurately reflect that it may return undefined. To address this change, account for a possible undefined value wherever you are using the `get` function.