### PR TITLE
fix(components/forms): fix focus flash when checkbox and radio buttons are clicked inside of a modal

### DIFF
--- a/libs/components/forms/src/lib/modules/checkbox/checkbox.component.html
+++ b/libs/components/forms/src/lib/modules/checkbox/checkbox.component.html
@@ -4,7 +4,10 @@
     'sky-control-label-required': required,
     'sky-switch-disabled': disabled
   }"
+  (mousedown)="$event.preventDefault()"
 >
+  <!-- The `preventDefault` above is to stop the browser from temporarily moving focus to a parent element mid-click.
+  This was causing flashes in our modals.-->
   <input
     class="sky-checkbox-input sky-switch-input"
     type="checkbox"

--- a/libs/components/forms/src/lib/modules/radio/radio.component.html
+++ b/libs/components/forms/src/lib/modules/radio/radio.component.html
@@ -1,7 +1,10 @@
 <label
   class="sky-radio-wrapper sky-switch"
   [ngClass]="{ 'sky-switch-disabled': disabled || radioGroupDisabled }"
+  (mousedown)="$event.preventDefault()"
 >
+  <!-- The `preventDefault` above is to stop the browser from temporarily moving focus to a parent element mid-click.
+  This was causing flashes in our modals.-->
   <input
     class="sky-radio-input sky-switch-input"
     type="radio"


### PR DESCRIPTION
[AB#1570854](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/1570854)