### PR TITLE
docs(components/indicators): fix `SkyWaitHarnessFilters` docs reference to `SkyWaitHarness` which incorrectly referenced `SkyAlertHarness`

### DIFF
--- a/libs/components/indicators/testing/src/wait/wait-harness-filters.ts
+++ b/libs/components/indicators/testing/src/wait/wait-harness-filters.ts
@@ -1,7 +1,7 @@
 import { SkyHarnessFilters } from '@skyux/core/testing';
 
 /**
- * A set of criteria that can be used to filter a list of SkyAlertHarness instances.
+ * A set of criteria that can be used to filter a list of SkyWaitHarness instances.
  */
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface SkyWaitHarnessFilters extends SkyHarnessFilters {


### PR DESCRIPTION
[AB#2492653](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/2492653)

BEGIN_COMMIT_OVERRIDE
fix(components/indicators): fix `SkyWaitHarnessFilters` docs reference to `SkyWaitHarness` which incorrectly referenced `SkyAlertHarness` (#1171)
END_COMMIT_OVERRIDE