### PR TITLE
fix(components/tabs): vertical tab animation states reset correctly when transitioning between responsive states (#1282)

### DIFF
--- a/apps/playground/src/app/components/tabs/vertical-tabset/vertical-tabset-routing.module.ts
+++ b/apps/playground/src/app/components/tabs/vertical-tabset/vertical-tabset-routing.module.ts
@@ -21,5 +21,5 @@ const routes: ComponentRouteInfo[] = [
   imports: [RouterModule.forChild(routes)],
 })
 export class VerticalTabsetRoutingModule {
-  public static routes;
+  public static routes = routes;
 }

--- a/libs/components/tabs/src/lib/modules/vertical-tabset/vertical-tabset-group.component.html
+++ b/libs/components/tabs/src/lib/modules/vertical-tabset/vertical-tabset-group.component.html
@@ -32,7 +32,9 @@
     class="sky-vertical-tabset-group-content"
     skyId
     [attr.labelledby]="groupHeadingButton.id"
-    [@skyAnimationSlide]="!disabled && open ? 'down' : 'up'"
+    [@.disabled]="animationDisabled"
+    [@skyAnimationSlide]="slideDirection"
+    (@skyAnimationSlide.done)="updateSlideDirection($event)"
     #groupContent
   >
     <ng-content></ng-content>


### PR DESCRIPTION
:cherries: Cherry picked from #1282 [fix(components/tabs): vertical tab animation states reset correctly when transitioning between responsive states](https://github.com/blackbaud/skyux/pull/1282)