### PR TITLE
revert(components/indicators): `SkyWaitService`'s `blockingWrap` and `nonBlockingWrap` methods now take in argument objects and the versions which take in an `Observable` are deprecated

### DIFF
--- a/libs/components/indicators/src/lib/modules/wait/types/wait-blocking-wrap-args.ts
+++ b/libs/components/indicators/src/lib/modules/wait/types/wait-blocking-wrap-args.ts
@@ -1,5 +1,0 @@
-import { Observable } from 'rxjs';
-
-export interface SkyWaitBlockingWrapArgs<T> {
-  observable: Observable<T>;
-}

--- a/libs/components/indicators/src/lib/modules/wait/types/wait-non-blocking-wrap-args.ts
+++ b/libs/components/indicators/src/lib/modules/wait/types/wait-non-blocking-wrap-args.ts
@@ -1,5 +1,0 @@
-import { Observable } from 'rxjs';
-
-export interface SkyWaitNonBlockingWrapArgs<T> {
-  observable: Observable<T>;
-}

--- a/libs/components/indicators/src/lib/modules/wait/wait.service.spec.ts
+++ b/libs/components/indicators/src/lib/modules/wait/wait.service.spec.ts
@@ -194,9 +194,7 @@ describe('Wait service', () => {
   describe('wraps', () => {
     it('should wrap with blocking wait when the given observable is hot', fakeAsync(() => {
       const subject = new ReplaySubject();
-      waitSvc
-        .blockingWrap({ observable: subject.asObservable() })
-        .subscribe(NO_OP_FUNC);
+      waitSvc.blockingWrap(subject.asObservable()).subscribe(NO_OP_FUNC);
       subject.next('A');
       tick();
       applicationRef.tick();
@@ -209,7 +207,7 @@ describe('Wait service', () => {
 
     it('should not wrap with blocking wait when the given observable is cold', fakeAsync(() => {
       const subject = new ReplaySubject();
-      waitSvc.blockingWrap({ observable: subject.asObservable() });
+      waitSvc.blockingWrap(subject.asObservable());
       subject.next('A');
       tick();
       applicationRef.tick();
@@ -223,7 +221,7 @@ describe('Wait service', () => {
     it('should wrap with blocking wait when the given observable throws error', fakeAsync(() => {
       const subject = new ReplaySubject();
       waitSvc
-        .blockingWrap({ observable: subject.asObservable() })
+        .blockingWrap(subject.asObservable())
         .subscribe(NO_OP_FUNC, NO_OP_FUNC);
       subject.next('A');
       tick();
@@ -235,24 +233,9 @@ describe('Wait service', () => {
       verifyBlockingPageWaitExists(false);
     }));
 
-    it('should wrap with blocking wait when the given observable is given outside of args', fakeAsync(() => {
-      const subject = new ReplaySubject();
-      waitSvc.blockingWrap(subject.asObservable()).subscribe(NO_OP_FUNC);
-      subject.next('A');
-      tick();
-      applicationRef.tick();
-      verifyBlockingPageWaitExists(true);
-      subject.complete();
-      tick();
-      applicationRef.tick();
-      verifyBlockingPageWaitExists(false);
-    }));
-
     it('should wrap with nonblocking wait when the given observable is hot', fakeAsync(() => {
       const subject = new ReplaySubject();
-      waitSvc
-        .nonBlockingWrap({ observable: subject.asObservable() })
-        .subscribe(NO_OP_FUNC);
+      waitSvc.nonBlockingWrap(subject.asObservable()).subscribe(NO_OP_FUNC);
       subject.next('A');
       tick();
       applicationRef.tick();
@@ -265,7 +248,7 @@ describe('Wait service', () => {
 
     it('should not wrap with nonblocking wait when the given observable is cold', fakeAsync(() => {
       const subject = new ReplaySubject();
-      waitSvc.nonBlockingWrap({ observable: subject.asObservable() });
+      waitSvc.nonBlockingWrap(subject.asObservable());
       subject.next('A');
       tick();
       applicationRef.tick();
@@ -279,26 +262,13 @@ describe('Wait service', () => {
     it('should wrap with nonblocking wait when the given observable throws error', fakeAsync(() => {
       const subject = new ReplaySubject();
       waitSvc
-        .nonBlockingWrap({ observable: subject.asObservable() })
+        .nonBlockingWrap(subject.asObservable())
         .subscribe(NO_OP_FUNC, NO_OP_FUNC);
       subject.next('A');
       tick();
       applicationRef.tick();
       verifyNonBlockingPageWaitExists(true);
       subject.error('error');
-      tick();
-      applicationRef.tick();
-      verifyNonBlockingPageWaitExists(false);
-    }));
-
-    it('should wrap with nonblocking wait when the given observable is given outside of args', fakeAsync(() => {
-      const subject = new ReplaySubject();
-      waitSvc.nonBlockingWrap(subject.asObservable()).subscribe(NO_OP_FUNC);
-      subject.next('A');
-      tick();
-      applicationRef.tick();
-      verifyNonBlockingPageWaitExists(true);
-      subject.complete();
       tick();
       applicationRef.tick();
       verifyNonBlockingPageWaitExists(false);
@@ -336,9 +306,7 @@ describe('Wait service', () => {
 
     it('should be accessible when a blocking wait is added with a wrap', waitForAsync(async () => {
       const subject = new ReplaySubject();
-      waitSvc
-        .blockingWrap({ observable: subject.asObservable() })
-        .subscribe(NO_OP_FUNC);
+      waitSvc.blockingWrap(subject.asObservable()).subscribe(NO_OP_FUNC);
       subject.next('A');
       // Kick off the observable
       applicationRef.tick();
@@ -359,9 +327,7 @@ describe('Wait service', () => {
 
     it('should be accessible when a non-blocking wait is added with a wrap', waitForAsync(async () => {
       const subject = new ReplaySubject();
-      waitSvc
-        .nonBlockingWrap({ observable: subject.asObservable() })
-        .subscribe(NO_OP_FUNC);
+      waitSvc.nonBlockingWrap(subject.asObservable()).subscribe(NO_OP_FUNC);
       subject.next('A');
       // Kick off the observable
       applicationRef.tick();

--- a/libs/components/indicators/src/lib/modules/wait/wait.service.ts
+++ b/libs/components/indicators/src/lib/modules/wait/wait.service.ts
@@ -3,13 +3,11 @@ import {
   ComponentFactoryResolver,
   Injectable,
 } from '@angular/core';
-import { SkyAppWindowRef, SkyLogService } from '@skyux/core';
+import { SkyAppWindowRef } from '@skyux/core';
 
 import { Observable, defer as observableDefer } from 'rxjs';
 import { finalize } from 'rxjs/operators';
 
-import { SkyWaitBlockingWrapArgs } from './types/wait-blocking-wrap-args';
-import { SkyWaitNonBlockingWrapArgs } from './types/wait-non-blocking-wrap-args';
 import { SkyWaitPageAdapterService } from './wait-page-adapter.service';
 import { SkyWaitPageComponent } from './wait-page.component';
 
@@ -28,20 +26,17 @@ export class SkyWaitService {
   #appRef: ApplicationRef;
   #waitAdapter: SkyWaitPageAdapterService;
   #windowSvc: SkyAppWindowRef;
-  #logService: SkyLogService;
 
   constructor(
     resolver: ComponentFactoryResolver,
     appRef: ApplicationRef,
     waitAdapter: SkyWaitPageAdapterService,
-    windowSvc: SkyAppWindowRef,
-    logService: SkyLogService
+    windowSvc: SkyAppWindowRef
   ) {
     this.#resolver = resolver;
     this.#appRef = appRef;
     this.#waitAdapter = waitAdapter;
     this.#windowSvc = windowSvc;
-    this.#logService = logService;
   }
 
   /**
@@ -97,29 +92,7 @@ export class SkyWaitService {
   /**
    * Launches a page wait and automatically stops when the specific asynchronous event completes.
    */
-  public blockingWrap<T>(args: SkyWaitBlockingWrapArgs<T>): Observable<T>;
-  /**
-   * @deprecated Use the version which takes in `SkyWaitBlockingWrapArgs` instead
-   */
-  public blockingWrap<T>(observable: Observable<T>): Observable<T>;
-  public blockingWrap<T>(
-    value: SkyWaitBlockingWrapArgs<T> | Observable<T>
-  ): Observable<T> {
-    let observable: Observable<T> = value as Observable<T>;
-    const typeChecker = value as SkyWaitBlockingWrapArgs<T>;
-    if (typeChecker.observable !== undefined) {
-      observable = (value as SkyWaitBlockingWrapArgs<T>).observable;
-    } else {
-      this.#logService.deprecated(
-        'Use of the `blockingWrap` method with an `Observable<T> parameter',
-        {
-          deprecationMajorVersion: 7,
-          replacementRecommendation:
-            'Use the version of the `blockingWrap` function which takes in `SkyWaitBlockingWrapArgs`.',
-        }
-      );
-    }
-
+  public blockingWrap<T>(observable: Observable<T>): Observable<T> {
     return observableDefer(() => {
       this.beginBlockingPageWait();
       return observable.pipe(finalize(() => this.endBlockingPageWait()));
@@ -130,29 +103,7 @@ export class SkyWaitService {
    * Launches a non-blocking page wait and automatically stops when the specific
    * asynchronous event completes.
    */
-  public nonBlockingWrap<T>(args: SkyWaitNonBlockingWrapArgs<T>): Observable<T>;
-  /**
-   * @deprecated Use the version which takes in `SkyWaitNonBlockingWrapArgs` instead
-   */
-  public nonBlockingWrap<T>(observable: Observable<T>): Observable<T>;
-  public nonBlockingWrap<T>(
-    value: SkyWaitNonBlockingWrapArgs<T> | Observable<T>
-  ): Observable<T> {
-    let observable: Observable<T> = value as Observable<T>;
-    const typeChecker = value as SkyWaitNonBlockingWrapArgs<T>;
-    if (typeChecker.observable !== undefined) {
-      observable = (value as SkyWaitNonBlockingWrapArgs<T>).observable;
-    } else {
-      this.#logService.deprecated(
-        'Use of the `nonBlockingWrap` method with an `Observable<T> parameter',
-        {
-          deprecationMajorVersion: 7,
-          replacementRecommendation:
-            'Use the version of the `nonBlockingWrap` function which takes in `SkyWaitNonBlockingWrapArgs`.',
-        }
-      );
-    }
-
+  public nonBlockingWrap<T>(observable: Observable<T>): Observable<T> {
     return observableDefer(() => {
       this.beginNonBlockingPageWait();
       return observable.pipe(finalize(() => this.endNonBlockingPageWait()));


### PR DESCRIPTION
[AB#2413570](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/2413570)