### PR TITLE
fix(components/layout): fix action button margins in responsive containers

### DIFF
--- a/libs/components/layout/src/lib/modules/action-button/action-button.component.scss
+++ b/libs/components/layout/src/lib/modules/action-button/action-button.component.scss
@@ -21,7 +21,6 @@
 @include mixins.sky-host-responsive-container-xs-min(false) {
   .sky-action-button {
     padding: $sky-padding-double $sky-padding-double $sky-padding-triple;
-    margin: 0 $sky-margin-plus-half;
   }
 
   .sky-action-button-icon-header-container {
@@ -32,7 +31,6 @@
 @include mixins.sky-host-responsive-container-sm-min(false) {
   .sky-action-button {
     padding: $sky-padding-triple $sky-padding-double;
-    margin: 0;
     max-width: 236px;
   }
 


### PR DESCRIPTION
As far as I can tell from the commit history, these margins were added in an effort to fix a weird/incorrect focus outline. They weren't ever taking effect until now because they weren't in a responsive container. Removing these does not impact the focus outline so I think it was just a mistake.