### PR TITLE
fix(components/forms): checkboxes only emit from the `valueChanges` reacive form observable once when the value changes and do not mark the form as dirty on programmatic changes

### DIFF
--- a/libs/components/forms/src/lib/modules/checkbox/checkbox.component.spec.ts
+++ b/libs/components/forms/src/lib/modules/checkbox/checkbox.component.spec.ts
@@ -965,9 +965,11 @@ describe('Checkbox component', () => {
       // eslint-disable-next-line @typescript-eslint/no-empty-function
       const callback = function (): void {};
       const callbackSpy = jasmine.createSpy('callback', callback);
+
       formControl.valueChanges.subscribe(() => {
         callbackSpy();
       });
+
       // This will give us 10 milliseconds pause before emitting the final valueChanges event that
       // was fired. Testing was done to ensure this was enough time to catch any bad behavior
       const subscription = formControl.valueChanges

--- a/libs/components/forms/src/lib/modules/checkbox/checkbox.component.ts
+++ b/libs/components/forms/src/lib/modules/checkbox/checkbox.component.ts
@@ -166,15 +166,7 @@ export class SkyCheckboxComponent implements ControlValueAccessor, OnInit {
     const checked = !!value;
     if (checked !== this.#_checked) {
       this.#_checked = checked;
-      this.#controlValueAccessorChangeFn(checked);
       this.#checkedChange.next(checked);
-
-      // Do not mark the field as "dirty"
-      // if the field has been initialized with a value.
-      if (this.#isFirstChange && this.#ngControl && this.#ngControl.control) {
-        this.#ngControl.control.markAsPristine();
-        this.#isFirstChange = false;
-      }
     }
   }
 
@@ -269,8 +261,6 @@ export class SkyCheckboxComponent implements ControlValueAccessor, OnInit {
   #indeterminateChange: BehaviorSubject<boolean>;
 
   #indeterminateChangeObs: Observable<boolean>;
-
-  #isFirstChange = true;
 
   #_checked = false;
 
@@ -367,6 +357,7 @@ export class SkyCheckboxComponent implements ControlValueAccessor, OnInit {
     if (!this.disabled) {
       this.indeterminate = false;
       this.#toggle();
+      this.#controlValueAccessorChangeFn(this.checked);
       this.#emitChangeEvent();
     }
   }
@@ -384,7 +375,6 @@ export class SkyCheckboxComponent implements ControlValueAccessor, OnInit {
   #controlValueAccessorChangeFn: (value: any) => void = (value) => {};
 
   #emitChangeEvent(): void {
-    this.#controlValueAccessorChangeFn(this.checked);
     this.change.emit({ source: this, checked: this.checked });
   }
 


### PR DESCRIPTION
[AB#2518706](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/2518706)

Also fixed programmatic changes to not mark the form as dirty. This matches what we have found is default for Angular and Material. Here is an example of Material's radio buttons: https://stackblitz.com/edit/angular-nnyi5q?file=src%2Fapp%2Fradio-ng-model-example.html,src%2Fapp%2Fradio-ng-model-example.ts,src%2Fapp%2Fradio-ng-model-example.css