### PR TITLE
fix(components/forms): file attachment component does not place invalid `aria-required` attribute on the label (#1301)

### DIFF
--- a/libs/components/forms/src/lib/modules/file-attachment/file-attachment.component.html
+++ b/libs/components/forms/src/lib/modules/file-attachment/file-attachment.component.html
@@ -1,7 +1,6 @@
 <div class="sky-file-attachment-wrapper">
   <div
     class="sky-file-attachment-label-wrapper"
-    [attr.aria-required]="required ? true : null"
     [attr.id]="labelElementId"
     [ngClass]="{ 'sky-control-label-required': required && hasLabelComponent }"
   >

--- a/libs/components/forms/src/lib/modules/file-attachment/file-attachment.component.spec.ts
+++ b/libs/components/forms/src/lib/modules/file-attachment/file-attachment.component.spec.ts
@@ -356,7 +356,6 @@ describe('File attachment', () => {
     expect(labelWrapper?.classList.contains('sky-control-label-required')).toBe(
       true
     );
-    expect(labelWrapper?.getAttribute('aria-required')).toBe('true');
   }));
 
   it('should have appropriate classes when file is required and initialized with file', fakeAsync(() => {
@@ -380,7 +379,6 @@ describe('File attachment', () => {
     expect(labelWrapper?.classList.contains('sky-control-label-required')).toBe(
       true
     );
-    expect(labelWrapper?.getAttribute('aria-required')).toBe('true');
   }));
 
   it('should not have disabled attribute when not disabled', fakeAsync(() => {
@@ -1258,6 +1256,13 @@ describe('File attachment', () => {
   });
 
   it('should pass accessibility', async () => {
+    fixture.detectChanges();
+    await fixture.whenStable();
+    await expectAsync(fixture.nativeElement).toBeAccessible();
+  });
+
+  it('should pass accessibility when required', async () => {
+    fixture.componentInstance.required = true;
     fixture.detectChanges();
     await fixture.whenStable();
     await expectAsync(fixture.nativeElement).toBeAccessible();


### PR DESCRIPTION
:cherries: Cherry picked from #1301 [fix(components/forms): file attachment component does not place invalid `aria-required` attribute on the label](https://github.com/blackbaud/skyux/pull/1301)

[AB#2511474](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/2511474) 