### PR TITLE
refactor(components/core): make environment injector required when creating dynamic components

### DIFF
--- a/apps/code-examples/src/app/features/progress-indicator.module.ts
+++ b/apps/code-examples/src/app/features/progress-indicator.module.ts
@@ -9,8 +9,8 @@ import { WaterfallIndicatorDocsComponent } from '../code-examples/progress-indic
 import { SkyProgressIndicatorPassiveDemoModule as SkyProgressIndicatorWaterfallDemoModule } from '../code-examples/progress-indicator/waterfall-indicator/basic/progress-indicator-waterfall-demo.module';
 import { WaterfallIndicatorDocsComponent as ProgressIndicatorWaterfallInlineHelpDemoComponent } from '../code-examples/progress-indicator/waterfall-indicator/inline-help/progress-indicator-waterfall-demo.component';
 import { SkyProgressIndicatorPassiveDemoModule as ProgressIndicatorWaterfallInlineHelpModule } from '../code-examples/progress-indicator/waterfall-indicator/inline-help/progress-indicator-waterfall-demo.module';
+import { WizardDemoComponent } from '../code-examples/progress-indicator/wizard/basic/wizard-demo.component';
 import { SkyProgressIndicatorPassiveDemoModule as SkyWizardDemoModule } from '../code-examples/progress-indicator/wizard/basic/wizard-demo.module';
-import { WizardDemoComponent } from '../code-examples/tabs/wizard/basic/wizard-demo.component';
 
 const routes: Routes = [
   { path: 'waterfall', component: WaterfallIndicatorDocsComponent },

--- a/libs/components/a11y/src/lib/modules/skip-link/skip-link.service.ts
+++ b/libs/components/a11y/src/lib/modules/skip-link/skip-link.service.ts
@@ -1,4 +1,9 @@
-import { ComponentRef, Injectable } from '@angular/core';
+import {
+  ComponentRef,
+  EnvironmentInjector,
+  Injectable,
+  inject,
+} from '@angular/core';
 import {
   SkyDynamicComponentLocation,
   SkyDynamicComponentService,
@@ -20,6 +25,7 @@ export class SkySkipLinkService {
   private static host: ComponentRef<SkySkipLinkHostComponent> | undefined;
 
   #dynamicComponentService: SkyDynamicComponentService;
+  #environmentInjector = inject(EnvironmentInjector);
 
   constructor(dynamicComponentService: SkyDynamicComponentService) {
     this.#dynamicComponentService = dynamicComponentService;
@@ -50,6 +56,7 @@ export class SkySkipLinkService {
       const componentRef = this.#dynamicComponentService.createComponent(
         SkySkipLinkHostComponent,
         {
+          environmentInjector: this.#environmentInjector,
           location: SkyDynamicComponentLocation.BodyTop,
         }
       );

--- a/libs/components/core/src/lib/modules/dynamic-component/dynamic-component-options.ts
+++ b/libs/components/core/src/lib/modules/dynamic-component/dynamic-component-options.ts
@@ -33,5 +33,5 @@ export interface SkyDynamicComponentOptions {
   /**
    * The environment injector to use instead of the dynamic component service's injector.
    */
-  environmentInjector?: EnvironmentInjector;
+  environmentInjector: EnvironmentInjector;
 }

--- a/libs/components/core/src/lib/modules/dynamic-component/dynamic-component.service.spec.ts
+++ b/libs/components/core/src/lib/modules/dynamic-component/dynamic-component.service.spec.ts
@@ -31,7 +31,7 @@ describe('Dynamic component service', () => {
     location?: SkyDynamicComponentLocation,
     reference?: HTMLElement,
     providers?: StaticProvider[],
-    injector?: EnvironmentInjector,
+    injector = TestBed.inject(EnvironmentInjector),
     viewRef?: ViewContainerRef
   ): ComponentRef<DynamicComponentTestComponent> {
     const svc: SkyDynamicComponentService = TestBed.inject(

--- a/libs/components/core/src/lib/modules/dynamic-component/dynamic-component.service.ts
+++ b/libs/components/core/src/lib/modules/dynamic-component/dynamic-component.service.ts
@@ -2,7 +2,6 @@ import {
   ApplicationRef,
   ComponentRef,
   EmbeddedViewRef,
-  EnvironmentInjector,
   Injectable,
   Renderer2,
   RendererFactory2,
@@ -21,15 +20,10 @@ import { SkyDynamicComponentOptions } from './dynamic-component-options';
  * @internal
  */
 @Injectable({
-  // Must be 'any' so that the component is created in the context of its module's injector.
-  // If set to 'root', the component's dependency injections would only be derived from the root
-  // injector and may lose context if the component is created within a lazy-loaded module.
-  providedIn: 'any',
+  providedIn: 'root',
 })
 export class SkyDynamicComponentService {
   #applicationRef: ApplicationRef;
-
-  #environmentInjector: EnvironmentInjector;
 
   #renderer: Renderer2;
 
@@ -38,12 +32,10 @@ export class SkyDynamicComponentService {
   constructor(
     applicationRef: ApplicationRef,
     windowRef: SkyAppWindowRef,
-    rendererFactory: RendererFactory2,
-    environmentInjector: EnvironmentInjector
+    rendererFactory: RendererFactory2
   ) {
     this.#applicationRef = applicationRef;
     this.#windowRef = windowRef;
-    this.#environmentInjector = environmentInjector;
 
     // Based on suggestions from https://github.com/angular/angular/issues/17824
     // for accessing an instance of Renderer2 in a service since Renderer2 can't
@@ -58,15 +50,15 @@ export class SkyDynamicComponentService {
    */
   public createComponent<T>(
     componentType: Type<T>,
-    options?: SkyDynamicComponentOptions
+    options: SkyDynamicComponentOptions
   ): ComponentRef<T> {
-    options ||= {
-      location: SkyDynamicComponentLocation.BodyBottom,
-    };
+    if (options.location === undefined) {
+      options.location = SkyDynamicComponentLocation.BodyBottom;
+    }
 
     const environmentInjector = createEnvironmentInjector(
       options.providers ?? [],
-      options.environmentInjector ?? this.#environmentInjector
+      options.environmentInjector
     );
 
     let componentRef: ComponentRef<T>;

--- a/libs/components/core/src/lib/modules/live-announcer/live-announcer.service.ts
+++ b/libs/components/core/src/lib/modules/live-announcer/live-announcer.service.ts
@@ -11,7 +11,9 @@ import { SkyLiveAnnouncerArgs } from './types/live-announcer-args';
  * Allows for announcing messages to screen reader users through the use of a common `aria-live` element.
  * @internal
  */
-@Injectable({ providedIn: 'root' })
+@Injectable({
+  providedIn: 'root',
+})
 export class SkyLiveAnnouncerService implements OnDestroy {
   public announcerElementChanged = new ReplaySubject<HTMLElement | undefined>(
     1

--- a/libs/components/core/src/lib/modules/resize-observer/resize-observer.service.ts
+++ b/libs/components/core/src/lib/modules/resize-observer/resize-observer.service.ts
@@ -13,7 +13,7 @@ type ResizeObserverTracking = {
  * Service to create rxjs observables for changes to the content box dimensions of elements.
  */
 @Injectable({
-  providedIn: 'any',
+  providedIn: 'root',
 })
 export class SkyResizeObserverService implements OnDestroy {
   #resizeObserver: ResizeObserver;


### PR DESCRIPTION
Because we're switching the `SkyDynamicComponentService` from `providedIn: 'any'` to `providedIn: 'root'` there's no reason that consuming services/components shouldn't provide their environment injector when creating dynamic components. This will also safeguard future usage of the `SkyDynamicComponentService` since it will require the author to make a decision about which environment injector to use in its implementation.