### PR TITLE
feat(components/lists): add click method to repeater item test harness (#1279)

### DIFF
--- a/libs/components/lists/testing/src/repeater/fixtures/repeater-harness-test.component.html
+++ b/libs/components/lists/testing/src/repeater/fixtures/repeater-harness-test.component.html
@@ -2,6 +2,7 @@
   data-sky-id="my-basic-repeater"
   [expandMode]="expandMode"
   [reorderable]="reorderable"
+  [(activeIndex)]="activeIndex"
 >
   <sky-repeater-item
     *ngFor="let item of items; let i = index"

--- a/libs/components/lists/testing/src/repeater/fixtures/repeater-harness-test.component.ts
+++ b/libs/components/lists/testing/src/repeater/fixtures/repeater-harness-test.component.ts
@@ -26,4 +26,6 @@ export class RepeaterHarnessTestComponent {
   public reorderable = false;
 
   public expandMode = 'none';
+
+  public activeIndex: number | undefined;
 }

--- a/libs/components/lists/testing/src/repeater/repeater-harness.spec.ts
+++ b/libs/components/lists/testing/src/repeater/repeater-harness.spec.ts
@@ -38,6 +38,20 @@ describe('Repeater harness', () => {
     expect(items[0] instanceof SkyRepeaterItemHarness).toBeTrue();
   });
 
+  it('should update the active index when a repeater item is clicked', async () => {
+    const { fixture, repeaterHarness } = await setupTest({
+      dataSkyId: 'my-basic-repeater',
+    });
+
+    fixture.componentInstance.activeIndex = 0;
+
+    const items = await repeaterHarness.getRepeaterItems();
+
+    await items[1].click();
+
+    expect(fixture.componentInstance.activeIndex).toBe(1);
+  });
+
   it('should select and deselect an item', async () => {
     const { fixture, repeaterHarness } = await setupTest({
       dataSkyId: 'my-basic-repeater',

--- a/libs/components/lists/testing/src/repeater/repeater-item-harness.ts
+++ b/libs/components/lists/testing/src/repeater/repeater-item-harness.ts
@@ -29,6 +29,8 @@ export class SkyRepeaterItemHarness extends SkyComponentHarness {
 
   #getContent = this.locatorFor('.sky-repeater-item-content');
 
+  #getItem = this.locatorFor('.sky-repeater-item');
+
   #getReorderHandle = this.locatorForOptional(
     'button.sky-repeater-item-grab-handle'
   );
@@ -49,27 +51,6 @@ export class SkyRepeaterItemHarness extends SkyComponentHarness {
       .addOption('titleText', filters.titleText, async (harness, text) =>
         HarnessPredicate.stringMatches(await harness.getTitleText(), text)
       );
-  }
-
-  /**
-   * Whether the repeater item is selectable.
-   */
-  public async isSelectable(): Promise<boolean> {
-    return !!(await this.#getCheckbox());
-  }
-
-  /**
-   * Whether the repeater item is selected.
-   */
-  public async isSelected(): Promise<boolean> {
-    const checkbox = await this.#getCheckbox();
-    if (!checkbox) {
-      throw new Error(
-        'Could not determine if repeater item is selected because it is not selectable.'
-      );
-    }
-
-    return checkbox.isChecked();
   }
 
   /**
@@ -102,6 +83,34 @@ export class SkyRepeaterItemHarness extends SkyComponentHarness {
    */
   public async querySelectorAll(selector: string): Promise<TestElement[]> {
     return this.locatorForAll(selector)();
+  }
+
+  /**
+   * Clicks on the repeater item.
+   */
+  public async click(): Promise<void> {
+    await (await this.#getItem()).click();
+  }
+
+  /**
+   * Whether the repeater item is selectable.
+   */
+  public async isSelectable(): Promise<boolean> {
+    return !!(await this.#getCheckbox());
+  }
+
+  /**
+   * Whether the repeater item is selected.
+   */
+  public async isSelected(): Promise<boolean> {
+    const checkbox = await this.#getCheckbox();
+    if (!checkbox) {
+      throw new Error(
+        'Could not determine if repeater item is selected because it is not selectable.'
+      );
+    }
+
+    return checkbox.isChecked();
   }
 
   /**


### PR DESCRIPTION
:cherries: Cherry picked from #1279 [feat(components/lists): add click method to repeater item test harness](https://github.com/blackbaud/skyux/pull/1279)