### PR TITLE
feat(components/a11y)!: move SkySkipLinkService to SkySkipLinkModule module providers

### DIFF
--- a/libs/components/a11y/src/lib/modules/skip-link/skip-link.module.ts
+++ b/libs/components/a11y/src/lib/modules/skip-link/skip-link.module.ts
@@ -5,6 +5,7 @@ import { SkyI18nModule } from '@skyux/i18n';
 import { SkyA11yResourcesModule } from '../shared/sky-a11y-resources.module';
 
 import { SkySkipLinkHostComponent } from './skip-link-host.component';
+import { SkySkipLinkService } from './skip-link.service';
 
 /**
  * The Angular module that enables "skip links" to be added to the page.
@@ -12,5 +13,6 @@ import { SkySkipLinkHostComponent } from './skip-link-host.component';
 @NgModule({
   declarations: [SkySkipLinkHostComponent],
   imports: [CommonModule, SkyI18nModule, SkyA11yResourcesModule],
+  providers: [SkySkipLinkService],
 })
 export class SkySkipLinkModule {}

--- a/libs/components/a11y/src/lib/modules/skip-link/skip-link.service.ts
+++ b/libs/components/a11y/src/lib/modules/skip-link/skip-link.service.ts
@@ -14,14 +14,8 @@ import { SkySkipLinkHostComponent } from './skip-link-host.component';
  * be displayed and focused.  Clicking the button will skip to the specified element.  Pressing
  * the Tab key again will move to the next skip link if more than one skip link is specified;
  * otherwise, focus will move to the first focusable element on the page.
- * @dynamic
  */
-@Injectable({
-  // Must be 'any' so that the skip link component is created in the context of its module's injector.
-  // If set to 'root', the component's dependency injections would only be derived from the root
-  // injector and may loose context if the skip link was created from within a lazy-loaded module.
-  providedIn: 'any',
-})
+@Injectable()
 export class SkySkipLinkService {
   private static host: ComponentRef<SkySkipLinkHostComponent> | undefined;
 
@@ -31,7 +25,7 @@ export class SkySkipLinkService {
     this.#dynamicComponentService = dynamicComponentService;
   }
 
-  public setSkipLinks(args: SkySkipLinkArgs) {
+  public setSkipLinks(args: SkySkipLinkArgs): void {
     args.links = args.links.filter((link: SkySkipLink) => {
       const elementRefExists = link.elementRef;
       return elementRefExists;


### PR DESCRIPTION
BREAKING CHANGE: The `SkySkipLinkService` cannot be used in isolation; any component that injects `SkySkipLinkService` must also import `SkySkipLinkModule` into its module's providers.