### PR TITLE
fix(components/forms): single file attachment emits the file when a file is removed

### DIFF
--- a/libs/components/forms/src/lib/modules/file-attachment/file-attachment.component.spec.ts
+++ b/libs/components/forms/src/lib/modules/file-attachment/file-attachment.component.spec.ts
@@ -573,7 +573,7 @@ describe('File attachment', () => {
 
     fixture.detectChanges();
 
-    expect(fileChangeActual?.file).toBeFalsy();
+    expect(fileChangeActual?.file).toEqual({ file: <File> file[0], url: '$/url' });
   });
 
   it('should show the appropriate file name', () => {

--- a/libs/components/forms/src/lib/modules/file-attachment/file-attachment.component.spec.ts
+++ b/libs/components/forms/src/lib/modules/file-attachment/file-attachment.component.spec.ts
@@ -573,7 +573,10 @@ describe('File attachment', () => {
 
     fixture.detectChanges();
 
-    expect(fileChangeActual?.file).toEqual({ file: <File> file[0], url: '$/url' });
+    expect(fileChangeActual?.file).toEqual({
+      file: file[0] as File,
+      url: '$/url',
+    });
   });
 
   it('should show the appropriate file name', () => {

--- a/libs/components/forms/src/lib/modules/file-attachment/file-attachment.component.ts
+++ b/libs/components/forms/src/lib/modules/file-attachment/file-attachment.component.ts
@@ -365,9 +365,9 @@ export class SkyFileAttachmentComponent
   }
 
   public deleteFileAttachment(): void {
+    this.#emitFileChangeEvent(this.value);
     this.value = undefined;
     this.#changeDetector.markForCheck();
-    this.#emitFileChangeEvent(this.value);
   }
 
   public ngOnDestroy(): void {


### PR DESCRIPTION
[AB#2492909](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/2492909)

BEGIN_COMMIT_OVERRIDE
chore: fix(components/forms): single file attachment emits the file when a file is removed (#1203)
END_COMMIT_OVERRIDE