### PR TITLE
feat(components/forms): update file attachment validateFn inputs to more specific type

### DIFF
--- a/libs/components/forms/src/lib/modules/file-attachment/file-attachment.component.spec.ts
+++ b/libs/components/forms/src/lib/modules/file-attachment/file-attachment.component.spec.ts
@@ -989,7 +989,7 @@ describe('File attachment', () => {
       'You may not upload a file that begins with the letter "w."';
 
     fileAttachmentInstance.validateFn = function (
-      inputFile: any
+      inputFile: SkyFileItem
     ): string | undefined {
       if (inputFile.file.name.indexOf('w') === 0) {
         return errorMessage;

--- a/libs/components/forms/src/lib/modules/file-attachment/file-attachment.component.ts
+++ b/libs/components/forms/src/lib/modules/file-attachment/file-attachment.component.ts
@@ -28,6 +28,7 @@ import { SkyFileAttachmentLabelComponent } from './file-attachment-label.compone
 import { SkyFileAttachmentService } from './file-attachment.service';
 import { SkyFileItem } from './file-item';
 import { SkyFileItemService } from './file-item.service';
+import { SkyFileValidateFn } from './file-validate-function';
 import { SkyFileAttachmentChange } from './types/file-attachment-change';
 import { SkyFileAttachmentClick } from './types/file-attachment-click';
 
@@ -104,8 +105,7 @@ export class SkyFileAttachmentComponent
    * file validation. This function takes a `SkyFileItem` object as a parameter.
    */
   @Input()
-  // TODO: Change `Function` to a more specific type in a breaking change.
-  public validateFn: Function | undefined;
+  public validateFn: SkyFileValidateFn | undefined;
 
   /**
    * Fires when users add or remove files.

--- a/libs/components/forms/src/lib/modules/file-attachment/file-attachment.service.ts
+++ b/libs/components/forms/src/lib/modules/file-attachment/file-attachment.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core';
 
 import { SkyFileItem } from './file-item';
+import { SkyFileValidateFn } from './file-validate-function';
 
 /**
  * @internal
@@ -12,7 +13,7 @@ export class SkyFileAttachmentService {
     minFileSize: number,
     maxFileSize: number,
     acceptedTypes?: string,
-    validateFn?: Function
+    validateFn?: SkyFileValidateFn
   ): SkyFileItem[] {
     const fileResults: SkyFileItem[] = [];
 

--- a/libs/components/forms/src/lib/modules/file-attachment/file-drop.component.spec.ts
+++ b/libs/components/forms/src/lib/modules/file-attachment/file-drop.component.spec.ts
@@ -2,6 +2,7 @@ import { Component, DebugElement } from '@angular/core';
 import { ComponentFixture, TestBed, fakeAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { SkyAppTestUtility, expect, expectAsync } from '@skyux-sdk/testing';
+import { SkyFileItem } from '@skyux/forms';
 
 import { SkyFileAttachmentsModule } from './file-attachments.module';
 import { SkyFileDropComponent } from './file-drop.component';
@@ -548,7 +549,9 @@ describe('File drop component', () => {
     const errorMessage =
       'You may not upload a file that begins with the letter "w."';
 
-    componentInstance.validateFn = function (file: any): string | undefined {
+    componentInstance.validateFn = function (
+      file: SkyFileItem
+    ): string | undefined {
       if (file.file.name.indexOf('w') === 0) {
         return errorMessage;
       }

--- a/libs/components/forms/src/lib/modules/file-attachment/file-drop.component.ts
+++ b/libs/components/forms/src/lib/modules/file-attachment/file-drop.component.ts
@@ -11,6 +11,7 @@ import {
 import { SkyFileAttachmentService } from './file-attachment.service';
 import { SkyFileItem } from './file-item';
 import { SkyFileLink } from './file-link';
+import { SkyFileValidateFn } from './file-validate-function';
 import { SkyFileDropChange } from './types/file-drop-change';
 
 const MAX_FILE_SIZE_DEFAULT = 500000;
@@ -102,8 +103,7 @@ export class SkyFileDropComponent implements OnDestroy {
    * file validation. This function takes a `SkyFileItem` object as a parameter.
    */
   @Input()
-  // TODO: Change `Function` to a more specific type in a breaking change.
-  public validateFn: Function | undefined;
+  public validateFn: SkyFileValidateFn | undefined;
 
   /**
    * Specifies a comma-delimited string literal of MIME types that users can attach.

--- a/libs/components/forms/src/lib/modules/file-attachment/file-validate-function.ts
+++ b/libs/components/forms/src/lib/modules/file-attachment/file-validate-function.ts
@@ -1,0 +1,3 @@
+import { SkyFileItem } from './file-item';
+
+export type SkyFileValidateFn = (file: SkyFileItem) => string | undefined;


### PR DESCRIPTION
BREAKING CHANGE: The `SkyFileDrop` and `SkyFileAttachment` components' `validateFn` input type was updated to receive a `SkyFileType` parameter and return a string or undefined. To address this, ensure all `validateFn` inputs have the correct parameter and return types.