### PR TITLE
fix(components/flyout): move `SkyFlyoutService` to `SkyFlyoutModule` providers

### DIFF
--- a/apps/playground/src/app/components/core/resize-observer/flyout/resize-observer-flyout.module.ts
+++ b/apps/playground/src/app/components/core/resize-observer/flyout/resize-observer-flyout.module.ts
@@ -4,6 +4,7 @@ import {
   SkyMediaQueryService,
   SkyResizeObserverMediaQueryService,
 } from '@skyux/core';
+import { SkyFlyoutModule } from '@skyux/flyout';
 import { SkyIconModule } from '@skyux/indicators';
 import { SkySectionedFormModule } from '@skyux/tabs';
 
@@ -12,7 +13,12 @@ import { ResizeObserverFlyoutComponent } from './resize-observer-flyout.componen
 
 @NgModule({
   declarations: [ResizeObserverFlyoutComponent, ResizeObserverContentComponent],
-  imports: [CommonModule, SkyIconModule, SkySectionedFormModule],
+  imports: [
+    CommonModule,
+    SkyFlyoutModule,
+    SkyIconModule,
+    SkySectionedFormModule,
+  ],
   exports: [ResizeObserverFlyoutComponent],
   providers: [
     SkyResizeObserverMediaQueryService,

--- a/apps/playground/src/app/components/flyout/flyout/flyout-demo.component.ts
+++ b/apps/playground/src/app/components/flyout/flyout/flyout-demo.component.ts
@@ -1,6 +1,5 @@
 import { ChangeDetectorRef, Component, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
-import { SkyFlyoutService } from '@skyux/flyout';
 import { SkyModalService } from '@skyux/modals';
 import { SkyToastService, SkyToastType } from '@skyux/toast';
 
@@ -10,7 +9,6 @@ import { FlyoutModalDemoComponent } from './flyout-modal.component';
 @Component({
   selector: 'app-flyout-demo',
   templateUrl: './flyout-demo.component.html',
-  providers: [SkyFlyoutService],
 })
 export class FlyoutDemoComponent implements OnInit {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/apps/playground/src/app/components/flyout/flyout/flyout-responsive-demo.component.ts
+++ b/apps/playground/src/app/components/flyout/flyout/flyout-responsive-demo.component.ts
@@ -1,9 +1,7 @@
 import { Component } from '@angular/core';
-import { SkyFlyoutService } from '@skyux/flyout';
 
 @Component({
   selector: 'app-flyout-responsive-demo',
   templateUrl: './flyout-responsive-demo.component.html',
-  providers: [SkyFlyoutService],
 })
 export class FlyoutResponsiveDemoComponent {}

--- a/apps/playground/src/app/components/flyout/flyout/flyout.module.ts
+++ b/apps/playground/src/app/components/flyout/flyout/flyout.module.ts
@@ -5,6 +5,7 @@ import { SkyFlyoutModule } from '@skyux/flyout';
 import { SkyInfiniteScrollModule } from '@skyux/lists';
 import { SkyModalModule } from '@skyux/modals';
 import { SkyDropdownModule } from '@skyux/popovers';
+import { SkyToastModule } from '@skyux/toast';
 
 import { DataManagerFlyoutModule } from './data-manager/data-manager-flyout.module';
 import { FlyoutDemoComponent } from './flyout-demo.component';
@@ -30,6 +31,7 @@ import { FlyoutComponent } from './flyout.component';
     SkyFlyoutModule,
     SkyInfiniteScrollModule,
     SkyModalModule,
+    SkyToastModule,
     RouterModule,
   ],
 })

--- a/libs/components/flyout/src/lib/modules/flyout/flyout.module.ts
+++ b/libs/components/flyout/src/lib/modules/flyout/flyout.module.ts
@@ -12,6 +12,7 @@ import { SkyFlyoutResourcesModule } from '../shared/sky-flyout-resources.module'
 
 import { SkyFlyoutIteratorComponent } from './flyout-iterator.component';
 import { SkyFlyoutComponent } from './flyout.component';
+import { SkyFlyoutService } from './flyout.service';
 
 @NgModule({
   declarations: [SkyFlyoutComponent, SkyFlyoutIteratorComponent],
@@ -27,5 +28,6 @@ import { SkyFlyoutComponent } from './flyout.component';
     SkyHrefModule,
   ],
   exports: [SkyFlyoutComponent],
+  providers: [SkyFlyoutService],
 })
 export class SkyFlyoutModule {}

--- a/libs/components/flyout/src/lib/modules/flyout/flyout.service.ts
+++ b/libs/components/flyout/src/lib/modules/flyout/flyout.service.ts
@@ -1,9 +1,11 @@
 import {
   ComponentRef,
+  EnvironmentInjector,
   Injectable,
   NgZone,
   OnDestroy,
   Type,
+  inject,
 } from '@angular/core';
 import { NavigationStart, Router } from '@angular/router';
 import {
@@ -27,9 +29,7 @@ import { SkyFlyoutMessageType } from './types/flyout-message-type';
  * This service dynamically generates the flyout component and appends it directly to the
  * document's `body` element. The `SkyFlyoutInstance` class watches for and triggers flyout events.
  */
-@Injectable({
-  providedIn: 'any',
-})
+@Injectable()
 export class SkyFlyoutService implements OnDestroy {
   #host: ComponentRef<SkyFlyoutComponent> | undefined;
   #removeAfterClosed = false;
@@ -37,6 +37,7 @@ export class SkyFlyoutService implements OnDestroy {
   #ngUnsubscribe = new Subject<boolean>();
 
   #coreAdapter: SkyCoreAdapterService;
+  #environmentInjector = inject(EnvironmentInjector);
   #windowRef: SkyAppWindowRef;
   #dynamicComponentService: SkyDynamicComponentService;
   #router: Router;
@@ -120,8 +121,12 @@ export class SkyFlyoutService implements OnDestroy {
   }
 
   #createHostComponent(): ComponentRef<SkyFlyoutComponent> {
-    this.#host =
-      this.#dynamicComponentService.createComponent(SkyFlyoutComponent);
+    this.#host = this.#dynamicComponentService.createComponent(
+      SkyFlyoutComponent,
+      {
+        environmentInjector: this.#environmentInjector,
+      }
+    );
     return this.#host;
   }
 


### PR DESCRIPTION
BREAKING CHANGE: The `SkyFlyoutService` cannot be used in isolation; any component that injects `SkyFlyoutService` must also import `SkyFlyoutModule` into its module's providers.