### PR TITLE
refactor(components/forms)!: update `checked` and `radioType` input types

### DIFF
--- a/libs/components/forms/src/index.ts
+++ b/libs/components/forms/src/index.ts
@@ -17,6 +17,7 @@ export * from './lib/modules/input-box/input-box-host.service';
 export * from './lib/modules/input-box/input-box-populate-args';
 
 export * from './lib/modules/radio/types/radio-change';
+export * from './lib/modules/radio/types/radio-type';
 export * from './lib/modules/radio/radio.module';
 
 export * from './lib/modules/selection-box/types/selection-box-grid-align-items';

--- a/libs/components/forms/src/lib/modules/radio/fixtures/radio-single.component.fixture.ts
+++ b/libs/components/forms/src/lib/modules/radio/fixtures/radio-single.component.fixture.ts
@@ -1,9 +1,11 @@
 import { Component } from '@angular/core';
 
+import { SkyRadioType } from '../types/radio-type';
+
 @Component({
   templateUrl: './radio-single.component.fixture.html',
 })
 export class SkySingleRadioComponent {
   public icon = 'bold';
-  public radioType: string | undefined;
+  public radioType: SkyRadioType | undefined;
 }

--- a/libs/components/forms/src/lib/modules/radio/radio-group.component.ts
+++ b/libs/components/forms/src/lib/modules/radio/radio-group.component.ts
@@ -220,7 +220,7 @@ export class SkyRadioGroupComponent
     }
   }
 
-  public watchForSelections() {
+  public watchForSelections(): void {
     /* istanbul ignore else */
     if (this.radios) {
       this.radios.forEach((radio) => {
@@ -238,7 +238,7 @@ export class SkyRadioGroupComponent
     }
   }
 
-  public ngOnDestroy() {
+  public ngOnDestroy(): void {
     this.#ngUnsubscribe.next();
     this.#ngUnsubscribe.complete();
   }
@@ -257,7 +257,7 @@ export class SkyRadioGroupComponent
    * @internal
    * Indicates whether to disable the control. Implemented as a part of ControlValueAccessor.
    */
-  public setDisabledState(isDisabled: boolean) {
+  public setDisabledState(isDisabled: boolean): void {
     this.disabled = isDisabled;
   }
 

--- a/libs/components/forms/src/lib/modules/radio/radio.component.spec.ts
+++ b/libs/components/forms/src/lib/modules/radio/radio.component.spec.ts
@@ -18,9 +18,6 @@ import { SkyRadioLabelComponent } from './radio-label.component';
 import { SkyRadioComponent } from './radio.component';
 
 describe('Radio component', function () {
-  let fixture: ComponentFixture<any>;
-  let componentInstance: any;
-
   beforeEach(function () {
     TestBed.configureTestingModule({
       imports: [SkyRadioFixturesModule],
@@ -32,35 +29,35 @@ describe('Radio component', function () {
     spyOn(idSvc, 'generateId').and.callFake(() => `MOCK_ID_${++uniqueId}`);
   });
 
-  afterEach(function () {
-    if (fixture) {
-      fixture.destroy();
-    }
-  });
-
   describe('Standard radio component', () => {
-    let testComponent: SkyRadioTestComponent;
+    let fixture: ComponentFixture<SkyRadioTestComponent>;
+    let componentInstance: SkyRadioTestComponent;
 
     beforeEach(fakeAsync(() => {
       fixture = TestBed.createComponent(SkyRadioTestComponent);
 
       componentInstance = fixture.componentInstance;
-      testComponent = fixture.debugElement.componentInstance;
 
       fixture.detectChanges();
       tick();
     }));
 
+    afterEach(function () {
+      if (fixture) {
+        fixture.destroy();
+      }
+    });
+
     it('should emit the new disabled value when it is modified', () => {
-      const onDisabledChangeSpy = spyOn(testComponent, 'onDisabledChange');
+      const onDisabledChangeSpy = spyOn(componentInstance, 'onDisabledChange');
       expect(onDisabledChangeSpy).toHaveBeenCalledTimes(0);
-      testComponent.disabled1 = true;
+      componentInstance.disabled1 = true;
       fixture.detectChanges();
       expect(onDisabledChangeSpy).toHaveBeenCalledTimes(1);
     });
 
     it('should emit when radio is checked', async () => {
-      const onCheckedChangeSpy = spyOn(testComponent, 'onCheckedChange');
+      const onCheckedChangeSpy = spyOn(componentInstance, 'onCheckedChange');
       const radios: NodeListOf<HTMLInputElement> =
         fixture.nativeElement.querySelectorAll('input');
 
@@ -224,7 +221,7 @@ describe('Radio component', function () {
     }));
 
     it('should pass a tabindex when specified', fakeAsync(function () {
-      componentInstance.tabindex2 = '3';
+      componentInstance.tabindex2 = 3;
       fixture.detectChanges();
       tick();
 
@@ -286,10 +283,17 @@ describe('Radio component', function () {
 
   describe('Radio icon component', () => {
     let debugElement: DebugElement;
+    let fixture: ComponentFixture<SkySingleRadioComponent>;
 
     beforeEach(() => {
       fixture = TestBed.createComponent(SkySingleRadioComponent);
       debugElement = fixture.debugElement;
+    });
+
+    afterEach(function () {
+      if (fixture) {
+        fixture.destroy();
+      }
     });
 
     it('should set icon based on input', () => {
@@ -344,11 +348,20 @@ describe('Radio component', function () {
   });
 
   describe('Radio component with a consumer using OnPush change detection', () => {
+    let fixture: ComponentFixture<SkyRadioOnPushTestComponent>;
+    let componentInstance: SkyRadioOnPushTestComponent;
+
     beforeEach(function () {
       fixture = TestBed.createComponent(SkyRadioOnPushTestComponent);
 
       fixture.detectChanges();
       componentInstance = fixture.componentInstance;
+    });
+
+    afterEach(function () {
+      if (fixture) {
+        fixture.destroy();
+      }
     });
 
     it('should update the ngModel properly when radio button is changed', async () => {

--- a/libs/components/forms/src/lib/modules/radio/radio.component.spec.ts
+++ b/libs/components/forms/src/lib/modules/radio/radio.component.spec.ts
@@ -42,12 +42,6 @@ describe('Radio component', function () {
       tick();
     }));
 
-    afterEach(function () {
-      if (fixture) {
-        fixture.destroy();
-      }
-    });
-
     it('should emit the new disabled value when it is modified', () => {
       const onDisabledChangeSpy = spyOn(componentInstance, 'onDisabledChange');
       expect(onDisabledChangeSpy).toHaveBeenCalledTimes(0);
@@ -290,12 +284,6 @@ describe('Radio component', function () {
       debugElement = fixture.debugElement;
     });
 
-    afterEach(function () {
-      if (fixture) {
-        fixture.destroy();
-      }
-    });
-
     it('should set icon based on input', () => {
       fixture.detectChanges();
 
@@ -356,12 +344,6 @@ describe('Radio component', function () {
 
       fixture.detectChanges();
       componentInstance = fixture.componentInstance;
-    });
-
-    afterEach(function () {
-      if (fixture) {
-        fixture.destroy();
-      }
     });
 
     it('should update the ngModel properly when radio button is changed', async () => {

--- a/libs/components/forms/src/lib/modules/radio/radio.component.ts
+++ b/libs/components/forms/src/lib/modules/radio/radio.component.ts
@@ -19,6 +19,7 @@ import { SkyFormsUtility } from '../shared/forms-utility';
 
 import { SkyRadioGroupIdService } from './radio-group-id.service';
 import { SkyRadioChange } from './types/radio-change';
+import { SkyRadioType } from './types/radio-type';
 
 /**
  * Provider Expression that allows sky-radio to register as a ControlValueAccessor.
@@ -53,7 +54,7 @@ export class SkyRadioComponent implements OnDestroy, ControlValueAccessor {
    * @default false
    */
   @Input()
-  public set checked(value: boolean) {
+  public set checked(value: boolean | undefined) {
     const newCheckedState = !!value;
 
     if (this.#_checked !== newCheckedState) {
@@ -214,15 +215,11 @@ export class SkyRadioComponent implements OnDestroy, ControlValueAccessor {
    * @default "info"
    */
   @Input()
-  public get radioType(): string {
+  public get radioType(): SkyRadioType {
     return this.#_radioType;
   }
-  public set radioType(value: string | undefined) {
-    if (value) {
-      this.#_radioType = value.toLocaleLowerCase();
-    } else {
-      this.#_radioType = 'info';
-    }
+  public set radioType(value: SkyRadioType | undefined) {
+    this.#_radioType = value ?? 'info';
   }
 
   /**
@@ -262,7 +259,7 @@ export class SkyRadioComponent implements OnDestroy, ControlValueAccessor {
   #_checked = false;
   #_disabled = false;
   #_name: string | undefined;
-  #_radioType = 'info';
+  #_radioType: SkyRadioType = 'info';
   #_selectedValue: unknown;
   #_tabindex = 0;
   #_value: any;

--- a/libs/components/forms/src/lib/modules/radio/types/radio-type.ts
+++ b/libs/components/forms/src/lib/modules/radio/types/radio-type.ts
@@ -1,0 +1,1 @@
+export type SkyRadioType = 'danger' | 'info' | 'success' | 'warning';


### PR DESCRIPTION
Add `undefined` to `checked`. Convert `radioType` to string union.
BEGIN_COMMIT_OVERRIDE
feat(components/forms): change radio component's `radioType` input property to be more strongly typed
BREAKING CHANGE: The radio component's `radioType` input was set to a type of `string`, but it really only accepts a handful of known string values. These values are represented by the new `SkyRadioType` string union. This might cause problems if you are setting the `radioType` input to a type of `string` in your consuming component's class.
END_COMMIT_OVERRIDE