### PR TITLE
fix: remove `@skyux/docs-tools` from packages update group

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -7,7 +7,7 @@ on:
     branches:
       - main
 env:
-  PRERELEASE: true
+  PRERELEASE: false
   MAJOR_VERSION: 8
 jobs:
   release:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -46,9 +46,8 @@ jobs:
           pull-request-title-pattern: 'chore: release ${version}'
           labels: 'autorelease ${{ github.ref_name }}: pending'
           release-labels: 'autorelease ${{ github.ref_name }}: tagged'
-          # release-as: '${{ steps.next-release.outputs.next-release }}'
-          # prerelease: ${{ env.PRERELEASE }}
-          release-as: '8.0.0'
+          release-as: '${{ steps.next-release.outputs.next-release }}'
+          prerelease: ${{ env.PRERELEASE }}
           draft-pull-request: true
           include-v-in-tag: false
           token: '${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}'

--- a/libs/components/packages/package.json
+++ b/libs/components/packages/package.json
@@ -51,7 +51,6 @@
       "@skyux/core": "0.0.0-PLACEHOLDER",
       "@skyux/data-manager": "0.0.0-PLACEHOLDER",
       "@skyux/datetime": "0.0.0-PLACEHOLDER",
-      "@skyux/docs-tools": "^7.0.0",
       "@skyux/errors": "0.0.0-PLACEHOLDER",
       "@skyux/flyout": "0.0.0-PLACEHOLDER",
       "@skyux/forms": "0.0.0-PLACEHOLDER",


### PR DESCRIPTION
Removing this package since it is only used by our internal documentation repos.