### PR TITLE
chore: add missing breaking change entry for the `SkyFileAttachmentChange` typing fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * **components/autonumeric:** The `@skyux/autonumeric` peer dependency has been updated to `4.8.1`. Version `4.8.0` of `autonumeric` introduced the `negativePositiveSignBehavior` option and this option defaults to `false`. However, the behavior this option enables was previously on by default. To maintain this behavior,  enable this option on the `skyAutonumeric` instance. For more information, see the [`autonumeric` library's CHANGELOG](https://github.com/autoNumeric/autoNumeric/blob/next/CHANGELOG.md]).
 * **components/config:** In previous major versions, query string config parameter values were not decoded when retrieving them via `SkyAppRuntimeConfigParams`. Any code that decoded these values after retrieving them should be removed.
 * **components/datetime:** The timepicker component's `timeFormat` input has been converted from a `string` input type to a `SkyTimepickerTimeFormatType` `string` union. This might cause problems if you are setting the `timeFormat` input to a type of `string` in your consuming comopnent's class.
+* **components/forms:** The typings for the single file attachment component's `SkyFileAttachmentChange` previously incorrectly listed that the `file` property would never be `undefined`. The underlying functionality has always returned `undefined` when a file is removed. Any code that did not account for the possiblility of `undefined` will need updated to account for this possiblity.
 * **components/layout:** Components that expect text expand repeater to have a top margin will need to be updated to compensate for the removed margin.
 * **components/lists:** The repeater component's `expandMode` input was set to allow values of type of `string` but it really only supported a handful of known `string` values represented by the `SkyRepeaterExpandModeType` `string` union. This ability to specify a `string` value has been removed. This might cause problems if you are setting the `expandMode` input to a type of `string` in your consuming component's class.
 * **components/packages:** A project name must be provided when a workspace has more than one project.
@@ -311,6 +312,10 @@ bc554d6208329509857f290e198402e6de46fd2a))
 
 ## [8.0.0-alpha.18](https://github.com/blackbaud/skyux/compare/8.0.0-alpha.17...8.0.0-alpha.18) (2023-04-06)
 
+
+### ⚠ BREAKING CHANGES
+
+* **components/forms:** The typings for the single file attachment component's `SkyFileAttachmentChange` previously incorrectly listed that the `file` property would never be `undefined`. The underlying functionality has always returned `undefined` when a file is removed. Any code that did not account for the possiblility of `undefined` will need updated to account for this possiblity.
 
 ### Bug Fixes
 


### PR DESCRIPTION
[AB#2549679](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/2549679)