### PR TITLE
feat(components/tabs): add `messageStream` and `tabsVisibleChanged` to sectioned form and deprecate public methods

### DIFF
--- a/libs/components/tabs/src/index.ts
+++ b/libs/components/tabs/src/index.ts
@@ -15,6 +15,9 @@ export * from './lib/modules/vertical-tabset/vertical-tabset.module';
 // TODO: Try to remove in a major release.
 export * from './lib/modules/sectioned-form/sectioned-form.component';
 
+export * from './lib/modules/sectioned-form/types/sectioned-form-message';
+export * from './lib/modules/sectioned-form/types/sectioned-form-message-type';
+
 // Components and directives must be exported to support Angular's "partial" Ivy compiler.
 // Obscure names are used to indicate types are not part of public API.
 export { SkyTabComponent as λ1 } from './lib/modules/tabs/tab.component';

--- a/libs/components/tabs/src/lib/modules/sectioned-form/fixtures/sectioned-form.component.fixture.html
+++ b/libs/components/tabs/src/lib/modules/sectioned-form/fixtures/sectioned-form.component.fixture.html
@@ -1,15 +1,17 @@
 <div id="activeIndexDiv">active index = {{ activeIndexDisplay }}</div>
 <sky-sectioned-form
   [maintainSectionContent]="maintainSectionContent"
+  [messageStream]="messageStream"
   (indexChanged)="updateIndex($event)"
+  (tabsVisibleChanged)="tabsVisibleChanged($event)"
 >
   <sky-sectioned-form-section heading="Information 1">
     <sky-sectioned-form-fixture-information-1></sky-sectioned-form-fixture-information-1>
   </sky-sectioned-form-section>
   <sky-sectioned-form-section
     heading="Information 1a"
-    itemCount="2"
     [active]="activeTab"
+    [itemCount]="2"
   >
     <sky-sectioned-form-fixture-information-2></sky-sectioned-form-fixture-information-2>
   </sky-sectioned-form-section>

--- a/libs/components/tabs/src/lib/modules/sectioned-form/fixtures/sectioned-form.component.fixture.ts
+++ b/libs/components/tabs/src/lib/modules/sectioned-form/fixtures/sectioned-form.component.fixture.ts
@@ -1,6 +1,9 @@
 import { AfterContentChecked, Component, ViewChild } from '@angular/core';
 
+import { Subject } from 'rxjs';
+
 import { SkySectionedFormComponent } from '../sectioned-form.component';
+import { SkySectionedFormMessage } from '../types/sectioned-form-message';
 
 @Component({
   selector: 'sky-sectioned-form-fixture',
@@ -13,6 +16,9 @@ export class SkySectionedFormFixtureComponent implements AfterContentChecked {
   public activeTab = true;
   public activeIndexDisplay: number | undefined;
   public maintainSectionContent = false;
+  public tabsVisible: boolean | undefined;
+  public messageStream: Subject<SkySectionedFormMessage> | undefined =
+    new Subject();
 
   #activeIndex: number | undefined;
 
@@ -22,5 +28,9 @@ export class SkySectionedFormFixtureComponent implements AfterContentChecked {
 
   public updateIndex(newIndex: number | undefined): void {
     this.#activeIndex = newIndex;
+  }
+
+  public tabsVisibleChanged(visible: boolean): void {
+    this.tabsVisible = visible;
   }
 }

--- a/libs/components/tabs/src/lib/modules/sectioned-form/sectioned-form.component.ts
+++ b/libs/components/tabs/src/lib/modules/sectioned-form/sectioned-form.component.ts
@@ -12,8 +12,9 @@ import {
   Output,
   ViewChild,
 } from '@angular/core';
+import { SkyLogService } from '@skyux/core';
 
-import { Subject } from 'rxjs';
+import { Subject, Subscription } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 
 import { SkyTabIdService } from '../shared/tab-id.service';
@@ -23,6 +24,8 @@ import {
   SkyVerticalTabsetService,
   VISIBLE_STATE,
 } from './../vertical-tabset/vertical-tabset.service';
+import { SkySectionedFormMessage } from './types/sectioned-form-message';
+import { SkySectionedFormMessageType } from './types/sectioned-form-message-type';
 
 /**
  * Creates a container for the sectioned forms.
@@ -59,12 +62,30 @@ export class SkySectionedFormComponent
   @Input()
   public maintainSectionContent: boolean | undefined = false;
 
+  @Input()
+  public set messageStream(
+    value: Subject<SkySectionedFormMessage> | undefined
+  ) {
+    this.#_messageStream = value || new Subject<SkySectionedFormMessage>();
+    this.#initMessageStream();
+  }
+
+  public get messageStream(): Subject<SkySectionedFormMessage> {
+    return this.#_messageStream;
+  }
+
   /**
    * Fires when the active tab changes and emits the index of the active
    * section. The index is based on the section's position when the form loads.
    */
   @Output()
   public indexChanged: EventEmitter<number> = new EventEmitter();
+
+  /**
+   * Fires when the sectioned form tabs are shown or hidden.
+   */
+  @Output()
+  public tabsVisibleChanged = new EventEmitter<boolean>();
 
   public ariaOwns: string | undefined;
 
@@ -75,16 +96,24 @@ export class SkySectionedFormComponent
 
   #ngUnsubscribe = new Subject<void>();
 
+  #messageStreamSub: Subscription | undefined;
   #changeRef: ChangeDetectorRef;
   #tabIdSvc: SkyTabIdService;
+  #logger: SkyLogService;
+
+  #_messageStream = new Subject<SkySectionedFormMessage>();
 
   constructor(
     public tabService: SkyVerticalTabsetService,
     changeRef: ChangeDetectorRef,
-    tabIdSvc: SkyTabIdService
+    tabIdSvc: SkyTabIdService,
+    logger: SkyLogService
   ) {
     this.#changeRef = changeRef;
     this.#tabIdSvc = tabIdSvc;
+    this.#logger = logger;
+
+    this.#initMessageStream();
 
     this.#tabIdSvc.ids.pipe(takeUntil(this.#ngUnsubscribe)).subscribe((ids) => {
       this.ariaOwns = ids.join(' ') || undefined;
@@ -114,6 +143,18 @@ export class SkySectionedFormComponent
         this.#changeRef.markForCheck();
       });
 
+    this.tabService.hidingTabs
+      .pipe(takeUntil(this.#ngUnsubscribe))
+      .subscribe(() => {
+        this.tabsVisibleChanged.emit(false);
+      });
+
+    this.tabService.showingTabs
+      .pipe(takeUntil(this.#ngUnsubscribe))
+      .subscribe(() => {
+        this.tabsVisibleChanged.emit(true);
+      });
+
     if (this.tabService.isMobile()) {
       this.ariaRole = undefined;
       this.tabService.animationContentVisibleState = VISIBLE_STATE;
@@ -131,13 +172,55 @@ export class SkySectionedFormComponent
     this.#ngUnsubscribe.complete();
   }
 
+  /**
+   * @deprecated Use the `tabsVisibleChanged` output to listen for tab visibility changes.
+   */
   public tabsVisible(): boolean {
+    this.#logger.deprecated('SectionedFormComponent.tabsVisible()', {
+      deprecationMajorVersion: 8,
+      moreInfoUrl:
+        'https://developer.blackbaud.com/skyux/components/sectioned-form',
+      replacementRecommendation:
+        'Use the `tabsVisibleChanged` output to listen for tab visibility changes.',
+    });
+
     this.#changeRef.markForCheck();
     return this.tabService.tabsVisible();
   }
 
+  /**
+   * @deprecated Use the `messageStream` input and push a `ShowTabs` message to the message stream instead.
+   */
   public showTabs(): void {
+    this.#logger.deprecated('SectionedFormComponent.showTabs()', {
+      deprecationMajorVersion: 8,
+      moreInfoUrl:
+        'https://developer.blackbaud.com/skyux/components/sectioned-form',
+      replacementRecommendation:
+        'Use the `messageStream` input and push a `ShowTabs` message to the message stream instead.',
+    });
+
+    this.#showTabs();
+  }
+
+  #showTabs(): void {
     this.tabService.showTabs();
     this.#changeRef.markForCheck();
+  }
+
+  #initMessageStream(): void {
+    if (this.#messageStreamSub) {
+      this.#messageStreamSub.unsubscribe();
+    }
+
+    this.#messageStreamSub = this.messageStream
+      .pipe(takeUntil(this.#ngUnsubscribe))
+      .subscribe((message) => {
+        switch (message.type) {
+          case SkySectionedFormMessageType.ShowTabs:
+            this.#showTabs();
+            break;
+        }
+      });
   }
 }

--- a/libs/components/tabs/src/lib/modules/sectioned-form/types/sectioned-form-message-type.ts
+++ b/libs/components/tabs/src/lib/modules/sectioned-form/types/sectioned-form-message-type.ts
@@ -1,0 +1,3 @@
+export enum SkySectionedFormMessageType {
+  ShowTabs = 1,
+}

--- a/libs/components/tabs/src/lib/modules/sectioned-form/types/sectioned-form-message.ts
+++ b/libs/components/tabs/src/lib/modules/sectioned-form/types/sectioned-form-message.ts
@@ -1,0 +1,5 @@
+import { SkySectionedFormMessageType } from './sectioned-form-message-type';
+
+export interface SkySectionedFormMessage {
+  type: SkySectionedFormMessageType;
+}


### PR DESCRIPTION
[AB#2315248](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/2315248)