### PR TITLE
revert: fix(components/forms): single file attachment emits the file when a file is removed (#1203)

### DIFF
--- a/libs/components/forms/src/lib/modules/file-attachment/file-attachment.component.spec.ts
+++ b/libs/components/forms/src/lib/modules/file-attachment/file-attachment.component.spec.ts
@@ -573,10 +573,7 @@ describe('File attachment', () => {
 
     fixture.detectChanges();
 
-    expect(fileChangeActual?.file).toEqual({
-      file: file[0] as File,
-      url: '$/url',
-    });
+    expect(fileChangeActual?.file).toBeFalsy();
   });
 
   it('should show the appropriate file name', () => {

--- a/libs/components/forms/src/lib/modules/file-attachment/file-attachment.component.ts
+++ b/libs/components/forms/src/lib/modules/file-attachment/file-attachment.component.ts
@@ -365,9 +365,9 @@ export class SkyFileAttachmentComponent
   }
 
   public deleteFileAttachment(): void {
-    this.#emitFileChangeEvent(this.value);
     this.value = undefined;
     this.#changeDetector.markForCheck();
+    this.#emitFileChangeEvent(this.value);
   }
 
   public ngOnDestroy(): void {


### PR DESCRIPTION
BEGIN_COMMIT_OVERRIDE
chore: revert: fix(components/forms): single file attachment emits the file when a file is removed (#1203) #1205
END_COMMIT_OVERRIDE