### PR TITLE
chore: allow `backticks` in cherry pick pull request

### DIFF
--- a/.github/workflows/cherry-pick.yml
+++ b/.github/workflows/cherry-pick.yml
@@ -72,8 +72,8 @@ jobs:
 
           # Create a pull request for the cherry-pick, using the same title as the original PR.
           gh pr create \
-            --title "${{ github.event.pull_request.title }} (#${{ github.event.pull_request.number }})" \
-            --body ":cherries: Cherry picked from #${{ github.event.pull_request.number }} [${{ github.event.pull_request.title }}](${{ github.event.pull_request.html_url }})" \
+            --title "${{ toJSON(github.event.pull_request.title) }} (#${{ github.event.pull_request.number }})" \
+            --body ":cherries: Cherry picked from #${{ github.event.pull_request.number }} [${{ toJSON(github.event.pull_request.title) }}](${{ github.event.pull_request.html_url }})" \
             --base ${{ env.TARGET_BRANCH }} \
             --head ${CHERRY_PICK_BRANCH}
 

--- a/.github/workflows/cherry-pick.yml
+++ b/.github/workflows/cherry-pick.yml
@@ -61,6 +61,8 @@ jobs:
 
           # Get the name of the cherry-pick branch.
           CHERRY_PICK_BRANCH=$(git branch --show-current)
+          # Add the cherry-pick branch to the environment.
+          echo "CHERRY_PICK_BRANCH=${CHERRY_PICK_BRANCH}" >> $GITHUB_ENV
 
           # Push the cherry-pick to a new cherry-pick branch.
           git push -u origin ${CHERRY_PICK_BRANCH}
@@ -69,25 +71,31 @@ jobs:
             echo "CHERRY_PICK_RESULT=failed" >> $GITHUB_ENV
             exit 0
           fi
-
-          # Create a pull request for the cherry-pick, using the same title as the original PR.
-          gh pr create \
-            --title "${{ format('{0} (#{1})', toJSON(github.event.pull_request.title), github.event.pull_request.number) }}" \
-            --body "${{ format(':cherries: Cherry picked from #{0} [{1}]({2})', github.event.pull_request.number, toJSON(github.event.pull_request.title), github.event.pull_request.html_url) }}" \
-            --base ${{ env.TARGET_BRANCH }} \
-            --head ${CHERRY_PICK_BRANCH}
-
-          if [ $? -ne 0 ]; then
-            echo "CHERRY_PICK_RESULT=failed" >> $GITHUB_ENV
-          else
-            echo "CHERRY_PICK_RESULT=success" >> $GITHUB_ENV
-
-            # Get the URL of the pull request and add it to the environment.
-            echo -n "PR_URL=" >> $GITHUB_ENV
-            gh pr list --json url --search "head:${CHERRY_PICK_BRANCH}" --limit 1 | jq -r '.[0].url' >> $GITHUB_ENV
-          fi
         env:
           GH_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+
+      - uses: actions/github-script@v6
+        if: ${{ env.CHERRY_PICK_RESULT != 'failed' }}
+        with:
+          github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+          script: |
+            const pr = context.payload.pull_request;
+            github.rest.pulls.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              head: process.env.CHERRY_PICK_BRANCH,
+              base: process.env.TARGET_BRANCH,
+              title: `${pr.title} (#${pr.number})`,
+              body: `:cherries: Cherry picked from #${pr.number} [${pr.title}](${pr.html_url})`
+            }).then(result => {
+              console.log(`Created PR #${result.data.number}: ${result.data.html_url}`);
+              core.exportVariable('PR_URL', result.data.html_url);
+              core.exportVariable('CHERRY_PICK_RESULT', 'success');
+            }).catch(error => {
+              console.log(error);
+              core.warning(`Failed to create PR: ${error.message}`);
+              core.exportVariable('CHERRY_PICK_RESULT', 'failed');
+            });
 
       - name: Comment on the original PR when cherry-pick is successful
         if: ${{ env.CHERRY_PICK_RESULT == 'success' }}

--- a/.github/workflows/cherry-pick.yml
+++ b/.github/workflows/cherry-pick.yml
@@ -72,8 +72,8 @@ jobs:
 
           # Create a pull request for the cherry-pick, using the same title as the original PR.
           gh pr create \
-            --title "${{ toJSON(github.event.pull_request.title) }} (#${{ github.event.pull_request.number }})" \
-            --body ":cherries: Cherry picked from #${{ github.event.pull_request.number }} [${{ toJSON(github.event.pull_request.title) }}](${{ github.event.pull_request.html_url }})" \
+            --title ${{ format('{0} (#{1})', toJSON(github.event.pull_request.title), github.event.pull_request.number) }} \
+            --body ${{ format(':cherries: Cherry picked from #{0} [{1}]({2})', github.event.pull_request.number, toJSON(github.event.pull_request.title), github.event.pull_request.html_url) }} \
             --base ${{ env.TARGET_BRANCH }} \
             --head ${CHERRY_PICK_BRANCH}
 

--- a/.github/workflows/cherry-pick.yml
+++ b/.github/workflows/cherry-pick.yml
@@ -72,8 +72,8 @@ jobs:
 
           # Create a pull request for the cherry-pick, using the same title as the original PR.
           gh pr create \
-            --title ${{ format('{0} (#{1})', toJSON(github.event.pull_request.title), github.event.pull_request.number) }} \
-            --body ${{ format(':cherries: Cherry picked from #{0} [{1}]({2})', github.event.pull_request.number, toJSON(github.event.pull_request.title), github.event.pull_request.html_url) }} \
+            --title "${{ format('{0} (#{1})', toJSON(github.event.pull_request.title), github.event.pull_request.number) }}" \
+            --body "${{ format(':cherries: Cherry picked from #{0} [{1}]({2})', github.event.pull_request.number, toJSON(github.event.pull_request.title), github.event.pull_request.html_url) }}" \
             --base ${{ env.TARGET_BRANCH }} \
             --head ${CHERRY_PICK_BRANCH}
 


### PR DESCRIPTION
Changed based on what I'm seeing here: https://stackoverflow.com/questions/73363167/github-actions-how-to-escape-characters-in-commit-message