### PR TITLE
revert: feat(components/modals): use Angular CDK focus trap within modals

### DIFF
--- a/libs/components/modals/src/lib/modules/modal/fixtures/modal-fixtures.module.ts
+++ b/libs/components/modals/src/lib/modules/modal/fixtures/modal-fixtures.module.ts
@@ -9,6 +9,7 @@ import { ModalMockThemeService } from './mock-theme.service';
 import { ModalAutofocusTestComponent } from './modal-autofocus.component.fixture';
 import { ModalFooterTestComponent } from './modal-footer.component.fixture';
 import { ModalLauncherTestComponent } from './modal-launcher.component.fixture';
+import { ModalNoHeaderTestComponent } from './modal-no-header.component.fixture';
 import { ModalTiledBodyTestComponent } from './modal-tiled-body.component.fixture';
 import { ModalWithCloseConfirmTestComponent } from './modal-with-close-confirm.component.fixture';
 import { ModalWithFocusContentTestComponent } from './modal-with-focus-content.fixture';
@@ -22,6 +23,7 @@ import { ModalTestComponent } from './modal.component.fixture';
     ModalWithValuesTestComponent,
     ModalAutofocusTestComponent,
     ModalFooterTestComponent,
+    ModalNoHeaderTestComponent,
     ModalTiledBodyTestComponent,
     ModalWithFocusContentTestComponent,
     ModalWithCloseConfirmTestComponent,

--- a/libs/components/modals/src/lib/modules/modal/fixtures/modal-no-header.component.fixture.html
+++ b/libs/components/modals/src/lib/modules/modal/fixtures/modal-no-header.component.fixture.html
@@ -1,0 +1,3 @@
+<sky-modal>
+  <sky-modal-content>Content</sky-modal-content>
+</sky-modal>

--- a/libs/components/modals/src/lib/modules/modal/fixtures/modal-no-header.component.fixture.ts
+++ b/libs/components/modals/src/lib/modules/modal/fixtures/modal-no-header.component.fixture.ts
@@ -1,0 +1,7 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'sky-test-cmp',
+  templateUrl: './modal-no-header.component.fixture.html',
+})
+export class ModalNoHeaderTestComponent {}

--- a/libs/components/modals/src/lib/modules/modal/modal-component-adapter.service.ts
+++ b/libs/components/modals/src/lib/modules/modal/modal-component-adapter.service.ts
@@ -37,6 +37,52 @@ export class SkyModalComponentAdapterService {
     }
   }
 
+  public isFocusInFirstItem(
+    event: KeyboardEvent,
+    list: Array<HTMLElement>
+  ): boolean {
+    /* istanbul ignore next */
+    /* sanity check */
+    const eventTarget = event.target || event.srcElement;
+    return list.length > 0 && eventTarget === list[0];
+  }
+
+  public isFocusInLastItem(
+    event: KeyboardEvent,
+    list: Array<HTMLElement>
+  ): boolean {
+    /* istanbul ignore next */
+    /* sanity check */
+    const eventTarget = event.target || event.srcElement;
+    return list.length > 0 && eventTarget === list[list.length - 1];
+  }
+
+  public isModalFocused(event: KeyboardEvent, modalEl: ElementRef): boolean {
+    /* istanbul ignore next */
+    /* sanity check */
+    const eventTarget = event.target || event.srcElement;
+    return (
+      modalEl &&
+      eventTarget === modalEl.nativeElement.querySelector('.sky-modal-dialog')
+    );
+  }
+
+  public focusLastElement(list: Array<HTMLElement>): boolean {
+    if (list.length > 0) {
+      list[list.length - 1].focus();
+      return true;
+    }
+    return false;
+  }
+
+  public focusFirstElement(list: Array<HTMLElement>): boolean {
+    if (list.length > 0) {
+      list[0].focus();
+      return true;
+    }
+    return false;
+  }
+
   public modalContentHasDirectChildViewkeeper(
     modalContentEl: ElementRef
   ): boolean {

--- a/libs/components/modals/src/lib/modules/modal/modal.component.html
+++ b/libs/components/modals/src/lib/modules/modal/modal.component.html
@@ -4,7 +4,6 @@
   [attr.aria-describedby]="ariaDescribedBy"
   [attr.aria-labelledby]="ariaLabelledBy"
   [attr.role]="ariaRoleOrDefault"
-  [cdkTrapFocus]="true"
   (window:resize)="windowResize()"
 >
   <div

--- a/libs/components/modals/src/lib/modules/modal/modal.module.ts
+++ b/libs/components/modals/src/lib/modules/modal/modal.module.ts
@@ -1,4 +1,3 @@
-import { A11yModule } from '@angular/cdk/a11y';
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { RouterModule } from '@angular/router';
@@ -25,7 +24,6 @@ import { SkyModalComponent } from './modal.component';
     SkyModalScrollShadowDirective,
   ],
   imports: [
-    A11yModule,
     CommonModule,
     RouterModule,
     SkyIconModule,


### PR DESCRIPTION
Reverts blackbaud/skyux#955

Reason: the `autofocus` attribute is not recognized by the focus trap. We need to investigate and put this in version 8.
See: Angular CDK's `focusInitial` directive?