### PR TITLE
test(components/datetime): timepicker visual test (#1516)

### DIFF
--- a/apps/e2e/datetime-storybook-e2e/src/e2e/timepicker.component.cy.ts
+++ b/apps/e2e/datetime-storybook-e2e/src/e2e/timepicker.component.cy.ts
@@ -1,0 +1,35 @@
+import { E2eVariations } from '@skyux-sdk/e2e-schematics';
+
+describe('datetime-storybook', () => {
+  E2eVariations.forEachTheme((theme) => {
+    describe(`in ${theme} theme`, () => {
+      ['12-hr', '24-hr'].forEach((mode) => {
+        describe(`in ${mode} mode`, () => {
+          beforeEach(() =>
+            cy.visit(
+              `/iframe.html?globals=theme:${theme}&id=timepickercomponent-timepicker--timepicker-${mode}`
+            )
+          );
+          it('should render the component', () => {
+            cy.get('.sky-input-group-timepicker-btn')
+              .last()
+              .should('exist')
+              .should('be.visible')
+              .click()
+              .end()
+              .get('body')
+              .should('exist')
+              .should('be.visible')
+              .skyVisualTest(
+                `timepickercomponent-timepicker--timepicker-${mode}-${theme}`,
+                {
+                  overwrite: true,
+                  disableTimersAndAnimations: true,
+                }
+              );
+          });
+        });
+      });
+    });
+  });
+});

--- a/apps/e2e/datetime-storybook/src/app/app.module.ts
+++ b/apps/e2e/datetime-storybook/src/app/app.module.ts
@@ -17,6 +17,11 @@ const routes: Route[] = [
         (m) => m.DateRangePickerModule
       ),
   },
+  {
+    path: 'timepicker',
+    loadChildren: () =>
+      import('./timepicker/timepicker.module').then((m) => m.TimepickerModule),
+  },
 ];
 if (routes.length > 0 && routes.findIndex((r) => r.path === '') === -1) {
   routes.push({ path: '', redirectTo: `${routes[0].path}`, pathMatch: 'full' });

--- a/apps/e2e/datetime-storybook/src/app/timepicker/timepicker.component.html
+++ b/apps/e2e/datetime-storybook/src/app/timepicker/timepicker.component.html
@@ -1,0 +1,29 @@
+<div style="height: 500px">
+  <sky-input-box>
+    <label class="sky-control-label" [for]="disabledTimepickerInput.id">
+      Disabled
+    </label>
+    <sky-timepicker #disabledTimepicker>
+      <input
+        skyId
+        [disabled]="true"
+        [skyTimepickerInput]="disabledTimepicker"
+        timeFormat="hh"
+        #disabledTimepickerInput="skyId"
+      />
+    </sky-timepicker>
+  </sky-input-box>
+
+  <sky-input-box>
+    <label class="sky-control-label" [for]="timepickerInput.id">Label</label>
+    <sky-timepicker #timepicker>
+      <input
+        skyId
+        [skyTimepickerInput]="timepicker"
+        [timeFormat]="timeFormat"
+        #timepickerInput="skyId"
+        [(ngModel)]="time"
+      />
+    </sky-timepicker>
+  </sky-input-box>
+</div>

--- a/apps/e2e/datetime-storybook/src/app/timepicker/timepicker.component.scss
+++ b/apps/e2e/datetime-storybook/src/app/timepicker/timepicker.component.scss
@@ -1,0 +1,3 @@
+:host {
+  display: block;
+}

--- a/apps/e2e/datetime-storybook/src/app/timepicker/timepicker.component.stories.ts
+++ b/apps/e2e/datetime-storybook/src/app/timepicker/timepicker.component.stories.ts
@@ -1,0 +1,25 @@
+import { Meta, StoryFn, moduleMetadata } from '@storybook/angular';
+
+import { TimepickerComponent } from './timepicker.component';
+import { TimepickerModule } from './timepicker.module';
+
+export default {
+  id: 'timepickercomponent-timepicker',
+  title: 'Components/Timepicker',
+  component: TimepickerComponent,
+  decorators: [
+    moduleMetadata({
+      imports: [TimepickerModule],
+    }),
+  ],
+} as Meta<TimepickerComponent>;
+export const Timepicker12Hr: StoryFn<TimepickerComponent> = (
+  args: TimepickerComponent
+) => ({
+  props: args,
+});
+
+export const Timepicker24Hr = Timepicker12Hr.bind({});
+Timepicker24Hr.args = {
+  timeFormat: 'HH',
+};

--- a/apps/e2e/datetime-storybook/src/app/timepicker/timepicker.component.ts
+++ b/apps/e2e/datetime-storybook/src/app/timepicker/timepicker.component.ts
@@ -1,0 +1,24 @@
+import { Component, Input } from '@angular/core';
+import { SkyTimepickerTimeOutput } from '@skyux/datetime';
+
+@Component({
+  selector: 'app-timepicker',
+  templateUrl: './timepicker.component.html',
+  styleUrls: ['./timepicker.component.scss'],
+})
+export class TimepickerComponent {
+  @Input()
+  public timeFormat: 'hh' | 'HH' = 'hh';
+
+  public time: SkyTimepickerTimeOutput = {
+    hour: 0,
+    minute: 30,
+    timezone: -4,
+    meridie: 'AM',
+    customFormat: 'h:mm A',
+    local: '12:30 AM',
+    iso8601: new Date(
+      'Mon Jul 31 2023 00:30:00 GMT-0400 (Eastern Daylight Time)'
+    ),
+  };
+}

--- a/apps/e2e/datetime-storybook/src/app/timepicker/timepicker.module.ts
+++ b/apps/e2e/datetime-storybook/src/app/timepicker/timepicker.module.ts
@@ -1,0 +1,25 @@
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { RouterModule, Routes } from '@angular/router';
+import { SkyIdModule } from '@skyux/core';
+import { SkyTimepickerModule } from '@skyux/datetime';
+import { SkyInputBoxModule } from '@skyux/forms';
+
+import { TimepickerComponent } from './timepicker.component';
+
+const routes: Routes = [{ path: '', component: TimepickerComponent }];
+@NgModule({
+  declarations: [TimepickerComponent],
+  imports: [
+    CommonModule,
+    RouterModule.forChild(routes),
+    FormsModule,
+    ReactiveFormsModule,
+    SkyTimepickerModule,
+    SkyIdModule,
+    SkyInputBoxModule,
+  ],
+  exports: [TimepickerComponent],
+})
+export class TimepickerModule {}


### PR DESCRIPTION
:cherries: Cherry picked from #1516 [test(components/datetime): timepicker visual test](https://github.com/blackbaud/skyux/pull/1516)

[AB#2195568](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/2195568) 