### PR TITLE
fix(components/lists): don't animate repeater items collapsing on initial render (#1219)

### DIFF
--- a/libs/components/lists/src/lib/modules/repeater/repeater-item.component.html
+++ b/libs/components/lists/src/lib/modules/repeater/repeater-item.component.html
@@ -144,6 +144,7 @@
     <div
       class="sky-repeater-item-content"
       [id]="contentId"
+      [@.disabled]="animationDisabled"
       [@skyAnimationSlide]="slideDirection"
       #itemContentRef
       [attr.role]="(itemRole$ | async)?.content"

--- a/libs/components/lists/src/lib/modules/repeater/repeater-item.component.ts
+++ b/libs/components/lists/src/lib/modules/repeater/repeater-item.component.ts
@@ -117,7 +117,7 @@ export class SkyRepeaterItemComponent
    */
   @Input()
   public set isExpanded(value: boolean | undefined) {
-    this.updateForExpanded(value !== false);
+    this.updateForExpanded(value !== false, true);
   }
 
   public get isExpanded(): boolean {
@@ -209,7 +209,7 @@ export class SkyRepeaterItemComponent
 
       /*istanbul ignore else */
       if (!this.#_isCollapsible) {
-        this.updateForExpanded(true);
+        this.updateForExpanded(true, true);
       }
     }
 
@@ -227,6 +227,8 @@ export class SkyRepeaterItemComponent
   public reorderState: string | undefined;
 
   public slideDirection: string | undefined;
+
+  public animationDisabled = false;
 
   @HostBinding('class')
   get repeaterGroupClass(): string {
@@ -282,7 +284,7 @@ export class SkyRepeaterItemComponent
     this.#elementRef = elementRef;
     this.#resourceService = resourceService;
 
-    this.#slideForExpanded();
+    this.#slideForExpanded(false);
 
     observableForkJoin([
       this.#resourceService.getString('skyux_repeater_item_reorder_cancel'),
@@ -428,12 +430,12 @@ export class SkyRepeaterItemComponent
 
   public headerClick(): void {
     if (this.isCollapsible) {
-      this.updateForExpanded(!this.isExpanded);
+      this.updateForExpanded(!this.isExpanded, true);
     }
   }
 
   public chevronDirectionChange(direction: string): void {
-    this.updateForExpanded(direction === 'up');
+    this.updateForExpanded(direction === 'up', true);
   }
 
   public onRepeaterItemClick(event: MouseEvent): void {
@@ -449,7 +451,7 @@ export class SkyRepeaterItemComponent
     }
   }
 
-  public updateForExpanded(value: boolean): void {
+  public updateForExpanded(value: boolean, animate: boolean): void {
     if (this.isCollapsible === false && value === false) {
       console.warn(
         `Setting isExpanded to false when the repeater item is not collapsible
@@ -465,7 +467,7 @@ export class SkyRepeaterItemComponent
       }
 
       this.#repeaterService.onItemCollapseStateChange(this);
-      this.#slideForExpanded();
+      this.#slideForExpanded(animate);
       this.#changeDetector.markForCheck();
     }
   }
@@ -551,7 +553,8 @@ export class SkyRepeaterItemComponent
     this.reorderState = undefined;
   }
 
-  #slideForExpanded(): void {
+  #slideForExpanded(animate: boolean): void {
+    this.animationDisabled = !animate;
     this.slideDirection = this.isExpanded ? 'down' : 'up';
   }
 

--- a/libs/components/lists/src/lib/modules/repeater/repeater.component.spec.ts
+++ b/libs/components/lists/src/lib/modules/repeater/repeater.component.spec.ts
@@ -326,6 +326,24 @@ describe('Repeater item component', () => {
   }));
 
   describe('with expand mode of "single"', () => {
+    it('should disabled collapse animations on initial render', fakeAsync(() => {
+      const fixture = TestBed.createComponent(RepeaterTestComponent);
+      const cmp: RepeaterTestComponent = fixture.componentInstance;
+
+      cmp.expandMode = 'single';
+      fixture.detectChanges();
+
+      tick();
+
+      const repeaterItems = cmp.repeater?.items?.toArray();
+
+      expect(repeaterItems?.[0].animationDisabled).toBeTrue();
+      expect(repeaterItems?.[1].animationDisabled).toBeTrue();
+      expect(repeaterItems?.[2].animationDisabled).toBeTrue();
+
+      flushDropdownTimer();
+    }));
+
     it('should collapse other items when an item is expanded', fakeAsync(() => {
       const fixture = TestBed.createComponent(RepeaterTestComponent);
       const cmp: RepeaterTestComponent = fixture.componentInstance;
@@ -386,6 +404,9 @@ describe('Repeater item component', () => {
       expect(repeaterItems?.[0].isExpanded).toBe(false);
       expect(repeaterItems?.[1].isExpanded).toBe(false);
       expect(repeaterItems?.[2].isExpanded).toBe(true);
+
+      // Validate that animation was enabled on the item that was collapsed.
+      expect(repeaterItems?.[0].animationDisabled).toBeFalse();
 
       flushDropdownTimer();
     }));

--- a/libs/components/lists/src/lib/modules/repeater/repeater.component.ts
+++ b/libs/components/lists/src/lib/modules/repeater/repeater.component.ts
@@ -269,17 +269,20 @@ export class SkyRepeaterComponent
         foundExpanded = true;
       }
 
-      this.items.forEach((item) => {
+      for (const item of this.items) {
         item.isCollapsible = isCollapsible && !!item.hasItemContent;
 
+        // Collapse any items that aren't the item that was just added.
         if (item !== itemAdded && isSingle && item.isExpanded) {
           if (foundExpanded) {
-            item.updateForExpanded(false);
+            // If this item is being collapsed because a new item was
+            // added, animate it.
+            item.updateForExpanded(false, !!itemAdded);
           }
 
           foundExpanded = true;
         }
-      });
+      }
 
       this.#updateRole();
     }


### PR DESCRIPTION
:cherries: Cherry picked from #1219 [fix(components/lists): don't animate repeater items collapsing on initial render](https://github.com/blackbaud/skyux/pull/1219)