### PR TITLE
feat(components/indicators): add ability to set aria controls and expanded states on the help inline component (#1225)

### DIFF
--- a/apps/playground/src/app/components/indicators/help-inline/help-inline.component.html
+++ b/apps/playground/src/app/components/indicators/help-inline/help-inline.component.html
@@ -1,6 +1,20 @@
 <div class="sky-help-inline-demo">
   <h2>
     Giving
-    <sky-help-inline (actionClick)="onActionClick()"> </sky-help-inline>
+    <sky-help-inline
+      ariaControls="popover"
+      [ariaExpanded]="popoverOpen"
+      [skyPopover]="myPopover"
+    >
+    </sky-help-inline>
+    <sky-popover
+      id="popover"
+      popoverTitle="Did you know?"
+      (popoverClosed)="popoverChange(false)"
+      (popoverOpened)="popoverChange(true)"
+      #myPopover
+    >
+      This is a popover.
+    </sky-popover>
   </h2>
 </div>

--- a/apps/playground/src/app/components/indicators/help-inline/help-inline.component.ts
+++ b/apps/playground/src/app/components/indicators/help-inline/help-inline.component.ts
@@ -1,13 +1,16 @@
-import { Component } from '@angular/core';
+import { ChangeDetectorRef, Component, inject } from '@angular/core';
 
 @Component({
   selector: 'app-help-inline',
   templateUrl: './help-inline.component.html',
 })
 export class HelpInlineComponent {
-  public buttonIsClicked = false;
+  public popoverOpen = false;
 
-  public onActionClick(): void {
-    this.buttonIsClicked = true;
+  #changeDetector = inject(ChangeDetectorRef);
+
+  public popoverChange(isOpen): void {
+    this.popoverOpen = isOpen;
+    this.#changeDetector.markForCheck();
   }
 }

--- a/apps/playground/src/app/components/indicators/help-inline/help-inline.module.ts
+++ b/apps/playground/src/app/components/indicators/help-inline/help-inline.module.ts
@@ -1,13 +1,19 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { SkyHelpInlineModule } from '@skyux/indicators';
+import { SkyPopoverModule } from '@skyux/popovers';
 
 import { HelpInlineRoutingModule } from './help-inline-routing.module';
 import { HelpInlineComponent } from './help-inline.component';
 
 @NgModule({
   declarations: [HelpInlineComponent],
-  imports: [CommonModule, HelpInlineRoutingModule, SkyHelpInlineModule],
+  imports: [
+    CommonModule,
+    HelpInlineRoutingModule,
+    SkyHelpInlineModule,
+    SkyPopoverModule,
+  ],
 })
 export class HelpInlineModule {
   public static routes = HelpInlineRoutingModule.routes;

--- a/libs/components/indicators/src/lib/modules/help-inline/fixtures/help-inline.component.fixture.html
+++ b/libs/components/indicators/src/lib/modules/help-inline/fixtures/help-inline.component.fixture.html
@@ -1,1 +1,8 @@
-<sky-help-inline (actionClick)="buttonClicked()"> </sky-help-inline>
+<sky-help-inline
+  [ariaControls]="ariaControls"
+  [ariaExpanded]="ariaExpanded"
+  (actionClick)="buttonClicked()"
+>
+</sky-help-inline>
+<!-- This isn't real world - but a11y testing requires a real element -->
+<p id="help-text" [hidden]="showHelpText">Show text</p>

--- a/libs/components/indicators/src/lib/modules/help-inline/fixtures/help-inline.component.fixture.ts
+++ b/libs/components/indicators/src/lib/modules/help-inline/fixtures/help-inline.component.fixture.ts
@@ -5,9 +5,11 @@ import { Component } from '@angular/core';
   templateUrl: './help-inline.component.fixture.html',
 })
 export class HelpInlineTestComponent {
-  public buttonIsClicked = false;
+  public ariaControls: string | undefined;
+  public ariaExpanded: boolean | undefined;
+  public showHelpText = false;
 
   public buttonClicked(): void {
-    this.buttonIsClicked = true;
+    this.showHelpText = !this.showHelpText;
   }
 }

--- a/libs/components/indicators/src/lib/modules/help-inline/help-inline-aria-expanded.pipe.ts
+++ b/libs/components/indicators/src/lib/modules/help-inline/help-inline-aria-expanded.pipe.ts
@@ -1,0 +1,13 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({
+  name: 'skyHelpInlineAriaExpanded',
+})
+export class SkyHelpInlineAriaExpandedPipe implements PipeTransform {
+  public transform(
+    ariaExpanded: boolean | undefined,
+    ariaControls: string | undefined
+  ): boolean | null {
+    return ariaControls ? !!ariaExpanded : null;
+  }
+}

--- a/libs/components/indicators/src/lib/modules/help-inline/help-inline.component.html
+++ b/libs/components/indicators/src/lib/modules/help-inline/help-inline.component.html
@@ -2,6 +2,8 @@
   class="sky-help-inline"
   type="button"
   [attr.aria-label]="'skyux_help_inline_button_title' | skyLibResources"
+  [attr.aria-controls]="ariaControls"
+  [attr.aria-expanded]="ariaExpanded | skyHelpInlineAriaExpanded: ariaControls"
   (click)="onClick()"
 >
   <sky-icon *skyThemeIf="'default'" icon="info-circle"> </sky-icon>

--- a/libs/components/indicators/src/lib/modules/help-inline/help-inline.component.html
+++ b/libs/components/indicators/src/lib/modules/help-inline/help-inline.component.html
@@ -3,7 +3,7 @@
   type="button"
   [attr.aria-label]="'skyux_help_inline_button_title' | skyLibResources"
   [attr.aria-controls]="ariaControls"
-  [attr.aria-expanded]="ariaExpanded | skyHelpInlineAriaExpanded: ariaControls"
+  [attr.aria-expanded]="ariaExpanded | skyHelpInlineAriaExpanded : ariaControls"
   (click)="onClick()"
 >
   <sky-icon *skyThemeIf="'default'" icon="info-circle"> </sky-icon>

--- a/libs/components/indicators/src/lib/modules/help-inline/help-inline.component.spec.ts
+++ b/libs/components/indicators/src/lib/modules/help-inline/help-inline.component.spec.ts
@@ -8,6 +8,19 @@ import { SkyHelpInlineModule } from '../help-inline/help-inline.module';
 import { HelpInlineTestComponent } from './fixtures/help-inline.component.fixture';
 
 describe('Help inline component', () => {
+  async function checkAriaPropertiesAndAccessibility(
+    ariaLabel: string,
+    ariaControls: string | null,
+    ariaExpanded: string | null
+  ): Promise<void> {
+    const helpInlineElement =
+      fixture.nativeElement.querySelector('.sky-help-inline');
+    expect(helpInlineElement?.getAttribute('aria-label')).toBe(ariaLabel);
+    expect(helpInlineElement?.getAttribute('aria-controls')).toBe(ariaControls);
+    expect(helpInlineElement?.getAttribute('aria-expanded')).toBe(ariaExpanded);
+    await expectAsync(fixture.nativeElement).toBeAccessible();
+  }
+
   let fixture: ComponentFixture<HelpInlineTestComponent>;
   let cmp: HelpInlineTestComponent;
   let debugElement: DebugElement;
@@ -30,12 +43,51 @@ describe('Help inline component', () => {
       .query(By.css('.sky-help-inline'))
       .triggerEventHandler('click', undefined);
     fixture.detectChanges();
-    expect(cmp.buttonIsClicked).toBe(true);
+    expect(cmp.showHelpText).toBe(true);
   });
 
-  it('should pass accessibility', async () => {
+  it('should pass accessibility (ariaControls: undefined, ariaExpanded: undefined)', async () => {
     fixture.detectChanges();
     await fixture.whenStable();
-    await expectAsync(fixture.nativeElement).toBeAccessible();
+
+    await checkAriaPropertiesAndAccessibility('Show help content', null, null);
+  });
+
+  it('should pass accessibility (ariaControls: "help-text", ariaExpanded: undefined)', async () => {
+    cmp.ariaControls = 'help-text';
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    await checkAriaPropertiesAndAccessibility(
+      'Show help content',
+      'help-text',
+      'false'
+    );
+  });
+
+  it('should pass accessibility (ariaControls: "help-text", ariaExpanded: false)', async () => {
+    cmp.ariaControls = 'help-text';
+    cmp.ariaExpanded = false;
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    await checkAriaPropertiesAndAccessibility(
+      'Show help content',
+      'help-text',
+      'false'
+    );
+  });
+
+  it('should pass accessibility (ariaControls: "help-text", ariaExpanded: true)', async () => {
+    cmp.ariaControls = 'help-text';
+    cmp.ariaExpanded = true;
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    await checkAriaPropertiesAndAccessibility(
+      'Show help content',
+      'help-text',
+      'true'
+    );
   });
 });

--- a/libs/components/indicators/src/lib/modules/help-inline/help-inline.component.ts
+++ b/libs/components/indicators/src/lib/modules/help-inline/help-inline.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Output } from '@angular/core';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
 
 @Component({
   selector: 'sky-help-inline',
@@ -6,6 +6,22 @@ import { Component, EventEmitter, Output } from '@angular/core';
   styleUrls: ['./help-inline.component.scss'],
 })
 export class SkyHelpInlineComponent {
+  /**
+   * The ID of the element that the help inline button controls.
+   * This property [supports accessibility rules for disclosures](https://www.w3.org/TR/wai-aria-practices-1.1/#disclosure).
+   * For more information about the `aria-controls` attribute, see the [WAI-ARIA definition](https://www.w3.org/TR/wai-aria/#aria-controls).
+   */
+  @Input()
+  public ariaControls: string | undefined;
+
+  /**
+   * Whether an element controlled by the help inline button is expanded. When set to `true`, the property will only be applied to the HTML element when the `ariaControls` input is also set.
+   * This property [supports accessibility rules for disclosures](https://www.w3.org/TR/wai-aria-practices-1.1/#disclosure).
+   * For more information about the `aria-expanded` attribute, see the [WAI-ARIA definition](https://www.w3.org/TR/wai-aria/#aria-expanded).
+   */
+  @Input()
+  public ariaExpanded: boolean | undefined;
+
   /**
    * Fires when the user clicks the help inline button.
    */

--- a/libs/components/indicators/src/lib/modules/help-inline/help-inline.module.ts
+++ b/libs/components/indicators/src/lib/modules/help-inline/help-inline.module.ts
@@ -6,10 +6,11 @@ import { SkyThemeModule } from '@skyux/theme';
 import { SkyIconModule } from '../icon/icon.module';
 import { SkyIndicatorsResourcesModule } from '../shared/sky-indicators-resources.module';
 
+import { SkyHelpInlineAriaExpandedPipe } from './help-inline-aria-expanded.pipe';
 import { SkyHelpInlineComponent } from './help-inline.component';
 
 @NgModule({
-  declarations: [SkyHelpInlineComponent],
+  declarations: [SkyHelpInlineComponent, SkyHelpInlineAriaExpandedPipe],
   imports: [
     CommonModule,
     SkyI18nModule,


### PR DESCRIPTION
:cherries: Cherry picked from #1225 [feat(components/indicators): add ability to set aria controls and expanded states on the help inline component](https://github.com/blackbaud/skyux/pull/1225)