### PR TITLE
fix(components/lookup): revert autocomplete dropdown absolute position change (#1269)

### DIFF
--- a/libs/components/lookup/src/lib/modules/autocomplete/autocomplete.component.scss
+++ b/libs/components/lookup/src/lib/modules/autocomplete/autocomplete.component.scss
@@ -2,7 +2,7 @@
 @use 'libs/components/theme/src/lib/styles/variables' as *;
 
 .sky-autocomplete-results-container {
-  position: absolute;
+  position: fixed;
   background-color: $sky-color-white;
 }
 

--- a/libs/components/lookup/src/lib/modules/autocomplete/autocomplete.component.ts
+++ b/libs/components/lookup/src/lib/modules/autocomplete/autocomplete.component.ts
@@ -831,7 +831,6 @@ export class SkyAutocompleteComponent implements OnDestroy, AfterViewInit {
       const overlay = this.#overlayService.create({
         enableClose: false,
         enablePointerEvents: true,
-        position: 'absolute',
         wrapperClass: this.wrapperClass,
       });
 
@@ -941,7 +940,6 @@ export class SkyAutocompleteComponent implements OnDestroy, AfterViewInit {
         isSticky: true,
         placement: 'below',
         horizontalAlignment: 'left',
-        position: 'absolute',
       });
 
       this.#affixer = affixer;


### PR DESCRIPTION
:cherries: Cherry picked from #1269 [fix(components/lookup): revert autocomplete dropdown absolute position change](https://github.com/blackbaud/skyux/pull/1269)