### PR TITLE
fix(components/forms): update file attachment button label to match updated standards

### DIFF
--- a/libs/components/forms/src/assets/locales/resources_en_US.json
+++ b/libs/components/forms/src/assets/locales/resources_en_US.json
@@ -9,7 +9,7 @@
   },
   "skyux_file_attachment_button_label_choose_file": {
     "_description": "Button label for single file attachment when input has no value",
-    "message": "Choose file"
+    "message": "Attach file"
   },
   "skyux_file_attachment_button_label_replace_file": {
     "_description": "Button label for single file attachment when file has been chosen",
@@ -81,6 +81,6 @@
   },
   "skyux_file_attachment_label_no_file_chosen": {
     "_description": "Label for single file attachment when no file is chosen",
-    "message": "No file chosen"
+    "message": "No file chosen."
   }
 }

--- a/libs/components/forms/src/lib/modules/file-attachment/file-attachment.component.spec.ts
+++ b/libs/components/forms/src/lib/modules/file-attachment/file-attachment.component.spec.ts
@@ -637,7 +637,7 @@ describe('File attachment', () => {
     fileAttachmentInstance.writeValue(undefined);
     fixture.detectChanges();
 
-    expect(getFileNameText()).toBe('No file chosen');
+    expect(getFileNameText()).toBe('No file chosen.');
     expect(fileAttachmentInstance.fileName).toBe('');
 
     // File with no name and truncated url

--- a/libs/components/forms/src/lib/modules/shared/sky-forms-resources.module.ts
+++ b/libs/components/forms/src/lib/modules/shared/sky-forms-resources.module.ts
@@ -20,7 +20,7 @@ const RESOURCES: { [locale: string]: SkyLibResources } = {
     skyux_character_count_over_limit: {
       message: 'You are over the character limit.',
     },
-    skyux_file_attachment_button_label_choose_file: { message: 'Choose file' },
+    skyux_file_attachment_button_label_choose_file: { message: 'Attach file' },
     skyux_file_attachment_button_label_replace_file: {
       message: 'Replace file',
     },
@@ -58,7 +58,7 @@ const RESOURCES: { [locale: string]: SkyLibResources } = {
       message: 'Paste a link to a file',
     },
     skyux_file_attachment_file_upload_paste_link_done: { message: 'Done' },
-    skyux_file_attachment_label_no_file_chosen: { message: 'No file chosen' },
+    skyux_file_attachment_label_no_file_chosen: { message: 'No file chosen.' },
   },
 };
 


### PR DESCRIPTION
[AB#1932608](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/1932608)

Based on https://github.com/blackbaud/skyux-forms/pull/296