### PR TITLE
fix(components/indicators): help inline utilizes correct sizes in modern theme

### DIFF
--- a/libs/components/indicators/src/lib/modules/help-inline/help-inline.component.scss
+++ b/libs/components/indicators/src/lib/modules/help-inline/help-inline.component.scss
@@ -21,22 +21,16 @@
   .sky-help-inline {
     // The button mixin sets the border radius to 6px but we only want 3px on help inline buttons.
     border-radius: 3px;
-    ::ng-deep .fa-stack-2x {
-      font-size: 16px;
-    }
+    font-size: 11.2px;
 
-    ::ng-deep .fa-stack-1x {
-      font-size: 10px;
-    }
-
-    // The 0px and 5px padding is because we want 1px top/bottom and 6px left/right but the mixin
+    // The 1px and 5px padding is because we want 2px top/bottom and 6px left/right but the mixin
     // adds a pixel to account for standard button drop shadows that do not exist on this button.
     @include modernMixins.sky-theme-modern-button-variant(
       $sky-text-color-action-primary,
       transparent,
       transparent,
       $sky-theme-modern-background-color-primary-dark,
-      0px 5px
+      1px 5px
     );
   }
 }


### PR DESCRIPTION
[AB#2413598](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/2413598)