### PR TITLE
fix(components/toast)!: move `SkyToastService` to `SkyToastModule` providers

### DIFF
--- a/apps/integration/src/app/integrations/toast/toast.component.spec.ts
+++ b/apps/integration/src/app/integrations/toast/toast.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { SkyToastModule } from '@skyux/toast';
 
 import { ToastComponent } from './toast.component';
 
@@ -9,6 +10,7 @@ describe('ToastComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       declarations: [ToastComponent],
+      imports: [SkyToastModule],
     }).compileComponents();
 
     fixture = TestBed.createComponent(ToastComponent);

--- a/libs/components/toast/src/lib/modules/toast/toast.module.ts
+++ b/libs/components/toast/src/lib/modules/toast/toast.module.ts
@@ -7,6 +7,7 @@ import { SkyToastResourcesModule } from '../shared/sky-toast-resources.module';
 
 import { SkyToastBodyComponent } from './toast-body.component';
 import { SkyToastComponent } from './toast.component';
+import { SkyToastService } from './toast.service';
 import { SkyToasterComponent } from './toaster.component';
 
 @NgModule({
@@ -18,5 +19,6 @@ import { SkyToasterComponent } from './toaster.component';
     SkyToastResourcesModule,
   ],
   exports: [SkyToastComponent],
+  providers: [SkyToastService],
 })
 export class SkyToastModule {}

--- a/libs/components/toast/src/lib/modules/toast/toast.service.ts
+++ b/libs/components/toast/src/lib/modules/toast/toast.service.ts
@@ -22,9 +22,7 @@ import { SkyToastInstance } from './toast-instance';
 import { SkyToasterComponent } from './toaster.component';
 import { SkyToastConfig } from './types/toast-config';
 
-@Injectable({
-  providedIn: 'root',
-})
+@Injectable()
 export class SkyToastService implements OnDestroy {
   /**
    * @internal


### PR DESCRIPTION
BREAKING CHANGE: The `SkyToastService` cannot be used in isolation; any component that injects `SkyToastService` must also import `SkyToastModule` into its module's providers.