### PR TITLE
fix(components/forms): inline help within an input box now displays focus only around the help inline

### DIFF
--- a/libs/components/forms/src/lib/modules/input-box/input-box.component.scss
+++ b/libs/components/forms/src/lib/modules/input-box/input-box.component.scss
@@ -18,10 +18,6 @@ sky-input-box {
     display: flex;
     flex-wrap: wrap;
 
-    .sky-control-help {
-      margin-left: $sky-margin-inline-compact;
-    }
-
     .sky-input-box-label-wrapper {
       display: flex;
       width: 100%;
@@ -270,15 +266,10 @@ sky-input-box {
         }
 
         .sky-control-help {
-          margin: 0;
+          margin: 3px 0 0 $sky-margin-inline-compact;
 
-          .sky-help-inline {
-            font-size: 16px;
-            padding: 3px $sky-theme-modern-margin-inline-sm 0;
-          }
-
-          &:last-child .sky-help-inline {
-            padding: 3px 0 0 $sky-theme-modern-margin-inline-sm;
+          &:not(:last-child) {
+            margin-right: $sky-theme-modern-margin-inline-xs;
           }
         }
 


### PR DESCRIPTION
[AB#2356239](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/2356239)