### PR TITLE
feat(components/lookup): add ability to set `aria-label` and `aria-labelledby` attributes on the search component (#1622)

### DIFF
--- a/apps/code-examples/src/app/code-examples/lookup/search/basic/search-demo.component.html
+++ b/apps/code-examples/src/app/code-examples/lookup/search/basic/search-demo.component.html
@@ -9,6 +9,7 @@
   </sky-toolbar-item>
   <sky-toolbar-item>
     <sky-search
+      [ariaLabel]="searchAriaLabel"
       [searchText]="searchText"
       [debounceTime]="250"
       (searchApply)="searchApplied($event)"

--- a/apps/code-examples/src/app/code-examples/lookup/search/basic/search-demo.component.ts
+++ b/apps/code-examples/src/app/code-examples/lookup/search/basic/search-demo.component.ts
@@ -32,6 +32,8 @@ export class SearchDemoComponent {
     },
   ];
 
+  public searchAriaLabel = 'Search reminders';
+
   public searchText = '';
 
   constructor() {

--- a/libs/components/lookup/src/lib/modules/search/fixtures/search.component.fixture.html
+++ b/libs/components/lookup/src/lib/modules/search/fixtures/search.component.fixture.html
@@ -1,4 +1,7 @@
+<label id="test-label">Test label element</label>
 <sky-search
+  [ariaLabel]="ariaLabel"
+  [ariaLabelledBy]="ariaLabelledBy"
   [debounceTime]="debounceTime"
   [disabled]="disabled"
   [searchText]="searchText"

--- a/libs/components/lookup/src/lib/modules/search/fixtures/search.component.fixture.ts
+++ b/libs/components/lookup/src/lib/modules/search/fixtures/search.component.fixture.ts
@@ -13,6 +13,9 @@ export class SearchTestComponent {
   })
   public searchComponent!: SkySearchComponent;
 
+  public ariaLabel: string | undefined;
+  public ariaLabelledBy: string | undefined;
+
   public disabled: boolean | undefined;
   public debounceTime: number | undefined = 0;
 

--- a/libs/components/lookup/src/lib/modules/search/search.component.html
+++ b/libs/components/lookup/src/lib/modules/search/search.component.html
@@ -32,7 +32,12 @@
           <input
             class="sky-form-control sky-search-input sky-rounded-corners"
             type="text"
-            [attr.aria-label]="'skyux_search_label' | skyLibResources"
+            [attr.aria-label]="
+              ariaLabelledBy
+                ? undefined
+                : (ariaLabel ?? 'skyux_search_label' | skyLibResources)
+            "
+            [attr.aria-labelledby]="ariaLabelledBy"
             [attr.placeholder]="
               placeholderText || ('skyux_search_placeholder' | skyLibResources)
             "

--- a/libs/components/lookup/src/lib/modules/search/search.component.spec.ts
+++ b/libs/components/lookup/src/lib/modules/search/search.component.spec.ts
@@ -513,16 +513,42 @@ describe('Search component', () => {
   });
 
   describe('a11y', async () => {
-    it('should be accessible using default theme at wide and small breakpoints', async () => {
+    it('should be accessible using default theme at wide and small breakpoints (ariaLabel: undefined, ariaLabelledBy: undefined)', async () => {
       fixture.detectChanges();
       await fixture.whenStable();
       await expectAsync(fixture.nativeElement).toBeAccessible();
       setInput('foo bar');
       await fixture.whenStable();
       await expectAsync(fixture.nativeElement).toBeAccessible();
+      expect(getInput().attributes['aria-label']).toBe('Search items');
+      expect(getInput().attributes['aria-labelledby']).toBeUndefined();
     });
 
-    it('should be accessible using modern theme at wide and small breakpoints', async () => {
+    it('should be accessible using default theme at wide and small breakpoints (ariaLabel: "Test label", ariaLabelledBy: undefined)', async () => {
+      component.ariaLabel = 'Test label';
+      fixture.detectChanges();
+      await fixture.whenStable();
+      await expectAsync(fixture.nativeElement).toBeAccessible();
+      setInput('foo bar');
+      await fixture.whenStable();
+      await expectAsync(fixture.nativeElement).toBeAccessible();
+      expect(getInput().attributes['aria-label']).toBe('Test label');
+      expect(getInput().attributes['aria-labelledby']).toBeUndefined();
+    });
+
+    it('should be accessible using default theme at wide and small breakpoints (ariaLabel: undefined, ariaLabelledBy: "test-label")', async () => {
+      component.ariaLabelledBy = 'test-label';
+      fixture.detectChanges();
+      await fixture.whenStable();
+      await expectAsync(fixture.nativeElement).toBeAccessible();
+      setInput('foo bar');
+      await fixture.whenStable();
+      await expectAsync(fixture.nativeElement).toBeAccessible();
+      expect(getInput().attributes['aria-label']).toBeUndefined();
+      expect(getInput().attributes['aria-labelledby']).toBe('test-label');
+    });
+
+    it('should be accessible using modern theme at wide and small breakpoints (ariaLabel: undefined, ariaLabelledBy: undefined)', async () => {
       mockThemeSvc.settingsChange.next({
         currentSettings: new SkyThemeSettings(
           SkyTheme.presets.modern,
@@ -536,6 +562,46 @@ describe('Search component', () => {
       setInput('foo bar');
       await fixture.whenStable();
       await expectAsync(fixture.nativeElement).toBeAccessible();
+      expect(getInput().attributes['aria-label']).toBe('Search items');
+      expect(getInput().attributes['aria-labelledby']).toBeUndefined();
+    });
+
+    it('should be accessible using modern theme at wide and small breakpoints (ariaLabel: "Test label", ariaLabelledBy: undefined)', async () => {
+      mockThemeSvc.settingsChange.next({
+        currentSettings: new SkyThemeSettings(
+          SkyTheme.presets.modern,
+          SkyThemeMode.presets.light
+        ),
+        previousSettings: mockThemeSvc.settingsChange.value.currentSettings,
+      });
+      component.ariaLabel = 'Test label';
+      fixture.detectChanges();
+      await fixture.whenStable();
+      await expectAsync(fixture.nativeElement).toBeAccessible();
+      setInput('foo bar');
+      await fixture.whenStable();
+      await expectAsync(fixture.nativeElement).toBeAccessible();
+      expect(getInput().attributes['aria-label']).toBe('Test label');
+      expect(getInput().attributes['aria-labelledby']).toBeUndefined();
+    });
+
+    it('should be accessible using modern theme at wide and small breakpoints (ariaLabel: undefined, ariaLabelledBy: "test-label")', async () => {
+      mockThemeSvc.settingsChange.next({
+        currentSettings: new SkyThemeSettings(
+          SkyTheme.presets.modern,
+          SkyThemeMode.presets.light
+        ),
+        previousSettings: mockThemeSvc.settingsChange.value.currentSettings,
+      });
+      component.ariaLabelledBy = 'test-label';
+      fixture.detectChanges();
+      await fixture.whenStable();
+      await expectAsync(fixture.nativeElement).toBeAccessible();
+      setInput('foo bar');
+      await fixture.whenStable();
+      await expectAsync(fixture.nativeElement).toBeAccessible();
+      expect(getInput().attributes['aria-label']).toBeUndefined();
+      expect(getInput().attributes['aria-labelledby']).toBe('test-label');
     });
   });
 });

--- a/libs/components/lookup/src/lib/modules/search/search.component.ts
+++ b/libs/components/lookup/src/lib/modules/search/search.component.ts
@@ -60,6 +60,25 @@ const EXPAND_MODE_NONE = 'none';
 })
 export class SkySearchComponent implements OnDestroy, OnInit, OnChanges {
   /**
+   * The ARIA label for the search. This sets the search's `aria-label` attribute to provide a text equivalent for screen readers
+   * [to support accessibility](https://developer.blackbaud.com/skyux/learn/accessibility).
+   * If the box includes a visible label, use `ariaLabelledBy` instead.
+   * For more information about the `aria-label` attribute, see the [WAI-ARIA definition](https://www.w3.org/TR/wai-aria/#aria-label).
+   */
+  @Input()
+  public ariaLabel: string | undefined;
+
+  /**
+   * The HTML element ID of the element that labels
+   * the search. This sets the search's `aria-labelledby` attribute to provide a text equivalent for screen readers
+   * [to support accessibility](https://developer.blackbaud.com/skyux/learn/accessibility).
+   * If the box does not include a visible label, use `ariaLabel` instead.
+   * For more information about the `aria-labelledby` attribute, see the [WAI-ARIA definition](https://www.w3.org/TR/wai-aria/#aria-labelledby).
+   */
+  @Input()
+  public ariaLabelledBy: string | undefined;
+
+  /**
    * Fires when the search text is applied.
    */
   @Output()

--- a/libs/components/lookup/testing/src/search/fixtures/search-harness-test.component.html
+++ b/libs/components/lookup/testing/src/search/fixtures/search-harness-test.component.html
@@ -1,5 +1,8 @@
+<label id="foo-search-id">Test label</label>
 <sky-search
   data-sky-id="my-search-1"
+  [ariaLabel]="ariaLabel"
+  [ariaLabelledBy]="ariaLabelledBy"
   [disabled]="disabled"
   [placeholderText]="placeholderText"
 >

--- a/libs/components/lookup/testing/src/search/fixtures/search-harness-test.component.ts
+++ b/libs/components/lookup/testing/src/search/fixtures/search-harness-test.component.ts
@@ -5,6 +5,10 @@ import { Component } from '@angular/core';
   templateUrl: './search-harness-test.component.html',
 })
 export class SearchHarnessTestComponent {
+  public ariaLabel: string | undefined;
+
+  public ariaLabelledBy: string | undefined = 'foo-search-id';
+
   public disabled = false;
 
   public placeholderText: string | undefined;

--- a/libs/components/lookup/testing/src/search/search-harness.spec.ts
+++ b/libs/components/lookup/testing/src/search/search-harness.spec.ts
@@ -35,6 +35,27 @@ describe('Search harness', () => {
     await expectAsync(searchHarness?.isFocused()).toBeResolvedTo(false);
   });
 
+  it('should get ARIA attributes', async () => {
+    const { searchHarness, fixture } = await setupTest({
+      dataSkyId: 'my-search-1',
+    });
+
+    await expectAsync(searchHarness.getAriaLabel()).toBeResolvedTo(null);
+    await expectAsync(searchHarness.getAriaLabelledby()).toBeResolvedTo(
+      'foo-search-id'
+    );
+
+    fixture.componentInstance.ariaLabel = 'Search emails';
+    fixture.componentInstance.ariaLabelledBy = undefined;
+
+    fixture.detectChanges();
+
+    await expectAsync(searchHarness.getAriaLabel()).toBeResolvedTo(
+      'Search emails'
+    );
+    await expectAsync(searchHarness.getAriaLabelledby()).toBeResolvedTo(null);
+  });
+
   it('should check if search is disabled', async () => {
     const { fixture, searchHarness } = await setupTest({
       dataSkyId: 'my-search-1',

--- a/libs/components/lookup/testing/src/search/search-harness.ts
+++ b/libs/components/lookup/testing/src/search/search-harness.ts
@@ -63,6 +63,20 @@ export class SkySearchHarness extends SkyComponentHarness {
   }
 
   /**
+   * Gets the search's aria-label.
+   */
+  public async getAriaLabel(): Promise<string | null> {
+    return (await this.#getInput()).getAttribute('aria-label');
+  }
+
+  /**
+   * Gets the search's aria-labelledby.
+   */
+  public async getAriaLabelledby(): Promise<string | null> {
+    return (await this.#getInput()).getAttribute('aria-labelledby');
+  }
+
+  /**
    * Gets the value of the input's placeholder attribute.
    */
   public async getPlaceholderText(): Promise<string | null> {


### PR DESCRIPTION
:cherries: Cherry picked from #1622 [feat(components/lookup): add ability to set `aria-label` and `aria-labelledby` attributes on the search component](https://github.com/blackbaud/skyux/pull/1622)

[AB#2346432](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/2346432) 