### PR TITLE
fix(components/angular-tree-component): node expansion button uses the node name as its aria-label

### DIFF
--- a/libs/components/angular-tree-component/src/lib/modules/angular-tree/angular-tree-node.component.html
+++ b/libs/components/angular-tree-component/src/lib/modules/angular-tree/angular-tree-node.component.html
@@ -50,9 +50,7 @@
         class="sky-btn sky-btn-link sky-toggle-children"
         tabindex="-1"
         type="button"
-        [attr.aria-label]="
-          'skyux_angular_tree_click_to_expand' | skyLibResources
-        "
+        [attr.aria-label]="node.data.name"
         [class.toggle-children-wrapper-expanded]="node.isExpanded"
         [class.toggle-children-wrapper-collapsed]="node.isCollapsed"
         (click)="node.mouseAction('expanderClick', $event)"


### PR DESCRIPTION
[AB#2588837](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/2588837)