### PR TITLE
fix(components/lookup): country field docs clarify that the `autocompleteAttribute` is for the HTML attribute and no longer list an internal input

### DIFF
--- a/libs/components/lookup/src/lib/modules/country-field/country-field.component.ts
+++ b/libs/components/lookup/src/lib/modules/country-field/country-field.component.ts
@@ -63,7 +63,7 @@ export class SkyCountryFieldComponent
   implements AfterViewInit, ControlValueAccessor, OnDestroy, OnInit, Validator
 {
   /**
-   * The value for the `autocomplete` attribute on the form input.
+   * The value for the HTML `autocomplete` attribute on the form input.
    */
   @Input()
   public autocompleteAttribute: string | undefined;
@@ -139,6 +139,7 @@ export class SkyCountryFieldComponent
   /**
    * Whether to include phone information in the selected country and country dropdown.
    * @default false
+   * @internal
    */
   @Input()
   public set includePhoneInfo(value: boolean | undefined) {


### PR DESCRIPTION
[AB#2598366](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/2598366)