### PR TITLE
fix(components/lookup): modern search clickbox takes up entire input box

### DIFF
--- a/libs/components/lookup/src/lib/modules/search/search.component.scss
+++ b/libs/components/lookup/src/lib/modules/search/search.component.scss
@@ -182,7 +182,6 @@ sky-search {
 
         .sky-input-box-form-group-inner {
           input {
-            flex-basis: auto;
             width: auto;
             padding: $sky-theme-modern-space-sm $sky-theme-modern-space-sm
               $sky-theme-modern-space-sm 0;


### PR DESCRIPTION
[AB#2316672](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/2316672)