### PR TITLE
fix(components/core)!: move `SkyNumericService` to `SkyNumericModule` providers

### DIFF
--- a/libs/components/core/src/lib/modules/numeric/numeric.module.ts
+++ b/libs/components/core/src/lib/modules/numeric/numeric.module.ts
@@ -4,10 +4,11 @@ import { SkyI18nModule } from '@skyux/i18n';
 import { SkyCoreResourcesModule } from '../shared/sky-core-resources.module';
 
 import { SkyNumericPipe } from './numeric.pipe';
+import { SkyNumericService } from './numeric.service';
 
 @NgModule({
   declarations: [SkyNumericPipe],
-  providers: [SkyNumericPipe],
+  providers: [SkyNumericPipe, SkyNumericService],
   imports: [SkyI18nModule, SkyCoreResourcesModule],
   exports: [SkyNumericPipe],
 })

--- a/libs/components/core/src/lib/modules/numeric/numeric.service.ts
+++ b/libs/components/core/src/lib/modules/numeric/numeric.service.ts
@@ -6,9 +6,7 @@ import { SkyNumberFormatUtility } from '../shared/number-format/number-format-ut
 import { SkyNumericSymbol } from './numeric-symbol';
 import { SkyNumericOptions } from './numeric.options';
 
-@Injectable({
-  providedIn: 'any',
-})
+@Injectable()
 export class SkyNumericService {
   /**
    * The browser's current locale.


### PR DESCRIPTION
BREAKING CHANGE: The `SkyNumericService` cannot be used in isolation; any component that injects `SkyNumericService` must also import `SkyNumericModule` into its module's providers.