### PR TITLE
fix(components/lookup): lookup control value accessor uses a copy of passed in arrays instead of using the original array directly

### DIFF
--- a/libs/components/lookup/src/lib/modules/lookup/lookup.component.spec.ts
+++ b/libs/components/lookup/src/lib/modules/lookup/lookup.component.spec.ts
@@ -563,6 +563,8 @@ describe('Lookup component', function () {
           tick();
           fixture.detectChanges();
           tick();
+          // Ensure that we get a copy of the original array back and that we aren't modifying the original
+          expect(lookupComponent.value).not.toBe(friends);
           expect(lookupComponent.value).toEqual(friends);
         }));
 
@@ -3748,6 +3750,8 @@ describe('Lookup component', function () {
           tick();
           fixture.detectChanges();
           tick();
+          // Ensure that we get a copy of the original array back and that we aren't modifying the original
+          expect(lookupComponent.value).not.toBe(friends);
           expect(lookupComponent.value).toEqual(friends);
         }));
 

--- a/libs/components/lookup/src/lib/modules/lookup/lookup.component.ts
+++ b/libs/components/lookup/src/lib/modules/lookup/lookup.component.ts
@@ -461,7 +461,8 @@ export class SkyLookupComponent
   }
 
   public writeValue(value: any[]): void {
-    this.value = value ? value : [];
+    // Since we are dealing with arrays - clone the array being sent in to ensure we aren't modifying a consumers outer array
+    this.value = value ? value.slice() : [];
     this.#updateForSelectMode();
   }
 


### PR DESCRIPTION
[AB#2174149](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/2174149)