### PR TITLE
fix(components/popovers): export `SkyDropdownButtonType` (#1262)

### DIFF
--- a/libs/components/popovers/testing/src/dropdown/dropdown-fixture.spec.ts
+++ b/libs/components/popovers/testing/src/dropdown/dropdown-fixture.spec.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { expect } from '@skyux-sdk/testing';
-import { SkyDropdownMenuChange } from '@skyux/popovers';
+import { SkyDropdownButtonType, SkyDropdownMenuChange } from '@skyux/popovers';
 import {
   SkyTheme,
   SkyThemeMode,
@@ -10,7 +10,6 @@ import {
   SkyThemeSettingsChange,
 } from '@skyux/theme';
 
-import { SkyDropdownButtonType } from 'libs/components/popovers/src/lib/modules/dropdown/types/dropdown-button-type';
 import { BehaviorSubject } from 'rxjs';
 
 import { SkyDropdownFixture } from './dropdown-fixture';

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -23,7 +23,7 @@
     "baseUrl": ".",
     "typeRoots": ["./node_modules/@types", "./vendor/types"],
     "paths": {
-      "*": ["*", "./vendor/types/*"],
+      "*": ["./vendor/types/*"],
       "@skyux-sdk/e2e-schematics": ["libs/sdk/e2e-schematics/src/index.ts"],
       "@skyux-sdk/prettier-schematics": [
         "libs/sdk/prettier-schematics/src/index.ts"


### PR DESCRIPTION
:cherries: Cherry picked from #1262 [fix(components/popovers): export `SkyDropdownButtonType`](https://github.com/blackbaud/skyux/pull/1262)