### PR TITLE
feat(components/autonumeric): update `autonumeric` peer dependency to `4.8.1`

### DIFF
--- a/libs/components/autonumeric/package.json
+++ b/libs/components/autonumeric/package.json
@@ -19,7 +19,7 @@
     "@angular/common": "^15.2.1",
     "@angular/core": "^15.2.1",
     "@angular/forms": "^15.2.1",
-    "autonumeric": "^4.6.0"
+    "autonumeric": "^4.8.1"
   },
   "dependencies": {
     "tslib": "^2.5.0"

--- a/libs/components/packages/src/schematics/migrations/migration-collection.json
+++ b/libs/components/packages/src/schematics/migrations/migration-collection.json
@@ -14,6 +14,11 @@
       "version": "8.0.0-alpha.0",
       "factory": "./update-8/add-compat-stylesheets/add-compat-stylesheets",
       "description": "Add a backwards-compatible stylesheet with styles that have been removed from components in SKY UX 8."
+    },
+    "update-autonumeric": {
+      "version": "8.0.0-alpha.0",
+      "factory": "./update-8/update-autonumeric/update-autonumeric",
+      "description": "Update autonumeric to version `4.8.1`."
     }
   }
 }

--- a/libs/components/packages/src/schematics/migrations/update-8/update-autonumeric/update-autonumeric.spec.ts
+++ b/libs/components/packages/src/schematics/migrations/update-8/update-autonumeric/update-autonumeric.spec.ts
@@ -1,0 +1,90 @@
+import { SchematicTestRunner } from '@angular-devkit/schematics/testing';
+
+import { join } from 'path';
+
+import { createTestApp } from '../../../testing/scaffold';
+
+describe('Migrations > Update autonumeric', () => {
+  const runner = new SchematicTestRunner(
+    'migrations',
+    join(__dirname, '../../migration-collection.json')
+  );
+
+  async function setupTest() {
+    const tree = await createTestApp(runner, {
+      projectName: 'my-app',
+    });
+
+    return {
+      runSchematic: () => runner.runSchematic('update-autonumeric', {}, tree),
+      tree,
+    };
+  }
+
+  it('should not install autonumeric as a dependency if autonumeric is not installed', async () => {
+    const { runSchematic, tree } = await setupTest();
+
+    tree.overwrite(
+      '/package.json',
+      '{"dependencies": { "@skyux/core": "8.0.0"}}'
+    );
+
+    await runSchematic();
+
+    expect(tree.readJson('/package.json')).toEqual({
+      dependencies: {
+        '@skyux/core': '8.0.0',
+      },
+    });
+  });
+
+  it('should update autonumeric if it is installed', async () => {
+    const { runSchematic, tree } = await setupTest();
+
+    // Add autonumeric to both dependencies and devDependencies.
+    tree.overwrite(
+      '/package.json',
+      JSON.stringify({
+        dependencies: {
+          '@skyux/autonumeric': '8.0.0',
+          autonumeric: '4.6.0',
+        },
+      })
+    );
+
+    await runSchematic();
+
+    // The version listed in devDependencies should be removed.
+    expect(tree.readJson('/package.json')).toEqual({
+      dependencies: {
+        '@skyux/autonumeric': '8.0.0',
+        autonumeric: '4.8.1',
+      },
+    });
+  });
+
+  it('should leave autonumeric as is if it is already at 4.8.1', async () => {
+    const { runSchematic, tree } = await setupTest();
+
+    // Add autonumeric to both dependencies and devDependencies.
+    tree.overwrite(
+      '/package.json',
+      JSON.stringify({
+        dependencies: {
+          '@skyux/autonumeric': '8.0.0',
+          autonumeric: '4.8.1',
+        },
+      })
+    );
+
+    await runSchematic();
+
+    // The version listed in devDependencies should be removed.
+    expect(tree.readJson('/package.json')).toEqual({
+      dependencies: {
+        '@skyux/autonumeric': '8.0.0',
+        autonumeric: '4.8.1',
+      },
+    });
+  });
+});

--- a/libs/components/packages/src/schematics/migrations/update-8/update-autonumeric/update-autonumeric.ts
+++ b/libs/components/packages/src/schematics/migrations/update-8/update-autonumeric/update-autonumeric.ts
@@ -25,7 +25,7 @@ function updateVersion(): Rule {
       return;
     }
 
-    let type = NodeDependencyType.Default;
+    const type = NodeDependencyType.Default;
     const overwrite = true;
     const version = UPDATE_TO_VERSION;
 

--- a/libs/components/packages/src/schematics/migrations/update-8/update-autonumeric/update-autonumeric.ts
+++ b/libs/components/packages/src/schematics/migrations/update-8/update-autonumeric/update-autonumeric.ts
@@ -1,0 +1,48 @@
+import {
+  Rule,
+  SchematicContext,
+  Tree,
+  chain,
+} from '@angular-devkit/schematics';
+import { NodePackageInstallTask } from '@angular-devkit/schematics/tasks';
+import {
+  NodeDependencyType,
+  addPackageJsonDependency,
+  getPackageJsonDependency,
+} from '@schematics/angular/utility/dependencies';
+
+export const UPDATE_TO_VERSION = '4.8.1';
+
+/**
+ * Update the version of the `autonumeric` dependency.
+ */
+function updateVersion(): Rule {
+  return (tree: Tree, context: SchematicContext) => {
+    const autonumericDependency = getPackageJsonDependency(tree, 'autonumeric');
+
+    // Autonumeric is not installed, so we don't need to do anything.
+    if (!autonumericDependency) {
+      return;
+    }
+
+    let type = NodeDependencyType.Default;
+    const overwrite = true;
+    const version = UPDATE_TO_VERSION;
+
+    addPackageJsonDependency(tree, {
+      name: `autonumeric`,
+      overwrite,
+      type,
+      version,
+    });
+
+    context.addTask(new NodePackageInstallTask());
+  };
+}
+
+/**
+ * Upgrade to `autonumeric` version `4.8.1`.
+ */
+export default function (): Rule {
+  return chain([updateVersion()]);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "skyux",
-      "version": "8.0.0-beta.0",
+      "version": "8.0.0-beta.3",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -27,7 +27,7 @@
         "@skyux/icons": "6.0.0",
         "ag-grid-angular": "28.2.1",
         "ag-grid-community": "28.2.1",
-        "autonumeric": "4.6.0",
+        "autonumeric": "4.8.1",
         "axe-core": "4.6.3",
         "comment-json": "4.2.3",
         "dom-autoscroller": "2.3.4",
@@ -19543,10 +19543,13 @@
       }
     },
     "node_modules/autonumeric": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/autonumeric/-/autonumeric-4.6.0.tgz",
-      "integrity": "sha512-bYnD2oD9UMZBTxSWcvXH1MTcp0w+CUBfXe4HI1QJLGzJu+O27Ny5gqzRcFuDsZB9jrZ5SJjqAG0PieJsaUdTcg==",
-      "hasInstallScript": true
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/autonumeric/-/autonumeric-4.8.1.tgz",
+      "integrity": "sha512-bXymqga5EvHSEyoifaw/+pGLJHPOv9+C31G1zUHAFU/2J+94LYm24BYqInw7XWmQJQ96r4VXUchurFmiqzxB5w==",
+      "funding": {
+        "type": "patreon",
+        "url": "https://www.patreon.com/AlexandreBonneau"
+      }
     },
     "node_modules/autoprefixer": {
       "version": "10.4.13",

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "@skyux/icons": "6.0.0",
     "ag-grid-angular": "28.2.1",
     "ag-grid-community": "28.2.1",
-    "autonumeric": "4.6.0",
+    "autonumeric": "4.8.1",
     "axe-core": "4.6.3",
     "comment-json": "4.2.3",
     "dompurify": "3.0.1",


### PR DESCRIPTION
BREAKING CHANGE: The `@skyux/autonumeric` peer dependency has been updated to `4.8.1`. Version `4.8.0` of `autonumeric` introduced the `negativePositiveSignBehavior` option and this option defaults to `false`. However, the behavior this option enables was previously on by default. To maintain this behavior,  enable this option on the `skyAutonumeric` instance. For more information, see the [`autonumeric` library's CHANGELOG](https://github.com/autoNumeric/autoNumeric/blob/next/CHANGELOG.md]).

[AB#2537426](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/2537426)