### PR TITLE
fix(components/forms): descenders are not cut off inside an input box when zoomed in (#1325)

### DIFF
--- a/libs/components/forms/src/lib/modules/input-box/input-box.component.scss
+++ b/libs/components/forms/src/lib/modules/input-box/input-box.component.scss
@@ -323,15 +323,11 @@ sky-input-box {
           an input box.
         */
         height: auto;
-        line-height: 18px;
+        line-height: 20px;
         padding-right: 15px;
-        padding-bottom: 10px;
+        padding-bottom: 9px;
         padding-left: 15px;
         position: relative;
-
-        &:first-line {
-          line-height: 19px;
-        }
 
         &:focus,
         &.ng-invalid {

--- a/libs/components/lookup/src/lib/modules/lookup/lookup.component.scss
+++ b/libs/components/lookup/src/lib/modules/lookup/lookup.component.scss
@@ -104,6 +104,10 @@ sky-input-box .sky-lookup {
   }
 
   sky-input-box .sky-lookup {
+    // Since we are applying the host template directly - add the same spacing styles that we do around a directly projected text area.
+    margin-top: -23px;
+    padding-top: 26px;
+
     sky-tokens.sky-lookup-tokens {
       // Input box adds a negative margin-top to elements with the
       // `sky-form-control` class in modern theme which causes that


### PR DESCRIPTION
:cherries: Cherry picked from #1325 [fix(components/forms): descenders are not cut off inside an input box when zoomed in](https://github.com/blackbaud/skyux/pull/1325)

[AB#2218932](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/2218932) 