### PR TITLE
fix(components/text-editor): only paste text once, only reinitialize editor if already rendered

### DIFF
--- a/libs/components/text-editor/src/lib/modules/text-editor/services/text-editor.service.ts
+++ b/libs/components/text-editor/src/lib/modules/text-editor/services/text-editor.service.ts
@@ -24,6 +24,10 @@ export class SkyTextEditorService {
     return this.#_editor;
   }
 
+  public get isInitialized(): boolean {
+    return this.#_editor !== undefined;
+  }
+
   #_editor: EditorSetting | undefined;
 
   /**

--- a/libs/components/text-editor/src/lib/modules/text-editor/services/text-editor.service.ts
+++ b/libs/components/text-editor/src/lib/modules/text-editor/services/text-editor.service.ts
@@ -13,22 +13,22 @@ export class SkyTextEditorService {
    * A dictionary representing all active text editors and their settings.
    */
   public set editor(value: EditorSetting) {
-    this.#_editor = value;
+    this.#editor = value;
   }
 
   public get editor(): EditorSetting {
-    if (!this.#_editor) {
+    if (!this.#editor) {
       throw new Error('Editor has not been initialized.');
     }
 
-    return this.#_editor;
+    return this.#editor;
   }
 
   public get isInitialized(): boolean {
-    return this.#_editor !== undefined;
+    return this.#editor !== undefined;
   }
 
-  #_editor: EditorSetting | undefined;
+  #editor: EditorSetting | undefined;
 
   /**
    * Returns the blur observable from the editor with the corresponding id.

--- a/libs/components/text-editor/src/lib/modules/text-editor/text-editor.component.html
+++ b/libs/components/text-editor/src/lib/modules/text-editor/text-editor.component.html
@@ -44,7 +44,8 @@
     [ngClass]="{
       'sky-text-editor-wrapper-disabled': disabled
     }"
-    (load)="onIframeLoad($event)"
+    (load)="onIframeLoad()"
+    #iframe
   >
   </iframe>
 </div>

--- a/libs/components/text-editor/src/lib/modules/text-editor/text-editor.component.spec.ts
+++ b/libs/components/text-editor/src/lib/modules/text-editor/text-editor.component.spec.ts
@@ -422,9 +422,8 @@ describe('Text editor', () => {
     beforeEach(() => {
       fixture = createComponent(TextEditorFixtureComponent);
       testComponent = fixture.componentInstance as TextEditorFixtureComponent;
-      iframeElement = getIframeElement();
-      SkyAppTestUtility.fireDomEvent(iframeElement, 'load');
       iframeDocument = getIframeDocument();
+      iframeElement = getIframeElement();
       textEditorDebugElement = fixture.debugElement.query(
         By.directive(SkyTextEditorComponent)
       );
@@ -1334,10 +1333,6 @@ describe('Text editor', () => {
     }));
 
     it('should set the style of the iframe body to the provided style state', fakeAsync(() => {
-      // We normally load the iframe in the `beforeEach`. However, we need to reset things here so that the initial styles can be applied first.
-      TestBed.resetTestingModule();
-      fixture = createComponent(TextEditorFixtureComponent);
-      testComponent = fixture.componentInstance as TextEditorFixtureComponent;
       const backColor = '#333333'; // rgb(51, 51, 51)
       const fontColor = '#EEEEEE'; // rgb(238, 238, 238)
       const font = 'Times New Roman';
@@ -1349,10 +1344,6 @@ describe('Text editor', () => {
         font: font,
         fontSize: fontSize,
       } as SkyTextEditorStyleState;
-      fixture.detectChanges();
-      iframeElement = getIframeElement();
-      SkyAppTestUtility.fireDomEvent(iframeElement, 'load');
-      iframeDocument = getIframeDocument();
       fixture.detectChanges();
 
       const style = iframeDocument.querySelector('body')
@@ -1641,11 +1632,9 @@ describe('Text editor', () => {
         By.directive(SkyTextEditorComponent)
       );
       textEditorNativeElement = textEditorDebugElement.nativeElement;
+      editableElement = getIframeDocument().body;
       ngModel = textEditorDebugElement.injector.get<NgModel>(NgModel);
-      iframeElement = getIframeElement();
-      SkyAppTestUtility.fireDomEvent(iframeElement, 'load');
       iframeDocument = getIframeDocument();
-      editableElement = iframeDocument.body;
     });
 
     it('should be pristine, untouched, and valid initially', () => {
@@ -1740,13 +1729,12 @@ describe('Text editor', () => {
       fixture.detectChanges();
 
       testComponent = fixture.componentInstance as TextEditorWithFormControl;
+      editableElement = getIframeDocument().body;
       textEditorDebugElement = fixture.debugElement.query(
         By.directive(SkyTextEditorComponent)
       );
       textEditorComponent = textEditorDebugElement.componentInstance;
       iframeElement = getIframeElement();
-      SkyAppTestUtility.fireDomEvent(iframeElement, 'load');
-      editableElement = getIframeDocument().body;
     });
 
     it('should toggle the disabled state', () => {
@@ -1775,8 +1763,6 @@ describe('Text editor', () => {
       // A bug in the order of setting value, initializing the text editor
       // and setting focus would cause this test to fail.
       fixture = createComponent(TextEditorFixtureComponent);
-      iframeElement = getIframeElement();
-      SkyAppTestUtility.fireDomEvent(iframeElement, 'load');
       const testComponent =
         fixture.componentInstance as TextEditorFixtureComponent;
       testComponent.autofocus = true;

--- a/libs/components/text-editor/src/lib/modules/text-editor/text-editor.component.ts
+++ b/libs/components/text-editor/src/lib/modules/text-editor/text-editor.component.ts
@@ -328,7 +328,10 @@ export class SkyTextEditorComponent implements AfterViewInit, OnDestroy {
   }
 
   public onIframeLoad(): void {
-    this.#initIframe();
+    // Reinitialize the editor if it already exists to cover situations where the text editor might have been moved in the DOM.
+    if (this.#editorService.isInitialized) {
+      this.#initIframe();
+    }
   }
 
   /**

--- a/libs/components/text-editor/src/lib/modules/text-editor/text-editor.component.ts
+++ b/libs/components/text-editor/src/lib/modules/text-editor/text-editor.component.ts
@@ -1,10 +1,13 @@
 import {
+  AfterViewInit,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
+  ElementRef,
   Input,
   NgZone,
   OnDestroy,
+  ViewChild,
   ViewEncapsulation,
 } from '@angular/core';
 import { NgControl } from '@angular/forms';
@@ -45,7 +48,7 @@ import { SkyTextEditorToolbarActionType } from './types/toolbar-action-type';
     SkyTextEditorAdapterService,
   ],
 })
-export class SkyTextEditorComponent implements OnDestroy {
+export class SkyTextEditorComponent implements AfterViewInit, OnDestroy {
   /**
    * Whether to put focus on the editor after it renders.
    */
@@ -67,7 +70,7 @@ export class SkyTextEditorComponent implements OnDestroy {
       /* istanbul ignore else */
       if (this.iframeRef) {
         focusableChildren = this.#coreAdapterService.getFocusableChildren(
-          this.iframeRef.contentDocument?.body,
+          this.iframeRef.nativeElement.contentDocument.body,
           {
             ignoreVisibility: true,
             ignoreTabIndex: true,
@@ -75,9 +78,15 @@ export class SkyTextEditorComponent implements OnDestroy {
         );
 
         if (this.#_disabled) {
-          this.#adapterService.disableEditor(focusableChildren, this.iframeRef);
+          this.#adapterService.disableEditor(
+            focusableChildren,
+            this.iframeRef.nativeElement
+          );
         } else {
-          this.#adapterService.enableEditor(focusableChildren, this.iframeRef);
+          this.#adapterService.enableEditor(
+            focusableChildren,
+            this.iframeRef.nativeElement
+          );
         }
         this.#changeDetector.markForCheck();
       }
@@ -204,7 +213,8 @@ export class SkyTextEditorComponent implements OnDestroy {
     return this.#_toolbarActions;
   }
 
-  public iframeRef: HTMLIFrameElement | undefined;
+  @ViewChild('iframe')
+  public iframeRef: ElementRef | undefined;
 
   /**
    * The internal value of the control.
@@ -307,14 +317,17 @@ export class SkyTextEditorComponent implements OnDestroy {
     ngControl.valueAccessor = this;
   }
 
+  public ngAfterViewInit(): void {
+    this.#initIframe();
+  }
+
   public ngOnDestroy(): void {
     this.#adapterService.removeObservers(this.#editorService.editor);
     this.#ngUnsubscribe.next();
     this.#ngUnsubscribe.complete();
   }
 
-  public onIframeLoad(event: Event): void {
-    this.iframeRef = event.target as HTMLIFrameElement;
+  public onIframeLoad(): void {
     this.#initIframe();
   }
 
@@ -363,68 +376,66 @@ export class SkyTextEditorComponent implements OnDestroy {
   }
 
   #initIframe(): void {
-    if (this.iframeRef) {
-      this.#adapterService.initEditor(
-        this.id,
-        this.iframeRef,
-        this.initialStyleState,
-        this.placeholder
-      );
+    this.#adapterService.initEditor(
+      this.id,
+      (this.iframeRef as ElementRef).nativeElement,
+      this.initialStyleState,
+      this.placeholder
+    );
 
-      this.#editorService
-        .inputListener()
-        .pipe(takeUntil(this.#ngUnsubscribe))
-        .subscribe(() => {
-          // Angular doesn't run change detection for changes originating inside an iframe,
-          // so we have to call the onChange() event inside NgZone to force change propagation to consuming components.
-          this.#zone.run(() => {
-            this.#viewToModelUpdate();
-          });
-        });
-
-      this.#editorService
-        .selectionChangeListener()
-        .pipe(takeUntil(this.#ngUnsubscribe))
-        .subscribe(() => {
-          this.#updateStyle();
-          this.editorFocusStream.next();
-        });
-
-      this.#editorService
-        .clickListener()
-        .pipe(takeUntil(this.#ngUnsubscribe))
-        .subscribe(() => {
-          this.editorFocusStream.next();
-        });
-
-      this.#editorService
-        .blurListener()
-        .pipe(takeUntil(this.#ngUnsubscribe))
-        .subscribe(() => {
-          // Angular doesn't run change detection for changes originating inside an iframe,
-          // so we have to run #_onTouched() inside the NgZone to force change propagation to consuming components.
-          this.#zone.run(() => {
-            this.#_onTouched();
-          });
-        });
-
-      this.#editorService
-        .commandChangeListener()
-        .pipe(takeUntil(this.#ngUnsubscribe))
-        .subscribe(() => {
-          this.#updateStyle();
+    this.#editorService
+      .inputListener()
+      .pipe(takeUntil(this.#ngUnsubscribe))
+      .subscribe(() => {
+        // Angular doesn't run change detection for changes originating inside an iframe,
+        // so we have to call the onChange() event inside NgZone to force change propagation to consuming components.
+        this.#zone.run(() => {
           this.#viewToModelUpdate();
         });
+      });
 
-      this.#adapterService.setEditorInnerHtml(this.#_value);
+    this.#editorService
+      .selectionChangeListener()
+      .pipe(takeUntil(this.#ngUnsubscribe))
+      .subscribe(() => {
+        this.#updateStyle();
+        this.editorFocusStream.next();
+      });
 
-      /* istanbul ignore next */
-      if (this.autofocus) {
-        this.#adapterService.focusEditor();
-      }
+    this.#editorService
+      .clickListener()
+      .pipe(takeUntil(this.#ngUnsubscribe))
+      .subscribe(() => {
+        this.editorFocusStream.next();
+      });
 
-      this.#initialized = true;
+    this.#editorService
+      .blurListener()
+      .pipe(takeUntil(this.#ngUnsubscribe))
+      .subscribe(() => {
+        // Angular doesn't run change detection for changes originating inside an iframe,
+        // so we have to run markForCheck() inside the NgZone to force change propagation to consuming components.
+        this.#zone.run(() => {
+          this.#_onTouched();
+        });
+      });
+
+    this.#editorService
+      .commandChangeListener()
+      .pipe(takeUntil(this.#ngUnsubscribe))
+      .subscribe(() => {
+        this.#updateStyle();
+        this.#viewToModelUpdate();
+      });
+
+    this.#adapterService.setEditorInnerHtml(this.#_value);
+
+    /* istanbul ignore next */
+    if (this.autofocus) {
+      this.#adapterService.focusEditor();
     }
+
+    this.#initialized = true;
   }
 
   #viewToModelUpdate(emitChange: boolean = true): void {


### PR DESCRIPTION
- Revert the initial copy/paste fix because it causes consumers' tests to fail
- The paste twice issue happens because the text editor is initialized twice. Add back the original check to only reinitialize if the load even occurs when the text editor has already been initialized, i.e. when it is removed and added back to the DOM