### PR TITLE
fix(components/phone-field): phone field inputs now animate in modern theme

### DIFF
--- a/libs/components/phone-field/src/lib/modules/phone-field/phone-field.component.html
+++ b/libs/components/phone-field/src/lib/modules/phone-field/phone-field.component.html
@@ -43,11 +43,6 @@
   <span
     *ngIf="phoneInputShown"
     class="sky-phone-field-container"
-    [@.disabled]="
-      inputBoxHostSvc &&
-      (themeSvc?.settingsChange | async)?.currentSettings?.theme?.name ===
-        'modern'
-    "
     [@phoneInputAnimation]="phoneInputShown ? 'open' : 'closed'"
     (@phoneInputAnimation.done)="phoneInputAnimationEnd($event)"
   >
@@ -56,12 +51,13 @@
   <span
     *ngIf="countrySearchShown"
     class="sky-phone-field-container"
-    [@.disabled]="
-      inputBoxHostSvc &&
-      (themeSvc?.settingsChange | async)?.currentSettings?.theme?.name ===
-        'modern'
+    [@countrySearchAnimation]="
+      'open' +
+      ((themeSvc?.settingsChange | async)?.currentSettings?.theme?.name ===
+      'modern'
+        ? '-modern'
+        : '')
     "
-    [@countrySearchAnimation]="countrySearchShown ? 'open' : 'closed'"
     (@countrySearchAnimation.done)="countrySearchAnimationEnd($event)"
   >
     <div class="sky-phone-field-country-search" [formGroup]="countrySearchForm">

--- a/libs/components/phone-field/src/lib/modules/phone-field/phone-field.component.ts
+++ b/libs/components/phone-field/src/lib/modules/phone-field/phone-field.component.ts
@@ -58,7 +58,7 @@ import { SkyPhoneFieldNumberReturnFormat } from './types/number-return-format';
   animations: [
     trigger('blockAnimationOnLoad', [transition(':enter', [])]),
     trigger('countrySearchAnimation', [
-      transition(':enter', [
+      transition('void => open', [
         style({
           opacity: 0,
           width: 0,
@@ -71,7 +71,7 @@ import { SkyPhoneFieldNumberReturnFormat } from './types/number-return-format';
           })
         ),
       ]),
-      transition(':leave', [
+      transition('open => void', [
         animate(
           '200ms ease-in',
           style({
@@ -80,22 +80,41 @@ import { SkyPhoneFieldNumberReturnFormat } from './types/number-return-format';
           })
         ),
       ]),
-    ]),
-    trigger('phoneInputAnimation', [
-      transition(':enter', [
+      transition('void => open-modern', [
         style({
           opacity: 0,
         }),
         animate(
-          '150ms ease-in',
+          '200ms ease-in',
           style({
             opacity: 1,
           })
         ),
       ]),
-      transition(':leave', [
+      transition('open-modern => void', [
         animate(
-          '150ms ease-in',
+          '200ms ease-in',
+          style({
+            opacity: 0,
+          })
+        ),
+      ]),
+    ]),
+    trigger('phoneInputAnimation', [
+      transition('void => open', [
+        style({
+          opacity: 0,
+        }),
+        animate(
+          '200ms ease-in',
+          style({
+            opacity: 1,
+          })
+        ),
+      ]),
+      transition('open => void', [
+        animate(
+          '200ms ease-in',
           style({
             opacity: 0,
           })


### PR DESCRIPTION
[AB#2476885](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/2476885)

In consultation with @Blackbaud-AdamFunderburk - we determined to go with a simple fade animation when in modern theme and the slide animation in default theme. This is because of how the input box is constructed in modern theme - the close button can not slide like it does in default.