### PR TITLE
fix(components/lookup)!: use `click` events for selecting items in an autocomplete or lookup dropdown and only close when clicking outside the dropdown

### DIFF
--- a/libs/components/ag-grid/src/lib/modules/ag-grid/cell-editors/cell-editor-lookup/cell-editor-lookup.component.spec.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/cell-editors/cell-editor-lookup/cell-editor-lookup.component.spec.ts
@@ -255,7 +255,7 @@ describe('SkyAgGridCellEditorLookupComponent', () => {
           '.sky-overlay.ag-custom-component-popup button.sky-autocomplete-action-add'
         );
         expect(addButton).toBeTruthy();
-        SkyAppTestUtility.fireDomEvent(addButton, 'mousedown');
+        SkyAppTestUtility.fireDomEvent(addButton, 'click');
         expect(component.skyComponentProperties?.addClick).toHaveBeenCalled();
       });
 
@@ -281,7 +281,7 @@ describe('SkyAgGridCellEditorLookupComponent', () => {
           '.sky-overlay.ag-custom-component-popup button.sky-autocomplete-action-add'
         );
         expect(addButton).toBeTruthy();
-        SkyAppTestUtility.fireDomEvent(addButton, 'mousedown');
+        SkyAppTestUtility.fireDomEvent(addButton, 'click');
         expect(component.skyComponentProperties?.addClick).toHaveBeenCalled();
       });
 

--- a/libs/components/lookup/src/lib/modules/autocomplete/autocomplete.component.html
+++ b/libs/components/lookup/src/lib/modules/autocomplete/autocomplete.component.html
@@ -3,21 +3,30 @@
   aria-haspopup="listbox"
   class="sky-autocomplete"
   role="combobox"
-  [attr.aria-expanded]="isDropdownVisible | async"
+  [attr.aria-expanded]="
+    isOpen && (showActionsArea || (isResultsVisible | async))
+  "
   [attr.aria-labelledby]="ariaLabelledBy"
-  [attr.aria-controls]="(isDropdownVisible | async) ? resultsListId : null"
+  [attr.aria-controls]="
+    isOpen && (showActionsArea || (isResultsVisible | async))
+      ? resultsListId
+      : null
+  "
   [attr.id]="resultsWrapperId"
 >
   <ng-content></ng-content>
 </div>
 
 <ng-template #resultsTemplateRef>
+  <!-- We do not want the blur to fire here so that the dropdown does not close. This is why we are preventing the mousedown default. -->
   <div
     class="sky-autocomplete-results-container"
+    [attr.id]="resultsListId"
     [skyThemeClass]="{
       'sky-shadow': 'default',
       'sky-elevation-4': 'modern'
     }"
+    (mousedown)="$event.preventDefault()"
     (keydown)="handleKeydown($event)"
     #resultsRef
   >
@@ -32,11 +41,10 @@
 
 <ng-template #resultControlsTemplateRef>
   <div
-    *ngIf="isDropdownVisible | async"
+    *ngIf="isResultsVisible | async"
     class="sky-autocomplete-results"
     role="listbox"
     [attr.aria-labelledby]="ariaLabelledBy"
-    [attr.id]="resultsListId"
   >
     <ng-container *ngFor="let result of searchResults; let i = index">
       <div
@@ -51,7 +59,7 @@
         [attr.data-descriptor-value]="result.data[descriptorProperty]"
         [attr.id]="result.elementId"
         [skyHighlight]="highlightText"
-        (mousedown)="onResultMouseDown(result.elementId, $event)"
+        (click)="onResultClick(result.elementId, $event)"
         (mousemove)="onResultMouseMove(i)"
         #searchResultEl
       >
@@ -79,7 +87,7 @@
       *ngIf="enableShowMore && (!searchText || searchResults.length > 0)"
       class="sky-autocomplete-action sky-autocomplete-action-more sky-btn sky-btn-link"
       type="button"
-      (mousedown)="moreButtonClicked()"
+      (click)="moreButtonClicked()"
     >
       <ng-container
         *ngIf="
@@ -130,7 +138,7 @@
       tabindex="0"
       type="button"
       [class.focused]="isElementFocused(addButtonEl)"
-      (mousedown)="addButtonClicked()"
+      (click)="addButtonClicked()"
       #addButtonEl
     >
       <sky-icon *skyThemeIf="'modern'" icon="add" iconType="skyux"></sky-icon>

--- a/libs/components/lookup/src/lib/modules/autocomplete/autocomplete.component.spec.ts
+++ b/libs/components/lookup/src/lib/modules/autocomplete/autocomplete.component.spec.ts
@@ -25,7 +25,7 @@ describe('Autocomplete component', () => {
   //#region helpers
 
   function clickAddButton(): void {
-    SkyAppTestUtility.fireDomEvent(getAddButton(), 'mousedown');
+    SkyAppTestUtility.fireDomEvent(getAddButton(), 'click');
   }
 
   function getAddButton(): HTMLElement {
@@ -67,7 +67,7 @@ describe('Autocomplete component', () => {
   }
 
   function clickShowMoreButton(): void {
-    SkyAppTestUtility.fireDomEvent(getShowMoreButton(), 'mousedown');
+    SkyAppTestUtility.fireDomEvent(getShowMoreButton(), 'click');
   }
 
   function getShowMoreButton(): HTMLElement {
@@ -128,7 +128,7 @@ describe('Autocomplete component', () => {
 
     // Note: the ordering of these events is important!
     SkyAppTestUtility.fireDomEvent(inputElement, 'change');
-    SkyAppTestUtility.fireDomEvent(searchResults[index], 'mousedown');
+    SkyAppTestUtility.fireDomEvent(searchResults[index], 'click');
     blurInput(inputElement, fixture);
   }
 
@@ -790,7 +790,7 @@ describe('Autocomplete component', () => {
       // Type 'r' to activate the autocomplete dropdown, then click the first result.
       enterSearch('r', fixture);
       const firstItem = getSearchResultItems().item(0);
-      SkyAppTestUtility.fireDomEvent(firstItem, 'mousedown');
+      SkyAppTestUtility.fireDomEvent(firstItem, 'click');
       tick();
 
       // Expect new changes to have been emitted.
@@ -1135,7 +1135,7 @@ describe('Autocomplete component', () => {
 
       enterSearch('r', fixture);
 
-      const searchResultsContainer = getSearchResultsSection();
+      const searchResultsContainer = getSearchResultsContainer();
       expect(wrapper?.getAttribute('aria-controls')).toEqual(
         searchResultsContainer?.id
       );
@@ -1737,7 +1737,7 @@ describe('Autocomplete component', () => {
         ).and.callThrough();
         const firstItem = getSearchResultItems().item(0);
 
-        SkyAppTestUtility.fireDomEvent(firstItem, 'mousedown');
+        SkyAppTestUtility.fireDomEvent(firstItem, 'click');
         tick();
 
         expect(getSearchResultsContainer()).toBeNull();
@@ -1755,7 +1755,7 @@ describe('Autocomplete component', () => {
         expect(getSearchResultsContainer()).not.toBeNull();
         const firstItem = getSearchResultItems().item(0);
 
-        SkyAppTestUtility.fireDomEvent(firstItem, 'mousedown');
+        SkyAppTestUtility.fireDomEvent(firstItem, 'click');
         tick();
 
         expect(getSearchResultsContainer()).not.toBeNull();
@@ -1769,7 +1769,7 @@ describe('Autocomplete component', () => {
         expect(getSearchResultsContainer()).not.toBeNull();
         const firstItem = getSearchResultItems().item(0);
 
-        SkyAppTestUtility.fireDomEvent(firstItem, 'mousedown');
+        SkyAppTestUtility.fireDomEvent(firstItem, 'click');
         tick();
 
         expect(getSearchResultsContainer()).not.toBeNull();

--- a/libs/components/lookup/src/lib/modules/autocomplete/autocomplete.component.ts
+++ b/libs/components/lookup/src/lib/modules/autocomplete/autocomplete.component.ts
@@ -135,7 +135,7 @@ export class SkyAutocompleteComponent implements OnDestroy, AfterViewInit {
   @Input()
   public set enableShowMore(value: boolean | undefined) {
     this.#_enableShowMore = !!value;
-    this.#updateIsDropdownVisible();
+    this.#updateIsResultsVisible();
   }
   public get enableShowMore(): boolean {
     return this.#_enableShowMore;
@@ -266,7 +266,7 @@ export class SkyAutocompleteComponent implements OnDestroy, AfterViewInit {
   @Input()
   public set showAddButton(value: boolean | undefined) {
     this.#_showAddButton = !!value;
-    this.#updateIsDropdownVisible();
+    this.#updateIsResultsVisible();
   }
   public get showAddButton(): boolean {
     return this.#_showAddButton;
@@ -442,7 +442,7 @@ export class SkyAutocompleteComponent implements OnDestroy, AfterViewInit {
 
   public searchOrDefault: SkyAutocompleteSearchFunction;
 
-  protected isDropdownVisible: Observable<boolean>;
+  protected isResultsVisible: Observable<boolean>;
 
   /**
    * Index that indicates which descendant of the overlay currently has focus.
@@ -482,7 +482,7 @@ export class SkyAutocompleteComponent implements OnDestroy, AfterViewInit {
 
   #currentSearchSub: Subscription | undefined;
 
-  #isDropdownVisible = new BehaviorSubject<boolean>(false);
+  #isResultsVisible = new BehaviorSubject<boolean>(false);
 
   #zIndex: Observable<number> | undefined;
 
@@ -543,7 +543,7 @@ export class SkyAutocompleteComponent implements OnDestroy, AfterViewInit {
     const id = ++uniqueId;
     this.resultsListId = `sky-autocomplete-list-${id}`;
     this.resultsWrapperId = `sky-autocomplete-wrapper-${id}`;
-    this.isDropdownVisible = this.#isDropdownVisible.asObservable();
+    this.isResultsVisible = this.#isResultsVisible.asObservable();
   }
 
   public ngAfterViewInit(): void {
@@ -554,7 +554,7 @@ export class SkyAutocompleteComponent implements OnDestroy, AfterViewInit {
     this.#cancelCurrentSearch();
     this.#inputDirectiveUnsubscribe.next();
     this.#inputDirectiveUnsubscribe.complete();
-    this.#isDropdownVisible.complete();
+    this.#isResultsVisible.complete();
     this.#ngUnsubscribe.next();
     this.#ngUnsubscribe.complete();
     this.#destroyAffixer();
@@ -593,7 +593,7 @@ export class SkyAutocompleteComponent implements OnDestroy, AfterViewInit {
             }
           } else {
             if (activeElement) {
-              activeElement.dispatchEvent(new MouseEvent('mousedown'));
+              activeElement.dispatchEvent(new MouseEvent('click'));
             }
           }
 
@@ -661,7 +661,7 @@ export class SkyAutocompleteComponent implements OnDestroy, AfterViewInit {
     this.#closeDropdown();
   }
 
-  public onResultMouseDown(id: string, event: MouseEvent): void {
+  public onResultClick(id: string, event: MouseEvent): void {
     this.#selectSearchResultById(id);
 
     if (!this.showActionsArea) {
@@ -719,7 +719,7 @@ export class SkyAutocompleteComponent implements OnDestroy, AfterViewInit {
       const isDifferent = searchText !== this.searchText;
 
       this.searchText = searchText.trim();
-      this.#updateIsDropdownVisible();
+      this.#updateIsResultsVisible();
 
       if (isLongEnough && isDifferent) {
         this.#cancelCurrentSearch();
@@ -753,7 +753,7 @@ export class SkyAutocompleteComponent implements OnDestroy, AfterViewInit {
               this.#activeElementIndex = -1;
             }
 
-            this.#updateIsDropdownVisible();
+            this.#updateIsResultsVisible();
             this.#changeDetector.markForCheck();
 
             if (this.isOpen) {
@@ -886,7 +886,7 @@ export class SkyAutocompleteComponent implements OnDestroy, AfterViewInit {
 
       this.#overlay = overlay;
       this.isOpen = true;
-      this.#updateIsDropdownVisible();
+      this.#updateIsResultsVisible();
       this.#changeDetector.markForCheck();
       this.#updateAriaControls();
       this.#initOverlayFocusableElements();
@@ -934,7 +934,7 @@ export class SkyAutocompleteComponent implements OnDestroy, AfterViewInit {
     this.searchResultsCount = undefined;
     this.#removeActiveDescendant();
     this.#initOverlayFocusableElements();
-    this.#updateIsDropdownVisible();
+    this.#updateIsResultsVisible();
     this.#changeDetector.markForCheck();
   }
 
@@ -1072,12 +1072,12 @@ export class SkyAutocompleteComponent implements OnDestroy, AfterViewInit {
     }
   }
 
-  #updateIsDropdownVisible(): void {
-    const isDropdownVisible =
+  #updateIsResultsVisible(): void {
+    const isResultsVisible =
       !!this.searchText &&
       (!this.showActionsArea || this.searchResults.length > 0);
-    if (isDropdownVisible !== this.#isDropdownVisible.getValue()) {
-      this.#isDropdownVisible.next(isDropdownVisible);
+    if (isResultsVisible !== this.#isResultsVisible.getValue()) {
+      this.#isResultsVisible.next(isResultsVisible);
     }
   }
 }

--- a/libs/components/lookup/src/lib/modules/country-field/country-field.component.spec.ts
+++ b/libs/components/lookup/src/lib/modules/country-field/country-field.component.spec.ts
@@ -99,7 +99,7 @@ describe('Country Field Component', () => {
 
     // Note: the ordering of these events is important!
     SkyAppTestUtility.fireDomEvent(inputElement, 'change');
-    SkyAppTestUtility.fireDomEvent(searchResults[index], 'mousedown');
+    SkyAppTestUtility.fireDomEvent(searchResults[index], 'click');
     blurInput(fixture);
   }
 
@@ -1564,7 +1564,7 @@ describe('Country Field Component', () => {
 
         // Note: the ordering of these events is important!
         SkyAppTestUtility.fireDomEvent(inputElement, 'change');
-        SkyAppTestUtility.fireDomEvent(searchResults[0], 'mousedown');
+        SkyAppTestUtility.fireDomEvent(searchResults[0], 'click');
         SkyAppTestUtility.fireDomEvent(getInputElement(), 'blur');
 
         fixture.detectChanges();

--- a/libs/components/lookup/src/lib/modules/lookup/fixtures/lookup-input-box.component.fixture.html
+++ b/libs/components/lookup/src/lib/modules/lookup/fixtures/lookup-input-box.component.fixture.html
@@ -9,3 +9,4 @@
     ></sky-lookup>
   </sky-input-box>
 </form>
+<button class="sky-btn sky-btn-primary" id="test-button">Test</button>

--- a/libs/components/lookup/src/lib/modules/lookup/fixtures/lookup-template.component.fixture.html
+++ b/libs/components/lookup/src/lib/modules/lookup/fixtures/lookup-template.component.fixture.html
@@ -58,3 +58,4 @@
   >
   </sky-lookup>
 </form>
+<button class="sky-btn sky-btn-primary" id="test-button">Test</button>

--- a/libs/components/lookup/src/lib/modules/lookup/fixtures/lookup.component.fixture.html
+++ b/libs/components/lookup/src/lib/modules/lookup/fixtures/lookup.component.fixture.html
@@ -56,3 +56,4 @@
     #asyncLookup
   ></sky-lookup>
 </form>
+<button class="sky-btn sky-btn-primary" id="test-button">Test</button>

--- a/libs/components/lookup/src/lib/modules/lookup/lookup.component.spec.ts
+++ b/libs/components/lookup/src/lib/modules/lookup/lookup.component.spec.ts
@@ -3641,26 +3641,28 @@ describe('Lookup component', function () {
           expect(event.preventDefault).toHaveBeenCalled();
         }));
 
-        it('should unfocus the component if it loses focus', fakeAsync(function () {
+        it('should unfocus the component if it loses focus', async function () {
           fixture.detectChanges();
 
           const inputElement = getInputElement(lookupComponent);
           inputElement.focus();
           SkyAppTestUtility.fireDomEvent(inputElement, 'focusin');
-          tick();
           fixture.detectChanges();
-          tick();
+          await fixture.whenStable();
+          fixture.detectChanges();
+          await fixture.whenStable();
 
           expect(lookupComponent.isInputFocused).toEqual(true);
 
           getTestButton().focus();
           SkyAppTestUtility.fireDomEvent(document, 'focusin');
-          tick();
           fixture.detectChanges();
-          tick();
+          await fixture.whenStable();
+          fixture.detectChanges();
+          await fixture.whenStable();
 
           expect(lookupComponent.isInputFocused).toEqual(false);
-        }));
+        });
       });
 
       describe('single-select', () => {
@@ -3689,26 +3691,28 @@ describe('Lookup component', function () {
           expect(event.preventDefault).toHaveBeenCalled();
         }));
 
-        it('should unfocus the component if it loses focus', fakeAsync(function () {
+        it('should unfocus the component if it loses focus', async function () {
           fixture.detectChanges();
 
           const inputElement = getInputElement(lookupComponent);
           inputElement.focus();
           SkyAppTestUtility.fireDomEvent(inputElement, 'focusin');
-          tick();
           fixture.detectChanges();
-          tick();
+          await fixture.whenStable();
+          fixture.detectChanges();
+          await fixture.whenStable();
 
           expect(lookupComponent.isInputFocused).toEqual(true);
 
           getTestButton().focus();
           SkyAppTestUtility.fireDomEvent(document, 'focusin');
-          tick();
           fixture.detectChanges();
-          tick();
+          await fixture.whenStable();
+          fixture.detectChanges();
+          await fixture.whenStable();
 
           expect(lookupComponent.isInputFocused).toEqual(false);
-        }));
+        });
       });
     });
 
@@ -6793,26 +6797,28 @@ describe('Lookup component', function () {
           expect(event.preventDefault).toHaveBeenCalled();
         }));
 
-        it('should unfocus the component if it loses focus', fakeAsync(function () {
+        it('should unfocus the component if it loses focus', async function () {
           fixture.detectChanges();
 
           const inputElement = getInputElement(lookupComponent);
           inputElement.focus();
           SkyAppTestUtility.fireDomEvent(inputElement, 'focusin');
-          tick();
           fixture.detectChanges();
-          tick();
+          await fixture.whenStable();
+          fixture.detectChanges();
+          await fixture.whenStable();
 
           expect(lookupComponent.isInputFocused).toEqual(true);
 
           getTestButton().focus();
           SkyAppTestUtility.fireDomEvent(document, 'focusin');
-          tick();
           fixture.detectChanges();
-          tick();
+          await fixture.whenStable();
+          fixture.detectChanges();
+          await fixture.whenStable();
 
           expect(lookupComponent.isInputFocused).toEqual(false);
-        }));
+        });
       });
 
       describe('single-select', () => {
@@ -6841,26 +6847,28 @@ describe('Lookup component', function () {
           expect(event.preventDefault).toHaveBeenCalled();
         }));
 
-        it('should unfocus the component if it loses focus', fakeAsync(function () {
+        it('should unfocus the component if it loses focus', async function () {
           fixture.detectChanges();
 
           const inputElement = getInputElement(lookupComponent);
           inputElement.focus();
           SkyAppTestUtility.fireDomEvent(inputElement, 'focusin');
-          tick();
           fixture.detectChanges();
-          tick();
+          await fixture.whenStable();
+          fixture.detectChanges();
+          await fixture.whenStable();
 
           expect(lookupComponent.isInputFocused).toEqual(true);
 
           getTestButton().focus();
           SkyAppTestUtility.fireDomEvent(document, 'focusin');
-          tick();
           fixture.detectChanges();
-          tick();
+          await fixture.whenStable();
+          fixture.detectChanges();
+          await fixture.whenStable();
 
           expect(lookupComponent.isInputFocused).toEqual(false);
-        }));
+        });
       });
     });
 
@@ -6938,26 +6946,28 @@ describe('Lookup component', function () {
       expect(containerEl).toHaveCssClass('sky-lookup');
     }));
 
-    it('should unfocus the component if it loses focus', fakeAsync(function () {
+    it('should unfocus the component if it loses focus', async function () {
       fixture.detectChanges();
 
       const inputElement = getInputElement(lookupComponent);
       inputElement.focus();
       SkyAppTestUtility.fireDomEvent(inputElement, 'focusin');
-      tick();
       fixture.detectChanges();
-      tick();
+      await fixture.whenStable();
+      fixture.detectChanges();
+      await fixture.whenStable();
 
       expect(lookupComponent.isInputFocused).toEqual(true);
 
       getTestButton().focus();
       SkyAppTestUtility.fireDomEvent(document, 'focusin');
-      tick();
       fixture.detectChanges();
-      tick();
+      await fixture.whenStable();
+      fixture.detectChanges();
+      await fixture.whenStable();
 
       expect(lookupComponent.isInputFocused).toEqual(false);
-    }));
+    });
 
     describe('mouse interactions', function () {
       it('should focus the input if the host is clicked', fakeAsync(function () {

--- a/libs/components/lookup/src/lib/modules/lookup/lookup.component.spec.ts
+++ b/libs/components/lookup/src/lib/modules/lookup/lookup.component.spec.ts
@@ -24,7 +24,7 @@ describe('Lookup component', function () {
   //#region helpers
 
   function clickAddButton(): void {
-    SkyAppTestUtility.fireDomEvent(getAddButton(), 'mousedown');
+    SkyAppTestUtility.fireDomEvent(getAddButton(), 'click');
   }
 
   function clearShowMoreSearch(fixture: ComponentFixture<any>): void {
@@ -45,7 +45,7 @@ describe('Lookup component', function () {
   }
 
   function clickShowMoreBase(fixture: ComponentFixture<any>): void {
-    SkyAppTestUtility.fireDomEvent(getShowMoreButton(), 'mousedown');
+    SkyAppTestUtility.fireDomEvent(getShowMoreButton(), 'click');
     fixture.detectChanges();
   }
 
@@ -267,6 +267,10 @@ describe('Lookup component', function () {
     }
   }
 
+  function getTestButton(): HTMLElement {
+    return document.querySelector('#test-button');
+  }
+
   /**
    * creates a Spy that mimics/delegates the behavior of an common example of a SkyAutocompleteSearchFunctionFilter
    */
@@ -379,7 +383,7 @@ describe('Lookup component', function () {
     const dropdownButtons = document.querySelectorAll(
       '.sky-autocomplete-result'
     );
-    SkyAppTestUtility.fireDomEvent(dropdownButtons.item(index), 'mousedown');
+    SkyAppTestUtility.fireDomEvent(dropdownButtons.item(index), 'click');
     tick();
     fixture.detectChanges();
     tick();
@@ -437,7 +441,7 @@ describe('Lookup component', function () {
     focusable = false
   ): void {
     if (element) {
-      SkyAppTestUtility.fireDomEvent(element, 'mousedown');
+      SkyAppTestUtility.fireDomEvent(element, 'click');
       tick();
       fixture.detectChanges();
       tick();
@@ -3641,6 +3645,7 @@ describe('Lookup component', function () {
           fixture.detectChanges();
 
           const inputElement = getInputElement(lookupComponent);
+          inputElement.focus();
           SkyAppTestUtility.fireDomEvent(inputElement, 'focusin');
           tick();
           fixture.detectChanges();
@@ -3648,6 +3653,7 @@ describe('Lookup component', function () {
 
           expect(lookupComponent.isInputFocused).toEqual(true);
 
+          getTestButton().focus();
           SkyAppTestUtility.fireDomEvent(document, 'focusin');
           tick();
           fixture.detectChanges();
@@ -3687,6 +3693,7 @@ describe('Lookup component', function () {
           fixture.detectChanges();
 
           const inputElement = getInputElement(lookupComponent);
+          inputElement.focus();
           SkyAppTestUtility.fireDomEvent(inputElement, 'focusin');
           tick();
           fixture.detectChanges();
@@ -3694,6 +3701,7 @@ describe('Lookup component', function () {
 
           expect(lookupComponent.isInputFocused).toEqual(true);
 
+          getTestButton().focus();
           SkyAppTestUtility.fireDomEvent(document, 'focusin');
           tick();
           fixture.detectChanges();
@@ -6789,6 +6797,7 @@ describe('Lookup component', function () {
           fixture.detectChanges();
 
           const inputElement = getInputElement(lookupComponent);
+          inputElement.focus();
           SkyAppTestUtility.fireDomEvent(inputElement, 'focusin');
           tick();
           fixture.detectChanges();
@@ -6796,6 +6805,7 @@ describe('Lookup component', function () {
 
           expect(lookupComponent.isInputFocused).toEqual(true);
 
+          getTestButton().focus();
           SkyAppTestUtility.fireDomEvent(document, 'focusin');
           tick();
           fixture.detectChanges();
@@ -6835,6 +6845,7 @@ describe('Lookup component', function () {
           fixture.detectChanges();
 
           const inputElement = getInputElement(lookupComponent);
+          inputElement.focus();
           SkyAppTestUtility.fireDomEvent(inputElement, 'focusin');
           tick();
           fixture.detectChanges();
@@ -6842,6 +6853,7 @@ describe('Lookup component', function () {
 
           expect(lookupComponent.isInputFocused).toEqual(true);
 
+          getTestButton().focus();
           SkyAppTestUtility.fireDomEvent(document, 'focusin');
           tick();
           fixture.detectChanges();
@@ -6930,6 +6942,7 @@ describe('Lookup component', function () {
       fixture.detectChanges();
 
       const inputElement = getInputElement(lookupComponent);
+      inputElement.focus();
       SkyAppTestUtility.fireDomEvent(inputElement, 'focusin');
       tick();
       fixture.detectChanges();
@@ -6937,6 +6950,7 @@ describe('Lookup component', function () {
 
       expect(lookupComponent.isInputFocused).toEqual(true);
 
+      getTestButton().focus();
       SkyAppTestUtility.fireDomEvent(document, 'focusin');
       tick();
       fixture.detectChanges();

--- a/libs/components/lookup/src/lib/modules/lookup/lookup.component.ts
+++ b/libs/components/lookup/src/lib/modules/lookup/lookup.component.ts
@@ -793,24 +793,24 @@ export class SkyLookupComponent
     // The input should NOT be focused if other elements (tokens, etc.)
     // are currently focused or being tabbed through.
 
-    observableFromEvent<MouseEvent>(documentObj, 'mousedown')
+    observableFromEvent<MouseEvent>(documentObj, 'click')
       .pipe(takeUntil(this.#idle))
-      .subscribe((event) => {
+      .subscribe(() => {
         hostElement = !this.inputBoxHostSvc
           ? this.#elementRef.nativeElement
           : this.lookupWrapperRef?.nativeElement;
-        this.isInputFocused = hostElement.contains(event.target);
+        this.isInputFocused = hostElement.contains(document.activeElement);
 
         this.#changeDetector.markForCheck();
       });
 
     observableFromEvent<KeyboardEvent>(documentObj, 'focusin')
       .pipe(takeUntil(this.#idle))
-      .subscribe((event) => {
+      .subscribe(() => {
         hostElement = !this.inputBoxHostSvc
           ? this.#elementRef.nativeElement
           : this.lookupWrapperRef?.nativeElement;
-        this.isInputFocused = hostElement.contains(event.target);
+        this.isInputFocused = hostElement.contains(document.activeElement);
 
         this.#changeDetector.markForCheck();
       });

--- a/libs/components/lookup/testing/src/country-field/country-field-fixture.ts
+++ b/libs/components/lookup/testing/src/country-field/country-field-fixture.ts
@@ -156,7 +156,7 @@ export class SkyCountryFieldFixture {
 
     // Note: the ordering of these events is important!
     SkyAppTestUtility.fireDomEvent(inputElement, 'change');
-    SkyAppTestUtility.fireDomEvent(searchResults[index], 'mousedown');
+    SkyAppTestUtility.fireDomEvent(searchResults[index], 'click');
     this.#blurInput(fixture);
   }
 

--- a/libs/components/phone-field/src/lib/modules/phone-field/phone-field.component.spec.ts
+++ b/libs/components/phone-field/src/lib/modules/phone-field/phone-field.component.spec.ts
@@ -136,7 +136,7 @@ describe('Phone Field Component', () => {
 
     SkyAppTestUtility.fireDomEvent(
       document.querySelector('.sky-autocomplete-result:first-child'),
-      'mousedown'
+      'click'
     );
 
     detectChangesAndTick(compFixture);


### PR DESCRIPTION
[AB#2647961](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/2647961)
[AB#2643556](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/2643556)