### PR TITLE
feat(components/datetime)!: datepicker hardcoded `aria-label` is removed and the label should now be provided through a wrapping input box

### DIFF
--- a/libs/components/datetime/src/assets/locales/resources_en_US.json
+++ b/libs/components/datetime/src/assets/locales/resources_en_US.json
@@ -1,8 +1,4 @@
 {
-  "skyux_date_field_default_label": {
-    "_description": "The label for the datepicker component's input field for screen readers when the consumer has not specified a label.",
-    "message": "Date"
-  },
   "skyux_datepicker_trigger_button_label": {
     "_description": "Label for the trigger button of the datepicker",
     "message": "Select date"

--- a/libs/components/datetime/src/lib/modules/datepicker/datepicker-input-fuzzy.directive.ts
+++ b/libs/components/datetime/src/lib/modules/datepicker/datepicker-input-fuzzy.directive.ts
@@ -20,7 +20,7 @@ import {
   ValidationErrors,
   Validator,
 } from '@angular/forms';
-import { SkyAppLocaleProvider, SkyLibResourcesService } from '@skyux/i18n';
+import { SkyAppLocaleProvider } from '@skyux/i18n';
 
 import { Subject } from 'rxjs';
 import { distinctUntilChanged, takeUntil } from 'rxjs/operators';
@@ -237,7 +237,6 @@ export class SkyFuzzyDatepickerInputDirective
   #elementRef: ElementRef;
   #fuzzyDateService: SkyFuzzyDateService;
   #renderer: Renderer2;
-  #resourcesService: SkyLibResourcesService;
   #datepickerComponent: SkyDatepickerComponent;
 
   constructor(
@@ -247,7 +246,6 @@ export class SkyFuzzyDatepickerInputDirective
     fuzzyDateService: SkyFuzzyDateService,
     localeProvider: SkyAppLocaleProvider,
     renderer: Renderer2,
-    resourcesService: SkyLibResourcesService,
     @Optional() datepickerComponent?: SkyDatepickerComponent
   ) {
     if (!datepickerComponent) {
@@ -262,7 +260,6 @@ export class SkyFuzzyDatepickerInputDirective
     this.#elementRef = elementRef;
     this.#fuzzyDateService = fuzzyDateService;
     this.#renderer = renderer;
-    this.#resourcesService = resourcesService;
     this.#datepickerComponent = datepickerComponent;
 
     this.#locale = localeProvider.defaultLocale;
@@ -289,18 +286,6 @@ export class SkyFuzzyDatepickerInputDirective
     const element = this.#elementRef.nativeElement;
 
     this.#renderer.addClass(element, 'sky-form-control');
-
-    const hasAriaLabel = element.getAttribute('aria-label');
-
-    /* istanbul ignore else */
-    if (!hasAriaLabel) {
-      this.#resourcesService
-        .getString('skyux_date_field_default_label')
-        .pipe(takeUntil(this.#ngUnsubscribe))
-        .subscribe((value: string) => {
-          this.#renderer.setAttribute(element, 'aria-label', value);
-        });
-    }
   }
 
   public ngAfterContentInit(): void {

--- a/libs/components/datetime/src/lib/modules/datepicker/datepicker-input.directive.ts
+++ b/libs/components/datetime/src/lib/modules/datepicker/datepicker-input.directive.ts
@@ -20,7 +20,7 @@ import {
   ValidationErrors,
   Validator,
 } from '@angular/forms';
-import { SkyAppLocaleProvider, SkyLibResourcesService } from '@skyux/i18n';
+import { SkyAppLocaleProvider } from '@skyux/i18n';
 
 import moment from 'moment';
 import { Subject } from 'rxjs';
@@ -229,7 +229,6 @@ export class SkyDatepickerInputDirective
   #elementRef: ElementRef;
   #localeProvider: SkyAppLocaleProvider;
   #renderer: Renderer2;
-  #resourcesService: SkyLibResourcesService;
   #datepickerComponent: SkyDatepickerComponent;
 
   constructor(
@@ -239,7 +238,6 @@ export class SkyDatepickerInputDirective
     elementRef: ElementRef,
     localeProvider: SkyAppLocaleProvider,
     renderer: Renderer2,
-    resourcesService: SkyLibResourcesService,
     @Optional() datepickerComponent?: SkyDatepickerComponent
   ) {
     if (!datepickerComponent) {
@@ -254,7 +252,6 @@ export class SkyDatepickerInputDirective
     this.#elementRef = elementRef;
     this.#localeProvider = localeProvider;
     this.#renderer = renderer;
-    this.#resourcesService = resourcesService;
     this.#datepickerComponent = datepickerComponent;
     this.#initialPlaceholder = this.#adapter.getPlaceholder(this.#elementRef);
     this.#updatePlaceholder();
@@ -274,17 +271,6 @@ export class SkyDatepickerInputDirective
     const element = this.#elementRef.nativeElement;
 
     this.#renderer.addClass(element, 'sky-form-control');
-
-    const hasAriaLabel = element.getAttribute('aria-label');
-
-    if (!hasAriaLabel) {
-      this.#resourcesService
-        .getString('skyux_date_field_default_label')
-        .pipe(takeUntil(this.#ngUnsubscribe))
-        .subscribe((value: string) => {
-          this.#renderer.setAttribute(element, 'aria-label', value);
-        });
-    }
   }
 
   public ngAfterContentInit(): void {

--- a/libs/components/datetime/src/lib/modules/datepicker/datepicker.component.spec.ts
+++ b/libs/components/datetime/src/lib/modules/datepicker/datepicker.component.spec.ts
@@ -296,12 +296,6 @@ describe('datepicker', () => {
       expect(getTriggerButton(fixture)).not.toBeNull();
     });
 
-    it('should apply aria-label to the datepicker input when none is provided', () => {
-      fixture.detectChanges();
-
-      expect(getInputElement(fixture)?.getAttribute('aria-label')).toBe('Date');
-    });
-
     it('should not overwrite aria-label on the datepicker input when one is provided', () => {
       getInputElement(fixture)?.setAttribute(
         'aria-label',

--- a/libs/components/datetime/src/lib/modules/datepicker/fixtures/datepicker-input-box.component.fixture.html
+++ b/libs/components/datetime/src/lib/modules/datepicker/fixtures/datepicker-input-box.component.fixture.html
@@ -1,5 +1,4 @@
-<sky-input-box>
-  <label class="sky-control-label"> Input box test </label>
+<sky-input-box labelText="Input box test">
   <sky-datepicker #picker>
     <input
       class="input-box-datepicker-input"

--- a/libs/components/datetime/src/lib/modules/datepicker/fixtures/fuzzy-datepicker.component.fixture.html
+++ b/libs/components/datetime/src/lib/modules/datepicker/fixtures/fuzzy-datepicker.component.fixture.html
@@ -2,6 +2,7 @@
   <input
     name="myDate"
     skyFuzzyDatepickerInput
+    [attr.aria-label]="ariaLabel"
     [futureDisabled]="futureDisabled"
     [dateFormat]="dateFormat"
     [disabled]="isDisabled"

--- a/libs/components/datetime/src/lib/modules/datepicker/fixtures/fuzzy-datepicker.component.fixture.ts
+++ b/libs/components/datetime/src/lib/modules/datepicker/fixtures/fuzzy-datepicker.component.fixture.ts
@@ -7,6 +7,8 @@ import { SkyFuzzyDatepickerInputDirective } from '../datepicker-input-fuzzy.dire
   templateUrl: './fuzzy-datepicker.component.fixture.html',
 })
 export class FuzzyDatepickerTestComponent {
+  public ariaLabel = 'This is a date field.';
+
   public futureDisabled: boolean | undefined;
 
   public dateFormat: string | undefined;

--- a/libs/components/datetime/src/lib/modules/datepicker/fuzzy-datepicker.component.spec.ts
+++ b/libs/components/datetime/src/lib/modules/datepicker/fuzzy-datepicker.component.spec.ts
@@ -240,12 +240,6 @@ describe('fuzzy datepicker input', () => {
       expect(getTriggerButton(fixture)).not.toBeNull();
     });
 
-    it('should apply aria-label to the datepicker input when none is provided', () => {
-      fixture.detectChanges();
-
-      expect(getInputElement(fixture)?.getAttribute('aria-label')).toBe('Date');
-    });
-
     it('should not overwrite aria-label on the datepicker input when one is provided', () => {
       getInputElement(fixture)?.setAttribute(
         'aria-label',

--- a/libs/components/datetime/src/lib/modules/shared/sky-datetime-resources.module.ts
+++ b/libs/components/datetime/src/lib/modules/shared/sky-datetime-resources.module.ts
@@ -49,7 +49,6 @@ const RESOURCES: { [locale: string]: SkyLibResources } = {
     },
   },
   'EN-US': {
-    skyux_date_field_default_label: { message: 'Date' },
     skyux_datepicker_trigger_button_label: { message: 'Select date' },
     skyux_timepicker_button_label: { message: 'Choose time' },
     skyux_timepicker_close: { message: 'Done' },


### PR DESCRIPTION
[AB#2346414](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/2346414)