### PR TITLE
fix(components/forms): update file attachment accessibility and visual labels on the input for linking to a file to be more descriptive (#1625)

### DIFF
--- a/libs/components/forms/src/assets/locales/resources_en_US.json
+++ b/libs/components/forms/src/assets/locales/resources_en_US.json
@@ -59,9 +59,9 @@
     "_description": "",
     "message": "This file type is invalid"
   },
-  "skyux_file_attachment_file_upload_link_input": {
-    "_description": "Label for input to upload file",
-    "message": "Add a link to a file"
+  "skyux_file_attachment_file_upload_link_label": {
+    "_description": "Label for input to link to a file",
+    "message": "Link to a file"
   },
   "skyux_file_attachment_file_upload_link_placeholder": {
     "_description": "",
@@ -71,11 +71,7 @@
     "_description": "",
     "message": "or click to browse"
   },
-  "skyux_file_attachment_file_upload_paste_link": {
-    "_description": "",
-    "message": "Paste a link to a file"
-  },
-  "skyux_file_attachment_file_upload_paste_link_done": {
+  "skyux_file_attachment_file_upload_link_done": {
     "_description": "",
     "message": "Done"
   },

--- a/libs/components/forms/src/lib/modules/file-attachment/file-drop.component.html
+++ b/libs/components/forms/src/lib/modules/file-attachment/file-drop.component.html
@@ -85,7 +85,7 @@
         <div class="sky-file-drop-link-header">
           <div class="sky-file-drop-text-header sky-font-display-3">
             {{
-              'skyux_file_attachment_file_upload_paste_link' | skyLibResources
+              'skyux_file_attachment_file_upload_link_label' | skyLibResources
             }}
           </div>
         </div>
@@ -95,7 +95,7 @@
             class="sky-form-control"
             [attr.aria-label]="
               linkUploadAriaLabel ||
-              ('skyux_file_attachment_file_upload_link_input' | skyLibResources)
+              ('skyux_file_attachment_file_upload_link_label' | skyLibResources)
             "
             [attr.placeholder]="
               'skyux_file_attachment_file_upload_link_placeholder'
@@ -112,10 +112,7 @@
           [disabled]="!linkUrl"
           (click)="addLink($event)"
         >
-          {{
-            'skyux_file_attachment_file_upload_paste_link_done'
-              | skyLibResources
-          }}
+          {{ 'skyux_file_attachment_file_upload_link_done' | skyLibResources }}
         </button>
       </div>
     </div>

--- a/libs/components/forms/src/lib/modules/file-attachment/file-drop.component.spec.ts
+++ b/libs/components/forms/src/lib/modules/file-attachment/file-drop.component.spec.ts
@@ -971,7 +971,7 @@ describe('File drop component', () => {
 
     expect(
       linkInput.nativeElement.attributes.getNamedItem('aria-label').value
-    ).toBe('Add a link to a file');
+    ).toBe('Link to a file');
     expect(dropEl.attributes.getNamedItem('aria-label')?.value).toBe(
       'Drag a file here or click to browse'
     );

--- a/libs/components/forms/src/lib/modules/file-attachment/file-drop.component.ts
+++ b/libs/components/forms/src/lib/modules/file-attachment/file-drop.component.ts
@@ -56,6 +56,7 @@ export class SkyFileDropComponent implements OnDestroy {
    * The ARIA label for the file upload button. This provides a text equivalent for
    * screen readers [to support accessibility](https://developer.blackbaud.com/skyux/learn/accessibility).
    * For more information about the `aria-label` attribute, see the [WAI-ARIA definition](https://www.w3.org/TR/wai-aria/#aria-label).
+   * @default "Drag a file here or click to browse"
    */
   @Input()
   public fileUploadAriaLabel: string | undefined;
@@ -64,6 +65,7 @@ export class SkyFileDropComponent implements OnDestroy {
    * The ARIA label for the link upload input. This sets the button's `aria-label` attribute to provide a text equivalent for
    * screen readers [to support accessibility](https://developer.blackbaud.com/skyux/learn/accessibility).
    * For more information about the `aria-label` attribute, see the [WAI-ARIA definition](https://www.w3.org/TR/wai-aria/#aria-label).
+   * @default "Link to a file"
    */
   @Input()
   public linkUploadAriaLabel: string | undefined;

--- a/libs/components/forms/src/lib/modules/shared/sky-forms-resources.module.ts
+++ b/libs/components/forms/src/lib/modules/shared/sky-forms-resources.module.ts
@@ -45,19 +45,14 @@ const RESOURCES: { [locale: string]: SkyLibResources } = {
     skyux_file_attachment_file_upload_invalid_file: {
       message: 'This file type is invalid',
     },
-    skyux_file_attachment_file_upload_link_input: {
-      message: 'Add a link to a file',
-    },
+    skyux_file_attachment_file_upload_link_label: { message: 'Link to a file' },
     skyux_file_attachment_file_upload_link_placeholder: {
       message: 'http://www.something.com/file',
     },
     skyux_file_attachment_file_upload_or_click_to_browse: {
       message: 'or click to browse',
     },
-    skyux_file_attachment_file_upload_paste_link: {
-      message: 'Paste a link to a file',
-    },
-    skyux_file_attachment_file_upload_paste_link_done: { message: 'Done' },
+    skyux_file_attachment_file_upload_link_done: { message: 'Done' },
     skyux_file_attachment_label_no_file_chosen: { message: 'No file chosen.' },
     skyux_input_box_error_character_count: {
       message: 'Limit {0} to {1} character(s).',


### PR DESCRIPTION
:cherries: Cherry picked from #1625 [fix(components/forms): update file attachment accessibility and visual labels on the input for linking to a file to be more descriptive](https://github.com/blackbaud/skyux/pull/1625)

[AB#2346418](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/2346418) 