### PR TITLE
test(components/lists): add missing accessibility test to repeater (#1252)

### DIFF
--- a/libs/components/lists/src/lib/modules/repeater/fixtures/a11y-repeater-item.ts
+++ b/libs/components/lists/src/lib/modules/repeater/fixtures/a11y-repeater-item.ts
@@ -1,0 +1,11 @@
+export interface A11yRepeaterItem {
+  selectable?: boolean;
+  selected?: boolean;
+  disabled?: boolean;
+  expanded?: boolean;
+  reorderable?: boolean;
+  title?: string;
+  message?: string;
+  context?: boolean;
+  tag?: string;
+}

--- a/libs/components/lists/src/lib/modules/repeater/fixtures/a11y-repeater.component.fixture.html
+++ b/libs/components/lists/src/lib/modules/repeater/fixtures/a11y-repeater.component.fixture.html
@@ -1,0 +1,27 @@
+<sky-repeater
+  [expandMode]="expandMode"
+  [reorderable]="reorderable"
+  [(activeIndex)]="activeIndex"
+>
+  <sky-repeater-item
+    *ngFor="let item of items"
+    [selectable]="item.selectable"
+    [disabled]="item.disabled"
+    [isExpanded]="item.expanded"
+    [isSelected]="item.selected"
+    [reorderable]="item.reorderable ?? reorderable"
+    [tag]="item.tag"
+  >
+    <sky-repeater-item-context-menu *ngIf="item.context">
+      <sky-dropdown buttonType="context-menu">
+        <sky-dropdown-button></sky-dropdown-button>
+      </sky-dropdown>
+    </sky-repeater-item-context-menu>
+    <sky-repeater-item-title *ngIf="item.title">
+      {{ item.title }}
+    </sky-repeater-item-title>
+    <sky-repeater-item-content *ngIf="item.message">
+      {{ item.message }}
+    </sky-repeater-item-content>
+  </sky-repeater-item>
+</sky-repeater>

--- a/libs/components/lists/src/lib/modules/repeater/fixtures/a11y-repeater.component.fixture.ts
+++ b/libs/components/lists/src/lib/modules/repeater/fixtures/a11y-repeater.component.fixture.ts
@@ -1,0 +1,27 @@
+import { Component } from '@angular/core';
+
+import { SkyRepeaterExpandModeType } from '../repeater-expand-mode-type';
+
+import { A11yRepeaterItem } from './a11y-repeater-item';
+
+@Component({
+  selector: 'sky-test-cmp',
+  templateUrl: './a11y-repeater.component.fixture.html',
+})
+export class A11yRepeaterTestComponent {
+  public set activeIndex(value: number | undefined) {
+    this.#_activeIndex = value;
+  }
+
+  public get activeIndex(): number | undefined {
+    return this.#_activeIndex;
+  }
+
+  public expandMode: SkyRepeaterExpandModeType | undefined;
+
+  public reorderable: boolean | undefined;
+
+  public items: A11yRepeaterItem[] | undefined;
+
+  #_activeIndex: number | undefined;
+}

--- a/libs/components/lists/src/lib/modules/repeater/fixtures/repeater-fixtures.module.ts
+++ b/libs/components/lists/src/lib/modules/repeater/fixtures/repeater-fixtures.module.ts
@@ -5,6 +5,7 @@ import { SkyDropdownModule } from '@skyux/popovers';
 
 import { SkyRepeaterModule } from '../repeater.module';
 
+import { A11yRepeaterTestComponent } from './a11y-repeater.component.fixture';
 import { NestedRepeaterTestComponent } from './nested-repeater.component.fixture';
 import { RepeaterAsyncItemsTestComponent } from './repeater-async-items.component.fixture';
 import { RepeaterInlineFormFixtureComponent } from './repeater-inline-form.component.fixture';
@@ -18,6 +19,7 @@ import { RepeaterTestComponent } from './repeater.component.fixture';
     RepeaterTestComponent,
     RepeaterWithMissingTagsFixtureComponent,
     NestedRepeaterTestComponent,
+    A11yRepeaterTestComponent,
   ],
   imports: [
     CommonModule,
@@ -31,6 +33,7 @@ import { RepeaterTestComponent } from './repeater.component.fixture';
     RepeaterTestComponent,
     RepeaterWithMissingTagsFixtureComponent,
     NestedRepeaterTestComponent,
+    A11yRepeaterTestComponent,
   ],
 })
 export class SkyRepeaterFixturesModule {}

--- a/libs/components/lists/src/lib/modules/repeater/repeater.component.spec.ts
+++ b/libs/components/lists/src/lib/modules/repeater/repeater.component.spec.ts
@@ -15,6 +15,8 @@ import { SkyInlineFormButtonLayout } from '@skyux/inline-form';
 
 import { DragulaService, Group } from 'ng2-dragula';
 
+import { A11yRepeaterItem } from './fixtures/a11y-repeater-item';
+import { A11yRepeaterTestComponent } from './fixtures/a11y-repeater.component.fixture';
 import { MockDragulaService } from './fixtures/mock-dragula.service';
 import { NestedRepeaterTestComponent } from './fixtures/nested-repeater.component.fixture';
 import { RepeaterAsyncItemsTestComponent } from './fixtures/repeater-async-items.component.fixture';
@@ -23,6 +25,7 @@ import { RepeaterInlineFormFixtureComponent } from './fixtures/repeater-inline-f
 import { RepeaterWithMissingTagsFixtureComponent } from './fixtures/repeater-missing-tag.fixture';
 import { RepeaterTestComponent } from './fixtures/repeater.component.fixture';
 import { SkyRepeaterAutoScrollService } from './repeater-auto-scroll.service';
+import { SkyRepeaterExpandModeType } from './repeater-expand-mode-type';
 import { SkyRepeaterComponent } from './repeater.component';
 import { SkyRepeaterService } from './repeater.service';
 
@@ -1268,6 +1271,22 @@ describe('Repeater item component', () => {
 
       flushDropdownTimer();
     }));
+
+    it('should be accessible', async () => {
+      cmp.showRepeaterWithActiveIndex = true;
+      cmp.expandMode = 'none';
+      cmp.activeIndex = 0;
+
+      // Detect active index.
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      // Role changes on next cycle.
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      await expectAsync(fixture.nativeElement).toBeAccessible();
+    });
   });
 
   describe('with inline-form', () => {
@@ -2044,5 +2063,361 @@ describe('Repeater item component', () => {
 
       expect(topRepeaterItem).toBe(initialBottomRepeaterItem);
     }));
+  });
+
+  describe('accessibility tests', () => {
+    async function setupTest(args: {
+      activeIndex?: number;
+      expandMode?: SkyRepeaterExpandModeType;
+      reorderable?: boolean;
+      selectable?: boolean;
+      context?: boolean;
+    }): Promise<ComponentFixture<A11yRepeaterTestComponent>> {
+      const fixture = TestBed.createComponent(A11yRepeaterTestComponent);
+      const cmp = fixture.componentInstance;
+
+      const items: A11yRepeaterItem[] = [
+        {
+          selectable: args.selectable,
+          context: args.context,
+          title: 'Item 1',
+          message: 'Content 1',
+          tag: 'item1',
+        },
+        {
+          selectable: args.selectable,
+          context: args.context,
+          title: 'Item 2',
+          message: 'Content 2',
+          tag: 'item2',
+        },
+      ];
+
+      cmp.items = items;
+      cmp.activeIndex = args.activeIndex;
+      cmp.expandMode = args.expandMode;
+      cmp.reorderable = args.reorderable;
+
+      fixture.detectChanges();
+      await fixture.whenStable();
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      return fixture;
+    }
+
+    it('should be accessible when selectable and expandable', async () => {
+      const fixture = await setupTest({
+        expandMode: 'single',
+        selectable: true,
+      });
+      await expectAsync(fixture.nativeElement).toBeAccessible();
+    });
+
+    it('should be accessible when selectable and multi expandable', async () => {
+      const fixture = await setupTest({
+        expandMode: 'multiple',
+        selectable: true,
+      });
+      await expectAsync(fixture.nativeElement).toBeAccessible();
+    });
+
+    it('should be accessible when reorderable and expandable', async () => {
+      const fixture = await setupTest({
+        reorderable: true,
+        expandMode: 'single',
+      });
+      await expectAsync(fixture.nativeElement).toBeAccessible();
+    });
+
+    it('should be accessible when reorderable and multi expandable', async () => {
+      const fixture = await setupTest({
+        reorderable: true,
+        expandMode: 'multiple',
+      });
+      await expectAsync(fixture.nativeElement).toBeAccessible();
+    });
+
+    it('should be accessible when expandable with context menu', async () => {
+      const fixture = await setupTest({
+        context: true,
+        expandMode: 'single',
+      });
+      await expectAsync(fixture.nativeElement).toBeAccessible();
+    });
+
+    it('should be accessible when multi expandable with context menu', async () => {
+      const fixture = await setupTest({
+        context: true,
+        expandMode: 'multiple',
+      });
+      await expectAsync(fixture.nativeElement).toBeAccessible();
+    });
+
+    it('should be accessible when expandable with active index', async () => {
+      const fixture = await setupTest({
+        expandMode: 'single',
+        activeIndex: 1,
+      });
+      await expectAsync(fixture.nativeElement).toBeAccessible();
+    });
+
+    it('should be accessible when multi expandable with active index', async () => {
+      const fixture = await setupTest({
+        expandMode: 'multiple',
+        activeIndex: 1,
+      });
+      await expectAsync(fixture.nativeElement).toBeAccessible();
+    });
+
+    it('should be accessible when selectable with a context menu', async () => {
+      const fixture = await setupTest({
+        selectable: true,
+        context: true,
+      });
+      await expectAsync(fixture.nativeElement).toBeAccessible();
+    });
+
+    it('should be accessible when reorderable and selectable', async () => {
+      const fixture = await setupTest({
+        reorderable: true,
+        selectable: true,
+      });
+      await expectAsync(fixture.nativeElement).toBeAccessible();
+    });
+
+    it('should be accessible when reorderable with a context menu', async () => {
+      const fixture = await setupTest({
+        reorderable: true,
+        context: true,
+      });
+      await expectAsync(fixture.nativeElement).toBeAccessible();
+    });
+
+    it('should be accessible when selectable with active index', async () => {
+      const fixture = await setupTest({
+        activeIndex: 1,
+        selectable: true,
+      });
+      await expectAsync(fixture.nativeElement).toBeAccessible();
+    });
+
+    it('should be accessible when reorderable with active index', async () => {
+      const fixture = await setupTest({
+        activeIndex: 1,
+        reorderable: true,
+      });
+      await expectAsync(fixture.nativeElement).toBeAccessible();
+    });
+
+    it('should be accessible with active index and context menu', async () => {
+      const fixture = await setupTest({
+        activeIndex: 1,
+        context: true,
+      });
+      await expectAsync(fixture.nativeElement).toBeAccessible();
+    });
+
+    it('should be accessible when selectable, reorderable, and expandable', async () => {
+      const fixture = await setupTest({
+        expandMode: 'single',
+        selectable: true,
+        reorderable: true,
+      });
+      await expectAsync(fixture.nativeElement).toBeAccessible();
+    });
+
+    it('should be accessible when selectable, reorderable, and multi expandable', async () => {
+      const fixture = await setupTest({
+        expandMode: 'multiple',
+        selectable: true,
+        reorderable: true,
+      });
+      await expectAsync(fixture.nativeElement).toBeAccessible();
+    });
+
+    it('should be accessible when selectable and expandable with context menu', async () => {
+      const fixture = await setupTest({
+        selectable: true,
+        context: true,
+        expandMode: 'single',
+      });
+      await expectAsync(fixture.nativeElement).toBeAccessible();
+    });
+
+    it('should be accessible when selectable and multi expandable with context menu', async () => {
+      const fixture = await setupTest({
+        selectable: true,
+        context: true,
+        expandMode: 'multiple',
+      });
+      await expectAsync(fixture.nativeElement).toBeAccessible();
+    });
+
+    it('should be accessible when selectable and expandable with active index', async () => {
+      const fixture = await setupTest({
+        selectable: true,
+        expandMode: 'single',
+        activeIndex: 1,
+      });
+      await expectAsync(fixture.nativeElement).toBeAccessible();
+    });
+
+    it('should be accessible when selectable and multi expandable with active index', async () => {
+      const fixture = await setupTest({
+        selectable: true,
+        expandMode: 'multiple',
+        activeIndex: 1,
+      });
+      await expectAsync(fixture.nativeElement).toBeAccessible();
+    });
+
+    it('should be accessible when selectable and reorderable with a context menu', async () => {
+      const fixture = await setupTest({
+        selectable: true,
+        reorderable: true,
+        context: true,
+      });
+      await expectAsync(fixture.nativeElement).toBeAccessible();
+    });
+
+    it('should be accessible when reorderable and selectable with active index', async () => {
+      const fixture = await setupTest({
+        reorderable: true,
+        selectable: true,
+        activeIndex: 1,
+      });
+      await expectAsync(fixture.nativeElement).toBeAccessible();
+    });
+
+    it('should be accessible when selectable with active index and context menu', async () => {
+      const fixture = await setupTest({
+        activeIndex: 1,
+        selectable: true,
+        context: true,
+      });
+      await expectAsync(fixture.nativeElement).toBeAccessible();
+    });
+
+    it('should be accessible when reorderable with active index and context', async () => {
+      const fixture = await setupTest({
+        activeIndex: 1,
+        reorderable: true,
+        context: true,
+      });
+      await expectAsync(fixture.nativeElement).toBeAccessible();
+    });
+
+    it('should be accessible when selectable, reorderable, and expandable with context menu', async () => {
+      const fixture = await setupTest({
+        expandMode: 'single',
+        selectable: true,
+        reorderable: true,
+        context: true,
+      });
+      await expectAsync(fixture.nativeElement).toBeAccessible();
+    });
+
+    it('should be accessible when selectable, reorderable, and multi expandable with context menu', async () => {
+      const fixture = await setupTest({
+        expandMode: 'multiple',
+        selectable: true,
+        reorderable: true,
+        context: true,
+      });
+      await expectAsync(fixture.nativeElement).toBeAccessible();
+    });
+
+    it('should be accessible when selectable and expandable with context menu and active index', async () => {
+      const fixture = await setupTest({
+        selectable: true,
+        context: true,
+        expandMode: 'single',
+        activeIndex: 1,
+      });
+      await expectAsync(fixture.nativeElement).toBeAccessible();
+    });
+
+    it('should be accessible when selectable and multi expandable with context menu and active index', async () => {
+      const fixture = await setupTest({
+        selectable: true,
+        context: true,
+        expandMode: 'multiple',
+        activeIndex: 1,
+      });
+      await expectAsync(fixture.nativeElement).toBeAccessible();
+    });
+
+    it('should be accessible when reorderable, selectable and expandable with active index', async () => {
+      const fixture = await setupTest({
+        selectable: true,
+        reorderable: true,
+        expandMode: 'single',
+        activeIndex: 1,
+      });
+      await expectAsync(fixture.nativeElement).toBeAccessible();
+    });
+
+    it('should be accessible when reorderable, selectable and multi expandable with active index', async () => {
+      const fixture = await setupTest({
+        selectable: true,
+        reorderable: true,
+        expandMode: 'multiple',
+        activeIndex: 1,
+      });
+      await expectAsync(fixture.nativeElement).toBeAccessible();
+    });
+
+    it('should be accessible when reorderable, selectable and expandable with context menu', async () => {
+      const fixture = await setupTest({
+        selectable: true,
+        reorderable: true,
+        context: true,
+        expandMode: 'single',
+      });
+      await expectAsync(fixture.nativeElement).toBeAccessible();
+    });
+
+    it('should be accessible when reorderable, selectable and multi expandable with context menu', async () => {
+      const fixture = await setupTest({
+        selectable: true,
+        reorderable: true,
+        context: true,
+        expandMode: 'multiple',
+      });
+      await expectAsync(fixture.nativeElement).toBeAccessible();
+    });
+
+    it('should be accessible when reorderable and selectable with context menu and active index', async () => {
+      const fixture = await setupTest({
+        selectable: true,
+        reorderable: true,
+        context: true,
+        activeIndex: 1,
+      });
+      await expectAsync(fixture.nativeElement).toBeAccessible();
+    });
+
+    it('should be accessible when reorderable, selectable, and expandable with context menu and active index', async () => {
+      const fixture = await setupTest({
+        reorderable: true,
+        expandMode: 'single',
+        activeIndex: 1,
+        selectable: true,
+        context: true,
+      });
+      await expectAsync(fixture.nativeElement).toBeAccessible();
+    });
+
+    it('should be accessible when reorderable, selectable, and multi expandable with context menu and active index', async () => {
+      const fixture = await setupTest({
+        reorderable: true,
+        expandMode: 'multiple',
+        activeIndex: 1,
+        selectable: true,
+        context: true,
+      });
+      await expectAsync(fixture.nativeElement).toBeAccessible();
+    });
   });
 });


### PR DESCRIPTION
:cherries: Cherry picked from #1252 [test(components/lists): add missing accessibility test to repeater](https://github.com/blackbaud/skyux/pull/1252)