### PR TITLE
feat(components/indicators): add ability to specify an accessibility label on help inline (#1235)

### DIFF
--- a/libs/components/indicators/src/lib/modules/help-inline/fixtures/help-inline.component.fixture.html
+++ b/libs/components/indicators/src/lib/modules/help-inline/fixtures/help-inline.component.fixture.html
@@ -1,6 +1,7 @@
 <sky-help-inline
   [ariaControls]="ariaControls"
   [ariaExpanded]="ariaExpanded"
+  [ariaLabel]="ariaLabel"
   (actionClick)="buttonClicked()"
 >
 </sky-help-inline>

--- a/libs/components/indicators/src/lib/modules/help-inline/fixtures/help-inline.component.fixture.ts
+++ b/libs/components/indicators/src/lib/modules/help-inline/fixtures/help-inline.component.fixture.ts
@@ -7,6 +7,7 @@ import { Component } from '@angular/core';
 export class HelpInlineTestComponent {
   public ariaControls: string | undefined;
   public ariaExpanded: boolean | undefined;
+  public ariaLabel: string | undefined;
   public showHelpText = false;
 
   public buttonClicked(): void {

--- a/libs/components/indicators/src/lib/modules/help-inline/help-inline.component.html
+++ b/libs/components/indicators/src/lib/modules/help-inline/help-inline.component.html
@@ -1,7 +1,9 @@
 <button
   class="sky-help-inline"
   type="button"
-  [attr.aria-label]="'skyux_help_inline_button_title' | skyLibResources"
+  [attr.aria-label]="
+    ariaLabel || 'skyux_help_inline_button_title' | skyLibResources
+  "
   [attr.aria-controls]="ariaControls"
   [attr.aria-expanded]="ariaExpanded | skyHelpInlineAriaExpanded : ariaControls"
   (click)="onClick()"

--- a/libs/components/indicators/src/lib/modules/help-inline/help-inline.component.spec.ts
+++ b/libs/components/indicators/src/lib/modules/help-inline/help-inline.component.spec.ts
@@ -46,14 +46,14 @@ describe('Help inline component', () => {
     expect(cmp.showHelpText).toBe(true);
   });
 
-  it('should pass accessibility (ariaControls: undefined, ariaExpanded: undefined)', async () => {
+  it('should pass accessibility (ariaLabel: undefined, ariaControls: undefined, ariaExpanded: undefined)', async () => {
     fixture.detectChanges();
     await fixture.whenStable();
 
     await checkAriaPropertiesAndAccessibility('Show help content', null, null);
   });
 
-  it('should pass accessibility (ariaControls: "help-text", ariaExpanded: undefined)', async () => {
+  it('should pass accessibility (ariaLabel: undefined, ariaControls: "help-text", ariaExpanded: undefined)', async () => {
     cmp.ariaControls = 'help-text';
     fixture.detectChanges();
     await fixture.whenStable();
@@ -65,7 +65,7 @@ describe('Help inline component', () => {
     );
   });
 
-  it('should pass accessibility (ariaControls: "help-text", ariaExpanded: false)', async () => {
+  it('should pass accessibility (ariaLabel: undefined, ariaControls: "help-text", ariaExpanded: false)', async () => {
     cmp.ariaControls = 'help-text';
     cmp.ariaExpanded = false;
     fixture.detectChanges();
@@ -78,7 +78,7 @@ describe('Help inline component', () => {
     );
   });
 
-  it('should pass accessibility (ariaControls: "help-text", ariaExpanded: true)', async () => {
+  it('should pass accessibility (ariaLabel: undefined, ariaControls: "help-text", ariaExpanded: true)', async () => {
     cmp.ariaControls = 'help-text';
     cmp.ariaExpanded = true;
     fixture.detectChanges();
@@ -86,6 +86,55 @@ describe('Help inline component', () => {
 
     await checkAriaPropertiesAndAccessibility(
       'Show help content',
+      'help-text',
+      'true'
+    );
+  });
+
+  it('should pass accessibility (ariaLabel: "Test label", ariaControls: undefined, ariaExpanded: undefined)', async () => {
+    cmp.ariaLabel = 'Test label';
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    await checkAriaPropertiesAndAccessibility('Test label', null, null);
+  });
+
+  it('should pass accessibility (ariaLabel: "Test label", ariaControls: "help-text", ariaExpanded: undefined)', async () => {
+    cmp.ariaLabel = 'Test label';
+    cmp.ariaControls = 'help-text';
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    await checkAriaPropertiesAndAccessibility(
+      'Test label',
+      'help-text',
+      'false'
+    );
+  });
+
+  it('should pass accessibility (ariaLabel: "Test label", ariaControls: "help-text", ariaExpanded: false)', async () => {
+    cmp.ariaLabel = 'Test label';
+    cmp.ariaControls = 'help-text';
+    cmp.ariaExpanded = false;
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    await checkAriaPropertiesAndAccessibility(
+      'Test label',
+      'help-text',
+      'false'
+    );
+  });
+
+  it('should pass accessibility (ariaLabel: "Test label", ariaControls: "help-text", ariaExpanded: true)', async () => {
+    cmp.ariaLabel = 'Test label';
+    cmp.ariaControls = 'help-text';
+    cmp.ariaExpanded = true;
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    await checkAriaPropertiesAndAccessibility(
+      'Test label',
       'help-text',
       'true'
     );

--- a/libs/components/indicators/src/lib/modules/help-inline/help-inline.component.ts
+++ b/libs/components/indicators/src/lib/modules/help-inline/help-inline.component.ts
@@ -23,6 +23,15 @@ export class SkyHelpInlineComponent {
   public ariaExpanded: boolean | undefined;
 
   /**
+   * The ARIA label for help inline button. This sets the button's `aria-label` to provide a text equivalent for screen readers
+   * [to support accessibility](https://developer.blackbaud.com/skyux/learn/accessibility).
+   * For more information about the `aria-label` attribute, see the [WAI-ARIA definition](https://www.w3.org/TR/wai-aria/#aria-label).
+   * @default "Show help content"
+   */
+  @Input()
+  public ariaLabel: string | undefined;
+
+  /**
    * Fires when the user clicks the help inline button.
    */
   @Output()


### PR DESCRIPTION
:cherries: Cherry picked from #1235 [feat(components/indicators): add ability to specify an accessibility label on help inline](https://github.com/blackbaud/skyux/pull/1235)