### PR TITLE
deprecation(components/forms): deprecate radioType and checkboxType (#1191)

### DIFF
--- a/libs/components/forms/src/lib/modules/checkbox/checkbox.component.spec.ts
+++ b/libs/components/forms/src/lib/modules/checkbox/checkbox.component.spec.ts
@@ -18,6 +18,7 @@ import {
 } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 import { expect, expectAsync } from '@skyux-sdk/testing';
+import { SkyLogService } from '@skyux/core';
 
 import { SkyCheckboxChange } from './checkbox-change';
 import { SkyCheckboxComponent } from './checkbox.component';
@@ -1142,6 +1143,21 @@ describe('Checkbox component', () => {
 
       span = debugElement.query(By.css('span')).nativeElement;
       expect(span).toHaveCssClass('sky-switch-control-danger');
+    });
+
+    it('should log a deprecation warning when checkboxType is set', () => {
+      const logService = TestBed.inject(SkyLogService);
+      const deprecatedLogSpy = spyOn(logService, 'deprecated').and.stub();
+
+      fixture.componentInstance.checkboxType = 'warning';
+      fixture.detectChanges();
+
+      expect(deprecatedLogSpy).toHaveBeenCalledWith(
+        'SkyCheckboxComponent.checkboxType',
+        Object({
+          deprecationMajorVersion: 7,
+        })
+      );
     });
 
     it('should pass accessibility', async () => {

--- a/libs/components/forms/src/lib/modules/checkbox/checkbox.component.ts
+++ b/libs/components/forms/src/lib/modules/checkbox/checkbox.component.ts
@@ -11,6 +11,7 @@ import {
   ViewChild,
 } from '@angular/core';
 import { ControlValueAccessor, NgControl } from '@angular/forms';
+import { SkyLogService } from '@skyux/core';
 
 import { BehaviorSubject, Observable } from 'rxjs';
 
@@ -137,9 +138,16 @@ export class SkyCheckboxComponent implements ControlValueAccessor, OnInit {
    * label types. `"info"` creates a blue background, `"success"` creates a green
    * background, `"warning"` creates an orange background, and `"danger"` creates a red background.
    * @default "info"
+   * @deprecated checkboxType is no longer supported
    */
   @Input()
   public set checkboxType(value: string | undefined) {
+    if (value) {
+      this.#logger.deprecated('SkyCheckboxComponent.checkboxType', {
+        deprecationMajorVersion: 7,
+      });
+    }
+
     this.#_checkboxType = value ? value.toLowerCase() : 'info';
   }
 
@@ -284,11 +292,15 @@ export class SkyCheckboxComponent implements ControlValueAccessor, OnInit {
 
   #ngControl: NgControl | undefined;
 
+  #logger: SkyLogService;
+
   constructor(
     changeDetector: ChangeDetectorRef,
+    logger: SkyLogService,
     @Self() @Optional() ngControl: NgControl
   ) {
     this.#changeDetector = changeDetector;
+    this.#logger = logger;
     this.#ngControl = ngControl;
     if (ngControl) {
       ngControl.valueAccessor = this;

--- a/libs/components/forms/src/lib/modules/radio/radio.component.spec.ts
+++ b/libs/components/forms/src/lib/modules/radio/radio.component.spec.ts
@@ -8,7 +8,7 @@ import {
 import { NgModel } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 import { SkyAppTestUtility, expect, expectAsync } from '@skyux-sdk/testing';
-import { SkyIdService } from '@skyux/core';
+import { SkyIdService, SkyLogService } from '@skyux/core';
 
 import { SkyRadioFixturesModule } from './fixtures/radio-fixtures.module';
 import { SkyRadioOnPushTestComponent } from './fixtures/radio-on-push.component.fixture';
@@ -326,6 +326,21 @@ describe('Radio component', function () {
 
       span = debugElement.query(By.css('span')).nativeElement;
       expect(span).toHaveCssClass('sky-switch-control-danger');
+    });
+
+    it('should log a deprecation warning when radioType is set', () => {
+      const logService = TestBed.inject(SkyLogService);
+      const deprecatedLogSpy = spyOn(logService, 'deprecated').and.stub();
+
+      fixture.componentInstance.radioType = 'warning';
+      fixture.detectChanges();
+
+      expect(deprecatedLogSpy).toHaveBeenCalledWith(
+        'SkyRadioComponent.radioType',
+        Object({
+          deprecationMajorVersion: 7,
+        })
+      );
     });
 
     it('should pass accessibility', async () => {

--- a/libs/components/forms/src/lib/modules/radio/radio.component.ts
+++ b/libs/components/forms/src/lib/modules/radio/radio.component.ts
@@ -11,7 +11,7 @@ import {
   forwardRef,
 } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
-import { SkyIdService } from '@skyux/core';
+import { SkyIdService, SkyLogService } from '@skyux/core';
 
 import { Subject } from 'rxjs';
 
@@ -215,12 +215,19 @@ export class SkyRadioComponent implements OnDestroy, ControlValueAccessor {
    * label types. `danger` creates a red background, `info` creates a blue background,
    * `success` creates a green background, and `warning` creates an orange background.
    * @default "info"
+   * @deprecated radioType is no longer supported
    */
   @Input()
   public get radioType(): SkyRadioType {
     return this.#_radioType;
   }
   public set radioType(value: SkyRadioType | undefined) {
+    if (value) {
+      this.#logger.deprecated('SkyRadioComponent.radioType', {
+        deprecationMajorVersion: 7,
+      });
+    }
+
     this.#_radioType = value ?? 'info';
   }
 
@@ -268,14 +275,17 @@ export class SkyRadioComponent implements OnDestroy, ControlValueAccessor {
 
   #changeDetector: ChangeDetectorRef;
   #radioGroupIdSvc: SkyRadioGroupIdService | undefined;
+  #logger: SkyLogService;
 
   constructor(
     changeDetector: ChangeDetectorRef,
     idService: SkyIdService,
+    logger: SkyLogService,
     @Optional() radioGroupIdService?: SkyRadioGroupIdService
   ) {
     this.#changeDetector = changeDetector;
     this.#radioGroupIdSvc = radioGroupIdService;
+    this.#logger = logger;
 
     this.#defaultId = idService.generateId();
     this.id = this.#defaultId;

--- a/libs/components/forms/src/lib/modules/radio/types/radio-type.ts
+++ b/libs/components/forms/src/lib/modules/radio/types/radio-type.ts
@@ -1,1 +1,4 @@
+/**
+ * @deprecated radioType is no longer supported
+ */
 export type SkyRadioType = 'danger' | 'info' | 'success' | 'warning';


### PR DESCRIPTION
:cherries: Cherry picked from #1191 [deprecation(components/forms): deprecate radioType and checkboxType](https://github.com/blackbaud/skyux/pull/1191)