### PR TITLE
fix(components/lists): validate tags for reorderable repeater when items change (#1255)

### DIFF
--- a/libs/components/lists/src/lib/modules/repeater/fixtures/repeater.component.fixture.html
+++ b/libs/components/lists/src/lib/modules/repeater/fixtures/repeater.component.fixture.html
@@ -81,11 +81,7 @@
   </sky-repeater-item>
 </sky-repeater>
 
-<sky-repeater
-  *ngIf="showRepeaterWithNgFor"
-  [expandMode]="expandMode"
-  [reorderable]="reorderable"
->
+<sky-repeater *ngIf="showRepeaterWithNgFor" [reorderable]="reorderable">
   <sky-repeater-item
     *ngFor="let item of items"
     [tag]="item.id"

--- a/libs/components/lists/src/lib/modules/repeater/fixtures/repeater.component.fixture.ts
+++ b/libs/components/lists/src/lib/modules/repeater/fixtures/repeater.component.fixture.ts
@@ -22,7 +22,7 @@ export class RepeaterTestComponent {
 
   public expandMode: SkyRepeaterExpandModeType | undefined = 'single';
 
-  public items = [
+  public items: { id?: string; title: string }[] = [
     {
       id: 'item1',
       title: 'Item 1',

--- a/libs/components/lists/src/lib/modules/repeater/repeater.component.spec.ts
+++ b/libs/components/lists/src/lib/modules/repeater/repeater.component.spec.ts
@@ -1466,7 +1466,7 @@ describe('Repeater item component', () => {
     function validateRepeaterItemReorderability(
       fixture: ComponentFixture<RepeaterTestComponent>,
       isReorderable: boolean
-    ) {
+    ): void {
       const cmp = fixture.componentInstance;
       const repeaterItems = cmp.repeater?.items?.toArray();
 
@@ -1852,6 +1852,28 @@ describe('Repeater item component', () => {
       detectChangesAndTick(fixture);
 
       validateRepeaterItemReorderability(fixture, true);
+    }));
+
+    it('should show a console warning when the items change and not all item tags are defined', fakeAsync(() => {
+      cmp.showRepeaterWithNgFor = true;
+      detectChangesAndTick(fixture);
+
+      expect(consoleSpy).not.toHaveBeenCalled();
+
+      cmp.items = [
+        {
+          id: 'item4',
+          title: 'Item 4',
+        },
+        {
+          title: 'Item 5',
+        },
+      ];
+      detectChangesAndTick(fixture);
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        'Please supply tag properties for each repeater item when reordering functionality is enabled.'
+      );
     }));
   });
 

--- a/libs/components/lists/src/lib/modules/repeater/repeater.component.ts
+++ b/libs/components/lists/src/lib/modules/repeater/repeater.component.ts
@@ -196,11 +196,7 @@ export class SkyRepeaterComponent
         this.#repeaterService.activateItemByIndex(this.activeIndex);
       }
 
-      if (this.reorderable && !this.#everyItemHasTag()) {
-        console.warn(
-          'Please supply tag properties for each repeater item when reordering functionality is enabled.'
-        );
-      }
+      this.#validateTags();
     });
 
     // HACK: Not updating for expand mode in a timeout causes an error.
@@ -220,6 +216,8 @@ export class SkyRepeaterComponent
         }
 
         this.#updateRole();
+
+        this.#validateTags();
       });
     });
 
@@ -450,6 +448,14 @@ export class SkyRepeaterComponent
       for (const item of this.items) {
         item.reorderable = this.reorderable;
       }
+    }
+  }
+
+  #validateTags(): void {
+    if (this.reorderable && !this.#everyItemHasTag()) {
+      console.warn(
+        'Please supply tag properties for each repeater item when reordering functionality is enabled.'
+      );
     }
   }
 }


### PR DESCRIPTION
:cherries: Cherry picked from #1255 [fix(components/lists): validate tags for reorderable repeater when items change](https://github.com/blackbaud/skyux/pull/1255)