### PR TITLE
feat(components/lists): add inline form repeater code example and improved other examples (#1261)

### DIFF
--- a/apps/code-examples/src/app/app.component.html
+++ b/apps/code-examples/src/app/app.component.html
@@ -451,6 +451,9 @@
           <li>
             <a routerLink="lists/repeater/add-remove">Add remove</a>
           </li>
+          <li>
+            <a routerLink="lists/repeater/inline-form">Inline form</a>
+          </li>
         </ul>
       </li>
       <li>

--- a/apps/code-examples/src/app/code-examples/lists/repeater/add-remove/repeater-demo.component.spec.ts
+++ b/apps/code-examples/src/app/code-examples/lists/repeater/add-remove/repeater-demo.component.spec.ts
@@ -55,31 +55,41 @@ describe('Repeater add remove demo', () => {
     const expectedContent = [
       {
         title: 'Call Robert Hernandez  Completed',
-        body: 'Robert recently gave a very generous gift.  We should call him to thank him.',
+        body: 'Robert recently gave a very generous gift. We should call him to thank him.',
       },
       {
         title: 'Send invitation to Spring Ball  Past due',
-        body: "The Spring Ball is coming up soon.  Let's get those invitations out!",
+        body: "The Spring Ball is coming up soon. Let's get those invitations out!",
+      },
+      {
+        title: 'Assign prospects  Due tomorrow',
+        body: 'There are 14 new prospects who are not assigned to fundraisers.',
+      },
+      {
+        title: 'Process gift receipts  Due next week',
+        body: 'There are 28 recent gifts that are not receipted.',
       },
     ];
 
     let repeaterItems = await repeaterHarness?.getRepeaterItems();
     expect(repeaterItems).toBeDefined();
-    expect(repeaterItems?.length).toBe(2);
+    expect(repeaterItems?.length).toBe(expectedContent.length);
 
-    for (const item of repeaterItems!) {
-      await expectAsync(item.isReorderable()).toBeResolvedTo(true);
+    if (repeaterItems) {
+      for (const item of repeaterItems) {
+        await expectAsync(item.isReorderable()).toBeResolvedTo(true);
+      }
+
+      await expectAsync(repeaterItems?.[1].getTitleText()).toBeResolvedTo(
+        expectedContent[1].title
+      );
+      await repeaterItems?.[1].sendToTop();
+
+      repeaterItems = await repeaterHarness?.getRepeaterItems();
+      await expectAsync(repeaterItems?.[1].getTitleText()).toBeResolvedTo(
+        expectedContent[0].title
+      );
     }
-
-    await expectAsync(repeaterItems?.[1].getTitleText()).toBeResolvedTo(
-      expectedContent[1].title
-    );
-    await repeaterItems?.[1].sendToTop();
-
-    repeaterItems = await repeaterHarness?.getRepeaterItems();
-    await expectAsync(repeaterItems?.[1].getTitleText()).toBeResolvedTo(
-      expectedContent[0].title
-    );
   });
 
   it('should allow items to be added and removed', async () => {
@@ -87,38 +97,40 @@ describe('Repeater add remove demo', () => {
 
     let repeaterItems = await repeaterHarness?.getRepeaterItems();
     expect(repeaterItems).toBeDefined();
-    expect(repeaterItems?.length).toBe(2);
+    expect(repeaterItems?.length).toBe(4);
 
-    for (const item of repeaterItems!) {
-      await expectAsync(item.isSelectable()).toBeResolvedTo(true);
+    if (repeaterItems) {
+      for (const item of repeaterItems) {
+        await expectAsync(item.isSelectable()).toBeResolvedTo(true);
+      }
+
+      const addButton = fixture.nativeElement.querySelector(
+        '[data-sky-id="add-button"]'
+      );
+      const removeButton = fixture.nativeElement.querySelector(
+        '[data-sky-id="remove-button"]'
+      );
+
+      addButton.click();
+      fixture.detectChanges();
+
+      repeaterItems = await repeaterHarness?.getRepeaterItems();
+      expect(repeaterItems).toBeDefined();
+      expect(repeaterItems?.length).toBe(5);
+
+      await expectAsync(repeaterItems?.[0].isSelected()).toBeResolvedTo(false);
+      await repeaterItems?.[0].select();
+      await expectAsync(repeaterItems?.[0].isSelected()).toBeResolvedTo(true);
+      await expectAsync(repeaterItems?.[1].isSelected()).toBeResolvedTo(false);
+      await repeaterItems?.[1].select();
+      await expectAsync(repeaterItems?.[1].isSelected()).toBeResolvedTo(true);
+
+      removeButton.click();
+      fixture.detectChanges();
+
+      repeaterItems = await repeaterHarness?.getRepeaterItems();
+      expect(repeaterItems).toBeDefined();
+      expect(repeaterItems?.length).toBe(3);
     }
-
-    const addButton = fixture.nativeElement.querySelector(
-      '[data-sky-id="add-button"]'
-    );
-    const removeButton = fixture.nativeElement.querySelector(
-      '[data-sky-id="remove-button"]'
-    );
-
-    addButton.click();
-    fixture.detectChanges();
-
-    repeaterItems = await repeaterHarness?.getRepeaterItems();
-    expect(repeaterItems).toBeDefined();
-    expect(repeaterItems?.length).toBe(3);
-
-    await expectAsync(repeaterItems?.[0].isSelected()).toBeResolvedTo(false);
-    await repeaterItems?.[0].select();
-    await expectAsync(repeaterItems?.[0].isSelected()).toBeResolvedTo(true);
-    await expectAsync(repeaterItems?.[1].isSelected()).toBeResolvedTo(false);
-    await repeaterItems?.[1].select();
-    await expectAsync(repeaterItems?.[1].isSelected()).toBeResolvedTo(true);
-
-    removeButton.click();
-    fixture.detectChanges();
-
-    repeaterItems = await repeaterHarness?.getRepeaterItems();
-    expect(repeaterItems).toBeDefined();
-    expect(repeaterItems?.length).toBe(1);
   });
 });

--- a/apps/code-examples/src/app/code-examples/lists/repeater/add-remove/repeater-demo.component.ts
+++ b/apps/code-examples/src/app/code-examples/lists/repeater/add-remove/repeater-demo.component.ts
@@ -13,14 +13,26 @@ export class RepeaterDemoComponent {
   public items: RepeaterDemoItem[] = [
     {
       title: 'Call Robert Hernandez',
-      note: 'Robert recently gave a very generous gift.  We should call him to thank him.',
+      note: 'Robert recently gave a very generous gift. We should call him to thank him.',
       status: 'Completed',
       isSelected: false,
     },
     {
       title: 'Send invitation to Spring Ball',
-      note: "The Spring Ball is coming up soon.  Let's get those invitations out!",
+      note: "The Spring Ball is coming up soon. Let's get those invitations out!",
       status: 'Past due',
+      isSelected: false,
+    },
+    {
+      title: 'Assign prospects',
+      note: 'There are 14 new prospects who are not assigned to fundraisers.',
+      status: 'Due tomorrow',
+      isSelected: false,
+    },
+    {
+      title: 'Process gift receipts',
+      note: 'There are 28 recent gifts that are not receipted.',
+      status: 'Due next week',
       isSelected: false,
     },
   ];

--- a/apps/code-examples/src/app/code-examples/lists/repeater/basic/repeater-demo.component.spec.ts
+++ b/apps/code-examples/src/app/code-examples/lists/repeater/basic/repeater-demo.component.spec.ts
@@ -39,21 +39,33 @@ describe('Repeater basic demo', () => {
     const expectedContent = [
       {
         title: 'Call Robert Hernandez  Completed',
-        body: 'Robert recently gave a very generous gift.  We should call him to thank him.',
+        body: 'Robert recently gave a very generous gift. We should call him to thank him.',
       },
       {
         title: 'Send invitation to Spring Ball  Past due',
-        body: "The Spring Ball is coming up soon.  Let's get those invitations out!",
+        body: "The Spring Ball is coming up soon. Let's get those invitations out!",
+      },
+      {
+        title: 'Assign prospects  Due tomorrow',
+        body: 'There are 14 new prospects who are not assigned to fundraisers.',
+      },
+      {
+        title: 'Process gift receipts  Due next week',
+        body: 'There are 28 recent gifts that are not receipted.',
       },
     ];
 
-    for (let i = 0; i < repeaterItems!.length; i++) {
-      await expectAsync(repeaterItems![i].getTitleText()).toBeResolvedTo(
-        expectedContent[i].title
-      );
-      await expectAsync(repeaterItems![i].getContentText()).toBeResolvedTo(
-        expectedContent[i].body
-      );
+    expect(repeaterItems?.length).toBe(expectedContent.length);
+
+    if (repeaterItems) {
+      for (let i = 0; i < repeaterItems.length; i++) {
+        await expectAsync(repeaterItems[i].getTitleText()).toBeResolvedTo(
+          expectedContent[i].title
+        );
+        await expectAsync(repeaterItems[i].getContentText()).toBeResolvedTo(
+          expectedContent[i].body
+        );
+      }
     }
   });
 });

--- a/apps/code-examples/src/app/code-examples/lists/repeater/basic/repeater-demo.component.ts
+++ b/apps/code-examples/src/app/code-examples/lists/repeater/basic/repeater-demo.component.ts
@@ -9,13 +9,23 @@ export class RepeaterDemoComponent {
   public items: any[] = [
     {
       title: 'Call Robert Hernandez',
-      note: 'Robert recently gave a very generous gift.  We should call him to thank him.',
+      note: 'Robert recently gave a very generous gift. We should call him to thank him.',
       status: 'Completed',
     },
     {
       title: 'Send invitation to Spring Ball',
-      note: "The Spring Ball is coming up soon.  Let's get those invitations out!",
+      note: "The Spring Ball is coming up soon. Let's get those invitations out!",
       status: 'Past due',
+    },
+    {
+      title: 'Assign prospects',
+      note: 'There are 14 new prospects who are not assigned to fundraisers.',
+      status: 'Due tomorrow',
+    },
+    {
+      title: 'Process gift receipts',
+      note: 'There are 28 recent gifts that are not receipted.',
+      status: 'Due next week',
     },
   ];
 

--- a/apps/code-examples/src/app/code-examples/lists/repeater/inline-form/repeater-demo-item.ts
+++ b/apps/code-examples/src/app/code-examples/lists/repeater/inline-form/repeater-demo-item.ts
@@ -1,0 +1,5 @@
+export interface RepeaterDemoItem {
+  id: string;
+  title: string | undefined;
+  note: string | undefined;
+}

--- a/apps/code-examples/src/app/code-examples/lists/repeater/inline-form/repeater-demo.component.html
+++ b/apps/code-examples/src/app/code-examples/lists/repeater/inline-form/repeater-demo.component.html
@@ -1,0 +1,58 @@
+<sky-repeater>
+  <sky-repeater-item
+    *ngFor="let item of items"
+    [inlineFormConfig]="inlineFormConfig"
+    [inlineFormTemplate]="inlineFormTemplate"
+    [showInlineForm]="activeInlineFormId === item.id"
+    (inlineFormClose)="onInlineFormClose($event)"
+  >
+    <sky-repeater-item-title class="demo-repeater-flex">
+      <div class="demo-repeater-item-title sky-font-emphasized">
+        {{ item.title }}
+      </div>
+      <div>
+        <button
+          aria-label="Edit"
+          class="sky-btn sky-btn-link sky-btn-link-inline sky-no-focus sky-demo-btn-edit"
+          type="button"
+          (click)="showInlineForm(item)"
+        >
+          <sky-icon icon="pencil"> </sky-icon>
+        </button>
+      </div>
+    </sky-repeater-item-title>
+
+    <sky-repeater-item-content>
+      {{ item.note }}
+    </sky-repeater-item-content>
+  </sky-repeater-item>
+</sky-repeater>
+
+<ng-template #inlineFormTemplate>
+  <form novalidate [formGroup]="myForm">
+    <div class="sky-form-group">
+      <sky-input-box>
+        <label class="sky-control-label" [for]="myTitle.id"> Title </label>
+        <input
+          class="sky-form-control"
+          formControlName="title"
+          skyId
+          type="text"
+          #myTitle="skyId"
+        />
+      </sky-input-box>
+    </div>
+    <div class="sky-form-group">
+      <sky-input-box>
+        <label class="sky-control-label" [for]="myNote.id"> Note </label>
+        <input
+          class="sky-form-control"
+          formControlName="note"
+          skyId
+          type="text"
+          #myNote="skyId"
+        />
+      </sky-input-box>
+    </div>
+  </form>
+</ng-template>

--- a/apps/code-examples/src/app/code-examples/lists/repeater/inline-form/repeater-demo.component.scss
+++ b/apps/code-examples/src/app/code-examples/lists/repeater/inline-form/repeater-demo.component.scss
@@ -1,0 +1,8 @@
+.demo-repeater-flex {
+  display: flex;
+  flex-wrap: wrap;
+
+  .demo-repeater-item-title {
+    flex-grow: 1;
+  }
+}

--- a/apps/code-examples/src/app/code-examples/lists/repeater/inline-form/repeater-demo.component.ts
+++ b/apps/code-examples/src/app/code-examples/lists/repeater/inline-form/repeater-demo.component.ts
@@ -1,0 +1,83 @@
+import { Component } from '@angular/core';
+import { FormBuilder, FormControl, FormGroup } from '@angular/forms';
+import {
+  SkyInlineFormButtonLayout,
+  SkyInlineFormCloseArgs,
+  SkyInlineFormConfig,
+} from '@skyux/inline-form';
+
+import { RepeaterDemoItem } from './repeater-demo-item';
+
+@Component({
+  selector: 'app-repeater-demo',
+  templateUrl: './repeater-demo.component.html',
+  styleUrls: ['./repeater-demo.component.scss'],
+})
+export class RepeaterDemoComponent {
+  public activeInlineFormId: string | undefined;
+
+  public inlineFormConfig: SkyInlineFormConfig = {
+    buttonLayout: SkyInlineFormButtonLayout.SaveCancel,
+  };
+
+  public items: RepeaterDemoItem[] = [
+    {
+      id: '1',
+      title: '2019 Spring Gala',
+      note: 'Gala for friends and family',
+    },
+    {
+      id: '2',
+      title: '2019 Special Winter Event',
+      note: 'A special event',
+    },
+    {
+      id: '3',
+      title: '2019 Donor Appreciation Event',
+      note: 'Event for all donors and families',
+    },
+    {
+      id: '4',
+      title: '2020 Spring Gala',
+      note: 'Gala for friends and family',
+    },
+  ];
+
+  public myForm: FormGroup;
+
+  constructor(formBuilder: FormBuilder) {
+    this.myForm = formBuilder.group({
+      id: new FormControl(),
+      title: new FormControl(),
+      note: new FormControl(),
+    });
+  }
+
+  public showInlineForm(item: RepeaterDemoItem): void {
+    this.activeInlineFormId = item.id;
+    this.myForm.patchValue({
+      note: item.note,
+      title: item.title,
+    });
+  }
+
+  public onInlineFormClose(args: SkyInlineFormCloseArgs): void {
+    if (args.reason === 'save') {
+      const found = this.items.find(
+        (item) => item.id === this.activeInlineFormId
+      );
+      if (found) {
+        found.note = this.myForm.get('note')?.value;
+        found.title = this.myForm.get('title')?.value;
+      }
+    }
+
+    this.myForm.patchValue({
+      note: undefined,
+      title: undefined,
+    });
+
+    // Close the active form.
+    this.activeInlineFormId = undefined;
+  }
+}

--- a/apps/code-examples/src/app/code-examples/lists/repeater/inline-form/repeater-demo.module.ts
+++ b/apps/code-examples/src/app/code-examples/lists/repeater/inline-form/repeater-demo.module.ts
@@ -1,0 +1,25 @@
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { ReactiveFormsModule } from '@angular/forms';
+import { SkyIdModule } from '@skyux/core';
+import { SkyInputBoxModule } from '@skyux/forms';
+import { SkyIconModule } from '@skyux/indicators';
+import { SkyInlineFormModule } from '@skyux/inline-form';
+import { SkyRepeaterModule } from '@skyux/lists';
+
+import { RepeaterDemoComponent } from './repeater-demo.component';
+
+@NgModule({
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    SkyIconModule,
+    SkyIdModule,
+    SkyInlineFormModule,
+    SkyInputBoxModule,
+    SkyRepeaterModule,
+  ],
+  exports: [RepeaterDemoComponent],
+  declarations: [RepeaterDemoComponent],
+})
+export class RepeaterDemoModule {}

--- a/apps/code-examples/src/app/features/lists.module.ts
+++ b/apps/code-examples/src/app/features/lists.module.ts
@@ -13,6 +13,8 @@ import { RepeaterDemoComponent as RepeaterAddRemoveDemoComponent } from '../code
 import { RepeaterDemoModule as RepeaterAddRemoveDemoModule } from '../code-examples/lists/repeater/add-remove/repeater-demo.module';
 import { RepeaterDemoComponent as RepeaterBasicDemoComponent } from '../code-examples/lists/repeater/basic/repeater-demo.component';
 import { RepeaterDemoModule as RepeaterBasicDemoModule } from '../code-examples/lists/repeater/basic/repeater-demo.module';
+import { RepeaterDemoComponent as RepeaterInlineFormDemoComponent } from '../code-examples/lists/repeater/inline-form/repeater-demo.component';
+import { RepeaterDemoModule as RepeaterInlineFormDemoModule } from '../code-examples/lists/repeater/inline-form/repeater-demo.module';
 import { SortDemoComponent } from '../code-examples/lists/sort/basic/sort-demo.component';
 import { SortDemoModule } from '../code-examples/lists/sort/basic/sort-demo.module';
 
@@ -42,6 +44,10 @@ const routes: Routes = [
     component: RepeaterAddRemoveDemoComponent,
   },
   {
+    path: 'repeater/inline-form',
+    component: RepeaterInlineFormDemoComponent,
+  },
+  {
     path: 'sort/basic',
     component: SortDemoComponent,
   },
@@ -58,6 +64,7 @@ export class ListsFeatureRoutingModule {}
     ListsFeatureRoutingModule,
     RepeaterAddRemoveDemoModule,
     RepeaterBasicDemoModule,
+    RepeaterInlineFormDemoModule,
     FilterDemoModule,
     FilterModalModule,
     InfiniteScrollRepeaterModule,


### PR DESCRIPTION
:cherries: Cherry picked from #1261 [feat(components/lists): add inline form repeater code example and improved other examples](https://github.com/blackbaud/skyux/pull/1261)