### PR TITLE
test(components/datetime): add missing fuzzy datepicker expectations and cover missing timepicker coverage

### DIFF
--- a/libs/components/datetime/karma.conf.js
+++ b/libs/components/datetime/karma.conf.js
@@ -11,15 +11,6 @@ module.exports = function (config) {
     coverageReporter: {
       ...baseConfig.coverageReporter,
       dir: join(__dirname, '../../../coverage/libs/components/datetime'),
-      // TODO: remove these threshold overrides to meet 100% coverage!
-      check: {
-        global: {
-          statements: 99,
-          branches: 99,
-          functions: 99,
-          lines: 99,
-        },
-      },
     },
   });
 };

--- a/libs/components/datetime/src/lib/modules/datepicker/fuzzy-datepicker.component.spec.ts
+++ b/libs/components/datetime/src/lib/modules/datepicker/fuzzy-datepicker.component.spec.ts
@@ -816,13 +816,18 @@ describe('fuzzy datepicker input', () => {
         flush();
       }));
 
-      // TODO: should this expect something?
-      it('should handle calendar date on invalid date', fakeAsync(() => {
+      it('should open the calendar to the current date when an invalid date is input', fakeAsync(() => {
         detectChanges(fixture);
 
         setInputElementValue(fixture.nativeElement, 'abcdebf', fixture);
 
         clickDatepickerButton(fixture);
+
+        const today = new Date();
+        const todayDateString = moment().format('MMMM YYYY');
+
+        expect(getCalendarTitle()).toHaveText(todayDateString);
+        expect(getSelectedCalendarItem()).toHaveText(`${today.getDate()}`);
 
         flush();
       }));
@@ -1532,13 +1537,18 @@ describe('fuzzy datepicker input', () => {
         flush();
       }));
 
-      // TODO: Should this test expect something?
-      it('should handle calendar date on invalid date', fakeAsync(() => {
+      it('should open the calendar to the current date when an invalid date is input', fakeAsync(() => {
         detectChanges(fixture);
 
         setInputElementValue(fixture.nativeElement, 'abcdebf', fixture);
 
         clickDatepickerButton(fixture);
+
+        const today = new Date();
+        const todayDateString = moment().format('MMMM YYYY');
+
+        expect(getCalendarTitle()).toHaveText(todayDateString);
+        expect(getSelectedCalendarItem()).toHaveText(`${today.getDate()}`);
 
         flush();
       }));

--- a/libs/components/datetime/src/lib/modules/timepicker/timepicker.component.spec.ts
+++ b/libs/components/datetime/src/lib/modules/timepicker/timepicker.component.spec.ts
@@ -98,6 +98,13 @@ function flushTimers(): void {
   flush();
 }
 
+function blurInput(fixture: ComponentFixture<any>): void {
+  const inputElement = fixture.nativeElement.querySelectorAll('input').item(0);
+  SkyAppTestUtility.fireDomEvent(inputElement, 'blur');
+  fixture.detectChanges();
+  tick();
+}
+
 function setInput(text: string, fixture: ComponentFixture<any>): void {
   const inputElement = fixture.nativeElement.querySelectorAll('input').item(0);
   inputElement.value = text;
@@ -106,6 +113,8 @@ function setInput(text: string, fixture: ComponentFixture<any>): void {
   SkyAppTestUtility.fireDomEvent(inputElement, 'change');
   fixture.detectChanges();
   tick();
+
+  blurInput(fixture);
 }
 
 function verifyTimepicker(fixture: ComponentFixture<any>): void {
@@ -697,6 +706,22 @@ describe('Timepicker', () => {
 
       expect(getInput(fixture).value).toBe('2:55 AM');
       expect(component.timeControl?.value.local).toEqual('2:55 AM');
+      expect(component.timeControl?.dirty).toBeFalse();
+      expect(component.timeControl?.touched).toBeFalse();
+    }));
+
+    it('should set the control to touched on blur', fakeAsync(() => {
+      detectChangesAndTick(fixture);
+
+      expect(getInput(fixture).value).toBe('2:55 AM');
+      expect(component.timeControl?.value.local).toEqual('2:55 AM');
+      expect(component.timeControl?.dirty).toBeFalse();
+      expect(component.timeControl?.touched).toBeFalse();
+
+      blurInput(fixture);
+
+      expect(component.timeControl?.dirty).toBeFalse();
+      expect(component.timeControl?.touched).toBeTrue();
     }));
 
     it('should update input value when form control is set programatically', fakeAsync(() => {
@@ -716,6 +741,8 @@ describe('Timepicker', () => {
 
       expect(getInput(fixture).value).toBe('2:55 AM');
       expect(component.timeControl?.value.local).toEqual('2:55 AM');
+      expect(component.timeControl?.dirty).toBeTrue();
+      expect(component.timeControl?.touched).toBeTrue();
     }));
 
     it('should handle an undefined date', fakeAsync(() => {


### PR DESCRIPTION
[AB#2315238](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/2315238)