### PR TITLE
feat(components/indicators): add keyboard support to chevron component (#1298)

### DIFF
--- a/libs/components/indicators/src/lib/modules/chevron/chevron.component.html
+++ b/libs/components/indicators/src/lib/modules/chevron/chevron.component.html
@@ -10,6 +10,7 @@
     'sky-btn sky-btn-icon-borderless': 'modern'
   }"
   (click)="chevronClick($event)"
+  (keydown)="chevronKeyDown($event)"
 >
   <sky-expansion-indicator
     [direction]="directionOrDefault"

--- a/libs/components/indicators/src/lib/modules/chevron/chevron.component.spec.ts
+++ b/libs/components/indicators/src/lib/modules/chevron/chevron.component.spec.ts
@@ -1,5 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { expect, expectAsync } from '@skyux-sdk/testing';
+import { SkyAppTestUtility, expect, expectAsync } from '@skyux-sdk/testing';
 import { SkyThemeService } from '@skyux/theme';
 
 import { take } from 'rxjs/operators';
@@ -37,6 +37,12 @@ describe('Chevron component', () => {
     getChevronEl().click();
   }
 
+  function keyChevron(keyName: string): void {
+    SkyAppTestUtility.fireDomEvent(getChevronEl(), 'keydown', {
+      keyboardEventInit: { key: keyName },
+    });
+  }
+
   it('should change direction when the user clicks the chevron', () => {
     const cmp = fixture.componentInstance as SkyChevronComponent;
     const el = fixture.nativeElement;
@@ -55,6 +61,35 @@ describe('Chevron component', () => {
     });
 
     clickChevron(el);
+  });
+
+  it('should change direction when the user activates the chevron with correct keyboard inputs', () => {
+    const cmp = fixture.componentInstance as SkyChevronComponent;
+
+    fixture.detectChanges();
+    validateDirection('up');
+
+    cmp.directionChange.pipe(take(1)).subscribe(() => {
+      validateDirection('down');
+    });
+
+    keyChevron(' ');
+
+    cmp.directionChange.pipe(take(1)).subscribe(() => {
+      validateDirection('up');
+    });
+
+    keyChevron('enter');
+
+    cmp.directionChange.pipe(take(1)).subscribe(() => {
+      validateDirection('down');
+    });
+
+    keyChevron('arrowUp');
+
+    cmp.directionChange.pipe(take(1)).subscribe(() => {
+      validateDirection('down');
+    });
   });
 
   it('should handle an undefined direction being passed in', () => {

--- a/libs/components/indicators/src/lib/modules/chevron/chevron.component.ts
+++ b/libs/components/indicators/src/lib/modules/chevron/chevron.component.ts
@@ -65,4 +65,21 @@ export class SkyChevronComponent {
     this.direction = this.directionOrDefault === 'up' ? 'down' : 'up';
     this.directionChange.emit(this.directionOrDefault);
   }
+
+  public chevronKeyDown(event: KeyboardEvent): void {
+    /* istanbul ignore else */
+    if (event.key) {
+      switch (event.key.toLowerCase()) {
+        case ' ':
+        case 'enter':
+          this.direction = this.directionOrDefault === 'up' ? 'down' : 'up';
+          this.directionChange.emit(this.directionOrDefault);
+          event.preventDefault();
+          event.stopPropagation();
+          break;
+        default:
+          break;
+      }
+    }
+  }
 }


### PR DESCRIPTION
:cherries: Cherry picked from #1298 [feat(components/indicators): add keyboard support to chevron component](https://github.com/blackbaud/skyux/pull/1298)