### PR TITLE
fix(components/packages): recognize leading tilde and relative paths when fixing SCSS imports

### DIFF
--- a/libs/components/packages/src/schematics/migrations/update-7/fix-scss-imports.spec.ts
+++ b/libs/components/packages/src/schematics/migrations/update-7/fix-scss-imports.spec.ts
@@ -173,6 +173,7 @@ describe('Migrations > Fix SKY UX SCSS imports', () => {
 @import './node_modules/@blackbaud/skyux-design-tokens/scss/mixins';
 @import '../../../../../node_modules/@skyux/theme/scss/mixins';
 @import '~@skyux/theme/scss/mixins';
+@import '@skyux/theme/scss/_compat/mixins';
 `
     );
 
@@ -183,6 +184,8 @@ describe('Migrations > Fix SKY UX SCSS imports', () => {
 @import '../../../../../node_modules/@skyux/theme/scss/variables';
 @import '~@skyux/theme/scss/mixins';
 @import '~@skyux/theme/scss/variables';
+@import '@skyux/theme/scss/_compat/mixins';
+@import '@skyux/theme/scss/_compat/variables';
 `);
   });
 

--- a/libs/components/packages/src/schematics/migrations/update-7/fix-scss-imports.spec.ts
+++ b/libs/components/packages/src/schematics/migrations/update-7/fix-scss-imports.spec.ts
@@ -164,6 +164,28 @@ describe('Migrations > Fix SKY UX SCSS imports', () => {
 `);
   });
 
+  it('should handle relative and tilde imports', async () => {
+    const { runSchematic, tree } = await setupTest();
+
+    tree.overwrite(
+      'src/styles.scss',
+      `
+@import './node_modules/@blackbaud/skyux-design-tokens/scss/mixins';
+@import '../../../../../node_modules/@skyux/theme/scss/mixins';
+@import '~@skyux/theme/scss/mixins';
+`
+    );
+
+    await runSchematic();
+
+    expect(tree.readContent('src/styles.scss')).toEqual(`
+@import '../../../../../node_modules/@skyux/theme/scss/mixins';
+@import '../../../../../node_modules/@skyux/theme/scss/variables';
+@import '~@skyux/theme/scss/mixins';
+@import '~@skyux/theme/scss/variables';
+`);
+  });
+
   it('should remove @blackbaud/skyux-design-tokens from package.json dependencies', async () => {
     const { runSchematic, tree } = await setupTest();
 

--- a/libs/components/packages/src/schematics/migrations/update-7/fix-scss-imports.ts
+++ b/libs/components/packages/src/schematics/migrations/update-7/fix-scss-imports.ts
@@ -8,7 +8,7 @@ import { getWorkspace } from '../../utility/workspace';
  */
 function replaceDesignTokensImports(contents: string): string {
   const matches = contents.matchAll(
-    /@import\s+['"]?node_modules\/@blackbaud\/skyux-design-tokens\/scss\/_?(mixins|variables)(?:\.scss)?['"]?;?\s+/g
+    /@import\s+['"]?[~]?(?:(?:\.|\/)+)?(?:node_modules\/)?@blackbaud\/skyux-design-tokens\/scss\/_?(mixins|variables)(?:\.scss)?['"]?;?\s+/g
   );
 
   for (const match of matches) {
@@ -16,7 +16,7 @@ function replaceDesignTokensImports(contents: string): string {
     const importType = match[1]; // mixins or variables
 
     const replacementTemplate = new RegExp(
-      `@import\\s+['"]?node_modules\\/@skyux\\/theme\\/scss\\/_?${importType}(?:\\.scss)?['"]?;?`
+      `@import\\s+['"]?[~]?(?:(?:\\.|\\/)+)?(?:node_modules\\/)?@skyux\\/theme\\/scss\\/_?${importType}(?:\\.scss)?['"]?;?`
     );
 
     // If the equivalent default import is already found, just remove the design tokens import.
@@ -41,7 +41,7 @@ function replaceDesignTokensImports(contents: string): string {
  */
 function addVariablesScssImports(contents: string): string {
   const matches = contents.matchAll(
-    /@import\s+['"]?node_modules\/@skyux\/theme\/scss\/(_compat\/|themes\/modern\/_compat\/)?_?mixins(?:\.scss)?['"]?;?/g
+    /@import\s+['"]?[~]?(?:(?:\.|\/)+)?(?:node_modules\/)?@skyux\/theme\/scss\/(_compat\/|themes\/modern\/_compat\/)?_?mixins(?:\.scss)?['"]?;?/g
   );
 
   for (const match of matches) {


### PR DESCRIPTION
Improved the RegExp to recognize leading `~` and relative paths (e.g. `../../../node_modules`).