### PR TITLE
feat(components/indicators): change alertType to SkyIndicatorIconType

### DIFF
--- a/apps/playground/src/app/components/indicators/alert/alert-routing.module.ts
+++ b/apps/playground/src/app/components/indicators/alert/alert-routing.module.ts
@@ -1,0 +1,26 @@
+import { NgModule } from '@angular/core';
+import { RouterModule } from '@angular/router';
+
+import { ComponentRouteInfo } from '../../../shared/component-info/component-route-info';
+
+import { AlertDemoComponent } from './alert.component';
+
+const routes: ComponentRouteInfo[] = [
+  {
+    path: '',
+    component: AlertDemoComponent,
+    data: {
+      name: 'Alert',
+      icon: 'key',
+      library: 'indicators',
+    },
+  },
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule],
+})
+export class AlertRoutingModule {
+  public static routes = routes;
+}

--- a/apps/playground/src/app/components/indicators/alert/alert-routing.module.ts
+++ b/apps/playground/src/app/components/indicators/alert/alert-routing.module.ts
@@ -11,7 +11,7 @@ const routes: ComponentRouteInfo[] = [
     component: AlertDemoComponent,
     data: {
       name: 'Alert',
-      icon: 'key',
+      icon: 'warning',
       library: 'indicators',
     },
   },

--- a/apps/playground/src/app/components/indicators/alert/alert.component.html
+++ b/apps/playground/src/app/components/indicators/alert/alert.component.html
@@ -1,0 +1,18 @@
+<div class="app-alert">
+  <sky-alert [alertType]="'info'" [closeable]="alertCloseable">
+    Info alert
+  </sky-alert>
+  <sky-alert [alertType]="'success'" [closeable]="alertCloseable">
+    Success alert
+  </sky-alert>
+  <sky-alert [alertType]="'warning'" [closeable]="alertCloseable">
+    Warning alert
+  </sky-alert>
+  <sky-alert [alertType]="'danger'" [closeable]="alertCloseable">
+    Danger alert
+  </sky-alert>
+  <sky-alert [closeable]="alertCloseable"> Default alert </sky-alert>
+  <sky-alert [alertType]="'test'" [closeable]="alertCloseable">
+    Invalid alert
+  </sky-alert>
+</div>

--- a/apps/playground/src/app/components/indicators/alert/alert.component.ts
+++ b/apps/playground/src/app/components/indicators/alert/alert.component.ts
@@ -1,0 +1,9 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-alert',
+  templateUrl: './alert.component.html',
+})
+export class AlertDemoComponent {
+  public alertCloseable = true;
+}

--- a/apps/playground/src/app/components/indicators/alert/alert.module.ts
+++ b/apps/playground/src/app/components/indicators/alert/alert.module.ts
@@ -1,0 +1,14 @@
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { SkyAlertModule } from '@skyux/indicators';
+
+import { AlertRoutingModule } from './alert-routing.module';
+import { AlertDemoComponent } from './alert.component';
+
+@NgModule({
+  declarations: [AlertDemoComponent],
+  imports: [CommonModule, AlertRoutingModule, SkyAlertModule],
+})
+export class AlertModule {
+  public static routes = AlertRoutingModule.routes;
+}

--- a/apps/playground/src/app/components/indicators/indicators.module.ts
+++ b/apps/playground/src/app/components/indicators/indicators.module.ts
@@ -18,6 +18,11 @@ const routes: Routes = [
     path: 'wait',
     loadChildren: () => import('./wait/wait.module').then((m) => m.WaitModule),
   },
+  {
+    path: 'alert',
+    loadChildren: () =>
+      import('./alert/alert.module').then((m) => m.AlertModule),
+  },
 ];
 
 @NgModule({

--- a/libs/components/indicators/src/lib/modules/alert/alert.component.ts
+++ b/libs/components/indicators/src/lib/modules/alert/alert.component.ts
@@ -23,7 +23,6 @@ const ALERT_TYPE_DEFAULT = 'warning';
   templateUrl: './alert.component.html',
 })
 export class SkyAlertComponent implements OnInit, OnDestroy {
-  // TODO: Change alertType to SkyIndicatorIconType in a breaking change.
   /**
    * Specifies a style for the alert to determine the icon and background color.
    * The valid options are `danger`, `info`, `success`, and `warning`.

--- a/libs/components/indicators/src/lib/modules/alert/alert.component.ts
+++ b/libs/components/indicators/src/lib/modules/alert/alert.component.ts
@@ -30,10 +30,9 @@ export class SkyAlertComponent implements OnInit, OnDestroy {
    * @default "warning"
    */
   @Input()
-  public set alertType(value: string | undefined) {
+  public set alertType(value: SkyIndicatorIconType | undefined) {
     if (value !== this.alertTypeOrDefault) {
-      this.alertTypeOrDefault =
-        (value as SkyIndicatorIconType) || ALERT_TYPE_DEFAULT;
+      this.alertTypeOrDefault = value || ALERT_TYPE_DEFAULT;
       this.#updateAlertIcon();
     }
   }


### PR DESCRIPTION
[AB#2195283](https://blackbaud.visualstudio.com/Products/_boards/board/t/SKY%20UX%20Components/Stories/?workitem=2195283)

- changes `alertType` from string to `SkyIndicatorIconType` 
- adds alert playground code to mono repo
- adds examples for default and invalid `alertType` to playground code
BREAKING CHANGE: This change removes support for `alertType` on the alert component being an
unaccepted string. To address this change, change the `alertType` to an accepted `SkyIndicatorTypeIcon` or
remove it to use the default `alertType` of `'warning'`.

BEGIN_COMMIT_OVERRIDE
feat(components/indicators): change `alertType` to `SkyIndicatorIconType` (#683)

BREAKING CHANGE: This change removes support for `alertType` on the alert component being an
unaccepted string. To address this change, change the `alertType` to an accepted `SkyIndicatorTypeIcon` or
remove it to use the default `alertType` of `'warning'`.
END_COMMIT_OVERRIDE
