### PR TITLE
fix(components/packages): modify all projects when `ng add` called without `project` option

### DIFF
--- a/libs/components/packages/src/schematics/ng-add/ng-add.schematic.spec.ts
+++ b/libs/components/packages/src/schematics/ng-add/ng-add.schematic.spec.ts
@@ -97,4 +97,20 @@ describe('ng-add.schematic', () => {
     const tsConfig = new JsonFile(updatedTree, 'tsconfig.json');
     expect(tsConfig.get(['compilerOptions', 'esModuleInterop'])).toEqual(true);
   });
+
+  it('should modify all projects if a specific project is not defined', async () => {
+    const { runSchematic } = await setupTest();
+
+    // Do not set 'project'.
+    const updatedTree = await runSchematic();
+
+    const angularJson = readJson(updatedTree, 'angular.json');
+    expect(
+      angularJson.projects['my-lib-showcase'].architect.build.options.styles
+    ).toEqual([
+      'node_modules/@skyux/theme/css/sky.css',
+      'node_modules/@skyux/theme/css/themes/modern/styles.css',
+      'projects/my-lib-showcase/src/styles.css',
+    ]);
+  });
 });

--- a/libs/components/packages/src/schematics/ng-add/ng-add.schematic.ts
+++ b/libs/components/packages/src/schematics/ng-add/ng-add.schematic.ts
@@ -12,7 +12,7 @@ import { addPolyfillsConfig } from '../rules/add-polyfills-config';
 import { applySkyuxStylesheetsToWorkspace } from '../rules/apply-skyux-stylesheets-to-workspace';
 import { installAngularCdk } from '../rules/install-angular-cdk';
 import { modifyTsConfig } from '../rules/modify-tsconfig';
-import { getRequiredProject } from '../utility/workspace';
+import { getRequiredProject, getWorkspace } from '../utility/workspace';
 
 import { Schema } from './schema';
 
@@ -38,21 +38,43 @@ function installEssentialSkyUxPackages(skyuxVersion: string): Rule {
 
 export default function ngAdd(options: Schema): Rule {
   return async (tree, context) => {
-    const { projectName } = await getRequiredProject(tree, options.project);
-
     // Get the currently installed version of SKY UX.
     const { version: skyuxVersion } = fs.readJsonSync(
       path.resolve(__dirname, '../../../package.json')
     );
 
-    context.addTask(new NodePackageInstallTask());
-
-    return chain([
+    const rules: Rule[] = [
       installEssentialSkyUxPackages(skyuxVersion),
       installAngularCdk(),
-      addPolyfillsConfig(projectName, ['build', 'test']),
-      applySkyuxStylesheetsToWorkspace(projectName),
       modifyTsConfig(),
-    ]);
+    ];
+
+    // Add to one project.
+    if (options.project) {
+      const projectName = (await getRequiredProject(tree, options.project))
+        .projectName;
+
+      rules.push(
+        addPolyfillsConfig(projectName, ['build', 'test']),
+        applySkyuxStylesheetsToWorkspace(projectName)
+      );
+    } else {
+      // Add to all projects.
+      const { workspace } = await getWorkspace(tree);
+
+      const projectNames = workspace.projects.keys();
+      let projectName: string;
+
+      while ((projectName = projectNames.next().value)) {
+        rules.push(
+          addPolyfillsConfig(projectName, ['build', 'test']),
+          applySkyuxStylesheetsToWorkspace(projectName)
+        );
+      }
+    }
+
+    context.addTask(new NodePackageInstallTask());
+
+    return chain(rules);
   };
 }


### PR DESCRIPTION
We made the decision to require `--project` when running `ng add @skyux/packages`. https://github.com/blackbaud/skyux/pull/1073