### PR TITLE
fix(components/toast): toast components default to an `Info` type if no type is provided (#1316)

### DIFF
--- a/libs/components/toast/src/lib/modules/toast/toast.component.ts
+++ b/libs/components/toast/src/lib/modules/toast/toast.component.ts
@@ -47,8 +47,7 @@ export class SkyToastComponent implements OnInit, OnDestroy {
    */
   @Input()
   public set toastType(value: SkyToastType | undefined) {
-    this.toastTypeOrDefault =
-      value === undefined ? SKY_TOAST_TYPE_DEFAULT : value;
+    this.toastTypeOrDefault = value ?? SKY_TOAST_TYPE_DEFAULT;
     this.#updateForToastType();
   }
 

--- a/libs/components/toast/src/lib/modules/toast/toaster.component.spec.ts
+++ b/libs/components/toast/src/lib/modules/toast/toaster.component.spec.ts
@@ -17,8 +17,10 @@ import { SkyToastInstance } from './toast-instance';
 import { SkyToastService } from './toast.service';
 import { SkyToasterComponent } from './toaster.component';
 import { SkyToasterService } from './toaster.service';
+import { SkyToastConfig } from './types/toast-config';
 import { SkyToastContainerOptions } from './types/toast-container-options';
 import { SkyToastDisplayDirection } from './types/toast-display-direction';
+import { SkyToastType } from './types/toast-type';
 
 describe('Toast component', () => {
   let fixture: ComponentFixture<SkyToasterTestComponent>;
@@ -79,8 +81,11 @@ describe('Toast component', () => {
     return document.querySelectorAll('sky-toast');
   }
 
-  function openMessage(message = ''): SkyToastInstance {
-    const instance = toastService.openMessage(message);
+  function openMessage(
+    message = '',
+    config?: SkyToastConfig
+  ): SkyToastInstance {
+    const instance = toastService.openMessage(message, config);
     fixture.detectChanges();
     tick();
     return instance;
@@ -136,6 +141,18 @@ describe('Toast component', () => {
     expect(toasts.length).toEqual(1);
     validateToastMessage(toasts[0], message);
     expect(toasts.item(0).querySelector('.sky-toast-info')).toExist();
+    expect(toasts.item(0).querySelector('.fa-exclamation-circle')).toExist();
+  }));
+
+  it('should display a toast component with a type set', fakeAsync(() => {
+    const message = 'Hello, World!';
+    openMessage(message, { type: SkyToastType.Danger });
+
+    const toasts = getToastElements();
+    expect(toasts.length).toEqual(1);
+    validateToastMessage(toasts[0], message);
+    expect(toasts.item(0).querySelector('.sky-toast-danger')).toExist();
+    expect(toasts.item(0).querySelector('.fa-warning')).toExist();
   }));
 
   it('should handle closing a toast', fakeAsync(() => {

--- a/libs/components/toast/src/lib/modules/toast/types/toast-config.ts
+++ b/libs/components/toast/src/lib/modules/toast/types/toast-config.ts
@@ -8,7 +8,7 @@ import { SkyToastType } from './toast-type';
  */
 export interface SkyToastConfig {
   /**
-   * The `SkyToastType` type that determines the color and icon for the toast.
+   * The `SkyToastType` type that determines the color and icon for the toast. This property defaults to `SkyToastType.Info`.
    */
   type?: SkyToastType;
 


### PR DESCRIPTION
:cherries: Cherry picked from #1316 [fix(components/toast): toast components default to an `Info` type if no type is provided](https://github.com/blackbaud/skyux/pull/1316)

[AB#2526623](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/2526623) 