### PR TITLE
fix(components/indicators): use correct alert and toast close icon size (#1313)

### DIFF
--- a/libs/components/indicators/src/lib/modules/alert/alert.component.html
+++ b/libs/components/indicators/src/lib/modules/alert/alert.component.html
@@ -38,7 +38,6 @@
         class="sky-alert-close-icon-theme-modern"
         icon="close"
         iconType="skyux"
-        size="2x"
       >
       </sky-icon>
     </span>

--- a/libs/components/toast/src/lib/modules/toast/toast.component.html
+++ b/libs/components/toast/src/lib/modules/toast/toast.component.html
@@ -34,7 +34,6 @@
         class="sky-toast-close-icon-theme-modern"
         icon="close"
         iconType="skyux"
-        size="2x"
       >
       </sky-icon>
     </button>

--- a/libs/components/toast/src/lib/modules/toast/toast.component.scss
+++ b/libs/components/toast/src/lib/modules/toast/toast.component.scss
@@ -122,8 +122,9 @@ sky-toast {
     .sky-toast-btn-close {
       border: solid 1px transparent;
       border-radius: $sky-theme-modern-border-radius-md;
-      height: 36px;
-      width: 36px;
+      height: 26px;
+      width: 26px;
+      flex-shrink: 0;
       margin-top: -10px;
       margin-right: -10px;
       opacity: 1;


### PR DESCRIPTION
:cherries: Cherry picked from #1313 [fix(components/indicators): use correct alert and toast close icon size](https://github.com/blackbaud/skyux/pull/1313)

[AB#2524107](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/2524107) 