### PR TITLE
fix(sdk/eslint-config): adjust `no-console` rule to allow "error" and "warn" logs

### DIFF
--- a/libs/sdk/eslint-config/recommended.json
+++ b/libs/sdk/eslint-config/recommended.json
@@ -37,7 +37,7 @@
     ],
     "no-alert": "error",
     "no-caller": "error",
-    "no-console": "error",
+    "no-console": ["error", { "allow": ["error", "warn"] }],
     "no-constant-binary-expression": "error",
     "no-constructor-return": "error",
     "no-duplicate-imports": ["error", { "includeExports": true }],


### PR DESCRIPTION
The `ng new` command creates a `main.ts` file with a `console.error`. This change would allow this line to pass linting.
```
platformBrowserDynamic()
  .bootstrapModule(AppModule)
  .catch((err) => { console.error(err); });
```