### PR TITLE
fix(components/lookup): use `position: absolute` for autocomplete dropdown

### DIFF
--- a/apps/playground/src/app/components/modal/modal-form-demo.component.html
+++ b/apps/playground/src/app/components/modal/modal-form-demo.component.html
@@ -59,6 +59,24 @@
       <label class="sky-control-label"> Field label </label>
       <input class="sky-form-control" type="text" value="Text value" />
     </sky-input-box>
+    <sky-autocomplete
+      [data]="data"
+      [enableShowMore]="true"
+      [showAddButton]="true"
+    >
+      <sky-input-box>
+        <label class="sky-control-label" [for]="favoriteColor.id">
+          Favorite color
+        </label>
+        <input
+          class="sky-form-control"
+          skyAutocomplete
+          skyId
+          type="text"
+          #favoriteColor="skyId"
+        />
+      </sky-input-box>
+    </sky-autocomplete>
     <sky-input-box>
       <label class="sky-control-label"> Field label </label>
       <input class="sky-form-control" type="text" value="Text value" />

--- a/apps/playground/src/app/components/modal/modal-form-demo.component.ts
+++ b/apps/playground/src/app/components/modal/modal-form-demo.component.ts
@@ -10,5 +10,19 @@ export class ModalFormDemoComponent {
   public title = 'Modal form with scroll';
   public showHelp = false;
 
+  public data: { name: string }[] = [
+    { name: 'Red' },
+    { name: 'Blue' },
+    { name: 'Green' },
+    { name: 'Orange' },
+    { name: 'Pink' },
+    { name: 'Purple' },
+    { name: 'Yellow' },
+    { name: 'Brown' },
+    { name: 'Turquoise' },
+    { name: 'White' },
+    { name: 'Black' },
+  ];
+
   constructor(public instance: SkyModalInstance) {}
 }

--- a/apps/playground/src/app/components/modal/modal-visual.module.ts
+++ b/apps/playground/src/app/components/modal/modal-visual.module.ts
@@ -1,9 +1,10 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
+import { SkyIdModule } from '@skyux/core';
 import { SkyInputBoxModule } from '@skyux/forms';
 import { SkyHelpInlineModule } from '@skyux/indicators';
-import { SkyLookupModule } from '@skyux/lookup';
+import { SkyAutocompleteModule, SkyLookupModule } from '@skyux/lookup';
 import { SkyModalModule } from '@skyux/modals';
 import { SkyTilesModule } from '@skyux/tiles';
 
@@ -36,6 +37,8 @@ import { ModalVisualComponent } from './modal-visual.component';
   imports: [
     CommonModule,
     FormsModule,
+    SkyAutocompleteModule,
+    SkyIdModule,
     SkyInputBoxModule,
     SkyTilesModule,
     SkyModalModule,

--- a/libs/components/core/src/index.ts
+++ b/libs/components/core/src/index.ts
@@ -9,6 +9,7 @@ export * from './lib/modules/affix/affix-offset';
 export * from './lib/modules/affix/affix-offset-change';
 export * from './lib/modules/affix/affix-placement';
 export * from './lib/modules/affix/affix-placement-change';
+export * from './lib/modules/affix/affix-position';
 export * from './lib/modules/affix/affix-vertical-alignment';
 export * from './lib/modules/affix/affix.module';
 export * from './lib/modules/affix/affix.service';
@@ -52,6 +53,7 @@ export * from './lib/modules/numeric/numeric.service';
 
 export * from './lib/modules/overlay/overlay-config';
 export * from './lib/modules/overlay/overlay-instance';
+export * from './lib/modules/overlay/overlay-position';
 export * from './lib/modules/overlay/overlay.module';
 export * from './lib/modules/overlay/overlay.service';
 

--- a/libs/components/core/src/lib/modules/affix/affix-config.ts
+++ b/libs/components/core/src/lib/modules/affix/affix-config.ts
@@ -2,6 +2,7 @@ import { SkyAffixAutoFitContext } from './affix-auto-fit-context';
 import { SkyAffixHorizontalAlignment } from './affix-horizontal-alignment';
 import { SkyAffixOffset } from './affix-offset';
 import { SkyAffixPlacement } from './affix-placement';
+import { SkyAffixPosition } from './affix-position';
 import { SkyAffixVerticalAlignment } from './affix-vertical-alignment';
 
 export interface SkyAffixConfig {
@@ -45,4 +46,9 @@ export interface SkyAffixConfig {
    * The vertical alignment of the affixed element to the base element.
    */
   verticalAlignment?: SkyAffixVerticalAlignment;
+
+  /**
+   * The position of the element being fixed.
+   */
+  position?: SkyAffixPosition;
 }

--- a/libs/components/core/src/lib/modules/affix/affix-config.ts
+++ b/libs/components/core/src/lib/modules/affix/affix-config.ts
@@ -48,7 +48,7 @@ export interface SkyAffixConfig {
   verticalAlignment?: SkyAffixVerticalAlignment;
 
   /**
-   * The position of the element being fixed.
+   * The position of the element being affixed.
    */
   position?: SkyAffixPosition;
 }

--- a/libs/components/core/src/lib/modules/affix/affix-position.ts
+++ b/libs/components/core/src/lib/modules/affix/affix-position.ts
@@ -1,0 +1,1 @@
+export type SkyAffixPosition = 'absolute' | 'fixed';

--- a/libs/components/core/src/lib/modules/affix/affix-rect.ts
+++ b/libs/components/core/src/lib/modules/affix/affix-rect.ts
@@ -1,0 +1,11 @@
+/**
+ * @internal
+ */
+export interface AffixRect {
+  bottom: number;
+  top: number;
+  left: number;
+  right: number;
+  width: number;
+  height: number;
+}

--- a/libs/components/core/src/lib/modules/affix/affix.directive.ts
+++ b/libs/components/core/src/lib/modules/affix/affix.directive.ts
@@ -19,6 +19,7 @@ import { SkyAffixOffset } from './affix-offset';
 import { SkyAffixOffsetChange } from './affix-offset-change';
 import { SkyAffixPlacement } from './affix-placement';
 import { SkyAffixPlacementChange } from './affix-placement-change';
+import { SkyAffixPosition } from './affix-position';
 import { SkyAffixVerticalAlignment } from './affix-vertical-alignment';
 import { SkyAffixService } from './affix.service';
 import { SkyAffixer } from './affixer';
@@ -71,6 +72,12 @@ export class SkyAffixDirective implements OnInit, OnChanges, OnDestroy {
    */
   @Input()
   public affixPlacement: SkyAffixPlacement | undefined;
+
+  /**
+   * Sets the `position` property of [[SkyAffixConfig]].
+   */
+  @Input()
+  public affixPosition: SkyAffixPosition | undefined;
 
   /**
    * Sets the `verticalAlignment` property of [[SkyAffixConfig]].
@@ -136,6 +143,7 @@ export class SkyAffixDirective implements OnInit, OnChanges, OnDestroy {
       changes.affixHorizontalAlignment ||
       changes.affixIsSticky ||
       changes.affixPlacement ||
+      changes.affixPosition ||
       changes.affixVerticalAlignment
     ) {
       this.#updateAlignment();
@@ -165,6 +173,7 @@ export class SkyAffixDirective implements OnInit, OnChanges, OnDestroy {
         horizontalAlignment: this.affixHorizontalAlignment,
         isSticky: this.affixIsSticky,
         placement: this.affixPlacement,
+        position: this.affixPosition,
         verticalAlignment: this.affixVerticalAlignment,
       });
     }

--- a/libs/components/core/src/lib/modules/affix/fixtures/affix.component.fixture.html
+++ b/libs/components/core/src/lib/modules/affix/fixtures/affix.component.fixture.html
@@ -23,7 +23,11 @@
     [affixHorizontalAlignment]="horizontalAlignment"
     [affixIsSticky]="isSticky"
     [affixPlacement]="placement"
+    [affixPosition]="position"
     [affixVerticalAlignment]="verticalAlignment"
+    [ngClass]="{
+      'affixed-absolute': position === 'absolute'
+    }"
     [skyAffixTo]="baseRef"
     (affixOffsetChange)="onAffixOffsetChange($event)"
     (affixOverflowScroll)="onAffixOverflowScroll($event)"

--- a/libs/components/core/src/lib/modules/affix/fixtures/affix.component.fixture.scss
+++ b/libs/components/core/src/lib/modules/affix/fixtures/affix.component.fixture.scss
@@ -37,4 +37,8 @@
   height: 50px;
   background-color: blue;
   position: fixed;
+
+  &-absolute {
+    position: absolute;
+  }
 }

--- a/libs/components/core/src/lib/modules/affix/fixtures/affix.component.fixture.ts
+++ b/libs/components/core/src/lib/modules/affix/fixtures/affix.component.fixture.ts
@@ -5,6 +5,7 @@ import { SkyAffixHorizontalAlignment } from '../affix-horizontal-alignment';
 import { SkyAffixOffset } from '../affix-offset';
 import { SkyAffixPlacement } from '../affix-placement';
 import { SkyAffixPlacementChange } from '../affix-placement-change';
+import { SkyAffixPosition } from '../affix-position';
 import { SkyAffixVerticalAlignment } from '../affix-vertical-alignment';
 import { SkyAffixDirective } from '../affix.directive';
 
@@ -29,6 +30,8 @@ export class AffixFixtureComponent {
   public placement: SkyAffixPlacement | undefined;
 
   public verticalAlignment: SkyAffixVerticalAlignment | undefined;
+
+  public position: SkyAffixPosition | undefined;
 
   // #endregion
 

--- a/libs/components/core/src/lib/modules/overlay/overlay-config.ts
+++ b/libs/components/core/src/lib/modules/overlay/overlay-config.ts
@@ -1,3 +1,5 @@
+import { SkyOverlayPosition } from './overlay-position';
+
 export interface SkyOverlayConfig {
   /**
    * Whether the overlay closes after a navigation change.
@@ -28,4 +30,9 @@ export interface SkyOverlayConfig {
    * Extra CSS classes to add to the overlay's wrapper element.
    */
   wrapperClass?: string;
+
+  /**
+   * The position of the overlay instance.
+   */
+  position?: SkyOverlayPosition;
 }

--- a/libs/components/core/src/lib/modules/overlay/overlay-position.ts
+++ b/libs/components/core/src/lib/modules/overlay/overlay-position.ts
@@ -1,0 +1,1 @@
+export type SkyOverlayPosition = 'absolute' | 'fixed';

--- a/libs/components/core/src/lib/modules/overlay/overlay.component.html
+++ b/libs/components/core/src/lib/modules/overlay/overlay.component.html
@@ -1,5 +1,5 @@
 <div
-  [class]="wrapperClass"
+  [class]="'sky-overlay-position-' + position + ' ' + wrapperClass"
   [style.z-index]="zIndex"
   [style.clip-path]="clipPath$ | async"
   [ngClass]="{

--- a/libs/components/core/src/lib/modules/overlay/overlay.component.scss
+++ b/libs/components/core/src/lib/modules/overlay/overlay.component.scss
@@ -1,5 +1,4 @@
 .sky-overlay {
-  position: fixed;
   top: 0;
   right: 0;
   left: 0;
@@ -8,6 +7,16 @@
   height: 100%;
   display: flex;
   pointer-events: auto;
+
+  &-position {
+    &-absolute {
+      position: absolute;
+    }
+
+    &-fixed {
+      position: fixed;
+    }
+  }
 }
 
 .sky-overlay-content {

--- a/libs/components/core/src/lib/modules/overlay/overlay.component.ts
+++ b/libs/components/core/src/lib/modules/overlay/overlay.component.ts
@@ -34,6 +34,9 @@ import { SKY_STACKING_CONTEXT } from '../stacking-context/stacking-context-token
 
 import { SkyOverlayConfig } from './overlay-config';
 import { SkyOverlayContext } from './overlay-context';
+import { SkyOverlayPosition } from './overlay-position';
+
+const POSITION_DEFAULT: SkyOverlayPosition = 'fixed';
 
 /**
  * Omnibar is 1000.
@@ -80,6 +83,8 @@ export class SkyOverlayComponent implements OnInit, OnDestroy {
   public zIndex = `${++uniqueZIndex}`;
 
   protected clipPath$ = new ReplaySubject<string | undefined>(1);
+
+  protected position = POSITION_DEFAULT;
 
   @ViewChild('overlayContentRef', {
     read: ElementRef,
@@ -229,6 +234,7 @@ export class SkyOverlayComponent implements OnInit, OnDestroy {
     this.wrapperClass = config.wrapperClass || '';
     this.showBackdrop = !!config.showBackdrop;
     this.enablePointerEvents = !!config.enablePointerEvents;
+    this.position = config.position || POSITION_DEFAULT;
     this.#changeDetector.markForCheck();
   }
 

--- a/libs/components/lookup/src/lib/modules/autocomplete/autocomplete.component.scss
+++ b/libs/components/lookup/src/lib/modules/autocomplete/autocomplete.component.scss
@@ -2,7 +2,7 @@
 @use 'libs/components/theme/src/lib/styles/variables' as *;
 
 .sky-autocomplete-results-container {
-  position: fixed;
+  position: absolute;
   background-color: $sky-color-white;
 }
 

--- a/libs/components/lookup/src/lib/modules/autocomplete/autocomplete.component.ts
+++ b/libs/components/lookup/src/lib/modules/autocomplete/autocomplete.component.ts
@@ -831,6 +831,7 @@ export class SkyAutocompleteComponent implements OnDestroy, AfterViewInit {
       const overlay = this.#overlayService.create({
         enableClose: false,
         enablePointerEvents: true,
+        position: 'absolute',
         wrapperClass: this.wrapperClass,
       });
 
@@ -940,6 +941,7 @@ export class SkyAutocompleteComponent implements OnDestroy, AfterViewInit {
         isSticky: true,
         placement: 'below',
         horizontalAlignment: 'left',
+        position: 'absolute',
       });
 
       this.#affixer = affixer;


### PR DESCRIPTION
[AB#2480553](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/2480553)

*Mobile Safari, position: fixed and the virtual keyboard — an erroneous combination*
https://medium.com/@im_rahul/safari-and-position-fixed-978122be5f29

**StackOverflow article**
https://stackoverflow.com/questions/43833049/how-to-make-fixed-content-go-above-ios-keyboard