### PR TITLE
fix(components/forms): checkboxes only emit from the `valueChanges` reacive form observable once when the value changes and do not mark the form as dirty on programmatic changes (#1292)

### DIFF
--- a/libs/components/forms/src/lib/modules/checkbox/checkbox.component.spec.ts
+++ b/libs/components/forms/src/lib/modules/checkbox/checkbox.component.spec.ts
@@ -20,6 +20,8 @@ import { By } from '@angular/platform-browser';
 import { expect, expectAsync } from '@skyux-sdk/testing';
 import { SkyLogService } from '@skyux/core';
 
+import { sampleTime } from 'rxjs/operators';
+
 import { SkyCheckboxChange } from './checkbox-change';
 import { SkyCheckboxComponent } from './checkbox.component';
 import { SkyCheckboxModule } from './checkbox.module';
@@ -956,6 +958,36 @@ describe('Checkbox component', () => {
       fixture.detectChanges();
       expect(inputElement?.getAttribute('required')).toBeNull();
       expect(inputElement?.getAttribute('aria-required')).toBeNull();
+    });
+
+    it('should only emit the form control valueChanged event once per change', (done) => {
+      fixture.detectChanges();
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      const callback = function (): void {};
+      const callbackSpy = jasmine.createSpy('callback', callback);
+
+      formControl.valueChanges.subscribe(() => {
+        callbackSpy();
+      });
+
+      // This will give us 10 milliseconds pause before emitting the final valueChanges event that
+      // was fired. Testing was done to ensure this was enough time to catch any bad behavior
+      const subscription = formControl.valueChanges
+        .pipe(sampleTime(10))
+        .subscribe(() => {
+          expect(callbackSpy).toHaveBeenCalledTimes(1);
+        })
+        .add(() => {
+          done();
+        });
+
+      labelElement?.click();
+
+      // Unsubscribe after 20 milliseconds so that the `add` callback will fire to end the test.
+      // Tested to ensure this is enough time to catch this issue.
+      setTimeout(() => {
+        subscription.unsubscribe();
+      }, 20);
     });
   });
 

--- a/libs/components/forms/src/lib/modules/checkbox/checkbox.component.ts
+++ b/libs/components/forms/src/lib/modules/checkbox/checkbox.component.ts
@@ -166,15 +166,7 @@ export class SkyCheckboxComponent implements ControlValueAccessor, OnInit {
     const checked = !!value;
     if (checked !== this.#_checked) {
       this.#_checked = checked;
-      this.#controlValueAccessorChangeFn(checked);
       this.#checkedChange.next(checked);
-
-      // Do not mark the field as "dirty"
-      // if the field has been initialized with a value.
-      if (this.#isFirstChange && this.#ngControl && this.#ngControl.control) {
-        this.#ngControl.control.markAsPristine();
-        this.#isFirstChange = false;
-      }
     }
   }
 
@@ -269,8 +261,6 @@ export class SkyCheckboxComponent implements ControlValueAccessor, OnInit {
   #indeterminateChange: BehaviorSubject<boolean>;
 
   #indeterminateChangeObs: Observable<boolean>;
-
-  #isFirstChange = true;
 
   #_checked = false;
 
@@ -367,6 +357,7 @@ export class SkyCheckboxComponent implements ControlValueAccessor, OnInit {
     if (!this.disabled) {
       this.indeterminate = false;
       this.#toggle();
+      this.#controlValueAccessorChangeFn(this.checked);
       this.#emitChangeEvent();
     }
   }
@@ -384,7 +375,6 @@ export class SkyCheckboxComponent implements ControlValueAccessor, OnInit {
   #controlValueAccessorChangeFn: (value: any) => void = (value) => {};
 
   #emitChangeEvent(): void {
-    this.#controlValueAccessorChangeFn(this.checked);
     this.change.emit({ source: this, checked: this.checked });
   }
 


### PR DESCRIPTION
:cherries: Cherry picked from #1292 [fix(components/forms): checkboxes only emit from the `valueChanges` reacive form observable once when the value changes and do not mark the form as dirty on programmatic changes](https://github.com/blackbaud/skyux/pull/1292)

[AB#2518706](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/2518706) 