### PR TITLE
fix(components/lookup): fix regression for lookup in modal (#1656)

### DIFF
--- a/libs/components/lookup/src/lib/modules/lookup/lookup.component.ts
+++ b/libs/components/lookup/src/lib/modules/lookup/lookup.component.ts
@@ -299,6 +299,8 @@ export class SkyLookupComponent
   #idle = new Subject<void>();
   #markForTokenFocusOnKeyUp = false;
   #ngUnsubscribe = new Subject<void>();
+  #openNativePicker: SkyModalInstance | undefined;
+  #openSelectionModal: SkySelectionModalInstance | undefined;
 
   #_autocompleteInputDirective: SkyAutocompleteInputDirective | undefined;
   #_data: any[] | undefined;
@@ -315,12 +317,6 @@ export class SkyLookupComponent
   #idService = inject(SkyIdService);
   #logSvc = inject(SkyLogService);
   #modalService = inject(SkyModalService);
-  #openNativePicker =
-    inject(SkyModalInstance, {
-      optional: true,
-    }) || undefined;
-  #openSelectionModal =
-    inject(SkySelectionModalInstance, { optional: true }) || undefined;
   #resourcesService = inject(SkyLibResourcesService);
   #selectionModalSvc = inject(SkySelectionModalService);
   #windowRef = inject(SkyAppWindowRef);


### PR DESCRIPTION
:cherries: Cherry picked from #1656 [fix(components/lookup): fix regression for lookup in modal](https://github.com/blackbaud/skyux/pull/1656)

[AB#2656730](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/2656730) 