### PR TITLE
feat(components/datetime)!: timepicker hardcoded `aria-label` is removed and the label should now be provided through a wrapping input box

### DIFF
--- a/libs/components/datetime/src/assets/locales/resources_en_US.json
+++ b/libs/components/datetime/src/assets/locales/resources_en_US.json
@@ -15,10 +15,6 @@
     "_description": "The close button for the timepicker modal",
     "message": "Done"
   },
-  "skyux_timepicker_input_default_label": {
-    "_description": "The label for the timepicker component's input field for screen readers when the consumer has not specified a label.",
-    "message": "Time"
-  },
   "skyux_date_range_picker_default_label": {
     "_description": "The default label for the date range picker.",
     "message": "Select a date range"

--- a/libs/components/datetime/src/lib/modules/shared/sky-datetime-resources.module.ts
+++ b/libs/components/datetime/src/lib/modules/shared/sky-datetime-resources.module.ts
@@ -53,7 +53,6 @@ const RESOURCES: { [locale: string]: SkyLibResources } = {
     skyux_datepicker_trigger_button_label: { message: 'Select date' },
     skyux_timepicker_button_label: { message: 'Choose time' },
     skyux_timepicker_close: { message: 'Done' },
-    skyux_timepicker_input_default_label: { message: 'Time' },
     skyux_date_range_picker_default_label: { message: 'Select a date range' },
     skyux_date_range_picker_format_label_specific_range: {
       message: 'Specific range',

--- a/libs/components/datetime/src/lib/modules/timepicker/fixtures/timepicker-component.fixture.html
+++ b/libs/components/datetime/src/lib/modules/timepicker/fixtures/timepicker-component.fixture.html
@@ -1,6 +1,7 @@
 <div>
   <sky-timepicker #timePicker>
     <input
+      aria-label="This is a time field."
       type="text"
       [disabled]="disabled ? 'disabled' : null"
       [required]="required ? 'required' : null"

--- a/libs/components/datetime/src/lib/modules/timepicker/fixtures/timepicker-input-box-component.fixture.html
+++ b/libs/components/datetime/src/lib/modules/timepicker/fixtures/timepicker-input-box-component.fixture.html
@@ -1,6 +1,5 @@
 <div>
   <sky-input-box labelText="Time">
-    <label class="sky-control-label"> Input box test </label>
     <sky-timepicker #timePicker>
       <input
         class="input-box-timepicker-input"

--- a/libs/components/datetime/src/lib/modules/timepicker/fixtures/timepicker-input-box-component.fixture.html
+++ b/libs/components/datetime/src/lib/modules/timepicker/fixtures/timepicker-input-box-component.fixture.html
@@ -1,5 +1,5 @@
 <div>
-  <sky-input-box>
+  <sky-input-box labelText="Time">
     <label class="sky-control-label"> Input box test </label>
     <sky-timepicker #timePicker>
       <input

--- a/libs/components/datetime/src/lib/modules/timepicker/timepicker.component.spec.ts
+++ b/libs/components/datetime/src/lib/modules/timepicker/timepicker.component.spec.ts
@@ -471,15 +471,7 @@ describe('Timepicker', () => {
       flushTimers();
     }));
 
-    it('should apply aria-label to the timepicker input when none is provided', fakeAsync(() => {
-      detectChangesAndTick(fixture);
-
-      expect(getInput(fixture).getAttribute('aria-label')).toBe('Time');
-    }));
-
     it('should not overwrite aria-label on the timepicker input when one is provided', fakeAsync(() => {
-      detectChangesAndTick(fixture);
-      getInput(fixture).setAttribute('aria-label', 'This is a time field.');
       detectChangesAndTick(fixture);
 
       expect(getInput(fixture).getAttribute('aria-label')).toBe(

--- a/libs/components/datetime/src/lib/modules/timepicker/timepicker.directive.ts
+++ b/libs/components/datetime/src/lib/modules/timepicker/timepicker.directive.ts
@@ -19,7 +19,6 @@ import {
   ValidationErrors,
   Validator,
 } from '@angular/forms';
-import { SkyLibResourcesService } from '@skyux/i18n';
 
 import moment from 'moment';
 import { Subscription } from 'rxjs';
@@ -134,18 +133,15 @@ export class SkyTimepickerInputDirective
 
   #renderer: Renderer2;
   #elRef: ElementRef;
-  #resourcesService: SkyLibResourcesService;
   #changeDetector: ChangeDetectorRef;
 
   constructor(
     renderer: Renderer2,
     elRef: ElementRef,
-    resourcesService: SkyLibResourcesService,
     changeDetector: ChangeDetectorRef
   ) {
     this.#renderer = renderer;
     this.#elRef = elRef;
-    this.#resourcesService = resourcesService;
     this.#changeDetector = changeDetector;
   }
 
@@ -158,19 +154,6 @@ export class SkyTimepickerInputDirective
           this.#_onTouched();
         }
       );
-
-    /* istanbul ignore else */
-    if (!this.#elRef.nativeElement.getAttribute('aria-label')) {
-      this.#resourcesService
-        .getString('skyux_timepicker_input_default_label')
-        .subscribe((value: string) => {
-          this.#renderer.setAttribute(
-            this.#elRef.nativeElement,
-            'aria-label',
-            value
-          );
-        });
-    }
   }
 
   public ngAfterContentInit(): void {


### PR DESCRIPTION
[AB#2346441](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/2346441)