### PR TITLE
fix(components/lookup): fix dropdown position in Safari on iOS (#1665)

### DIFF
--- a/libs/components/core/src/lib/modules/affix/affix.directive.spec.ts
+++ b/libs/components/core/src/lib/modules/affix/affix.directive.spec.ts
@@ -1,8 +1,9 @@
-import { ElementRef, RendererFactory2 } from '@angular/core';
+import { ViewportRuler } from '@angular/cdk/overlay';
+import { ElementRef, NgZone, RendererFactory2 } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { SkyAppTestUtility, expectAsync } from '@skyux-sdk/testing';
 
-import { Subject } from 'rxjs';
+import { Observable, Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 
 import { SkyAffixAutoFitContext } from './affix-auto-fit-context';
@@ -114,6 +115,12 @@ describe('Affix directive', () => {
       const fixture = TestBed.createComponent(AffixFixtureComponent);
       const affixService = TestBed.inject(SkyAffixService);
       const rendererFactory = TestBed.inject(RendererFactory2);
+      const viewportRulerChange = new Subject<Event>();
+      const viewportRuler = {
+        getViewportScrollPosition: () => ({ top: 0, left: 0 }),
+        change: (): Observable<Event> => viewportRulerChange,
+      } as ViewportRuler;
+      const zone = TestBed.inject(NgZone);
       const renderer = rendererFactory.createRenderer(undefined, null);
 
       fixture.componentInstance.position = position;
@@ -127,7 +134,12 @@ describe('Affix directive', () => {
       spyOn(affixService, 'createAffixer').and.callFake(
         (affixed: ElementRef) => {
           ngUnsubscribe = new Subject<void>();
-          affixer = new SkyAffixer(affixed.nativeElement, renderer);
+          affixer = new SkyAffixer(
+            affixed.nativeElement,
+            renderer,
+            viewportRuler,
+            zone
+          );
           affixer.offsetChange.pipe(takeUntil(ngUnsubscribe)).subscribe((x) => {
             offset = x.offset;
           });
@@ -168,6 +180,7 @@ describe('Affix directive', () => {
         getRecentOffsetChange,
         getNumOverflowScrollEmitted,
         getRecentPlacementChange,
+        viewportRuler,
       };
     }
 
@@ -451,14 +464,15 @@ describe('Affix directive', () => {
 
       // Scroll down until the affixed item is clipped at its top, then trigger the scroll event.
       window.scrollTo(0, 200);
-      SkyAppTestUtility.fireDomEvent(window, 'scroll');
+      SkyAppTestUtility.fireDomEvent(window.visualViewport, 'scroll');
       fixture.detectChanges();
 
       expect(getRecentPlacementChange()).toEqual('below');
     });
 
     it('should update placement on window resize', async () => {
-      const { fixture, getRecentPlacementChange } = await setupTest();
+      const { fixture, getRecentPlacementChange, viewportRuler } =
+        await setupTest();
       const componentInstance = fixture.componentInstance;
 
       componentInstance.isSticky = true;
@@ -469,7 +483,7 @@ describe('Affix directive', () => {
 
       // Scroll down until the affixed item is clipped at its top, then trigger the resize event.
       window.scrollTo(0, 200);
-      SkyAppTestUtility.fireDomEvent(window, 'resize');
+      (viewportRuler.change() as Subject<Event>).next(new Event('resize'));
       fixture.detectChanges();
 
       expect(getRecentPlacementChange()).toEqual('below');
@@ -868,7 +882,7 @@ describe('Affix directive', () => {
       fixture.detectChanges();
 
       componentInstance.scrollTargetToBottom();
-      SkyAppTestUtility.fireDomEvent(window, 'scroll');
+      SkyAppTestUtility.fireDomEvent(window.visualViewport, 'scroll');
       fixture.detectChanges();
 
       // Confirm baseline expectation.
@@ -878,7 +892,7 @@ describe('Affix directive', () => {
       const baseElementHeight =
         componentInstance.baseRef.nativeElement.getBoundingClientRect().height;
       componentInstance.scrollTargetToBottom(baseElementHeight);
-      SkyAppTestUtility.fireDomEvent(window, 'scroll');
+      SkyAppTestUtility.fireDomEvent(window.visualViewport, 'scroll');
       fixture.detectChanges();
 
       expect(getRecentPlacementChange()).toBeNull();

--- a/libs/components/core/src/lib/modules/affix/affix.service.ts
+++ b/libs/components/core/src/lib/modules/affix/affix.service.ts
@@ -1,8 +1,10 @@
+import { ViewportRuler } from '@angular/cdk/overlay';
 import {
   ElementRef,
   Injectable,
-  Renderer2,
+  NgZone,
   RendererFactory2,
+  inject,
 } from '@angular/core';
 
 import { SkyAffixer } from './affixer';
@@ -11,17 +13,22 @@ import { SkyAffixer } from './affixer';
   providedIn: 'root',
 })
 export class SkyAffixService {
-  #renderer: Renderer2;
+  readonly #renderer = inject(RendererFactory2).createRenderer(undefined, null);
 
-  constructor(rendererFactory: RendererFactory2) {
-    this.#renderer = rendererFactory.createRenderer(undefined, null);
-  }
+  readonly #viewportRuler = inject(ViewportRuler);
+
+  readonly #zone = inject(NgZone);
 
   /**
    * Creates an instance of [[SkyAffixer]].
    * @param affixed The element to be affixed.
    */
   public createAffixer(affixed: ElementRef): SkyAffixer {
-    return new SkyAffixer(affixed.nativeElement, this.#renderer);
+    return new SkyAffixer(
+      affixed.nativeElement,
+      this.#renderer,
+      this.#viewportRuler,
+      this.#zone
+    );
   }
 }

--- a/libs/components/core/src/lib/modules/affix/affixer.spec.ts
+++ b/libs/components/core/src/lib/modules/affix/affixer.spec.ts
@@ -1,0 +1,127 @@
+import { ViewportRuler } from '@angular/cdk/overlay';
+import {
+  Component,
+  ElementRef,
+  NgZone,
+  RendererFactory2,
+  ViewChild,
+} from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { Observable, Subject } from 'rxjs';
+
+import { SkyAffixer } from './affixer';
+
+@Component({
+  template: `
+    <div class="affixer-container">
+      <div #baseElement class="affixer-base">base</div>
+    </div>
+    <div #affixedElement class="affixed">affixed</div>
+  `,
+  styles: [
+    `
+      .affixer-container {
+        position: relative;
+        height: 100px;
+        width: 100px;
+      }
+
+      .affixer-base {
+        position: absolute;
+        top: 11px;
+        left: 12px;
+        height: 20px;
+        width: 40px;
+      }
+
+      .affixed {
+        font-size: 8px;
+        height: 10px;
+        width: 15px;
+      }
+    `,
+  ],
+  standalone: true,
+})
+class AffixerSpecComponent {
+  @ViewChild('affixedElement', { static: true })
+  public affixedElement: ElementRef<HTMLDivElement> | undefined;
+
+  @ViewChild('baseElement', { static: true })
+  public baseRef: ElementRef<HTMLDivElement> | undefined;
+}
+
+describe('Affixer', () => {
+  let fixture: ComponentFixture<AffixerSpecComponent>;
+  let component: AffixerSpecComponent;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [AffixerSpecComponent],
+    });
+    fixture = TestBed.createComponent(AffixerSpecComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('should create an instance, place above the top', async () => {
+    fixture.detectChanges();
+    await fixture.whenStable();
+    expect(component).toBeTruthy();
+    expect(component.affixedElement?.nativeElement).toBeTruthy();
+    const affixer = new SkyAffixer(
+      component.affixedElement?.nativeElement as HTMLElement,
+      TestBed.inject(RendererFactory2).createRenderer(undefined, null),
+      TestBed.inject(ViewportRuler),
+      TestBed.inject(NgZone)
+    );
+    expect(affixer).toBeTruthy();
+    expect(component.baseRef?.nativeElement).toBeTruthy();
+    affixer.affixTo(component.baseRef?.nativeElement as HTMLElement, {
+      placement: 'above',
+      verticalAlignment: 'top',
+      isSticky: true,
+    });
+    expect(component.affixedElement?.nativeElement.style.top).toEqual('11px');
+    affixer.destroy();
+  });
+
+  it('should create an instance, place at top right', async () => {
+    fixture.detectChanges();
+    await fixture.whenStable();
+    const affixer = new SkyAffixer(
+      component.affixedElement?.nativeElement as HTMLElement,
+      TestBed.inject(RendererFactory2).createRenderer(undefined, null),
+      TestBed.inject(ViewportRuler),
+      TestBed.inject(NgZone)
+    );
+    expect(affixer).toBeTruthy();
+    affixer.affixTo(component.baseRef?.nativeElement as HTMLElement, {
+      isSticky: true,
+      placement: 'above',
+    });
+    expect(component.affixedElement?.nativeElement.style.top).toEqual('1px');
+  });
+
+  it('should use viewport ruler change observable', async () => {
+    fixture.detectChanges();
+    await fixture.whenStable();
+    const viewportRulerChange = new Subject<Event>();
+    const viewportRuler = {
+      getViewportScrollPosition: () => ({ top: 50, left: 0 }),
+      change: (): Observable<Event> => viewportRulerChange,
+    } as ViewportRuler;
+    const affixer = new SkyAffixer(
+      component.affixedElement?.nativeElement as HTMLElement,
+      TestBed.inject(RendererFactory2).createRenderer(undefined, null),
+      viewportRuler,
+      TestBed.inject(NgZone)
+    );
+    expect(affixer).toBeTruthy();
+    affixer.affixTo(component.baseRef?.nativeElement as HTMLElement, {
+      isSticky: true,
+      placement: 'above',
+    });
+    expect(component.affixedElement?.nativeElement.style.top).toEqual('1px');
+  });
+});

--- a/libs/components/datetime/src/lib/modules/datepicker/datepicker.component.spec.ts
+++ b/libs/components/datetime/src/lib/modules/datepicker/datepicker.component.spec.ts
@@ -392,7 +392,7 @@ describe('datepicker', () => {
 
       // Scroll datepicker offscreen.
       window.scrollTo(0, 1000);
-      SkyAppTestUtility.fireDomEvent(window, 'scroll');
+      SkyAppTestUtility.fireDomEvent(window.visualViewport, 'scroll');
       fixture.detectChanges();
       tick();
 

--- a/libs/components/datetime/src/lib/modules/timepicker/timepicker.component.spec.ts
+++ b/libs/components/datetime/src/lib/modules/timepicker/timepicker.component.spec.ts
@@ -527,7 +527,7 @@ describe('Timepicker', () => {
 
       // Scroll timepicker offscreen.
       window.scrollTo(0, 1000);
-      SkyAppTestUtility.fireDomEvent(window, 'scroll');
+      SkyAppTestUtility.fireDomEvent(window.visualViewport, 'scroll');
       detectChangesAndTick(fixture);
 
       expect(component.timepickerComponent.isVisible).toBe(false);

--- a/libs/components/lookup/src/lib/modules/autocomplete/autocomplete.component.scss
+++ b/libs/components/lookup/src/lib/modules/autocomplete/autocomplete.component.scss
@@ -2,7 +2,7 @@
 @use 'libs/components/theme/src/lib/styles/variables' as *;
 
 .sky-autocomplete-results-container {
-  position: fixed;
+  position: absolute;
   background-color: $sky-color-white;
 }
 

--- a/libs/components/lookup/src/lib/modules/autocomplete/autocomplete.component.spec.ts
+++ b/libs/components/lookup/src/lib/modules/autocomplete/autocomplete.component.spec.ts
@@ -1,3 +1,5 @@
+import { ViewportRuler } from '@angular/cdk/overlay';
+import { ViewportScrollPosition } from '@angular/cdk/scrolling';
 import {
   ComponentFixture,
   TestBed,
@@ -235,8 +237,10 @@ describe('Autocomplete component', () => {
     let component: SkyAutocompleteFixtureComponent;
     let autocomplete: SkyAutocompleteComponent;
     let asyncAutocomplete: SkyAutocompleteComponent;
+    let viewportRulerChange: Subject<Event>;
 
     beforeEach(() => {
+      viewportRulerChange = new Subject();
       TestBed.configureTestingModule({
         imports: [SkyAutocompleteFixturesModule],
         providers: [
@@ -245,6 +249,16 @@ describe('Autocomplete component', () => {
             useValue: {
               zIndex: new BehaviorSubject(10),
             },
+          },
+          {
+            provide: ViewportRuler,
+            useValue: {
+              change: (): Observable<Event> => viewportRulerChange,
+              getViewportScrollPosition: (): ViewportScrollPosition => ({
+                top: 0,
+                left: 0,
+              }),
+            } as ViewportRuler,
           },
         ],
       });
@@ -256,6 +270,7 @@ describe('Autocomplete component', () => {
     });
 
     afterEach(() => {
+      viewportRulerChange.complete();
       (
         TestBed.inject(SKY_STACKING_CONTEXT).zIndex as BehaviorSubject<number>
       ).complete();
@@ -681,6 +696,7 @@ describe('Autocomplete component', () => {
       ).and.callThrough();
 
       SkyAppTestUtility.fireDomEvent(window, 'resize');
+      viewportRulerChange.next(new Event('resize'));
       fixture.detectChanges();
       tick();
 

--- a/libs/components/lookup/src/lib/modules/autocomplete/autocomplete.component.ts
+++ b/libs/components/lookup/src/lib/modules/autocomplete/autocomplete.component.ts
@@ -879,6 +879,7 @@ export class SkyAutocompleteComponent implements OnDestroy, AfterViewInit {
         enablePointerEvents: true,
         environmentInjector: this.#environmentInjector,
         wrapperClass: this.wrapperClass,
+        position: 'absolute',
       });
 
       if (this.#zIndex) {
@@ -991,6 +992,7 @@ export class SkyAutocompleteComponent implements OnDestroy, AfterViewInit {
         isSticky: true,
         placement: 'below',
         horizontalAlignment: 'left',
+        position: 'absolute',
       });
 
       this.#affixer = affixer;

--- a/libs/components/tabs/src/lib/modules/tabs/tabset.component.spec.ts
+++ b/libs/components/tabs/src/lib/modules/tabs/tabset.component.spec.ts
@@ -1,3 +1,5 @@
+import { ViewportRuler } from '@angular/cdk/overlay';
+import { ViewportScrollPosition } from '@angular/cdk/scrolling';
 import { Location } from '@angular/common';
 import { DebugElement } from '@angular/core';
 import {
@@ -21,7 +23,7 @@ import {
   SkyThemeSettingsChange,
 } from '@skyux/theme';
 
-import { BehaviorSubject } from 'rxjs';
+import { BehaviorSubject, Observable, Subject } from 'rxjs';
 
 import { SkyTabsFixturesModule } from './fixtures/tabs-fixtures.module';
 import { TabsetActiveTwoWayBindingTestComponent } from './fixtures/tabset-active-two-way.component.fixture';
@@ -52,8 +54,10 @@ describe('Tabset component', () => {
   let mockThemeSvc: {
     settingsChange: BehaviorSubject<SkyThemeSettingsChange>;
   };
+  let viewportRulerChange: Subject<Event>;
 
   beforeEach(() => {
+    viewportRulerChange = new Subject();
     mockThemeSvc = {
       settingsChange: new BehaviorSubject<SkyThemeSettingsChange>({
         currentSettings: new SkyThemeSettings(
@@ -89,8 +93,22 @@ describe('Tabset component', () => {
           provide: SkyThemeService,
           useValue: mockThemeSvc,
         },
+        {
+          provide: ViewportRuler,
+          useValue: {
+            change: (): Observable<Event> => viewportRulerChange,
+            getViewportScrollPosition: (): ViewportScrollPosition => ({
+              top: 0,
+              left: 0,
+            }),
+          } as ViewportRuler,
+        },
       ],
     });
+  });
+
+  afterEach(() => {
+    viewportRulerChange.complete();
   });
 
   function validateTabSelected(
@@ -631,6 +649,7 @@ describe('Tabset component', () => {
 
     function fireResizeEvent() {
       SkyAppTestUtility.fireDomEvent(window, 'resize');
+      viewportRulerChange.next(new Event('resize'));
       fixture.detectChanges();
       tick();
       fixture.detectChanges();


### PR DESCRIPTION
:cherries: Cherry picked from #1665 [fix(components/lookup): fix dropdown position in Safari on iOS](https://github.com/blackbaud/skyux/pull/1665)

[AB#2502219](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/2502219) 