### PR TITLE
fix(components/ag-grid): support right-align header in AG Grid 28 (#998)

### DIFF
--- a/libs/components/ag-grid/src/lib/styles/_base.scss
+++ b/libs/components/ag-grid/src/lib/styles/_base.scss
@@ -175,9 +175,17 @@ ag-grid-angular {
     text-overflow: clip;
   }
 
-  .ag-header-cell.sky-ag-grid-header-right-aligned
-    > .ag-header-cell-comp-wrapper {
-    flex-direction: row-reverse;
+  .ag-header-cell.ag-right-aligned-header,
+  .ag-header-cell.sky-ag-grid-header-right-aligned {
+    .ag-header-cell-comp-wrapper {
+      flex-direction: row-reverse;
+    }
+
+    .ag-header-cell-label,
+    .ag-cell-label-container {
+      display: flex;
+      flex-direction: row;
+    }
   }
 }
 


### PR DESCRIPTION
[AB#2456680](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/2456680)