### PR TITLE
fix(components/forms)!: use `EventEmitter` for radio component outputs

### DIFF
--- a/libs/components/forms/src/lib/modules/radio/radio.component.html
+++ b/libs/components/forms/src/lib/modules/radio/radio.component.html
@@ -13,7 +13,7 @@
     [name]="name"
     [tabIndex]="tabindex"
     [value]="value"
-    (blur)="onInputFocusChange($event)"
+    (blur)="onInputFocusChange()"
     (change)="onInputChange($event)"
   />
   <span


### PR DESCRIPTION
Prior to this change, the radio component's `Output` properties were set to a type of `Observable`, but it's best practice to use `EventEmitter` instead. This change is marked as a breaking change only because it's a public property, but it shouldn't affect our consumers.