### PR TITLE
refactor: remove redundant import of `SkyI18nModule`

### DIFF
--- a/libs/components/a11y/src/lib/modules/skip-link/skip-link.module.ts
+++ b/libs/components/a11y/src/lib/modules/skip-link/skip-link.module.ts
@@ -1,6 +1,5 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
-import { SkyI18nModule } from '@skyux/i18n';
 
 import { SkyA11yResourcesModule } from '../shared/sky-a11y-resources.module';
 
@@ -12,7 +11,7 @@ import { SkySkipLinkService } from './skip-link.service';
  */
 @NgModule({
   declarations: [SkySkipLinkHostComponent],
-  imports: [CommonModule, SkyI18nModule, SkyA11yResourcesModule],
+  imports: [CommonModule, SkyA11yResourcesModule],
   providers: [SkySkipLinkService],
 })
 export class SkySkipLinkModule {}

--- a/libs/components/action-bars/src/lib/modules/summary-action-bar/summary-action-bar.module.ts
+++ b/libs/components/action-bars/src/lib/modules/summary-action-bar/summary-action-bar.module.ts
@@ -1,6 +1,5 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
-import { SkyI18nModule } from '@skyux/i18n';
 import { SkyChevronModule, SkyIconModule } from '@skyux/indicators';
 import { SkyDropdownModule } from '@skyux/popovers';
 import { SkyThemeModule } from '@skyux/theme';
@@ -31,7 +30,6 @@ import { SkySummaryActionBarSummaryComponent } from './summary/summary-action-ba
     CommonModule,
     SkyChevronModule,
     SkyDropdownModule,
-    SkyI18nModule,
     SkyIconModule,
     SkyActionBarsResourcesModule,
     SkyThemeModule,

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/ag-grid.module.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/ag-grid.module.ts
@@ -2,12 +2,13 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { SkyViewkeeperModule } from '@skyux/core';
 import { SkyDataManagerModule } from '@skyux/data-manager';
-import { SkyI18nModule } from '@skyux/i18n';
 import { SkyIconModule } from '@skyux/indicators';
 import { SkyInlineDeleteModule } from '@skyux/layout';
 import { SkyThemeModule } from '@skyux/theme';
 
 import { AgGridModule } from 'ag-grid-angular';
+
+import { SkyAgGridResourcesModule } from '../shared/sky-ag-grid-resources.module';
 
 import { SkyAgGridDataManagerAdapterDirective } from './ag-grid-data-manager-adapter.directive';
 import { SkyAgGridRowDeleteComponent } from './ag-grid-row-delete.component';
@@ -50,8 +51,8 @@ import { SkyAgGridHeaderComponent } from './header/header.component';
     SkyAgGridCellRendererValidatorTooltipModule,
     SkyAgGridCellValidatorModule,
     SkyAgGridCellEditorTextModule,
+    SkyAgGridResourcesModule,
     SkyDataManagerModule,
-    SkyI18nModule,
     SkyIconModule,
     SkyInlineDeleteModule,
     SkyViewkeeperModule,

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/cell-editors/cell-editor-lookup/cell-editor-lookup.module.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/cell-editors/cell-editor-lookup/cell-editor-lookup.module.ts
@@ -2,7 +2,6 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
 import { SkyInputBoxModule } from '@skyux/forms';
-import { SkyI18nModule } from '@skyux/i18n';
 import { SkyLookupModule } from '@skyux/lookup';
 
 import { SkyAgGridCellEditorLookupComponent } from './cell-editor-lookup.component';
@@ -13,7 +12,6 @@ import { SkyAgGridCellEditorLookupComponent } from './cell-editor-lookup.compone
   imports: [
     CommonModule,
     ReactiveFormsModule,
-    SkyI18nModule,
     SkyInputBoxModule,
     SkyLookupModule,
   ],

--- a/libs/components/avatar/src/lib/modules/avatar/avatar.module.ts
+++ b/libs/components/avatar/src/lib/modules/avatar/avatar.module.ts
@@ -2,7 +2,6 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { SkyErrorModule } from '@skyux/errors';
 import { SkyFileAttachmentsModule, SkyFileSizePipe } from '@skyux/forms';
-import { SkyI18nModule } from '@skyux/i18n';
 import { SkyThemeModule } from '@skyux/theme';
 
 import { SkyAvatarResourcesModule } from '../shared/sky-avatar-resources.module';
@@ -17,7 +16,6 @@ import { SkyAvatarInnerComponent } from './avatar.inner.component';
     SkyAvatarResourcesModule,
     SkyErrorModule,
     SkyFileAttachmentsModule,
-    SkyI18nModule,
     SkyThemeModule,
   ],
   providers: [SkyFileSizePipe],

--- a/libs/components/colorpicker/src/lib/modules/colorpicker/colorpicker.module.ts
+++ b/libs/components/colorpicker/src/lib/modules/colorpicker/colorpicker.module.ts
@@ -2,7 +2,6 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { SkyAffixModule, SkyOverlayModule } from '@skyux/core';
 import { SkyInputBoxModule } from '@skyux/forms';
-import { SkyI18nModule } from '@skyux/i18n';
 import { SkyIconModule } from '@skyux/indicators';
 import { SkyThemeModule } from '@skyux/theme';
 
@@ -24,7 +23,6 @@ import { SkyColorpickerComponent } from './colorpicker.component';
     CommonModule,
     SkyAffixModule,
     SkyColorpickerResourcesModule,
-    SkyI18nModule,
     SkyIconModule,
     SkyInputBoxModule,
     SkyOverlayModule,

--- a/libs/components/core/src/lib/modules/numeric/numeric.module.ts
+++ b/libs/components/core/src/lib/modules/numeric/numeric.module.ts
@@ -1,5 +1,4 @@
 import { NgModule } from '@angular/core';
-import { SkyI18nModule } from '@skyux/i18n';
 
 import { SkyCoreResourcesModule } from '../shared/sky-core-resources.module';
 
@@ -8,7 +7,7 @@ import { SkyNumericPipe } from './numeric.pipe';
 @NgModule({
   declarations: [SkyNumericPipe],
   providers: [SkyNumericPipe],
-  imports: [SkyI18nModule, SkyCoreResourcesModule],
+  imports: [SkyCoreResourcesModule],
   exports: [SkyNumericPipe],
 })
 export class SkyNumericModule {}

--- a/libs/components/datetime/src/lib/modules/date-range-picker/date-range-picker.module.ts
+++ b/libs/components/datetime/src/lib/modules/date-range-picker/date-range-picker.module.ts
@@ -2,7 +2,6 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { SkyInputBoxModule } from '@skyux/forms';
-import { SkyI18nModule } from '@skyux/i18n';
 
 import { SkyDatepickerModule } from '../datepicker/datepicker.module';
 import { SkyDatetimeResourcesModule } from '../shared/sky-datetime-resources.module';
@@ -22,7 +21,6 @@ import { SkyDateRangeService } from './date-range.service';
     CommonModule,
     FormsModule,
     ReactiveFormsModule,
-    SkyI18nModule,
     SkyDatepickerModule,
     SkyDatetimeResourcesModule,
     SkyInputBoxModule,

--- a/libs/components/datetime/src/lib/modules/datepicker/datepicker.module.ts
+++ b/libs/components/datetime/src/lib/modules/datepicker/datepicker.module.ts
@@ -2,7 +2,6 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { SkyAffixModule, SkyOverlayModule } from '@skyux/core';
-import { SkyI18nModule } from '@skyux/i18n';
 import { SkyIconModule, SkyWaitModule } from '@skyux/indicators';
 import { SkyPopoverModule } from '@skyux/popovers';
 import { SkyThemeModule } from '@skyux/theme';
@@ -36,7 +35,6 @@ import { SkyYearPickerComponent } from './yearpicker.component';
   ],
   imports: [
     CommonModule,
-    SkyI18nModule,
     FormsModule,
     SkyIconModule,
     SkyDatetimeResourcesModule,

--- a/libs/components/datetime/src/lib/modules/timepicker/timepicker.module.ts
+++ b/libs/components/datetime/src/lib/modules/timepicker/timepicker.module.ts
@@ -1,7 +1,6 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { SkyAffixModule, SkyOverlayModule } from '@skyux/core';
-import { SkyI18nModule } from '@skyux/i18n';
 import { SkyIconModule } from '@skyux/indicators';
 import { SkyThemeModule } from '@skyux/theme';
 
@@ -14,7 +13,6 @@ import { SkyTimepickerInputDirective } from './timepicker.directive';
   declarations: [SkyTimepickerInputDirective, SkyTimepickerComponent],
   imports: [
     CommonModule,
-    SkyI18nModule,
     SkyIconModule,
     SkyDatetimeResourcesModule,
     SkyAffixModule,

--- a/libs/components/flyout/src/lib/modules/flyout/flyout.module.ts
+++ b/libs/components/flyout/src/lib/modules/flyout/flyout.module.ts
@@ -3,7 +3,6 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { RouterModule } from '@angular/router';
-import { SkyI18nModule } from '@skyux/i18n';
 import { SkyIconModule } from '@skyux/indicators';
 import { SkyHrefModule } from '@skyux/router';
 import { SkyThemeModule } from '@skyux/theme';
@@ -20,7 +19,6 @@ import { SkyFlyoutComponent } from './flyout.component';
     CommonModule,
     FormsModule,
     RouterModule,
-    SkyI18nModule,
     SkyIconModule,
     SkyFlyoutResourcesModule,
     SkyThemeModule,

--- a/libs/components/forms/src/lib/modules/character-counter/character-counter.module.ts
+++ b/libs/components/forms/src/lib/modules/character-counter/character-counter.module.ts
@@ -1,7 +1,6 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
-import { SkyI18nModule } from '@skyux/i18n';
 
 import { SkyFormsResourcesModule } from '../shared/sky-forms-resources.module';
 
@@ -18,7 +17,6 @@ import { SkyCharacterCounterInputDirective } from './character-counter.directive
     FormsModule,
     ReactiveFormsModule,
     SkyFormsResourcesModule,
-    SkyI18nModule,
   ],
   exports: [
     SkyCharacterCounterInputDirective,

--- a/libs/components/forms/src/lib/modules/file-attachment/file-attachments.module.ts
+++ b/libs/components/forms/src/lib/modules/file-attachment/file-attachments.module.ts
@@ -2,7 +2,6 @@ import { CommonModule, DecimalPipe } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { SkyTrimModule } from '@skyux/core';
-import { SkyI18nModule } from '@skyux/i18n';
 import { SkyIconModule } from '@skyux/indicators';
 import { SkyThemeModule } from '@skyux/theme';
 
@@ -27,7 +26,6 @@ import { SkyFileSizePipe } from './file-size.pipe';
     CommonModule,
     FormsModule,
     SkyFormsResourcesModule,
-    SkyI18nModule,
     SkyIconModule,
     SkyThemeModule,
     SkyTrimModule,

--- a/libs/components/indicators/src/lib/modules/alert/alert.module.ts
+++ b/libs/components/indicators/src/lib/modules/alert/alert.module.ts
@@ -1,6 +1,5 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
-import { SkyI18nModule } from '@skyux/i18n';
 import { SkyThemeModule } from '@skyux/theme';
 
 import { SkyIconModule } from '../icon/icon.module';
@@ -12,7 +11,6 @@ import { SkyAlertComponent } from './alert.component';
   declarations: [SkyAlertComponent],
   imports: [
     CommonModule,
-    SkyI18nModule,
     SkyIconModule,
     SkyIndicatorsResourcesModule,
     SkyThemeModule,

--- a/libs/components/indicators/src/lib/modules/chevron/chevron.module.ts
+++ b/libs/components/indicators/src/lib/modules/chevron/chevron.module.ts
@@ -1,6 +1,5 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
-import { SkyI18nModule } from '@skyux/i18n';
 import { SkyThemeModule } from '@skyux/theme';
 
 import { SkyExpansionIndicatorModule } from '../expansion-indicator/expansion-indicator.module';
@@ -12,7 +11,6 @@ import { SkyChevronComponent } from './chevron.component';
   declarations: [SkyChevronComponent],
   imports: [
     CommonModule,
-    SkyI18nModule,
     SkyIndicatorsResourcesModule,
     SkyThemeModule,
     SkyExpansionIndicatorModule,

--- a/libs/components/indicators/src/lib/modules/help-inline/help-inline.module.ts
+++ b/libs/components/indicators/src/lib/modules/help-inline/help-inline.module.ts
@@ -1,6 +1,5 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
-import { SkyI18nModule } from '@skyux/i18n';
 import { SkyThemeModule } from '@skyux/theme';
 
 import { SkyIconModule } from '../icon/icon.module';
@@ -13,7 +12,6 @@ import { SkyHelpInlineComponent } from './help-inline.component';
   declarations: [SkyHelpInlineComponent, SkyHelpInlineAriaExpandedPipe],
   imports: [
     CommonModule,
-    SkyI18nModule,
     SkyIconModule,
     SkyIndicatorsResourcesModule,
     SkyThemeModule,

--- a/libs/components/indicators/src/lib/modules/label/label.module.ts
+++ b/libs/components/indicators/src/lib/modules/label/label.module.ts
@@ -1,6 +1,5 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
-import { SkyI18nModule } from '@skyux/i18n';
 
 import { SkyIconModule } from '../icon/icon.module';
 import { SkyIndicatorsResourcesModule } from '../shared/sky-indicators-resources.module';
@@ -9,12 +8,7 @@ import { SkyLabelComponent } from './label.component';
 
 @NgModule({
   declarations: [SkyLabelComponent],
-  imports: [
-    CommonModule,
-    SkyI18nModule,
-    SkyIconModule,
-    SkyIndicatorsResourcesModule,
-  ],
+  imports: [CommonModule, SkyIconModule, SkyIndicatorsResourcesModule],
   exports: [SkyLabelComponent],
 })
 export class SkyLabelModule {}

--- a/libs/components/indicators/src/lib/modules/status-indicator/status-indicator.module.ts
+++ b/libs/components/indicators/src/lib/modules/status-indicator/status-indicator.module.ts
@@ -1,7 +1,6 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { SkyTrimModule } from '@skyux/core';
-import { SkyI18nModule } from '@skyux/i18n';
 
 import { SkyIconModule } from '../icon/icon.module';
 import { SkyIndicatorsResourcesModule } from '../shared/sky-indicators-resources.module';
@@ -12,7 +11,6 @@ import { SkyStatusIndicatorComponent } from './status-indicator.component';
   declarations: [SkyStatusIndicatorComponent],
   imports: [
     CommonModule,
-    SkyI18nModule,
     SkyIconModule,
     SkyIndicatorsResourcesModule,
     SkyTrimModule,

--- a/libs/components/indicators/src/lib/modules/tokens/tokens.module.ts
+++ b/libs/components/indicators/src/lib/modules/tokens/tokens.module.ts
@@ -1,6 +1,5 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
-import { SkyI18nModule } from '@skyux/i18n';
 
 import { SkyIconModule } from '../icon/icon.module';
 import { SkyIndicatorsResourcesModule } from '../shared/sky-indicators-resources.module';
@@ -10,12 +9,7 @@ import { SkyTokensComponent } from './tokens.component';
 
 @NgModule({
   declarations: [SkyTokenComponent, SkyTokensComponent],
-  imports: [
-    CommonModule,
-    SkyI18nModule,
-    SkyIconModule,
-    SkyIndicatorsResourcesModule,
-  ],
+  imports: [CommonModule, SkyIconModule, SkyIndicatorsResourcesModule],
   exports: [SkyTokenComponent, SkyTokensComponent],
 })
 export class SkyTokensModule {}

--- a/libs/components/indicators/src/lib/modules/wait/wait.module.ts
+++ b/libs/components/indicators/src/lib/modules/wait/wait.module.ts
@@ -1,6 +1,5 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
-import { SkyI18nModule } from '@skyux/i18n';
 
 import { SkyIndicatorsResourcesModule } from '../shared/sky-indicators-resources.module';
 
@@ -9,7 +8,7 @@ import { SkyWaitComponent } from './wait.component';
 
 @NgModule({
   declarations: [SkyWaitComponent, SkyWaitPageComponent],
-  imports: [CommonModule, SkyI18nModule, SkyIndicatorsResourcesModule],
+  imports: [CommonModule, SkyIndicatorsResourcesModule],
   exports: [SkyWaitComponent],
 })
 export class SkyWaitModule {}

--- a/libs/components/layout/src/lib/modules/back-to-top/back-to-top.module.ts
+++ b/libs/components/layout/src/lib/modules/back-to-top/back-to-top.module.ts
@@ -1,7 +1,6 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { SkyDockModule } from '@skyux/core';
-import { SkyI18nModule } from '@skyux/i18n';
 import { SkyThemeModule } from '@skyux/theme';
 
 import { SkyLayoutResourcesModule } from '../shared/sky-layout-resources.module';
@@ -14,7 +13,6 @@ import { SkyBackToTopDirective } from './back-to-top.directive';
   imports: [
     CommonModule,
     SkyDockModule,
-    SkyI18nModule,
     SkyLayoutResourcesModule,
     SkyThemeModule,
   ],

--- a/libs/components/layout/src/lib/modules/card/card.module.ts
+++ b/libs/components/layout/src/lib/modules/card/card.module.ts
@@ -2,7 +2,6 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { SkyCheckboxModule } from '@skyux/forms';
-import { SkyI18nModule } from '@skyux/i18n';
 
 import { SkyInlineDeleteModule } from '../inline-delete/inline-delete.module';
 import { SkyLayoutResourcesModule } from '../shared/sky-layout-resources.module';
@@ -26,7 +25,6 @@ import { SkyCardComponent } from './card.component';
     CommonModule,
     FormsModule,
     SkyCheckboxModule,
-    SkyI18nModule,
     SkyLayoutResourcesModule,
     SkyInlineDeleteModule,
   ],

--- a/libs/components/layout/src/lib/modules/definition-list/definition-list.module.ts
+++ b/libs/components/layout/src/lib/modules/definition-list/definition-list.module.ts
@@ -1,6 +1,5 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
-import { SkyI18nModule } from '@skyux/i18n';
 
 import { SkyLayoutResourcesModule } from '../shared/sky-layout-resources.module';
 
@@ -21,7 +20,7 @@ import { SkyDefinitionListComponent } from './definition-list.component';
     SkyDefinitionListLabelComponent,
     SkyDefinitionListValueComponent,
   ],
-  imports: [CommonModule, SkyI18nModule, SkyLayoutResourcesModule],
+  imports: [CommonModule, SkyLayoutResourcesModule],
   exports: [
     SkyDefinitionListComponent,
     SkyDefinitionListContentComponent,

--- a/libs/components/layout/src/lib/modules/description-list/description-list.module.ts
+++ b/libs/components/layout/src/lib/modules/description-list/description-list.module.ts
@@ -1,7 +1,6 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { SkyTrimModule } from '@skyux/core';
-import { SkyI18nModule } from '@skyux/i18n';
 import { SkyThemeModule } from '@skyux/theme';
 
 import { SkyLayoutResourcesModule } from '../shared/sky-layout-resources.module';
@@ -20,7 +19,6 @@ import { SkyDescriptionListComponent } from './description-list.component';
   ],
   imports: [
     CommonModule,
-    SkyI18nModule,
     SkyLayoutResourcesModule,
     SkyThemeModule,
     SkyTrimModule,

--- a/libs/components/layout/src/lib/modules/inline-delete/inline-delete.module.ts
+++ b/libs/components/layout/src/lib/modules/inline-delete/inline-delete.module.ts
@@ -1,6 +1,5 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
-import { SkyI18nModule } from '@skyux/i18n';
 import { SkyWaitModule } from '@skyux/indicators';
 
 import { SkyLayoutResourcesModule } from '../shared/sky-layout-resources.module';
@@ -9,12 +8,7 @@ import { SkyInlineDeleteComponent } from './inline-delete.component';
 
 @NgModule({
   declarations: [SkyInlineDeleteComponent],
-  imports: [
-    CommonModule,
-    SkyI18nModule,
-    SkyLayoutResourcesModule,
-    SkyWaitModule,
-  ],
+  imports: [CommonModule, SkyLayoutResourcesModule, SkyWaitModule],
   exports: [SkyInlineDeleteComponent],
 })
 export class SkyInlineDeleteModule {}

--- a/libs/components/layout/src/lib/modules/text-expand-repeater/text-expand-repeater.module.ts
+++ b/libs/components/layout/src/lib/modules/text-expand-repeater/text-expand-repeater.module.ts
@@ -1,6 +1,5 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
-import { SkyI18nModule } from '@skyux/i18n';
 
 import { SkyLayoutResourcesModule } from '../shared/sky-layout-resources.module';
 
@@ -8,7 +7,7 @@ import { SkyTextExpandRepeaterComponent } from './text-expand-repeater.component
 
 @NgModule({
   declarations: [SkyTextExpandRepeaterComponent],
-  imports: [SkyI18nModule, SkyLayoutResourcesModule, CommonModule],
+  imports: [SkyLayoutResourcesModule, CommonModule],
   exports: [SkyTextExpandRepeaterComponent],
 })
 export class SkyTextExpandRepeaterModule {}

--- a/libs/components/layout/src/lib/modules/text-expand/text-expand.module.ts
+++ b/libs/components/layout/src/lib/modules/text-expand/text-expand.module.ts
@@ -1,6 +1,5 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
-import { SkyI18nModule } from '@skyux/i18n';
 import { SkyModalModule } from '@skyux/modals';
 
 import { SkyLayoutResourcesModule } from '../shared/sky-layout-resources.module';
@@ -10,12 +9,7 @@ import { SkyTextExpandComponent } from './text-expand.component';
 
 @NgModule({
   declarations: [SkyTextExpandComponent, SkyTextExpandModalComponent],
-  imports: [
-    SkyI18nModule,
-    SkyLayoutResourcesModule,
-    SkyModalModule,
-    CommonModule,
-  ],
+  imports: [SkyLayoutResourcesModule, SkyModalModule, CommonModule],
   exports: [SkyTextExpandComponent],
 })
 export class SkyTextExpandModule {}

--- a/libs/components/list-builder-view-grids/src/lib/modules/column-selector/column-selector-modal.module.ts
+++ b/libs/components/list-builder-view-grids/src/lib/modules/column-selector/column-selector-modal.module.ts
@@ -1,9 +1,10 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
-import { SkyI18nModule } from '@skyux/i18n';
 import { SkyListModule, SkyListToolbarModule } from '@skyux/list-builder';
 import { SkyListViewChecklistModule } from '@skyux/list-builder-view-checklist';
 import { SkyModalModule } from '@skyux/modals';
+
+import { SkyListBuilderViewGridsResourcesModule } from '../shared/sky-list-builder-view-grids-resources.module';
 
 import { SkyColumnSelectorComponent } from './column-selector-modal.component';
 
@@ -14,8 +15,8 @@ import { SkyColumnSelectorComponent } from './column-selector-modal.component';
   declarations: [SkyColumnSelectorComponent],
   imports: [
     CommonModule,
-    SkyI18nModule,
     SkyModalModule,
+    SkyListBuilderViewGridsResourcesModule,
     SkyListModule,
     SkyListToolbarModule,
     SkyListViewChecklistModule,

--- a/libs/components/list-builder-view-grids/src/lib/modules/list-column-selector-action/list-column-selector-action.module.ts
+++ b/libs/components/list-builder-view-grids/src/lib/modules/list-column-selector-action/list-column-selector-action.module.ts
@@ -1,6 +1,5 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
-import { SkyI18nModule } from '@skyux/i18n';
 import { SkyIconModule } from '@skyux/indicators';
 import {
   SkyListSecondaryActionsModule,
@@ -9,6 +8,7 @@ import {
 import { SkyModalModule } from '@skyux/modals';
 
 import { SkyColumnSelectorModule } from '../column-selector/column-selector-modal.module';
+import { SkyListBuilderViewGridsResourcesModule } from '../shared/sky-list-builder-view-grids-resources.module';
 
 import { SkyListColumnSelectorActionComponent } from './list-column-selector-action.component';
 import { SkyListColumnSelectorButtonComponent } from './list-column-selector-button.component';
@@ -23,8 +23,8 @@ import { SkyListColumnSelectorButtonComponent } from './list-column-selector-but
   ],
   imports: [
     CommonModule,
-    SkyI18nModule,
     SkyModalModule,
+    SkyListBuilderViewGridsResourcesModule,
     SkyListSecondaryActionsModule,
     SkyListToolbarModule,
     SkyIconModule,

--- a/libs/components/list-builder/src/lib/modules/list-toolbar/list-secondary-actions/list-secondary-actions.module.ts
+++ b/libs/components/list-builder/src/lib/modules/list-toolbar/list-secondary-actions/list-secondary-actions.module.ts
@@ -1,6 +1,5 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
-import { SkyI18nModule } from '@skyux/i18n';
 import { SkyIconModule } from '@skyux/indicators';
 import { SkyDropdownModule } from '@skyux/popovers';
 
@@ -22,7 +21,6 @@ import { SkyListSecondaryActionsComponent } from './list-secondary-actions.compo
   imports: [
     CommonModule,
     SkyDropdownModule,
-    SkyI18nModule,
     SkyIconModule,
     SkyListBuilderResourcesModule,
   ],

--- a/libs/components/list-builder/src/lib/modules/list-toolbar/list-toolbar.module.ts
+++ b/libs/components/list-builder/src/lib/modules/list-toolbar/list-toolbar.module.ts
@@ -1,7 +1,6 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { SkyCheckboxModule } from '@skyux/forms';
-import { SkyI18nModule } from '@skyux/i18n';
 import { SkyIconModule } from '@skyux/indicators';
 import { SkyToolbarModule } from '@skyux/layout';
 import { SkyFilterModule, SkySortModule } from '@skyux/lists';
@@ -34,7 +33,6 @@ import { SkyListToolbarComponent } from './list-toolbar.component';
   imports: [
     CommonModule,
     SkyCheckboxModule,
-    SkyI18nModule,
     SkyToolbarModule,
     SkySearchModule,
     SkySortModule,

--- a/libs/components/lookup/src/lib/modules/country-field/country-field.module.ts
+++ b/libs/components/lookup/src/lib/modules/country-field/country-field.module.ts
@@ -1,7 +1,6 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
-import { SkyI18nModule } from '@skyux/i18n';
 import { SkyIconModule } from '@skyux/indicators';
 import { SkyThemeModule } from '@skyux/theme';
 
@@ -18,7 +17,6 @@ import { SkyCountryFieldComponent } from './country-field.component';
     ReactiveFormsModule,
     SkyAutocompleteModule,
     SkyIconModule,
-    SkyI18nModule,
     SkyLookupResourcesModule,
     SkyThemeModule,
   ],

--- a/libs/components/lookup/src/lib/modules/lookup/lookup.module.ts
+++ b/libs/components/lookup/src/lib/modules/lookup/lookup.module.ts
@@ -3,7 +3,6 @@ import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { SkyViewkeeperModule } from '@skyux/core';
 import { SkyCheckboxModule } from '@skyux/forms';
-import { SkyI18nModule } from '@skyux/i18n';
 import {
   SkyIconModule,
   SkyTokensModule,
@@ -31,7 +30,6 @@ import { SkyLookupComponent } from './lookup.component';
     SkyCheckboxModule,
     SkyIconModule,
     SkyInfiniteScrollModule,
-    SkyI18nModule,
     SkyLookupResourcesModule,
     SkyModalModule,
     SkyRepeaterModule,

--- a/libs/components/lookup/src/lib/modules/selection-modal/selection-modal.module.ts
+++ b/libs/components/lookup/src/lib/modules/selection-modal/selection-modal.module.ts
@@ -2,7 +2,6 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { SkyViewkeeperModule } from '@skyux/core';
 import { SkyCheckboxModule } from '@skyux/forms';
-import { SkyI18nModule } from '@skyux/i18n';
 import { SkyIconModule, SkyWaitModule } from '@skyux/indicators';
 import { SkyToolbarModule } from '@skyux/layout';
 import { SkyInfiniteScrollModule, SkyRepeaterModule } from '@skyux/lists';
@@ -10,6 +9,7 @@ import { SkyModalModule } from '@skyux/modals';
 import { SkyThemeModule } from '@skyux/theme';
 
 import { SkySearchModule } from '../search/search.module';
+import { SkyLookupResourcesModule } from '../shared/sky-lookup-resources.module';
 
 import { SkySelectionModalItemSelectedPipe } from './selection-modal-item-selected.pipe';
 import { SkySelectionModalComponent } from './selection-modal.component';
@@ -19,9 +19,9 @@ import { SkySelectionModalComponent } from './selection-modal.component';
   imports: [
     CommonModule,
     SkyCheckboxModule,
-    SkyI18nModule,
     SkyIconModule,
     SkyInfiniteScrollModule,
+    SkyLookupResourcesModule,
     SkyModalModule,
     SkyRepeaterModule,
     SkySearchModule,

--- a/libs/components/pages/src/lib/modules/action-hub/action-hub.module.ts
+++ b/libs/components/pages/src/lib/modules/action-hub/action-hub.module.ts
@@ -1,6 +1,5 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
-import { SkyI18nModule } from '@skyux/i18n';
 import { SkyWaitModule } from '@skyux/indicators';
 import { SkyBoxModule, SkyFluidGridModule } from '@skyux/layout';
 import { SkyThemeModule } from '@skyux/theme';
@@ -22,7 +21,6 @@ import { SkyActionHubComponent } from './action-hub.component';
     CommonModule,
     SkyBoxModule,
     SkyFluidGridModule,
-    SkyI18nModule,
     SkyLinkListModule,
     SkyModalLinkListModule,
     SkyNeedsAttentionModule,

--- a/libs/components/pages/src/lib/modules/link-list/link-list.module.ts
+++ b/libs/components/pages/src/lib/modules/link-list/link-list.module.ts
@@ -1,6 +1,5 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
-import { SkyI18nModule } from '@skyux/i18n';
 import { SkyWaitModule } from '@skyux/indicators';
 import { SkyAppLinkModule, SkyHrefModule } from '@skyux/router';
 import { SkyThemeModule } from '@skyux/theme';
@@ -16,7 +15,6 @@ import { SkyLinkListComponent } from './link-list.component';
     CommonModule,
     SkyAppLinkModule,
     SkyHrefModule,
-    SkyI18nModule,
     SkyThemeModule,
     SkyWaitModule,
     LinkAsModule,

--- a/libs/components/pages/src/lib/modules/modal-link-list/modal-link-list.module.ts
+++ b/libs/components/pages/src/lib/modules/modal-link-list/modal-link-list.module.ts
@@ -1,6 +1,5 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
-import { SkyI18nModule } from '@skyux/i18n';
 import { SkyWaitModule } from '@skyux/indicators';
 import { SkyAppLinkModule, SkyHrefModule } from '@skyux/router';
 
@@ -15,7 +14,6 @@ import { SkyModalLinkListComponent } from './modal-link-list.component';
     CommonModule,
     SkyAppLinkModule,
     SkyHrefModule,
-    SkyI18nModule,
     SkyWaitModule,
     LinkAsModule,
   ],

--- a/libs/components/pages/src/lib/modules/needs-attention/needs-attention.module.ts
+++ b/libs/components/pages/src/lib/modules/needs-attention/needs-attention.module.ts
@@ -1,7 +1,6 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { SkyTrimModule } from '@skyux/core';
-import { SkyI18nModule } from '@skyux/i18n';
 import { SkyIconModule, SkyWaitModule } from '@skyux/indicators';
 import { SkyBoxModule } from '@skyux/layout';
 import { SkyAppLinkModule, SkyHrefModule } from '@skyux/router';
@@ -20,7 +19,6 @@ import { SkyNeedsAttentionComponent } from './needs-attention.component';
     SkyAppLinkModule,
     SkyBoxModule,
     SkyHrefModule,
-    SkyI18nModule,
     SkyIconModule,
     SkyPagesResourcesModule,
     SkyThemeModule,

--- a/libs/components/phone-field/src/lib/modules/phone-field/phone-field.module.ts
+++ b/libs/components/phone-field/src/lib/modules/phone-field/phone-field.module.ts
@@ -1,7 +1,6 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
-import { SkyI18nModule } from '@skyux/i18n';
 import { SkyIconModule } from '@skyux/indicators';
 import { SkyCountryFieldModule } from '@skyux/lookup';
 import { SkyThemeModule } from '@skyux/theme';
@@ -18,7 +17,6 @@ import { SkyPhoneFieldComponent } from './phone-field.component';
     FormsModule,
     ReactiveFormsModule,
     SkyCountryFieldModule,
-    SkyI18nModule,
     SkyIconModule,
     SkyPhoneFieldResourcesModule,
     SkyThemeModule,

--- a/libs/components/progress-indicator/src/lib/modules/progress-indicator/progress-indicator.module.ts
+++ b/libs/components/progress-indicator/src/lib/modules/progress-indicator/progress-indicator.module.ts
@@ -1,7 +1,6 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { SkyTrimModule } from '@skyux/core';
-import { SkyI18nModule } from '@skyux/i18n';
 import { SkyIconModule } from '@skyux/indicators';
 import { SkyThemeModule } from '@skyux/theme';
 
@@ -31,7 +30,6 @@ import { SkyProgressIndicatorComponent } from './progress-indicator.component';
   ],
   imports: [
     CommonModule,
-    SkyI18nModule,
     SkyIconModule,
     SkyProgressIndicatorResourcesModule,
     SkyThemeModule,

--- a/libs/components/select-field/src/lib/modules/select-field/select-field.module.ts
+++ b/libs/components/select-field/src/lib/modules/select-field/select-field.module.ts
@@ -1,7 +1,6 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
-import { SkyI18nModule } from '@skyux/i18n';
 import { SkyIconModule, SkyTokensModule } from '@skyux/indicators';
 import {
   SkyListFiltersModule,
@@ -26,7 +25,6 @@ import { SkySelectFieldComponent } from './select-field.component';
     FormsModule,
     ReactiveFormsModule,
     SkySelectFieldResourcesModule,
-    SkyI18nModule,
     SkyListFiltersModule,
     SkyListModule,
     SkyListPagingModule,

--- a/libs/components/tabs/src/lib/modules/tabs/tabs.module.ts
+++ b/libs/components/tabs/src/lib/modules/tabs/tabs.module.ts
@@ -1,7 +1,6 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { RouterModule } from '@angular/router';
-import { SkyI18nModule } from '@skyux/i18n';
 import { SkyIconModule } from '@skyux/indicators';
 import { SkyDropdownModule } from '@skyux/popovers';
 import { SkyThemeModule } from '@skyux/theme';
@@ -26,7 +25,6 @@ import { SkyTabsetComponent } from './tabset.component';
     CommonModule,
     RouterModule,
     SkyDropdownModule,
-    SkyI18nModule,
     SkyIconModule,
     SkyTabsResourcesModule,
     SkyThemeModule,

--- a/libs/components/text-editor/src/lib/modules/text-editor/text-editor.module.ts
+++ b/libs/components/text-editor/src/lib/modules/text-editor/text-editor.module.ts
@@ -4,7 +4,6 @@ import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { SkyColorpickerModule } from '@skyux/colorpicker';
 import { SkyCoreAdapterModule, SkyIdModule } from '@skyux/core';
 import { SkyCheckboxModule, SkyInputBoxModule } from '@skyux/forms';
-import { SkyI18nModule } from '@skyux/i18n';
 import { SkyIconModule } from '@skyux/indicators';
 import { SkyToolbarModule } from '@skyux/layout';
 import { SkyModalModule } from '@skyux/modals';
@@ -26,7 +25,6 @@ import { SkyTextEditorUrlModalComponent } from './url-modal/text-editor-url-moda
     ReactiveFormsModule,
     SkyCoreAdapterModule,
     SkyTextEditorResourcesModule,
-    SkyI18nModule,
     SkyIconModule,
     SkyIdModule,
     SkyInputBoxModule,

--- a/libs/components/tiles/src/lib/modules/tiles/tile/tile.module.ts
+++ b/libs/components/tiles/src/lib/modules/tiles/tile/tile.module.ts
@@ -1,7 +1,6 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { SkyIdModule, SkyTrimModule } from '@skyux/core';
-import { SkyI18nModule } from '@skyux/i18n';
 import { SkyChevronModule, SkyIconModule } from '@skyux/indicators';
 import { SkyThemeModule } from '@skyux/theme';
 
@@ -21,7 +20,6 @@ import { SkyTileComponent } from './tile.component';
     CommonModule,
     SkyChevronModule,
     SkyIdModule,
-    SkyI18nModule,
     SkyIconModule,
     SkyThemeModule,
     SkyTilesResourcesModule,

--- a/libs/components/toast/src/lib/modules/toast/toast.module.ts
+++ b/libs/components/toast/src/lib/modules/toast/toast.module.ts
@@ -1,6 +1,5 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
-import { SkyI18nModule } from '@skyux/i18n';
 import { SkyIconModule } from '@skyux/indicators';
 
 import { SkyToastResourcesModule } from '../shared/sky-toast-resources.module';
@@ -11,12 +10,7 @@ import { SkyToasterComponent } from './toaster.component';
 
 @NgModule({
   declarations: [SkyToastBodyComponent, SkyToastComponent, SkyToasterComponent],
-  imports: [
-    CommonModule,
-    SkyI18nModule,
-    SkyIconModule,
-    SkyToastResourcesModule,
-  ],
+  imports: [CommonModule, SkyIconModule, SkyToastResourcesModule],
   exports: [SkyToastComponent],
 })
 export class SkyToastModule {}


### PR DESCRIPTION
The "resources" modules for every library already export `SkyI18nModule`, so we can safely remove these from the modules' imports.