### PR TITLE
fix(components/indicators): use role 'grid' for tokens component

### DIFF
--- a/apps/e2e/indicators-storybook-e2e/src/e2e/tokens.component.cy.ts
+++ b/apps/e2e/indicators-storybook-e2e/src/e2e/tokens.component.cy.ts
@@ -13,8 +13,10 @@ describe('indicators-storybook', () => {
           .should('exist')
           .should('be.visible')
           // Capture the focus style of the first token.
-          .get('sky-tokens:first-child sky-token:first-child > .sky-token')
-          .click({ multiple: true })
+          .get(
+            'sky-tokens:first-child sky-token:first-child .sky-token-btn-action'
+          )
+          .click()
           .get('app-tokens')
           .screenshot(`tokenscomponent-tokens--tokens-${theme}`)
           .percySnapshot(`tokenscomponent-tokens--tokens-${theme}`, {

--- a/apps/e2e/split-view-storybook/project.json
+++ b/apps/e2e/split-view-storybook/project.json
@@ -32,7 +32,7 @@
             {
               "type": "anyComponentStyle",
               "maximumWarning": "2kb",
-              "maximumError": "4kb"
+              "maximumError": "5kb"
             }
           ],
           "fileReplacements": [

--- a/libs/components/indicators/src/lib/modules/tokens/fixtures/token-a11y.component.fixture.html
+++ b/libs/components/indicators/src/lib/modules/tokens/fixtures/token-a11y.component.fixture.html
@@ -1,0 +1,13 @@
+<sky-tokens
+  data-sky-id="non-dismissible-tokens"
+  [dismissible]="false"
+  [focusable]="false"
+  [tokens]="data"
+></sky-tokens>
+
+<sky-tokens
+  data-sky-id="dismissible-tokens"
+  [dismissible]="true"
+  [focusable]="true"
+  [tokens]="data"
+></sky-tokens>

--- a/libs/components/indicators/src/lib/modules/tokens/fixtures/token-a11y.component.fixture.ts
+++ b/libs/components/indicators/src/lib/modules/tokens/fixtures/token-a11y.component.fixture.ts
@@ -1,0 +1,21 @@
+import { Component } from '@angular/core';
+
+import { SkyToken } from '../types/token';
+
+@Component({
+  selector: 'sky-token-a11y-test',
+  templateUrl: './token-a11y.component.fixture.html',
+})
+export class SkyTokenA11yTestComponent {
+  public data: SkyToken<{ name: string }>[] = [
+    {
+      value: { name: 'Apple' },
+    },
+    {
+      value: { name: 'Orange' },
+    },
+    {
+      value: { name: 'Strawberry' },
+    },
+  ];
+}

--- a/libs/components/indicators/src/lib/modules/tokens/fixtures/tokens-fixtures.module.ts
+++ b/libs/components/indicators/src/lib/modules/tokens/fixtures/tokens-fixtures.module.ts
@@ -4,12 +4,21 @@ import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
 import { SkyTokensModule } from '../tokens.module';
 
+import { SkyTokenA11yTestComponent } from './token-a11y.component.fixture';
 import { SkyTokenTestComponent } from './token.component.fixture';
 import { SkyTokensTestComponent } from './tokens.component.fixture';
 
 @NgModule({
-  declarations: [SkyTokenTestComponent, SkyTokensTestComponent],
+  declarations: [
+    SkyTokenA11yTestComponent,
+    SkyTokenTestComponent,
+    SkyTokensTestComponent,
+  ],
   imports: [CommonModule, NoopAnimationsModule, SkyTokensModule],
-  exports: [SkyTokenTestComponent, SkyTokensTestComponent],
+  exports: [
+    SkyTokenA11yTestComponent,
+    SkyTokenTestComponent,
+    SkyTokensTestComponent,
+  ],
 })
 export class SkyTokensFixturesModule {}

--- a/libs/components/indicators/src/lib/modules/tokens/token.component.html
+++ b/libs/components/indicators/src/lib/modules/tokens/token.component.html
@@ -1,39 +1,69 @@
 <div
   class="sky-token sky-btn sky-btn-default"
-  role="button"
-  [attr.aria-disabled]="disabled"
-  [attr.tabindex]="tabIndex"
+  [attr.role]="role"
   [ngClass]="{
     'sky-btn-disabled': disabled,
-    'sky-token-dismissable': dismissible,
-    'sky-token-active': tokenActive && !closeActive
+    'sky-token-disabled': disabled,
+    'sky-token-dismissible': dismissible,
+    'sky-token-active': tokenActive && !closeActive,
+    'sky-token-focused': isFocused
   }"
   (document:mouseup)="setTokenActive(false)"
-  (focus)="tokenFocus.emit()"
+  (focusin)="onFocusIn()"
+  (focusout)="onFocusOut($event)"
   (mousedown)="setTokenActive(true)"
 >
-  <ng-content></ng-content>
-  <button
-    *ngIf="dismissible"
-    class="sky-btn sky-token-btn-close"
-    type="button"
-    [attr.aria-label]="ariaLabel"
-    [attr.tabindex]="tabIndex"
-    [attr.title]="ariaLabel"
-    [disabled]="disabled"
-    [ngClass]="{
-      'sky-token-btn-close-active': closeActive
-    }"
-    (click)="dismissToken($event)"
-    (document:mouseup)="setCloseActive(false)"
-    (mousedown)="setCloseActive(true)"
+  <span
+    [attr.role]="role === 'row' ? 'gridcell' : undefined"
+    class="sky-token-cell"
   >
-    <sky-icon class="sky-token-btn-close-icon-default" icon="times"></sky-icon>
-    <sky-icon
-      class="sky-token-btn-close-icon-modern"
-      icon="close"
-      iconType="skyux"
+    <button
+      class="sky-btn sky-btn-default sky-token-btn sky-token-btn-action"
+      type="button"
+      [attr.tabindex]="tabIndex"
+      [disabled]="disabled"
+      [ngClass]="{
+        'sky-btn-disabled': disabled
+      }"
+      #actionButton
     >
-    </sky-icon>
-  </button>
+      <ng-content></ng-content>
+    </button>
+  </span>
+  <span
+    *ngIf="dismissible"
+    class="sky-token-cell"
+    [attr.role]="role === 'row' ? 'gridcell' : undefined"
+  >
+    <button
+      class="sky-btn sky-token-btn sky-token-btn-close"
+      type="button"
+      [attr.aria-label]="
+        ariaLabel || ('skyux_tokens_dismiss_button_title' | skyLibResources)
+      "
+      [attr.tabindex]="tabIndex"
+      [attr.title]="
+        ariaLabel || ('skyux_tokens_dismiss_button_title' | skyLibResources)
+      "
+      [disabled]="disabled"
+      [ngClass]="{
+        'sky-btn-disabled': disabled,
+        'sky-token-btn-close-active': closeActive
+      }"
+      (click)="dismissToken($event)"
+      (document:mouseup)="setCloseActive(false)"
+      (mousedown)="setCloseActive(true)"
+    >
+      <sky-icon
+        class="sky-token-btn-close-icon-default"
+        icon="times"
+      ></sky-icon>
+      <sky-icon
+        class="sky-token-btn-close-icon-modern"
+        icon="close"
+        iconType="skyux"
+      >
+      </sky-icon>
+    </button>
+  </span>
 </div>

--- a/libs/components/indicators/src/lib/modules/tokens/token.component.scss
+++ b/libs/components/indicators/src/lib/modules/tokens/token.component.scss
@@ -25,10 +25,6 @@
   }
 }
 
-.sky-token-cell {
-  display: flex;
-}
-
 .sky-btn-disabled {
   cursor: default;
   user-select: none;

--- a/libs/components/indicators/src/lib/modules/tokens/token.component.scss
+++ b/libs/components/indicators/src/lib/modules/tokens/token.component.scss
@@ -4,21 +4,29 @@
 .sky-token {
   background-color: $sky-background-color-info-light;
   border: 1px solid $sky-highlight-color-info;
-  overflow: hidden;
-  padding: 2px 8px;
+  padding: 0;
   display: inline-block;
-  user-select: none;
 
   &:hover,
-  &:focus {
+  &.sky-token-focused {
     background-color: darken($sky-background-color-info-light, 10%);
     border-color: darken($sky-highlight-color-info, 10%);
     cursor: pointer;
   }
 
-  &:focus {
+  &.sky-token-focused {
     @include mixins.sky-field-status('active');
   }
+
+  &.sky-btn-disabled {
+    .sky-btn-disabled {
+      opacity: 1;
+    }
+  }
+}
+
+.sky-token-cell {
+  display: flex;
 }
 
 .sky-btn-disabled {
@@ -26,16 +34,31 @@
   user-select: none;
 }
 
-.sky-token-btn-close {
-  background: transparent;
-  padding: 0;
+.sky-token-btn {
+  background-color: transparent;
   border: 0;
-  margin-left: 2px;
+  padding: 2px 8px;
+}
+
+.sky-token-btn-action {
+  &:focus-visible {
+    outline: none;
+  }
+}
+
+.sky-token-btn-close {
+  margin-left: -2px;
   opacity: 0.9;
 
   &:hover,
-  &:focus {
+  &:focus-visible {
     opacity: 1;
+  }
+}
+
+.sky-token-dismissible {
+  .sky-token-btn-action {
+    padding-right: 0;
   }
 }
 
@@ -47,19 +70,18 @@
   .sky-token {
     align-items: center;
     display: inline-flex;
-    padding: 1px 5px;
     font-size: 14px;
-
-    &.sky-btn-disabled {
-      color: $sky-text-color-default;
-    }
 
     &:not(.sky-btn-disabled) {
       @include mixins.sky-theme-modern-border($sky-background-color-info);
     }
 
-    &.sky-token-dismissable {
+    &.sky-token-dismissible {
       padding-right: 1px;
+
+      .sky-token-btn-action {
+        padding-right: 0;
+      }
     }
 
     &:hover:not(:active) {
@@ -70,14 +92,29 @@
       @include mixins.sky-theme-modern-border-active;
     }
 
-    &:focus:not(:active) {
+    &.sky-token-focused:not(:active) {
       @include mixins.sky-theme-modern-border-focus;
     }
 
-    &:focus,
+    &.sky-token-focused,
     &:hover {
       background-color: $sky-background-color-info-light;
     }
+  }
+
+  .sky-token-btn {
+    padding: 1px 5px;
+    border: 0;
+    box-shadow: none;
+    background-color: transparent;
+
+    &.sky-btn-disabled {
+      color: $sky-text-color-default;
+    }
+  }
+
+  .sky-token-btn-action {
+    font-size: 14px;
   }
 
   .sky-token-btn-close {
@@ -87,6 +124,7 @@
     height: 20px;
     margin-left: $sky-theme-modern-margin-inline-xs;
     width: 20px;
+    padding: 0;
 
     &:hover {
       @include mixins.sky-theme-modern-border-hover(transparent);
@@ -96,7 +134,7 @@
       @include mixins.sky-theme-modern-border-active;
     }
 
-    &:focus {
+    &:focus-visible {
       outline: none;
 
       &:not(:active) {

--- a/libs/components/indicators/src/lib/modules/tokens/token.component.spec.ts
+++ b/libs/components/indicators/src/lib/modules/tokens/token.component.spec.ts
@@ -42,6 +42,37 @@ describe('Token component', () => {
     validateActive('sky-token-btn-close');
   });
 
+  it('should emit when token focused', () => {
+    const fixture = TestBed.createComponent(SkyTokenComponent);
+    const tokenEl = fixture.nativeElement.querySelector('.sky-token');
+
+    const focusSpy = spyOn(
+      fixture.componentInstance.tokenFocus,
+      'emit'
+    ).and.callThrough();
+
+    fixture.componentInstance.focusable = true;
+    fixture.detectChanges();
+
+    SkyAppTestUtility.fireDomEvent(tokenEl, 'focusin');
+    fixture.detectChanges();
+
+    // Ensure CSS class is added on focus.
+    expect(tokenEl).toHaveClass('sky-token-focused');
+    expect(focusSpy).toHaveBeenCalled();
+
+    SkyAppTestUtility.fireDomEvent(tokenEl, 'focusout', {
+      customEventInit: {
+        // Mock an element that is not a child of the token.
+        relatedTarget: document.createElement('div'),
+      },
+    });
+    fixture.detectChanges();
+
+    // Ensure CSS class is removed on blur.
+    expect(tokenEl).not.toHaveClass('sky-token-focused');
+  });
+
   it('should use the specified ARIA label', () => {
     const fixture = TestBed.createComponent(SkyTokenTestComponent);
 
@@ -58,5 +89,13 @@ describe('Token component', () => {
     fixture.detectChanges();
 
     expect(btnEl.getAttribute('aria-label')).toBe('Remove item');
+  });
+
+  it('should not have a role by default', () => {
+    const fixture = TestBed.createComponent(SkyTokenTestComponent);
+    fixture.detectChanges();
+    expect(
+      fixture.nativeElement.querySelector('.sky-token').getAttribute('role')
+    ).toBeNull();
   });
 });

--- a/libs/components/indicators/src/lib/modules/tokens/tokens.component.html
+++ b/libs/components/indicators/src/lib/modules/tokens/tokens.component.html
@@ -1,11 +1,11 @@
 <div
   class="sky-tokens"
   [@blockAnimationOnLoad]
-  [attr.role]="tokens.length ? 'list' : null"
+  [attr.role]="tokens.length ? 'grid' : null"
 >
   <sky-token
     *ngFor="let token of tokens; let i = index; trackBy: trackTokenFn"
-    role="listitem"
+    role="row"
     [@.disabled]="!trackWith"
     [@dismiss]
     [disabled]="disabled"

--- a/libs/components/indicators/src/lib/modules/tokens/tokens.component.spec.ts
+++ b/libs/components/indicators/src/lib/modules/tokens/tokens.component.spec.ts
@@ -8,6 +8,7 @@ import { SkyAppTestUtility, expect, expectAsync } from '@skyux-sdk/testing';
 
 import { Subject } from 'rxjs';
 
+import { SkyTokenA11yTestComponent } from './fixtures/token-a11y.component.fixture';
 import { SkyTokensFixturesModule } from './fixtures/tokens-fixtures.module';
 import { SkyTokensTestComponent } from './fixtures/tokens.component.fixture';
 import { SkyTokensMessageType } from './types/tokens-message-type';
@@ -37,7 +38,7 @@ describe('Tokens component', () => {
     fixture.detectChanges();
     expect(component.tokensComponent?.activeIndex).toEqual(1);
     expect(document.activeElement).toEqual(
-      tokenElements.item(1).querySelector('.sky-token')
+      tokenElements.item(1).querySelector('.sky-token-btn-action')
     );
 
     SkyAppTestUtility.fireDomEvent(tokenElements.item(1), 'keydown', {
@@ -47,7 +48,7 @@ describe('Tokens component', () => {
 
     expect(component.tokensComponent?.activeIndex).toEqual(0);
     expect(document.activeElement).toEqual(
-      tokenElements.item(0).querySelector('.sky-token')
+      tokenElements.item(0).querySelector('.sky-token-btn-action')
     );
   }
 
@@ -58,7 +59,9 @@ describe('Tokens component', () => {
     component.messageStream?.next({ type });
     fixture.detectChanges();
 
-    const tokenElements = fixture.nativeElement.querySelectorAll('.sky-token');
+    const tokenElements = fixture.nativeElement.querySelectorAll(
+      '.sky-token-btn-action'
+    );
     const focusedToken = tokenElements[index] as HTMLElement;
 
     expect(component.tokensComponent?.activeIndex).toEqual(index);
@@ -318,8 +321,9 @@ describe('Tokens component', () => {
 
       fixture.detectChanges();
 
-      const tokenElements =
-        fixture.nativeElement.querySelectorAll('.sky-token');
+      const tokenElements = fixture.nativeElement.querySelectorAll(
+        '.sky-token-btn-action'
+      );
       const lastToken = tokenElements[tokenElements.length - 1] as HTMLElement;
 
       expect(component.tokensComponent?.activeIndex).toEqual(
@@ -464,22 +468,40 @@ describe('Tokens component', () => {
       component.publishTokens();
       fixture.detectChanges();
 
-      let tokenDivs: NodeListOf<HTMLDivElement> =
+      let tokenButtons: NodeListOf<HTMLDivElement> =
         component.tokensElementRef?.nativeElement.querySelectorAll(
-          '.sky-token'
+          '.sky-token-btn-action'
         );
 
-      expect(tokenDivs.item(0).tabIndex).toEqual(0);
+      expect(tokenButtons.item(0).tabIndex).toEqual(0);
 
       component.focusable = false;
       fixture.detectChanges();
-      tokenDivs =
+      tokenButtons =
         component.tokensElementRef?.nativeElement.querySelectorAll(
           '.sky-token'
         );
-      expect(tokenDivs.item(0).tabIndex).toEqual(-1);
+      expect(tokenButtons.item(0).tabIndex).toEqual(-1);
 
       await expectAsync(fixture.nativeElement).toBeAccessible();
     });
+  });
+
+  it('should be accessible', async () => {
+    const a11yFixture = TestBed.createComponent(SkyTokenA11yTestComponent);
+
+    a11yFixture.detectChanges();
+
+    await expectAsync(
+      a11yFixture.nativeElement.querySelector(
+        '[data-sky-id="non-dismissible-tokens"]'
+      )
+    ).toBeAccessible();
+
+    await expectAsync(
+      a11yFixture.nativeElement.querySelector(
+        '[data-sky-id="dismissible-tokens"]'
+      )
+    ).toBeAccessible();
   });
 });

--- a/libs/components/indicators/src/lib/modules/tokens/tokens.component.ts
+++ b/libs/components/indicators/src/lib/modules/tokens/tokens.component.ts
@@ -221,11 +221,12 @@ export class SkyTokensComponent implements OnDestroy {
 
   constructor(changeDetector: ChangeDetectorRef) {
     this.#changeDetector = changeDetector;
+    this.#initMessageStream();
 
     // Angular calls the trackBy function without applying the component instance's scope.
     // Use a fat-arrow function so the current component instance's trackWith property can
     // be referenced.
-    this.trackTokenFn = (_index, item) => {
+    this.trackTokenFn = (_index, item): unknown => {
       if (this.trackWith) {
         return item.value[this.trackWith];
       }

--- a/libs/components/indicators/testing/src/tokens/token-harness.ts
+++ b/libs/components/indicators/testing/src/tokens/token-harness.ts
@@ -11,6 +11,8 @@ export class SkyTokenHarness extends ComponentHarness {
    */
   public static hostSelector = 'sky-token';
 
+  #getActionButton = this.locatorFor('button.sky-token-btn-action');
+
   #getDismissButton = this.locatorFor('button.sky-token-btn-close');
 
   #getWrapper = this.locatorFor('.sky-token');
@@ -50,7 +52,7 @@ export class SkyTokenHarness extends ComponentHarness {
   public async dismiss(): Promise<void> {
     if (!(await this.isDismissible())) {
       throw new Error(
-        'Could not dismiss the token because it is not dismissable.'
+        'Could not dismiss the token because it is not dismissible.'
       );
     }
 
@@ -68,20 +70,20 @@ export class SkyTokenHarness extends ComponentHarness {
    * Whether the token is disabled.
    */
   public async isDisabled(): Promise<boolean> {
-    return (await this.#getWrapper()).hasClass('sky-btn-disabled');
+    return (await this.#getWrapper()).hasClass('sky-token-disabled');
   }
 
   /**
    * Whether the token is dismissible.
    */
   public async isDismissible(): Promise<boolean> {
-    return (await this.#getWrapper()).hasClass('sky-token-dismissable');
+    return (await this.#getWrapper()).hasClass('sky-token-dismissible');
   }
 
   /**
    * Whether the token is focused.
    */
   public async isFocused(): Promise<boolean> {
-    return (await this.#getWrapper()).isFocused();
+    return (await this.#getActionButton()).isFocused();
   }
 }

--- a/libs/components/indicators/testing/src/tokens/tokens-harness.spec.ts
+++ b/libs/components/indicators/testing/src/tokens/tokens-harness.spec.ts
@@ -89,7 +89,7 @@ describe('Tokens harness', () => {
 
     await expectAsync(tokens[0].isDismissible()).toBeResolvedTo(false);
     await expectAsync(tokens[0].dismiss()).toBeRejectedWithError(
-      'Could not dismiss the token because it is not dismissable.'
+      'Could not dismiss the token because it is not dismissible.'
     );
   });
 
@@ -147,7 +147,9 @@ describe('Tokens harness', () => {
 
     await expectAsync(firstToken.isFocused()).toBeResolvedTo(false);
 
-    fixture.nativeElement.querySelectorAll('sky-token .sky-btn')[0].focus();
+    fixture.nativeElement
+      .querySelectorAll('sky-token .sky-token-btn')[0]
+      .focus();
 
     await expectAsync(firstToken.isFocused()).toBeResolvedTo(true);
   });

--- a/libs/components/lookup/src/lib/modules/lookup/lookup.component.spec.ts
+++ b/libs/components/lookup/src/lib/modules/lookup/lookup.component.spec.ts
@@ -106,14 +106,14 @@ describe('Lookup component', function () {
     if (async) {
       (
         document.querySelectorAll(
-          '#my-async-lookup .sky-lookup-tokens .sky-token'
+          '#my-async-lookup .sky-lookup-tokens .sky-token-btn-action'
         )[index] as HTMLElement
       ).click();
     } else {
       (
-        document.querySelectorAll('#my-lookup .sky-lookup-tokens .sky-token')[
-          index
-        ] as HTMLElement
+        document.querySelectorAll(
+          '#my-lookup .sky-lookup-tokens .sky-token-btn-action'
+        )[index] as HTMLElement
       ).click();
     }
     fixture.detectChanges();
@@ -301,9 +301,11 @@ describe('Lookup component', function () {
 
   function getTokenElements(async: boolean = false): NodeListOf<Element> {
     if (async) {
-      return document.querySelectorAll('#my-async-lookup .sky-token');
+      return document.querySelectorAll(
+        '#my-async-lookup .sky-token-btn-action'
+      );
     } else {
-      return document.querySelectorAll('#my-lookup .sky-token');
+      return document.querySelectorAll('#my-lookup .sky-token-btn-action');
     }
   }
 
@@ -3486,10 +3488,9 @@ describe('Lookup component', function () {
         performSearch('s', fixture);
         selectSearchResult(0, fixture);
 
-        const tokenElements = getTokenElements();
         const input = getInputElement(lookupComponent);
 
-        triggerClick(tokenElements.item(0), fixture, true);
+        clickToken(0, fixture, false);
 
         expect(document.activeElement).not.toEqual(input);
       }));
@@ -6446,10 +6447,9 @@ describe('Lookup component', function () {
         performSearch('s', fixture);
         selectSearchResult(0, fixture);
 
-        const tokenElements = getTokenElements();
         const input = getInputElement(lookupComponent);
 
-        triggerClick(tokenElements.item(0), fixture, true);
+        clickToken(0, fixture, false);
 
         expect(document.activeElement).not.toEqual(input);
       }));
@@ -6537,10 +6537,9 @@ describe('Lookup component', function () {
         performSearch('s', fixture);
         selectSearchResult(0, fixture);
 
-        const tokenElements = getTokenElements();
         const input = getInputElement(lookupComponent);
 
-        triggerClick(tokenElements.item(0), fixture, true);
+        clickToken(0, fixture, false);
 
         expect(document.activeElement).not.toEqual(input);
       }));

--- a/libs/components/select-field/src/lib/modules/select-field/select-field.component.spec.ts
+++ b/libs/components/select-field/src/lib/modules/select-field/select-field.component.spec.ts
@@ -97,7 +97,7 @@ describe('Select field component', () => {
 
   function closeToken(index: number) {
     const tokens = getTokens();
-    tokens.item(index).querySelector('button').click();
+    tokens.item(index).querySelector('button.sky-token-btn-close').click();
     tick();
     fixture.detectChanges();
   }


### PR DESCRIPTION
- Angular Material had the same problem with its chip component: https://github.com/angular/components/issues/24605
- They addressed it by using the `grid` role (currently in RC.15) https://rc.material.angular.io/components/chips/examples
- The visual tests are valid failures since I want to capture the focus state of the buttons, whereas the main branch did not.