### PR TITLE
feat(components/ag-grid)!: move `SkyAgGridService` to `SkyAgGridModule` providers

### DIFF
--- a/libs/components/ag-grid/src/lib/modules/ag-grid/ag-grid-adapter.service.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/ag-grid-adapter.service.ts
@@ -1,6 +1,9 @@
 import { Injectable } from '@angular/core';
 import { SkyCoreAdapterService } from '@skyux/core';
 
+/**
+ * @internal
+ */
 @Injectable({
   providedIn: 'root',
 })

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/ag-grid.module.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/ag-grid.module.ts
@@ -13,6 +13,7 @@ import { SkyAgGridDataManagerAdapterDirective } from './ag-grid-data-manager-ada
 import { SkyAgGridRowDeleteComponent } from './ag-grid-row-delete.component';
 import { SkyAgGridRowDeleteDirective } from './ag-grid-row-delete.directive';
 import { SkyAgGridWrapperComponent } from './ag-grid-wrapper.component';
+import { SkyAgGridService } from './ag-grid.service';
 import { SkyAgGridCellEditorAutocompleteModule } from './cell-editors/cell-editor-autocomplete/cell-editor-autocomplete.module';
 import { SkyAgGridCellEditorCurrencyModule } from './cell-editors/cell-editor-currency/cell-editor-currency.module';
 import { SkyAgGridCellEditorDatepickerModule } from './cell-editors/cell-editor-datepicker/cell-editor-datepicker.module';
@@ -65,5 +66,6 @@ import { SkyAgGridHeaderComponent } from './header/header.component';
     SkyAgGridHeaderComponent,
     SkyAgGridHeaderGroupComponent,
   ],
+  providers: [SkyAgGridService],
 })
 export class SkyAgGridModule {}

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/ag-grid.service.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/ag-grid.service.ts
@@ -120,9 +120,7 @@ let rowNodeId = -1;
 /**
  * `SkyAgGridService` provides methods to get AG Grid `gridOptions` to ensure grids match SKY UX functionality. The `gridOptions` can be overridden, and include registered SKY UX column types.
  */
-@Injectable({
-  providedIn: 'any',
-})
+@Injectable()
 export class SkyAgGridService implements OnDestroy {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   #keyMap = new WeakMap<any, string>();


### PR DESCRIPTION
BREAKING CHANGE: The `SkyAgGridService` cannot be used in isolation; any component that injects `SkyAgGridService` must also import `SkyAgGridModule` into its module's providers.