### PR TITLE
fix(components/lookup)!: move `SkySelectionModalService` to `SkySelectionModalModule` providers

### DIFF
--- a/libs/components/lookup/src/lib/modules/selection-modal/selection-modal.module.ts
+++ b/libs/components/lookup/src/lib/modules/selection-modal/selection-modal.module.ts
@@ -13,6 +13,7 @@ import { SkySearchModule } from '../search/search.module';
 
 import { SkySelectionModalItemSelectedPipe } from './selection-modal-item-selected.pipe';
 import { SkySelectionModalComponent } from './selection-modal.component';
+import { SkySelectionModalService } from './selection-modal.service';
 
 @NgModule({
   declarations: [SkySelectionModalComponent, SkySelectionModalItemSelectedPipe],
@@ -30,5 +31,6 @@ import { SkySelectionModalComponent } from './selection-modal.component';
     SkyViewkeeperModule,
     SkyWaitModule,
   ],
+  providers: [SkySelectionModalService],
 })
 export class SkySelectionModalModule {}

--- a/libs/components/lookup/src/lib/modules/selection-modal/selection-modal.service.spec.ts
+++ b/libs/components/lookup/src/lib/modules/selection-modal/selection-modal.service.spec.ts
@@ -11,6 +11,7 @@ import { Subject } from 'rxjs';
 import { SkyLookupAddClickEventArgs } from '../lookup/types/lookup-add-click-event-args';
 
 import { SkySelectionModalComponent } from './selection-modal.component';
+import { SkySelectionModalModule } from './selection-modal.module';
 import { SkySelectionModalService } from './selection-modal.service';
 import { SkySelectionModalContext } from './types/selection-modal-context';
 import { SkySelectionModalOpenArgs } from './types/selection-modal-open-args';
@@ -63,6 +64,7 @@ describe('Selection modal service', () => {
     });
 
     TestBed.configureTestingModule({
+      imports: [SkySelectionModalModule],
       providers: [
         {
           provide: SkyModalService,

--- a/libs/components/lookup/src/lib/modules/selection-modal/selection-modal.service.ts
+++ b/libs/components/lookup/src/lib/modules/selection-modal/selection-modal.service.ts
@@ -16,9 +16,7 @@ import { SkySelectionModalOpenArgs } from './types/selection-modal-open-args';
 /**
  * Displays a modal for selecting one or more values.
  */
-@Injectable({
-  providedIn: 'any',
-})
+@Injectable()
 export class SkySelectionModalService {
   #modalSvc: SkyModalService;
 


### PR DESCRIPTION
BREAKING CHANGE: The `SkySelectionModalService` cannot be used in isolation; any component that injects `SkySelectionModalService` must also import `SkySelectionModalModule` into its module's providers.