### PR TITLE
fix(components/theme): remove variables exports from SCSS mixins

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,6 +7,7 @@
     "blackbaud",
     "compat",
     "skyux",
+    "stylesheet",
     "tabindex",
     "tablist",
     "tabset"

--- a/libs/components/packages/src/schematics/migrations/migration-collection.json
+++ b/libs/components/packages/src/schematics/migrations/migration-collection.json
@@ -19,6 +19,11 @@
       "version": "7.0.0-beta.0",
       "factory": "./update-7/add-compat-stylesheets",
       "description": "Add a backwards-compatible stylesheet with styles that have been removed from components in SKY UX 7."
+    },
+    "fix-scss-imports": {
+      "version": "7.0.0-beta.0",
+      "factory": "./update-7/fix-scss-imports",
+      "description": "Fix SCSS imports"
     }
   }
 }

--- a/libs/components/packages/src/schematics/migrations/update-7/fix-scss-imports.spec.ts
+++ b/libs/components/packages/src/schematics/migrations/update-7/fix-scss-imports.spec.ts
@@ -1,0 +1,204 @@
+import { SchematicTestRunner } from '@angular-devkit/schematics/testing';
+
+import { join } from 'path';
+
+import { createTestApp } from '../../testing/scaffold';
+
+describe('Migrations > Fix SKY UX SCSS imports', () => {
+  const runner = new SchematicTestRunner(
+    'migrations',
+    join(__dirname, '../migration-collection.json')
+  );
+
+  async function setupTest() {
+    const tree = await createTestApp(runner, {
+      projectName: 'my-app',
+    });
+
+    return {
+      runSchematic: () =>
+        runner.runSchematicAsync('fix-scss-imports', {}, tree).toPromise(),
+      tree,
+    };
+  }
+
+  it('should replace design tokens mixins imports with @skyux/theme equivalents', async () => {
+    const { runSchematic, tree } = await setupTest();
+
+    tree.overwrite(
+      'src/styles.scss',
+      `
+@import 'node_modules/@blackbaud/skyux-design-tokens/scss/mixins';
+`
+    );
+
+    await runSchematic();
+
+    expect(tree.readContent('src/styles.scss')).toEqual(`
+@import 'node_modules/@skyux/theme/scss/mixins';
+@import 'node_modules/@skyux/theme/scss/variables';
+`);
+  });
+
+  it('should replace design tokens variables imports', async () => {
+    const { runSchematic, tree } = await setupTest();
+
+    tree.overwrite(
+      'src/styles.scss',
+      `
+@import 'node_modules/@blackbaud/skyux-design-tokens/scss/variables';
+`
+    );
+
+    await runSchematic();
+
+    expect(tree.readContent('src/styles.scss')).toEqual(`
+@import 'node_modules/@skyux/theme/scss/variables';
+`);
+  });
+
+  it('should remove design tokens imports if default imports already found', async () => {
+    const { runSchematic, tree } = await setupTest();
+
+    tree.overwrite(
+      'src/styles.scss',
+      `
+@import 'node_modules/@blackbaud/skyux-design-tokens/scss/mixins';
+@import 'node_modules/@skyux/theme/scss/mixins';
+`
+    );
+
+    await runSchematic();
+
+    expect(tree.readContent('src/styles.scss')).toEqual(`
+@import 'node_modules/@skyux/theme/scss/mixins';
+@import 'node_modules/@skyux/theme/scss/variables';
+`);
+  });
+
+  it('should remove design tokens imports if default variables imports already found', async () => {
+    const { runSchematic, tree } = await setupTest();
+
+    tree.overwrite(
+      'src/styles.scss',
+      `
+@import 'node_modules/@blackbaud/skyux-design-tokens/scss/mixins';
+@import 'node_modules/@blackbaud/skyux-design-tokens/scss/variables';
+@import 'node_modules/@skyux/theme/scss/mixins';
+`
+    );
+
+    await runSchematic();
+
+    expect(tree.readContent('src/styles.scss')).toEqual(`
+@import 'node_modules/@skyux/theme/scss/variables';
+@import 'node_modules/@skyux/theme/scss/mixins';
+`);
+  });
+
+  it('should add default variables import if mixins import exists', async () => {
+    const { runSchematic, tree } = await setupTest();
+
+    tree.overwrite(
+      'src/styles.scss',
+      `
+@import 'node_modules/@skyux/theme/scss/themes/modern/_compat/mixins';
+@import 'node_modules/@skyux/theme/scss/_compat/mixins';
+@import 'node_modules/@skyux/theme/scss/mixins';
+`
+    );
+
+    await runSchematic();
+
+    expect(tree.readContent('src/styles.scss')).toEqual(`
+@import 'node_modules/@skyux/theme/scss/themes/modern/_compat/mixins';
+@import 'node_modules/@skyux/theme/scss/themes/modern/_compat/variables';
+@import 'node_modules/@skyux/theme/scss/_compat/mixins';
+@import 'node_modules/@skyux/theme/scss/_compat/variables';
+@import 'node_modules/@skyux/theme/scss/mixins';
+@import 'node_modules/@skyux/theme/scss/variables';
+`);
+  });
+
+  it('should not add variables import if it already exists', async () => {
+    const { runSchematic, tree } = await setupTest();
+
+    tree.overwrite(
+      'src/styles.scss',
+      `
+@import 'node_modules/@skyux/theme/scss/mixins';
+@import 'node_modules/@skyux/theme/scss/variables';
+`
+    );
+
+    await runSchematic();
+
+    expect(tree.readContent('src/styles.scss')).toEqual(`
+@import 'node_modules/@skyux/theme/scss/mixins';
+@import 'node_modules/@skyux/theme/scss/variables';
+`);
+  });
+
+  it('should handle import style variations', async () => {
+    const { runSchematic, tree } = await setupTest();
+
+    tree.overwrite(
+      'src/styles.scss',
+      `
+@import node_modules/@blackbaud/skyux-design-tokens/scss/mixins
+@import 'node_modules/@skyux/theme/scss/themes/modern/_compat/mixins';
+@import "node_modules/@skyux/theme/scss/_compat/_mixins";
+@import "node_modules/@skyux/theme/scss/_mixins.scss";
+`
+    );
+
+    await runSchematic();
+
+    expect(tree.readContent('src/styles.scss')).toEqual(`
+@import 'node_modules/@skyux/theme/scss/themes/modern/_compat/mixins';
+@import 'node_modules/@skyux/theme/scss/themes/modern/_compat/variables';
+@import "node_modules/@skyux/theme/scss/_compat/_mixins";
+@import "node_modules/@skyux/theme/scss/_compat/_variables";
+@import "node_modules/@skyux/theme/scss/_mixins.scss";
+@import "node_modules/@skyux/theme/scss/_variables.scss";
+`);
+  });
+
+  it('should remove @blackbaud/skyux-design-tokens from package.json dependencies', async () => {
+    const { runSchematic, tree } = await setupTest();
+
+    tree.overwrite(
+      'package.json',
+      JSON.stringify({
+        dependencies: {
+          '@blackbaud/skyux-design-tokens': '0.0.1',
+        },
+      })
+    );
+
+    await runSchematic();
+
+    expect(tree.readJson('package.json')).toEqual({
+      dependencies: {},
+    });
+  });
+
+  it('should remove @blackbaud/skyux-design-tokens from package.json devDependencies', async () => {
+    const { runSchematic, tree } = await setupTest();
+
+    tree.overwrite(
+      'package.json',
+      JSON.stringify({
+        devDependencies: {
+          '@blackbaud/skyux-design-tokens': '0.0.1',
+        },
+      })
+    );
+
+    await runSchematic();
+
+    expect(tree.readJson('package.json')).toEqual({
+      devDependencies: {},
+    });
+  });
+});

--- a/libs/components/packages/src/schematics/migrations/update-7/fix-scss-imports.ts
+++ b/libs/components/packages/src/schematics/migrations/update-7/fix-scss-imports.ts
@@ -13,13 +13,14 @@ function replaceDesignTokensImports(contents: string): string {
 
   for (const match of matches) {
     const importPath = match[0];
-    const importType = match[1];
+    const importType = match[1]; // mixins or variables
 
     const replacementTemplate = new RegExp(
       `@import\\s+['"]?node_modules\\/@skyux\\/theme\\/scss\\/_?${importType}(?:\\.scss)?['"]?;?`
     );
-    const m = contents.match(replacementTemplate);
-    if (m) {
+
+    // If the equivalent default import is already found, just remove the design tokens import.
+    if (replacementTemplate.test(contents)) {
       contents = contents.replace(importPath, '');
       continue;
     }

--- a/libs/components/packages/src/schematics/migrations/update-7/fix-scss-imports.ts
+++ b/libs/components/packages/src/schematics/migrations/update-7/fix-scss-imports.ts
@@ -1,0 +1,106 @@
+import { Rule, chain } from '@angular-devkit/schematics';
+
+import { readRequiredFile } from '../../utility/tree';
+import { getWorkspace } from '../../utility/workspace';
+
+/**
+ * Replaces any @blackbaud/skyux-design-tokens imports with their @skyux/theme equivalents.
+ */
+function replaceDesignTokensImports(contents: string): string {
+  const matches = contents.matchAll(
+    /@import\s+['"]?node_modules\/@blackbaud\/skyux-design-tokens\/scss\/_?(mixins|variables)(?:\.scss)?['"]?;?\s+/g
+  );
+
+  for (const match of matches) {
+    const importPath = match[0];
+    const importType = match[1];
+
+    const replacementTemplate = new RegExp(
+      `@import\\s+['"]?node_modules\\/@skyux\\/theme\\/scss\\/_?${importType}(?:\\.scss)?['"]?;?`
+    );
+    const m = contents.match(replacementTemplate);
+    if (m) {
+      contents = contents.replace(importPath, '');
+      continue;
+    }
+
+    contents = contents.replace(
+      importPath,
+      `@import 'node_modules/@skyux/theme/scss/${importType}';\n`
+    );
+  }
+
+  return contents;
+}
+
+/**
+ * If a mixins import exists, add the variables import as well.
+ * In prior versions of SKY UX, the variables were exported from the mixins file, but
+ * this creates a circular reference.
+ */
+function addVariablesScssImports(contents: string): string {
+  const matches = contents.matchAll(
+    /@import\s+['"]?node_modules\/@skyux\/theme\/scss\/(_compat\/|themes\/modern\/_compat\/)?_?mixins(?:\.scss)?['"]?;?/g
+  );
+
+  for (const match of matches) {
+    const mixinsImport = match[0];
+    const variablesImport = mixinsImport.replace('mixins', 'variables');
+    if (!contents.includes(variablesImport)) {
+      contents = contents.replace(
+        mixinsImport,
+        `${mixinsImport}\n${variablesImport}`
+      );
+    }
+  }
+
+  return contents;
+}
+
+/**
+ * Fixes SKY UX SCSS imports.
+ */
+function fixScssImports(): Rule {
+  return async (tree) => {
+    const { workspace } = await getWorkspace(tree);
+
+    for (const [, projectDefinition] of workspace.projects.entries()) {
+      tree.getDir(projectDefinition.root).visit((filePath) => {
+        if (filePath.endsWith('.scss')) {
+          const contents = readRequiredFile(tree, filePath);
+
+          let updatedContents = contents;
+          updatedContents = replaceDesignTokensImports(updatedContents);
+          updatedContents = addVariablesScssImports(updatedContents);
+
+          if (updatedContents !== contents) {
+            tree.overwrite(filePath, updatedContents);
+          }
+        }
+      });
+    }
+  };
+}
+
+/**
+ * Removes the local version of '@blackbaud/skyux-design-tokens' from package.json;
+ */
+function removeDesignTokensPackage(): Rule {
+  return (tree) => {
+    const packageJson = JSON.parse(readRequiredFile(tree, 'package.json'));
+
+    if (packageJson.dependencies) {
+      delete packageJson.dependencies['@blackbaud/skyux-design-tokens'];
+    }
+
+    if (packageJson.devDependencies) {
+      delete packageJson.devDependencies['@blackbaud/skyux-design-tokens'];
+    }
+
+    tree.overwrite('package.json', JSON.stringify(packageJson));
+  };
+}
+
+export default function (): Rule {
+  return chain([fixScssImports(), removeDesignTokensPackage()]);
+}

--- a/libs/components/packages/src/schematics/migrations/update-7/fix-scss-imports.ts
+++ b/libs/components/packages/src/schematics/migrations/update-7/fix-scss-imports.ts
@@ -36,8 +36,8 @@ function replaceDesignTokensImports(contents: string): string {
 
 /**
  * If a mixins import exists, add the variables import as well.
- * In prior versions of SKY UX, the variables were exported from the mixins file, but
- * this creates a circular reference.
+ * (In prior versions of SKY UX, the variables were exported from the mixins file, but
+ * this created a circular reference, hence the fix.)
  */
 function addVariablesScssImports(contents: string): string {
   const matches = contents.matchAll(
@@ -58,9 +58,6 @@ function addVariablesScssImports(contents: string): string {
   return contents;
 }
 
-/**
- * Fixes SKY UX SCSS imports.
- */
 function fixScssImports(): Rule {
   return async (tree) => {
     const { workspace } = await getWorkspace(tree);

--- a/libs/components/theme/src/lib/styles/_public-api/_compat/_mixins.scss
+++ b/libs/components/theme/src/lib/styles/_public-api/_compat/_mixins.scss
@@ -1,8 +1,3 @@
-// Export variables for backward compatibility.
-// (Some stylesheets only import the mixins.scss file and expected the variables to be available.)
-// TODO: Remove this forward in a breaking change.
-@forward 'variables';
-
 @use '../variables' as *;
 @use 'variables' as *;
 

--- a/libs/components/theme/src/lib/styles/_public-api/_mixins.scss
+++ b/libs/components/theme/src/lib/styles/_public-api/_mixins.scss
@@ -2,11 +2,6 @@
 
 @forward 'node_modules/@blackbaud/skyux-design-tokens/scss/mixins';
 
-// Export variables for backward compatibility.
-// (Some stylesheets only import the mixins.scss file and expected the variables to be available.)
-// TODO: Remove this forward in a breaking change.
-@forward 'variables';
-
 @use 'variables' as *;
 
 @mixin sky-host-responsive-container-xs-min($encapsulate: true) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4539,8 +4539,8 @@
       "integrity": "sha512-JvWDO0me+uAHdetH38OyDJIBX2nW8M1vdLSiy1F8Ebm7D2JvvK/LotlqFtMjmHS5Mb4dadDX89LGE3mvUH/Vvg=="
     },
     "@skyux/dev-infra-private": {
-      "version": "github:blackbaud/skyux-dev-infra-private-builds#450524c43a19119fe977d9e2daabe19d3f42b6eb",
-      "from": "github:blackbaud/skyux-dev-infra-private-builds#2.1.1",
+      "version": "github:blackbaud/skyux-dev-infra-private-builds#79be29cb21ab2bb72722aa8d391baf1944043039",
+      "from": "github:blackbaud/skyux-dev-infra-private-builds#2.1.2",
       "dev": true,
       "requires": {
         "axios": "0.26.1",
@@ -21351,9 +21351,9 @@
       "dev": true
     },
     "marked": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-4.1.0.tgz",
-      "integrity": "sha512-+Z6KDjSPa6/723PQYyc1axYZpYYpDnECDaU6hkaf5gqBieBkMKYReL5hteF2QizhlMbgbo8umXl/clZ67+GlsA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.1.1.tgz",
+      "integrity": "sha512-0cNMnTcUJPxbA6uWmCmjWz4NJRe/0Xfk2NhXCUHjew9qJzFN20krFnsUe7QynwqOwa5m1fZ4UDg0ycKFVC0ccw==",
       "dev": true
     },
     "md5.js": {

--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
     "@percy/storybook": "4.3.3",
     "@ryansonshine/commitizen": "4.2.8",
     "@ryansonshine/cz-conventional-changelog": "3.3.4",
-    "@skyux/dev-infra-private": "github:blackbaud/skyux-dev-infra-private-builds#2.1.1",
+    "@skyux/dev-infra-private": "github:blackbaud/skyux-dev-infra-private-builds#2.1.2",
     "@storybook/addon-a11y": "6.5.10",
     "@storybook/addon-essentials": "6.5.10",
     "@storybook/angular": "6.5.10",


### PR DESCRIPTION
Exporting variables from mixins is causing a few circular references depending on how the consumers `@import` their SKY UX Theme SCSS files. We need to remove the `@forward` for the variables, but create a schematic that also imports the SKY UX Theme variables SCSS file, if needed.