### PR TITLE
deprecation(components/indicators): deprecate use of alert without descriptionType

### DIFF
--- a/libs/components/indicators/src/lib/modules/alert/alert.component.spec.ts
+++ b/libs/components/indicators/src/lib/modules/alert/alert.component.spec.ts
@@ -1,5 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { expect, expectAsync } from '@skyux-sdk/testing';
+import { SkyLogService } from '@skyux/core';
 import {
   SkyTheme,
   SkyThemeMode,
@@ -20,6 +21,24 @@ describe('Alert component', () => {
   let mockThemeSvc: {
     settingsChange: BehaviorSubject<SkyThemeSettingsChange>;
   };
+
+  function validateDeprecatedCalled(
+    deprecatedSpy: jasmine.Spy,
+    expected: boolean
+  ): void {
+    if (expected) {
+      expect(deprecatedSpy).toHaveBeenCalledOnceWith(
+        'SkyAlertComponent without `descriptionType`',
+        {
+          deprecationMajorVersion: 8,
+          replacementRecommendation:
+            'Always specify a `descriptionType` property.',
+        }
+      );
+    } else {
+      expect(deprecatedSpy).not.toHaveBeenCalled();
+    }
+  }
 
   beforeEach(() => {
     mockThemeSvc = {
@@ -126,6 +145,33 @@ describe('Alert component', () => {
     const alertEl = el.querySelector('.sky-alert');
     expect(alertEl?.getAttribute('role')).toBe('alert');
     await expectAsync(fixture.nativeElement).toBeAccessible();
+  });
+
+  it('should warn when descriptionType is not set on render', () => {
+    const logSvc = TestBed.inject(SkyLogService);
+    const deprecatedSpy = spyOn(logSvc, 'deprecated');
+
+    const fixture = TestBed.createComponent(AlertTestComponent);
+    fixture.componentInstance.descriptionType = undefined;
+    fixture.detectChanges();
+
+    validateDeprecatedCalled(deprecatedSpy, true);
+  });
+
+  it('should warn when descriptionType is unset after initial render', () => {
+    const logSvc = TestBed.inject(SkyLogService);
+    const deprecatedSpy = spyOn(logSvc, 'deprecated');
+
+    const fixture = TestBed.createComponent(AlertTestComponent);
+    fixture.componentInstance.descriptionType = 'attention';
+    fixture.detectChanges();
+
+    validateDeprecatedCalled(deprecatedSpy, false);
+
+    fixture.componentInstance.descriptionType = undefined;
+    fixture.detectChanges();
+
+    validateDeprecatedCalled(deprecatedSpy, true);
   });
 
   describe('with description', () => {

--- a/libs/components/indicators/src/lib/modules/alert/fixtures/alert.component.fixture.ts
+++ b/libs/components/indicators/src/lib/modules/alert/fixtures/alert.component.fixture.ts
@@ -1,6 +1,7 @@
 import { Component } from '@angular/core';
 
 import { SkyIndicatorDescriptionType } from '../../shared/indicator-description-type';
+import { SkyIndicatorIconType } from '../../shared/indicator-icon-type';
 
 @Component({
   selector: 'sky-test-cmp',
@@ -11,7 +12,7 @@ export class AlertTestComponent {
 
   public closed: boolean | undefined = false;
 
-  public alertType: string | undefined = 'info';
+  public alertType: SkyIndicatorIconType | undefined = 'info';
 
   public descriptionType?: SkyIndicatorDescriptionType;
 


### PR DESCRIPTION
[AB#2315254](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/2315254)