### PR TITLE
feat(components/modals): make `dynamicComponentService` required in `SkyModalService` constructor

### DIFF
--- a/libs/components/errors/src/lib/modules/error/error-modal.service.spec.ts
+++ b/libs/components/errors/src/lib/modules/error/error-modal.service.spec.ts
@@ -1,5 +1,5 @@
 import { TestBed } from '@angular/core/testing';
-import { SkyLogService } from '@skyux/core';
+import { SkyDynamicComponentService, SkyLogService } from '@skyux/core';
 import { SkyModalConfigurationInterface, SkyModalService } from '@skyux/modals';
 
 import { ErrorModalConfig } from './error-modal-config';
@@ -9,7 +9,8 @@ import { MockModalService } from './fixtures/mocks';
 
 describe('Error modal service', () => {
   function createMockModalService() {
-    return new MockModalService();
+    const dynamicComponentService = TestBed.inject(SkyDynamicComponentService);
+    return new MockModalService(dynamicComponentService);
   }
 
   it('should open with correct parameters (log service undefined)', () => {

--- a/libs/components/modals/src/lib/modules/modal/modal.service.ts
+++ b/libs/components/modals/src/lib/modules/modal/modal.service.ts
@@ -21,10 +21,8 @@ export class SkyModalService {
 
   #dynamicComponentService: SkyDynamicComponentService;
 
-  // TODO: Make `dynamicComponentService` required. It is optional today to maintain binary compatibility for consumers when they construct
-  // the service for unit testing.
-  constructor(dynamicComponentService?: SkyDynamicComponentService) {
-    this.#dynamicComponentService = dynamicComponentService!;
+  constructor(dynamicComponentService: SkyDynamicComponentService) {
+    this.#dynamicComponentService = dynamicComponentService;
   }
 
   /**


### PR DESCRIPTION
BREAKING CHANGE: `dynamicComponentService` is now a required parameter of `SkyModalService`. To address this change, provide the `dynamicComponentService` wherever you are constructing the `SkyModalService` for unit testing.