### PR TITLE
fix(components/i18n)!: move SkyLibResourcesService to SkyI18nModule providers

### DIFF
--- a/libs/components/i18n/src/lib/modules/i18n/i18n.module.ts
+++ b/libs/components/i18n/src/lib/modules/i18n/i18n.module.ts
@@ -1,10 +1,12 @@
 import { NgModule } from '@angular/core';
 
 import { SkyLibResourcesPipe } from './lib-resources.pipe';
+import { SkyLibResourcesService } from './lib-resources.service';
 import { SkyAppResourcesPipe } from './resources.pipe';
 
 @NgModule({
   declarations: [SkyAppResourcesPipe, SkyLibResourcesPipe],
   exports: [SkyAppResourcesPipe, SkyLibResourcesPipe],
+  providers: [SkyLibResourcesService],
 })
 export class SkyI18nModule {}

--- a/libs/components/i18n/src/lib/modules/i18n/lib-resources.service.ts
+++ b/libs/components/i18n/src/lib/modules/i18n/lib-resources.service.ts
@@ -18,9 +18,7 @@ type ResourceKey = string;
 type TemplatedResource = [ResourceKey, ...any[]];
 type ResourceDictionary = Record<string, ResourceKey | TemplatedResource>;
 
-@Injectable({
-  providedIn: 'any',
-})
+@Injectable()
 export class SkyLibResourcesService {
   #localeProvider: SkyAppLocaleProvider;
   #providers: SkyLibResourcesProvider[] | undefined;


### PR DESCRIPTION
BREAKING CHANGE: Library authors injecting `SkyLibResourcesService` into their component must import `SkyI18nModule` into that component's module providers.