### PR TITLE
fix(components/tabs): vertical tab modern theme spacing has been updated to match design specifications

### DIFF
--- a/libs/components/tabs/src/lib/modules/vertical-tabset/vertical-tab.component.scss
+++ b/libs/components/tabs/src/lib/modules/vertical-tabset/vertical-tab.component.scss
@@ -64,14 +64,14 @@
     color: $sky-text-color-deemphasized;
     cursor: pointer;
     padding: $sky-theme-modern-space-sm 0 $sky-theme-modern-space-sm
-      $sky-theme-modern-space-sm;
-    margin: $sky-theme-modern-margin-inline-sm 0
-      $sky-theme-modern-margin-inline-lg $sky-theme-modern-margin-inline-sm;
+      $sky-theme-modern-space-md;
+    margin: $sky-theme-modern-margin-inline-md 0
+      $sky-theme-modern-margin-inline-md $sky-theme-modern-margin-inline-sm;
 
     &:not(.sky-vertical-tab-active):not(:active):hover {
       color: $sky-text-color-default;
       background-color: transparent;
-      padding-left: 9px;
+      padding-left: 14px;
       border-left: 1px solid $sky-highlight-color-info;
     }
 
@@ -88,9 +88,9 @@
     }
 
     &:active {
-      border-left: 3px solid $sky-highlight-color-info;
+      border-left: 4px solid $sky-highlight-color-info;
       color: $sky-text-color-default;
-      padding-left: 7px;
+      padding-left: 11px;
     }
     .sky-vertical-tab-heading-error {
       padding-left: $sky-theme-modern-space-sm;
@@ -101,7 +101,7 @@
   .sky-vertical-tab-active {
     background: none;
     color: $sky-text-color-default;
-    padding-left: 7px;
-    border-left: 3px solid $sky-theme-modern-color-blue-74;
+    padding-left: 11px;
+    border-left: 4px solid $sky-theme-modern-color-blue-74;
   }
 }

--- a/libs/components/tabs/src/lib/modules/vertical-tabset/vertical-tabset-group.component.scss
+++ b/libs/components/tabs/src/lib/modules/vertical-tabset/vertical-tabset-group.component.scss
@@ -35,12 +35,12 @@
 @include mixins.sky-theme-modern {
   .sky-vertical-tabset-group {
     border: none;
-    margin: $sky-theme-modern-space-sm 0;
+    margin: $sky-theme-modern-space-md 0;
   }
 
   .sky-vertical-tabset-group-content {
     border: none;
-    padding-left: 25px;
+    padding-left: 10px;
   }
 
   .sky-vertical-tabset-group-header {


### PR DESCRIPTION
[AB#2612934](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/2612934)

I chatted with @Blackbaud-AdamFunderburk about this and we came up with a few decisions

1. The padding on the tab buttons should be 15px to the left and not 18px
2. The 4px for the left border should be included in the 15px to the left (1 & 2 are based on what we are doing for split view to maintain consistency)
3. The left border for the active state should be 4px instead of 3px to match split view.
4. The top and bottom padding on a tab button should be 10px and not the 15px in the story. This is in the original spec and we could not find evidence as to where the 15px came from.
5. Tab groups should have 15px between them
6. Margins should be maintained on top when the tab or group is the first tab or group. The same applies for the bottom margin on last-of-kind elements
7. We are ok that this will affect sectioned form
8. Tabs should have 10px left margin along with the 15px padding on the tab button (just like is specified for tab groups)

BEGIN_COMMIT_OVERRIDE
fix(components/tabs)!: vertical tab modern theme spacing has been updated to match design specifications
END_COMMIT_OVERRIDE