### PR TITLE
test(components/ag-grid): assert icons are loaded for e2e screenshots

### DIFF
--- a/apps/e2e/ag-grid-storybook-e2e/src/support/commands.ts
+++ b/apps/e2e/ag-grid-storybook-e2e/src/support/commands.ts
@@ -33,13 +33,15 @@ Cypress.Commands.add('waitForFonts', (...fonts: string[]) => {
   return cy
     .document()
     .its('fonts.status', { timeout: 20000 })
-    .should('equal', 'loaded')
+    .should('equal', 'loaded', { timeout: 20000 })
     .end()
     .document()
     .then((doc) => {
       cy.wrap(doc.fonts).should('not.be.undefined');
       fonts.forEach((font) => {
-        cy.wrap(doc.fonts).invoke('check', `16px "${font}"`).should('be.true');
+        cy.wrap(doc.fonts)
+          .invoke('check', `16px "${font}"`)
+          .should('be.true', undefined, { timeout: 20000 });
       });
     })
     .end();

--- a/apps/e2e/ag-grid-storybook/src/app/ag-grid/ag-grid-stories.component.html
+++ b/apps/e2e/ag-grid-storybook/src/app/ag-grid/ag-grid-stories.component.html
@@ -31,6 +31,9 @@
   </div>
 </div>
 
+<br />
+<sky-icon icon="check" iconType="fa"></sky-icon>
+
 <span id="ready" *ngIf="ready | async"></span>
 
 <sky-preview-wrapper *ngIf="addPreviewWrapper$ | async"></sky-preview-wrapper>

--- a/apps/e2e/ag-grid-storybook/src/app/ag-grid/ag-grid-stories.module.ts
+++ b/apps/e2e/ag-grid-storybook/src/app/ag-grid/ag-grid-stories.module.ts
@@ -2,6 +2,7 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 import { SkyAgGridModule } from '@skyux/ag-grid';
+import { SkyIconModule } from '@skyux/indicators';
 import { SkyBackToTopModule } from '@skyux/layout';
 import { SkyDropdownModule } from '@skyux/popovers';
 import { PreviewWrapperModule } from '@skyux/storybook';
@@ -24,6 +25,7 @@ const routes: Routes = [{ path: '', component: AgGridStoriesComponent }];
     SkyBackToTopModule,
     SkyThemeModule,
     PreviewWrapperModule,
+    SkyIconModule,
   ],
   providers: [SkyThemeService],
   exports: [AgGridStoriesComponent, ContextMenuComponent],

--- a/apps/e2e/ag-grid-storybook/src/app/data-entry-grid/data-entry-grid.component.html
+++ b/apps/e2e/ag-grid-storybook/src/app/data-entry-grid/data-entry-grid.component.html
@@ -26,6 +26,9 @@
   *ngIf="isActive$ | async; then gridTemplate; else themeWrap"
 ></ng-container>
 
+<br />
+<sky-icon icon="check" iconType="fa"></sky-icon>
+
 <span id="ready" *ngIf="ready | async"></span>
 
 <sky-preview-wrapper *ngIf="addPreviewWrapper$ | async"></sky-preview-wrapper>

--- a/apps/e2e/ag-grid-storybook/src/app/data-entry-grid/data-entry-grid.module.ts
+++ b/apps/e2e/ag-grid-storybook/src/app/data-entry-grid/data-entry-grid.module.ts
@@ -2,6 +2,7 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 import { SkyAgGridModule } from '@skyux/ag-grid';
+import { SkyIconModule } from '@skyux/indicators';
 import { PreviewWrapperModule } from '@skyux/storybook';
 import { SkyThemeModule, SkyThemeService } from '@skyux/theme';
 
@@ -19,6 +20,7 @@ const routes: Routes = [{ path: '', component: DataEntryGridComponent }];
     AgGridModule,
     SkyThemeModule,
     PreviewWrapperModule,
+    SkyIconModule,
   ],
   providers: [SkyThemeService],
   exports: [DataEntryGridComponent],


### PR DESCRIPTION
Followup to #756 , adding an icon element to ensure that icon font is loaded.