### PR TITLE
fix(components/ag-grid): change tab navigation into grid (#1276)

### DIFF
--- a/libs/components/ag-grid/src/lib/modules/ag-grid/ag-grid-adapter.service.spec.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/ag-grid-adapter.service.spec.ts
@@ -143,4 +143,25 @@ describe('SkyAgGridAdapterService', () => {
       expect(document.activeElement).toEqual(firstChildElement);
     });
   });
+
+  describe('focusOnColumnHeader', () => {
+    it('should move focus to the column header if there is one', () => {
+      agGridAdapterService.focusOnColumnHeader(
+        agGridAdapterServiceFixture.nativeElement,
+        'col1'
+      );
+      expect(document.activeElement).toEqual(
+        document.getElementById('col1-header')
+      );
+    });
+
+    it('should leave focus on the given element if the column header is not available', () => {
+      firstChildElement.focus();
+      agGridAdapterService.focusOnColumnHeader(
+        agGridAdapterServiceFixture.nativeElement,
+        'col2'
+      );
+      expect(document.activeElement).toEqual(firstChildElement);
+    });
+  });
 });

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/ag-grid-adapter.service.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/ag-grid-adapter.service.ts
@@ -69,4 +69,11 @@ export class SkyAgGridAdapterService {
       focusableChildren[0].focus();
     }
   }
+
+  public focusOnColumnHeader(parentEl: HTMLElement, colId: string): void {
+    const columnHeader = parentEl.querySelector(
+      `.ag-header-cell[col-id="${colId}"]`
+    ) as HTMLElement | undefined;
+    columnHeader?.focus();
+  }
 }

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/ag-grid-wrapper.component.spec.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/ag-grid-wrapper.component.spec.ts
@@ -350,17 +350,15 @@ describe('SkyAgGridWrapperComponent', () => {
         '#button-after-grid'
       ) as HTMLElement;
       const column = new Column({}, {}, 'name', true);
-      const rowIndex = 0;
 
       spyOn(agGrid.columnApi, 'getAllDisplayedColumns').and.returnValue([
         column,
       ]);
-      spyOn(agGrid.api, 'getFirstDisplayedRow').and.returnValue(rowIndex);
-      spyOn(agGrid.api, 'setFocusedCell');
+      spyOn(agGrid.api, 'ensureColumnVisible').and.stub();
 
       focusOnAnchor(afterAnchorEl, afterButtonEl);
 
-      expect(agGrid.api.setFocusedCell).toHaveBeenCalledWith(rowIndex, column);
+      expect(agGrid.api.ensureColumnVisible).toHaveBeenCalledWith(column);
     });
 
     it('should not shift focus to the first grid cell if there is no cell', () => {

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/ag-grid-wrapper.component.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/ag-grid-wrapper.component.ts
@@ -233,23 +233,19 @@ export class SkyAgGridWrapperComponent
   }
 
   public onAnchorFocus(event: FocusEvent): void {
-    const gridId = this.gridId;
-    const relatedTarget = event.relatedTarget as HTMLElement;
-    const previousFocusedId = relatedTarget && relatedTarget.id;
-    const previousWasCell =
-      relatedTarget &&
-      !!this.#adapterService.getElementOrParentWithClass(
-        relatedTarget,
-        'ag-cell'
-      );
+    const relatedTarget = event.relatedTarget as HTMLElement | undefined;
+    const previousWasGrid =
+      relatedTarget && !!this.#elementRef.nativeElement.contains(relatedTarget);
 
-    if (previousFocusedId !== gridId && !previousWasCell) {
-      const columns = this.agGrid?.columnApi.getAllDisplayedColumns();
-      const firstColumn = columns?.[0];
-      const rowIndex = this.agGrid?.api.getFirstDisplayedRow();
+    if (this.agGrid && !previousWasGrid) {
+      const firstColumn = this.agGrid.columnApi.getAllDisplayedColumns()[0];
 
-      if (firstColumn && rowIndex !== undefined && rowIndex >= 0) {
-        this.agGrid?.api.setFocusedCell(rowIndex, firstColumn);
+      if (firstColumn) {
+        this.agGrid.api.ensureColumnVisible(firstColumn);
+        this.#adapterService.focusOnColumnHeader(
+          this.#elementRef.nativeElement,
+          firstColumn.getColId()
+        );
       }
     }
   }

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/ag-grid.service.spec.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/ag-grid.service.spec.ts
@@ -18,6 +18,7 @@ import {
   GridOptions,
   RowClassParams,
   RowNode,
+  SuppressHeaderKeyboardEventParams,
   SuppressKeyboardEventParams,
   ValueFormatterFunc,
   ValueFormatterParams,
@@ -530,15 +531,29 @@ describe('SkyAgGridService', () => {
 
   describe('suppressKeyboardEvent', () => {
     const mockEl = document.createElement('div');
+    let suppressHeaderKeypressFunction: (
+      params: SuppressHeaderKeyboardEventParams<any>
+    ) => boolean;
     let suppressKeypressFunction: (
       params: SuppressKeyboardEventParams<any>
     ) => boolean;
 
     beforeEach(() => {
+      suppressHeaderKeypressFunction = defaultGridOptions.defaultColDef
+        ?.suppressHeaderKeyboardEvent as (
+        params: SuppressHeaderKeyboardEventParams<any>
+      ) => boolean;
       suppressKeypressFunction = defaultGridOptions.defaultColDef
         ?.suppressKeyboardEvent as (
         params: SuppressKeyboardEventParams<any>
       ) => boolean;
+    });
+
+    it('should return true to suppress the event when the tab key is pressed on a header cell', () => {
+      const params = {
+        event: { code: 'Tab' },
+      } as SuppressHeaderKeyboardEventParams;
+      expect(suppressHeaderKeypressFunction(params)).toBe(true);
     });
 
     it('should return true to suppress the event when the tab key is pressed and cells are not being edited', () => {

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/ag-grid.service.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/ag-grid.service.ts
@@ -9,6 +9,7 @@ import {
   GridOptions,
   ICellRendererParams,
   RowClassParams,
+  SuppressHeaderKeyboardEventParams,
   SuppressKeyboardEventParams,
   ValueFormatterParams,
 } from 'ag-grid-community';
@@ -382,6 +383,9 @@ export class SkyAgGridService implements OnDestroy {
         minWidth: 100,
         resizable: true,
         sortable: true,
+        suppressHeaderKeyboardEvent: (
+          keypress: SuppressHeaderKeyboardEventParams
+        ) => keypress.event.code === 'Tab',
         suppressKeyboardEvent: (keypress: SuppressKeyboardEventParams) =>
           this.#suppressTab(keypress),
       },
@@ -389,6 +393,7 @@ export class SkyAgGridService implements OnDestroy {
         headerGroupComponent: SkyAgGridHeaderGroupComponent,
       },
       domLayout: 'autoHeight',
+      ensureDomOrder: true,
       enterMovesDownAfterEdit: true,
       components: {
         'sky-ag-grid-cell-renderer-currency':
@@ -555,7 +560,7 @@ export class SkyAgGridService implements OnDestroy {
           currentlyFocusedEl,
           'ag-popup-editor'
         );
-        const parentEl = cellEl || (popupEl as HTMLElement);
+        const parentEl = cellEl || popupEl;
 
         const nextFocusableElementInCell =
           this.#agGridAdapterService.getNextFocusableElement(

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/fixtures/ag-grid-adapter.component.fixture.html
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/fixtures/ag-grid-adapter.component.fixture.html
@@ -2,3 +2,4 @@
   <div class="class2" id="child1" tabindex="0"></div>
   <div class="class2" id="child2" tabindex="0"></div>
 </div>
+<div class="ag-header-cell" id="col1-header" col-id="col1" tabindex="-1"></div>


### PR DESCRIPTION
:cherries: Cherry picked from #1276 [fix(components/ag-grid): change tab navigation into grid](https://github.com/blackbaud/skyux/pull/1276)