### PR TITLE
feat(components/tabs): update the `SkyTabsetNavButtonComponent` `buttonType` input to no longer support `string` values

### DIFF
--- a/libs/components/tabs/src/lib/modules/tabs/tabset-nav-button.component.ts
+++ b/libs/components/tabs/src/lib/modules/tabs/tabset-nav-button.component.ts
@@ -56,11 +56,11 @@ export class SkyTabsetNavButtonComponent implements OnDestroy {
    * @required
    */
   @Input()
-  public get buttonType(): SkyTabsetNavButtonType | string | undefined {
+  public get buttonType(): SkyTabsetNavButtonType | undefined {
     return this.#_buttonType;
   }
 
-  public set buttonType(value: SkyTabsetNavButtonType | string | undefined) {
+  public set buttonType(value: SkyTabsetNavButtonType | undefined) {
     this.#_buttonType = value;
     this.#updateTabToSelect();
     this.#updateButtonProperties();
@@ -101,7 +101,7 @@ export class SkyTabsetNavButtonComponent implements OnDestroy {
 
   protected tabToSelect: SkyTabComponent | undefined;
 
-  #_buttonType: SkyTabsetNavButtonType | string | undefined;
+  #_buttonType: SkyTabsetNavButtonType | undefined;
   #_disabled: boolean | undefined;
   #_tabset: SkyTabsetComponent | undefined;
   #activeIndexNumber: number | undefined;


### PR DESCRIPTION
BREAKING CHANGE: The tabset nav button component's `buttonType` input was set to allow values of type of `string` but it really only supported a handful of known `string` values represented by the `SkyTabsetNavButtonType` string union. This ability to specify a `string` value has been removed. This might cause problems if you are setting the `buttonType` input to a type of `string` in your consuming component's class.

[AB#2442904](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/2442904)