### PR TITLE
fix: add aria-label passing for accessibility checks

### DIFF
--- a/libs/components/modals/src/lib/modules/modal/modal-configuration.ts
+++ b/libs/components/modals/src/lib/modules/modal/modal-configuration.ts
@@ -11,6 +11,7 @@ export class SkyModalConfiguration {
   public size?: string;
   public ariaDescribedBy?: string;
   public ariaLabelledBy?: string;
+  public ariaLabel?: string;
   public ariaRole?: string;
   public tiledBody?: boolean;
   public helpKey?: string;

--- a/libs/components/modals/src/lib/modules/modal/modal.component.html
+++ b/libs/components/modals/src/lib/modules/modal/modal.component.html
@@ -3,6 +3,7 @@
   aria-modal="true"
   [attr.aria-describedby]="ariaDescribedBy || modalContentId.id"
   [attr.aria-labelledby]="ariaLabelledBy || headerId.id"
+  [attr.aria-label]="ariaLabel || headerId.id"
   [attr.role]="ariaRoleOrDefault"
   (window:resize)="windowResize()"
 >

--- a/libs/components/modals/src/lib/modules/modal/modal.component.spec.ts
+++ b/libs/components/modals/src/lib/modules/modal/modal.component.spec.ts
@@ -779,10 +779,11 @@ describe('Modal component', () => {
     closeModal(modalInstance);
   }));
 
-  it('should accept configuration options for role, aria-labelledBy, and aria-describedby', fakeAsync(() => {
+  it('should accept configuration options for role, aria-labelledBy, aria-describedby, and aria-label', fakeAsync(() => {
     const modalInstance = openModal(ModalTestComponent, {
       ariaLabelledBy: 'customLabelledBy',
       ariaDescribedBy: 'customDescribedBy',
+      ariaLabel: 'label',
       ariaRole: 'alertdialog',
     });
 

--- a/libs/components/modals/src/lib/modules/modal/modal.component.ts
+++ b/libs/components/modals/src/lib/modules/modal/modal.component.ts
@@ -80,6 +80,18 @@ export class SkyModalComponent implements AfterViewInit, OnDestroy {
     return this.#_ariaLabelledBy;
   }
 
+  /**
+   * @internal
+   */
+  @Input()
+  public set ariaLabel(id: string | undefined) {
+    this.#_ariaLabel = id;
+  }
+
+  public get ariaLabel(): string | undefined {
+    return this.#_ariaLabel;
+  }
+
   public helpKey: string | undefined;
 
   public modalState = 'in';
@@ -103,6 +115,7 @@ export class SkyModalComponent implements AfterViewInit, OnDestroy {
 
   #_ariaDescribedBy: string | undefined;
   #_ariaLabelledBy: string | undefined;
+  #_ariaLabel: string | undefined;
 
   constructor(
     hostService: SkyModalHostService,
@@ -125,6 +138,7 @@ export class SkyModalComponent implements AfterViewInit, OnDestroy {
 
     this.ariaDescribedBy = config.ariaDescribedBy;
     this.ariaLabelledBy = config.ariaLabelledBy;
+    this.ariaLabel = config.ariaLabel;
     this.ariaRole = config.ariaRole;
     this.helpKey = config.helpKey;
     this.tiledBody = config.tiledBody;


### PR DESCRIPTION
axe-core v4 will fail it's toBeAccesible check in tests if aria-label isn't set