### PR TITLE
fix(components/ag-grid): set header to use default text color (#1062)

### DIFF
--- a/libs/components/ag-grid/src/lib/styles/_base.scss
+++ b/libs/components/ag-grid/src/lib/styles/_base.scss
@@ -212,6 +212,14 @@ sky-ag-grid-wrapper + sky-infinite-scroll {
   }
 }
 
+.ag-header .ag-header-cell .ag-header-cell-label-sortable {
+  color: var(--sky-text-color-deemphasized);
+
+  &:hover {
+    color: var(--sky-text-color-default);
+  }
+}
+
 .ag-theme-sky-default {
   .ag-header .ag-header-cell .ag-header-cell-text {
     font-weight: normal;


### PR DESCRIPTION
[AB#2475889](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/2475889)