### PR TITLE
fix(components/ag-grid): switch row delete overlay to only clip in stacking context

### DIFF
--- a/libs/components/ag-grid/src/lib/modules/ag-grid/ag-grid-row-delete.directive.spec.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/ag-grid-row-delete.directive.spec.ts
@@ -1,7 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { SKY_STACKING_CONTEXT } from '@skyux/core';
+import { SKY_STACKING_CONTEXT, SkyScrollableHostService } from '@skyux/core';
 
-import { BehaviorSubject } from 'rxjs';
+import { BehaviorSubject, Observable, of } from 'rxjs';
 
 import { SkyAgGridRowDeleteFixtureComponent } from './fixtures/ag-grid-row-delete.component.fixture';
 import { SkyAgGridFixtureModule } from './fixtures/ag-grid.module.fixture';
@@ -20,6 +20,17 @@ describe('SkyAgGridRowDeleteDirective', () => {
                 zIndex: new BehaviorSubject(options.stackingContextZIndex),
               }
             : undefined,
+        },
+        {
+          provide: SkyScrollableHostService,
+          useValue: {
+            watchScrollableHost: jasmine
+              .createSpy('watchScrollableHost')
+              .and.returnValue(new Observable()),
+            watchScrollableHostClipPathChanges: jasmine
+              .createSpy('watchScrollableHostClipPathChanges')
+              .and.returnValue(of('none')),
+          },
         },
       ],
     });
@@ -394,6 +405,10 @@ describe('SkyAgGridRowDeleteDirective', () => {
       expect(overlay.style.zIndex.toString()).toBe('998')
     );
     expect(fixture.componentInstance.rowDeleteIds).toEqual(['0', '1']);
+    expect(
+      TestBed.inject(SkyScrollableHostService)
+        .watchScrollableHostClipPathChanges
+    ).not.toHaveBeenCalled();
   });
 
   it('should set the z-index of the row delete overlays with stacking context', async () => {
@@ -414,6 +429,10 @@ describe('SkyAgGridRowDeleteDirective', () => {
     expect(overlays.length).toBe(2);
     overlays.forEach((overlay) => expect(overlay.style.zIndex).toBe('1111'));
     expect(fixture.componentInstance.rowDeleteIds).toEqual(['0', '1']);
+    expect(
+      TestBed.inject(SkyScrollableHostService)
+        .watchScrollableHostClipPathChanges
+    ).toHaveBeenCalled();
   });
 
   it('should not change the column widths when a row delete is triggered', async () => {

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/ag-grid-row-delete.directive.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/ag-grid-row-delete.directive.ts
@@ -176,6 +176,7 @@ export class SkyAgGridRowDeleteDirective
   #scrollableHostService: SkyScrollableHostService;
   #clipPath = new BehaviorSubject<string | undefined>(undefined);
   #zIndex = new BehaviorSubject(998);
+  #hasStackingContext: boolean;
 
   constructor(
     affixService: SkyAffixService,
@@ -194,6 +195,7 @@ export class SkyAgGridRowDeleteDirective
     this.#overlayService = overlayService;
     this.#viewContainerRef = viewContainerRef;
     this.#scrollableHostService = scrollableHostService;
+    this.#hasStackingContext = !!stackingContext;
     if (stackingContext) {
       stackingContext.zIndex
         .pipe(takeUntil(this.#ngUnsubscribe))
@@ -230,12 +232,14 @@ export class SkyAgGridRowDeleteDirective
   }
 
   public ngAfterViewInit(): void {
-    this.#scrollableHostService
-      .watchScrollableHostClipPathChanges(this.#elementRef)
-      .pipe(takeUntil(this.#ngUnsubscribe))
-      .subscribe((clipPath) => {
-        this.#clipPath.next(clipPath);
-      });
+    if (this.#hasStackingContext) {
+      this.#scrollableHostService
+        .watchScrollableHostClipPathChanges(this.#elementRef)
+        .pipe(takeUntil(this.#ngUnsubscribe))
+        .subscribe((clipPath) => {
+          this.#clipPath.next(clipPath);
+        });
+    }
   }
 
   public ngOnDestroy(): void {


### PR DESCRIPTION
[AB#2481143](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/2481143)