### PR TITLE
feat(components/lists): update the `SkyRepeaterComponent` `expandMode` input to no longer support `string` values

### DIFF
--- a/libs/components/lists/src/lib/modules/repeater/repeater.component.ts
+++ b/libs/components/lists/src/lib/modules/repeater/repeater.component.ts
@@ -86,14 +86,13 @@ export class SkyRepeaterComponent
    * and users only occasionally need to view the body content.
    * @default "none"
    */
-  // TODO: Remove 'string' as a valid type in a breaking change.
   @Input()
-  public set expandMode(value: SkyRepeaterExpandModeType | string | undefined) {
+  public set expandMode(value: SkyRepeaterExpandModeType | undefined) {
     this.#repeaterService.expandMode = value;
     this.#updateForExpandMode();
   }
 
-  public get expandMode(): SkyRepeaterExpandModeType | string {
+  public get expandMode(): SkyRepeaterExpandModeType {
     return this.#repeaterService.expandMode;
   }
 

--- a/libs/components/lists/src/lib/modules/repeater/repeater.service.ts
+++ b/libs/components/lists/src/lib/modules/repeater/repeater.service.ts
@@ -25,10 +25,10 @@ export class SkyRepeaterService implements OnDestroy {
   public enableActiveState = false;
 
   // TODO: Remove 'string' as a valid type in a breaking change.
-  public get expandMode(): SkyRepeaterExpandModeType | string {
+  public get expandMode(): SkyRepeaterExpandModeType {
     return this.#_expandMode;
   }
-  public set expandMode(value: SkyRepeaterExpandModeType | string | undefined) {
+  public set expandMode(value: SkyRepeaterExpandModeType | undefined) {
     this.#_expandMode = value ?? DEFAULT_EXPAND_MODE;
   }
 
@@ -46,7 +46,7 @@ export class SkyRepeaterService implements OnDestroy {
 
   public repeaterGroupId = ++uniqueId;
 
-  #_expandMode: SkyRepeaterExpandModeType | string = DEFAULT_EXPAND_MODE;
+  #_expandMode = DEFAULT_EXPAND_MODE;
 
   public ngOnDestroy(): void {
     this.activeItemChange.complete();


### PR DESCRIPTION
BREAKING CHANGE: The repeater component's `expandMode` input was set to allow values of type of `string` but it really only supported a handful of known `string` values represented by the `SkyRepeaterExpandModeType` string union. This ability to specify a `string` value has been removed. This might cause problems if you are setting the `expandMode` input to a type of `string` in your consuming component's class.