### PR TITLE
fix(components/errors): remove extra whitespace around error description

### DIFF
--- a/libs/components/errors/src/lib/modules/error/error.component.html
+++ b/libs/components/errors/src/lib/modules/error/error.component.html
@@ -14,9 +14,8 @@
   <div class="sky-error-title sky-font-heading-1 sky-margin-stacked-lg">
     <ng-container
       *ngIf="defaultTitle && (errorSvc.replaceDefaultTitle | async) === false"
+      >{{ defaultTitle }}</ng-container
     >
-      {{ defaultTitle }}
-    </ng-container>
     <ng-content select="sky-error-title"></ng-content>
   </div>
 
@@ -28,9 +27,8 @@
         defaultDescription &&
         (errorSvc.replaceDefaultDescription | async) === false
       "
+      >{{ defaultDescription }}</span
     >
-      {{ defaultDescription }}
-    </span>
     <ng-content select="sky-error-description"></ng-content>
   </div>
 

--- a/libs/components/errors/src/lib/modules/error/error.component.spec.ts
+++ b/libs/components/errors/src/lib/modules/error/error.component.spec.ts
@@ -203,6 +203,15 @@ describe('Error component', () => {
     );
   });
 
+  it('should not add extraneous whitespace around description', () => {
+    component.errorType = 'broken';
+    fixture.detectChanges();
+
+    expect(getErrorDescription('#test-error').innerText).toBe(
+      resourceStrings.brokenDescription
+    );
+  });
+
   it('should replace title and description', () => {
     component.errorType = 'broken';
     component.replaceDefaultDescription = true;
@@ -246,12 +255,12 @@ describe('Error component', () => {
     ).not.toExist();
 
     expect(getErrorTitle('#test-error-custom-replace-default')).toHaveText(
-      `${resourceStrings.brokenTitle}  ${component.customTitle}`
+      `${resourceStrings.brokenTitle} ${component.customTitle}`
     );
     expect(
       getErrorDescription('#test-error-custom-replace-default')
     ).toHaveText(
-      `${resourceStrings.brokenDescription}  ${component.customDescription}`
+      `${resourceStrings.brokenDescription} ${component.customDescription}`
     );
   });
 


### PR DESCRIPTION
The error component's description previously added extra whitespace to the start and end of the description text.

BREAKING CHANGE: Unit tests that expect this extra whitespace will need to be updated.