### PR TITLE
fix(components/indicators)!: move `SkyWaitService` to `SkyWaitModule` providers

### DIFF
--- a/libs/components/indicators/src/lib/modules/wait/wait.module.ts
+++ b/libs/components/indicators/src/lib/modules/wait/wait.module.ts
@@ -6,10 +6,12 @@ import { SkyIndicatorsResourcesModule } from '../shared/sky-indicators-resources
 
 import { SkyWaitPageComponent } from './wait-page.component';
 import { SkyWaitComponent } from './wait.component';
+import { SkyWaitService } from './wait.service';
 
 @NgModule({
   declarations: [SkyWaitComponent, SkyWaitPageComponent],
   imports: [CommonModule, SkyI18nModule, SkyIndicatorsResourcesModule],
   exports: [SkyWaitComponent],
+  providers: [SkyWaitService],
 })
 export class SkyWaitModule {}

--- a/libs/components/indicators/src/lib/modules/wait/wait.service.ts
+++ b/libs/components/indicators/src/lib/modules/wait/wait.service.ts
@@ -1,4 +1,9 @@
-import { ComponentRef, Injectable, inject } from '@angular/core';
+import {
+  ComponentRef,
+  EnvironmentInjector,
+  Injectable,
+  inject,
+} from '@angular/core';
 import {
   SkyAppWindowRef,
   SkyDynamicComponentLocation,
@@ -15,15 +20,11 @@ let waitComponentRef: ComponentRef<SkyWaitPageComponent> | undefined;
 let pageWaitBlockingCount = 0;
 let pageWaitNonBlockingCount = 0;
 
-// Need to add the following to classes which contain static methods.
-// See: https://github.com/ng-packagr/ng-packagr/issues/641
-// @dynamic
-@Injectable({
-  providedIn: 'root',
-})
+@Injectable()
 export class SkyWaitService {
   #windowSvc = inject(SkyAppWindowRef);
   #dynamicComponentService = inject(SkyDynamicComponentService);
+  #environmentInjector = inject(EnvironmentInjector);
 
   /**
    * Starts a blocking page wait on the page.
@@ -120,7 +121,10 @@ export class SkyWaitService {
         if (!waitComponent) {
           waitComponentRef = this.#dynamicComponentService.createComponent(
             SkyWaitPageComponent,
-            { location: SkyDynamicComponentLocation.BodyBottom }
+            {
+              environmentInjector: this.#environmentInjector,
+              location: SkyDynamicComponentLocation.BodyBottom,
+            }
           );
           waitComponent = waitComponentRef.instance;
         }


### PR DESCRIPTION
BREAKING CHANGE: The `SkyWaitService` cannot be used in isolation; any component that injects `SkyWaitService` must also import `SkyWaitModule` into its module's providers.