### PR TITLE
chore(apps/playground): add standalone modal demo

### DIFF
--- a/apps/playground/src/app/components/components.module.ts
+++ b/apps/playground/src/app/components/components.module.ts
@@ -77,6 +77,15 @@ export const componentRoutes: Routes = [
       import('./modal/modal-visual.module').then((m) => m.ModalVisualModule),
   },
   {
+    path: 'modal/standalone',
+    loadComponent: () => import('./modal/standalone/modal-opener.component'),
+    data: {
+      name: 'Modal (standalone)',
+      library: 'modal',
+      icon: 'universal-access',
+    },
+  },
+  {
     path: 'pages',
     loadChildren: () =>
       import('./pages/pages.module').then((m) => m.PagesModule),

--- a/apps/playground/src/app/components/modal/standalone/modal-opener.component.ts
+++ b/apps/playground/src/app/components/modal/standalone/modal-opener.component.ts
@@ -1,0 +1,21 @@
+import { Component, inject } from '@angular/core';
+import { SkyModalService } from '@skyux/modals';
+
+import { ModalStandaloneComponent } from './modal-standalone.component';
+
+/**
+ * This standalone route opens a standalone modal component to ensure providers are correctly setup.
+ */
+@Component({
+  standalone: true,
+  template: `
+    <button class="sky-btn sky-btn-default" (click)="open()">Open modal</button>
+  `,
+})
+export default class ModalOpenerComponent {
+  #modalSvc = inject(SkyModalService);
+
+  protected open(): void {
+    this.#modalSvc.open(ModalStandaloneComponent, {});
+  }
+}

--- a/apps/playground/src/app/components/modal/standalone/modal-standalone.component.ts
+++ b/apps/playground/src/app/components/modal/standalone/modal-standalone.component.ts
@@ -1,0 +1,18 @@
+import { CommonModule } from '@angular/common';
+import { Component, inject } from '@angular/core';
+import { SkyModalInstance, SkyModalModule } from '@skyux/modals';
+
+@Component({
+  standalone: true,
+  imports: [CommonModule, SkyModalModule],
+  template: `<sky-modal [isDirty]="true">
+    <sky-modal-header>Modal test</sky-modal-header>
+    <sky-modal-content> Hello World! </sky-modal-content>
+    <sky-modal-footer>
+      <button (click)="instance.close()">Close</button>
+    </sky-modal-footer>
+  </sky-modal> `,
+})
+export class ModalStandaloneComponent {
+  protected readonly instance = inject(SkyModalInstance);
+}


### PR DESCRIPTION
Added a standalone modal to the playground to demonstrate the problem we're having with providers and dynamically created components.
<img width="629" alt="Screenshot 2023-08-08 at 9 06 34 AM" src="https://github.com/blackbaud/skyux/assets/12497062/03799c45-dda6-4543-b12e-d56061177242">
