### PR TITLE
ci: switch pr-preview spas to use location hash

### DIFF
--- a/apps/code-examples/src/app/app-routing.module.ts
+++ b/apps/code-examples/src/app/app-routing.module.ts
@@ -149,7 +149,7 @@ const routes: Routes = [
 ];
 
 @NgModule({
-  imports: [RouterModule.forRoot(routes)],
+  imports: [RouterModule.forRoot(routes, { useHash: true })],
   exports: [RouterModule],
 })
 export class AppRoutingModule {}

--- a/apps/integration/src/app/app-routing.module.ts
+++ b/apps/integration/src/app/app-routing.module.ts
@@ -16,7 +16,7 @@ const routes: Routes = [
 ];
 
 @NgModule({
-  imports: [RouterModule.forRoot(routes)],
+  imports: [RouterModule.forRoot(routes, { useHash: true })],
   exports: [RouterModule],
 })
 export class AppRoutingModule {}

--- a/apps/playground/src/app/app-routing.module.ts
+++ b/apps/playground/src/app/app-routing.module.ts
@@ -14,7 +14,7 @@ const routes: Routes = [
 ];
 
 @NgModule({
-  imports: [RouterModule.forRoot(routes)],
+  imports: [RouterModule.forRoot(routes, { useHash: true })],
   exports: [RouterModule],
 })
 export class AppRoutingModule {}


### PR DESCRIPTION
Allows for deep linking to PR previews without getting 404 errors.