### PR TITLE
deprecation(components/lookup): inputs to set autcomplete HTML attributes on the autocomplete, lookup, and country field components have been deprecated

### DIFF
--- a/libs/components/ag-grid/src/lib/modules/ag-grid/types/lookup-properties.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/types/lookup-properties.ts
@@ -12,6 +12,7 @@ export interface SkyAgGridLookupProperties {
   addClick?: (args: SkyLookupAddClickEventArgs) => void;
   ariaLabel?: string;
   ariaLabelledBy?: string;
+  /** @deprecated */
   autocompleteAttribute?: string;
   data?: unknown[];
   debounceTime?: number;

--- a/libs/components/lookup/src/lib/modules/autocomplete/autocomplete-input.directive.ts
+++ b/libs/components/lookup/src/lib/modules/autocomplete/autocomplete-input.directive.ts
@@ -43,6 +43,7 @@ export class SkyAutocompleteInputDirective
   /**
    * The value for the `autocomplete` attribute on the form input.
    * @default "off"
+   * @deprecated SKY UX only supports browser autofill on components where the direct input matches the return value. This input may not behave as expected due to the dropdown selection interaction.
    */
   @Input()
   public set autocompleteAttribute(value: string | undefined) {

--- a/libs/components/lookup/src/lib/modules/country-field/country-field.component.ts
+++ b/libs/components/lookup/src/lib/modules/country-field/country-field.component.ts
@@ -63,6 +63,8 @@ export class SkyCountryFieldComponent
 {
   /**
    * The value for the HTML `autocomplete` attribute on the form input.
+   * @default 'off'
+   * @deprecated SKY UX only supports browser autofill on components where the direct input matches the return value. This input may not behave as expected due to the dropdown selection interaction.
    */
   @Input()
   public autocompleteAttribute: string | undefined;

--- a/libs/components/lookup/src/lib/modules/lookup/lookup.component.ts
+++ b/libs/components/lookup/src/lib/modules/lookup/lookup.component.ts
@@ -82,6 +82,8 @@ export class SkyLookupComponent
 
   /**
    * The value for the `autocomplete` attribute on the form input.
+   * @default 'off'
+   * @deprecated SKY UX only supports browser autofill on components where the direct input matches the return value. This input may not behave as expected due to the dropdown selection interaction.
    */
   @Input()
   public autocompleteAttribute: string | undefined;

--- a/libs/components/lookup/testing/src/country-field/country-field-fixture.ts
+++ b/libs/components/lookup/testing/src/country-field/country-field-fixture.ts
@@ -12,6 +12,7 @@ export class SkyCountryFieldFixture {
 
   /**
    * The value of the input field's autocomplete attribute.
+   * @deprecated The country field component's `autocompleteAttribute` is deprecated.
    */
   public get autocompleteAttribute(): string | null {
     return this.#getInputElement().getAttribute('autocomplete');


### PR DESCRIPTION
[AB#2346450](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/2346450)