### PR TITLE
fix(components/text-editor): only paste text once, only reinitialize editor if already rendered (#1143)

### DIFF
--- a/libs/components/text-editor/src/lib/modules/text-editor/services/text-editor.service.ts
+++ b/libs/components/text-editor/src/lib/modules/text-editor/services/text-editor.service.ts
@@ -13,18 +13,22 @@ export class SkyTextEditorService {
    * A dictionary representing all active text editors and their settings.
    */
   public set editor(value: EditorSetting) {
-    this.#_editor = value;
+    this.#editor = value;
   }
 
   public get editor(): EditorSetting {
-    if (!this.#_editor) {
+    if (!this.#editor) {
       throw new Error('Editor has not been initialized.');
     }
 
-    return this.#_editor;
+    return this.#editor;
   }
 
-  #_editor: EditorSetting | undefined;
+  public get isInitialized(): boolean {
+    return this.#editor !== undefined;
+  }
+
+  #editor: EditorSetting | undefined;
 
   /**
    * Returns the blur observable from the editor with the corresponding id.

--- a/libs/components/text-editor/src/lib/modules/text-editor/text-editor.component.html
+++ b/libs/components/text-editor/src/lib/modules/text-editor/text-editor.component.html
@@ -44,7 +44,8 @@
     [ngClass]="{
       'sky-text-editor-wrapper-disabled': disabled
     }"
-    (load)="onIframeLoad($event)"
+    (load)="onIframeLoad()"
+    #iframe
   >
   </iframe>
 </div>

--- a/libs/components/text-editor/src/lib/modules/text-editor/text-editor.component.spec.ts
+++ b/libs/components/text-editor/src/lib/modules/text-editor/text-editor.component.spec.ts
@@ -422,9 +422,8 @@ describe('Text editor', () => {
     beforeEach(() => {
       fixture = createComponent(TextEditorFixtureComponent);
       testComponent = fixture.componentInstance as TextEditorFixtureComponent;
-      iframeElement = getIframeElement();
-      SkyAppTestUtility.fireDomEvent(iframeElement, 'load');
       iframeDocument = getIframeDocument();
+      iframeElement = getIframeElement();
       textEditorDebugElement = fixture.debugElement.query(
         By.directive(SkyTextEditorComponent)
       );
@@ -1334,10 +1333,6 @@ describe('Text editor', () => {
     }));
 
     it('should set the style of the iframe body to the provided style state', fakeAsync(() => {
-      // We normally load the iframe in the `beforeEach`. However, we need to reset things here so that the initial styles can be applied first.
-      TestBed.resetTestingModule();
-      fixture = createComponent(TextEditorFixtureComponent);
-      testComponent = fixture.componentInstance as TextEditorFixtureComponent;
       const backColor = '#333333'; // rgb(51, 51, 51)
       const fontColor = '#EEEEEE'; // rgb(238, 238, 238)
       const font = 'Times New Roman';
@@ -1349,10 +1344,6 @@ describe('Text editor', () => {
         font: font,
         fontSize: fontSize,
       } as SkyTextEditorStyleState;
-      fixture.detectChanges();
-      iframeElement = getIframeElement();
-      SkyAppTestUtility.fireDomEvent(iframeElement, 'load');
-      iframeDocument = getIframeDocument();
       fixture.detectChanges();
 
       const style = iframeDocument.querySelector('body')
@@ -1641,11 +1632,9 @@ describe('Text editor', () => {
         By.directive(SkyTextEditorComponent)
       );
       textEditorNativeElement = textEditorDebugElement.nativeElement;
+      editableElement = getIframeDocument().body;
       ngModel = textEditorDebugElement.injector.get<NgModel>(NgModel);
-      iframeElement = getIframeElement();
-      SkyAppTestUtility.fireDomEvent(iframeElement, 'load');
       iframeDocument = getIframeDocument();
-      editableElement = iframeDocument.body;
     });
 
     it('should be pristine, untouched, and valid initially', () => {
@@ -1740,13 +1729,12 @@ describe('Text editor', () => {
       fixture.detectChanges();
 
       testComponent = fixture.componentInstance as TextEditorWithFormControl;
+      editableElement = getIframeDocument().body;
       textEditorDebugElement = fixture.debugElement.query(
         By.directive(SkyTextEditorComponent)
       );
       textEditorComponent = textEditorDebugElement.componentInstance;
       iframeElement = getIframeElement();
-      SkyAppTestUtility.fireDomEvent(iframeElement, 'load');
-      editableElement = getIframeDocument().body;
     });
 
     it('should toggle the disabled state', () => {
@@ -1775,8 +1763,6 @@ describe('Text editor', () => {
       // A bug in the order of setting value, initializing the text editor
       // and setting focus would cause this test to fail.
       fixture = createComponent(TextEditorFixtureComponent);
-      iframeElement = getIframeElement();
-      SkyAppTestUtility.fireDomEvent(iframeElement, 'load');
       const testComponent =
         fixture.componentInstance as TextEditorFixtureComponent;
       testComponent.autofocus = true;


### PR DESCRIPTION
:cherries: Cherry picked from #1143 [fix(components/text-editor): only paste text once, only reinitialize editor if already rendered](https://github.com/blackbaud/skyux/pull/1143)