### PR TITLE
fix(components/split-view): clarify split-view footer uses and remove the workspace header from the public documentation

### DIFF
--- a/apps/e2e/action-bars-storybook/src/app/summary-action-bar/summary-action-bar.component.html
+++ b/apps/e2e/action-bars-storybook/src/app/summary-action-bar/summary-action-bar.component.html
@@ -37,7 +37,6 @@
 >
   <sky-split-view-drawer>Drawer</sky-split-view-drawer>
   <sky-split-view-workspace>
-    <sky-split-view-workspace-header>Header</sky-split-view-workspace-header>
     <sky-split-view-workspace-content>Content</sky-split-view-workspace-content>
     <sky-split-view-workspace-footer
       ><ng-container *ngTemplateOutlet="actionBar"></ng-container

--- a/apps/e2e/split-view-storybook/src/app/split-view/split-view.component.html
+++ b/apps/e2e/split-view-storybook/src/app/split-view/split-view.component.html
@@ -2,7 +2,6 @@
 <sky-split-view dock="fill" backButtonText="Responsive button text">
   <sky-split-view-drawer>Drawer</sky-split-view-drawer>
   <sky-split-view-workspace>
-    <sky-split-view-workspace-header>Header</sky-split-view-workspace-header>
     <sky-split-view-workspace-content>Content</sky-split-view-workspace-content>
     <sky-split-view-workspace-footer>Footer</sky-split-view-workspace-footer>
   </sky-split-view-workspace>

--- a/libs/components/split-view/src/lib/modules/split-view/split-view-workspace-footer.component.ts
+++ b/libs/components/split-view/src/lib/modules/split-view/split-view-workspace-footer.component.ts
@@ -1,7 +1,7 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core';
 
 /**
- * Specifies the footer to display in the split view's workspace panel. This component is often used to display a summary action bar.
+ * Specifies the footer to display in the split view's workspace panel. This component is often used with a summary action bar.
  */
 @Component({
   selector: 'sky-split-view-workspace-footer',

--- a/libs/components/split-view/src/lib/modules/split-view/split-view-workspace-footer.component.ts
+++ b/libs/components/split-view/src/lib/modules/split-view/split-view-workspace-footer.component.ts
@@ -1,7 +1,7 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core';
 
 /**
- * Specifies the footer to display in the split view's workspace panel.
+ * Specifies the footer to display in the split view's workspace panel. This component is often used to display a summary action bar.
  */
 @Component({
   selector: 'sky-split-view-workspace-footer',

--- a/libs/components/split-view/src/lib/modules/split-view/split-view-workspace-header.component.ts
+++ b/libs/components/split-view/src/lib/modules/split-view/split-view-workspace-header.component.ts
@@ -12,6 +12,7 @@ import { SkySplitViewService } from './split-view.service';
 
 /**
  * Specifies the header to display in the split view's workspace panel.
+ * @internal
  */
 @Component({
   selector: 'sky-split-view-workspace-header',


### PR DESCRIPTION
[AB#2638182](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/2638182)