### PR TITLE
feat(components/http): add callerid query string to bbid requests

### DIFF
--- a/libs/components/http/src/lib/modules/auth-http-client/auth-interceptor.ts
+++ b/libs/components/http/src/lib/modules/auth-http-client/auth-interceptor.ts
@@ -125,6 +125,9 @@ export class SkyAuthInterceptor implements HttpInterceptor {
     }
 
     let newUrl = runtimeParams.getUrl(url);
+    if (!newUrl) {
+      return url;
+    }
 
     const svcId = runtimeParams.get('svcid');
     const spaName = this.#config?.runtime?.app?.name;

--- a/libs/components/http/src/lib/modules/auth-http-client/auth-interceptor.ts
+++ b/libs/components/http/src/lib/modules/auth-http-client/auth-interceptor.ts
@@ -125,9 +125,6 @@ export class SkyAuthInterceptor implements HttpInterceptor {
     }
 
     let newUrl = runtimeParams.getUrl(url);
-    if (!newUrl) {
-      return url;
-    }
 
     const svcId = runtimeParams.get('svcid');
     const spaName = this.#config?.runtime?.app?.name;

--- a/libs/components/http/src/lib/modules/auth-http-client/testing/sky-http-interceptor.test-utils.ts
+++ b/libs/components/http/src/lib/modules/auth-http-client/testing/sky-http-interceptor.test-utils.ts
@@ -57,7 +57,8 @@ export function validateRequest(
 export function createAppConfig(
   envId?: string,
   leId?: string,
-  getUrlResult?: string
+  getUrlResult?: string,
+  svcId?: string
 ) {
   return {
     runtime: {
@@ -68,6 +69,8 @@ export function createAppConfig(
               return envId;
             case 'leid':
               return leId;
+            case 'svcid':
+              return svcId;
             default:
               return undefined;
           }

--- a/libs/components/http/testing/src/auth-http-client/auth-http-client-controller.spec.ts
+++ b/libs/components/http/testing/src/auth-http-client/auth-http-client-controller.spec.ts
@@ -70,7 +70,7 @@ describe('Auth HTTP client controller', () => {
   it('should assert that the request was authenticated', fakeAsync(() => {
     service.doSomething().subscribe();
     tick();
-    const req = httpTestingController.expectOne('https://www.example.com/');
+    const req = httpTestingController.expectOne('https://www.example.com/?callerid=test-svcid,spa-test');
     expect(req.request.headers.has('Authorization')).toBeTrue();
     skyAuthHttpTestingController.expectAuth(req);
     const mockProvider = TestBed.inject(SkyAuthTokenMockProvider);

--- a/libs/components/http/testing/src/auth-http-client/mock-app-config.ts
+++ b/libs/components/http/testing/src/auth-http-client/mock-app-config.ts
@@ -8,6 +8,13 @@ export class SkyMockAppConfig {
     },
     params: {
       getUrl: (url: string) => url,
+      get: (key: string) => {
+        if (key === 'svcid') {
+          return 'test-svcid';
+        }
+
+        return undefined;
+      },
     },
   };
 }

--- a/libs/components/http/testing/src/auth-http-client/mock-app-config.ts
+++ b/libs/components/http/testing/src/auth-http-client/mock-app-config.ts
@@ -8,13 +8,7 @@ export class SkyMockAppConfig {
     },
     params: {
       getUrl: (url: string) => url,
-      get: (key: string) => {
-        if (key === 'svcid') {
-          return 'test-svcid';
-        }
-
-        return undefined;
-      },
+      get: (_: string) => 'test-svcid'
     },
   };
 }


### PR DESCRIPTION
This adds a query string to bbid requests to the backend that represents the service (svcid) and SPA. We'll propagate this request on telemetry baggage across backend requests, which will eventually end up on usage-based billing events, so we can say "this amount of cost initiated from svcid=renxt". Backend .NET implementation is here: https://dev.azure.com/blackbaud/Products/_git/core-webservice-aspnetcore/pullrequest/311779