### PR TITLE
fix(components/avatar): max avatar file size default is now correctly documented

### DIFF
--- a/libs/components/avatar/src/lib/modules/avatar/avatar.component.ts
+++ b/libs/components/avatar/src/lib/modules/avatar/avatar.component.ts
@@ -69,6 +69,7 @@ export class SkyAvatarComponent {
 
   /**
    * The maximum file size for the image in bytes.
+   * @default 500000 bytes
    */
   @Input()
   public maxFileSize: number | undefined = MAX_FILE_SIZE_DEFAULT;


### PR DESCRIPTION
[AB#2402774](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/2402774)