### PR TITLE
fix(components/packages): remove forward slash to compat stylesheet in angular.json

### DIFF
--- a/libs/components/packages/src/schematics/migrations/update-7/add-compat-stylesheets.spec.ts
+++ b/libs/components/packages/src/schematics/migrations/update-7/add-compat-stylesheets.spec.ts
@@ -5,7 +5,7 @@ import { join } from 'path';
 import { createTestApp, createTestLibrary } from '../../testing/scaffold';
 
 describe('Migrations > Add compat stylesheets', () => {
-  const compatStylesheetPath = '/src/app/skyux7-compat.css';
+  const compatStylesheetPath = 'src/app/skyux7-compat.css';
   const alertContents = `/*******************************************************************************
  * TODO: The following component libraries introduced visual breaking changes
  * in SKY UX 7. Each block of CSS reintroduces the styles that were changed or

--- a/libs/components/packages/src/schematics/migrations/update-7/add-compat-stylesheets.ts
+++ b/libs/components/packages/src/schematics/migrations/update-7/add-compat-stylesheets.ts
@@ -3,7 +3,7 @@ import { Rule, chain } from '@angular-devkit/schematics';
 import { readRequiredFile } from '../../utility/tree';
 import { updateWorkspace } from '../../utility/workspace';
 
-const SKYUX7_COMPAT_CSS_PATH = '/src/app/skyux7-compat.css';
+const SKYUX7_COMPAT_CSS_PATH = 'src/app/skyux7-compat.css';
 
 const compatStyles = {
   libraries: [


### PR DESCRIPTION
This change fixes the following error (produced after running `ng update @skyux/packages --next`.
<img width="778" alt="Screen Shot 2022-10-17 at 1 14 24 PM" src="https://user-images.githubusercontent.com/12497062/196241168-541cf544-be06-4a24-8e5d-68b5b23acab1.png">
