### PR TITLE
fix(components/popovers)!: dropdown menu buttons only specify a default aria-label when configured to be a context menu

### DIFF
--- a/apps/code-examples/src/app/code-examples/popovers/dropdown/basic/dropdown-demo.component.html
+++ b/apps/code-examples/src/app/code-examples/popovers/dropdown/basic/dropdown-demo.component.html
@@ -1,4 +1,4 @@
-<sky-dropdown data-sky-id="dropdown-demo">
+<sky-dropdown data-sky-id="dropdown-demo" label="Test dropdown">
   <sky-dropdown-button> Show dropdown </sky-dropdown-button>
   <sky-dropdown-menu>
     <sky-dropdown-item *ngFor="let item of items">

--- a/apps/code-examples/src/app/code-examples/popovers/dropdown/basic/dropdown-demo.component.spec.ts
+++ b/apps/code-examples/src/app/code-examples/popovers/dropdown/basic/dropdown-demo.component.spec.ts
@@ -39,7 +39,7 @@ describe('Basic dropdown', () => {
     await expectAsync(dropdownHarness.getButtonType()).toBeResolvedTo('select');
     await expectAsync(dropdownHarness.isDisabled()).toBeResolvedTo(false);
     await expectAsync(dropdownHarness.getAriaLabel()).toBeResolvedTo(
-      'Context menu'
+      'Test dropdown'
     );
     await expectAsync(dropdownHarness.getTitle()).toBeResolvedTo(null);
     await expectAsync(dropdownHarness.isOpen()).toBeResolvedTo(false);

--- a/apps/playground/src/app/components/popovers/dropdown/dropdown.component.html
+++ b/apps/playground/src/app/components/popovers/dropdown/dropdown.component.html
@@ -31,6 +31,24 @@
   </sky-dropdown>
   <br />
 
+  <sky-dropdown label="Filter">
+    <sky-dropdown-button
+      ><sky-icon icon="filter"></sky-icon
+    ></sky-dropdown-button>
+    <sky-dropdown-menu>
+      <sky-dropdown-item *ngFor="let item of items">
+        <button
+          type="button"
+          [attr.disabled]="item.disabled ? '' : null"
+          (click)="actionClicked(item.name)"
+        >
+          {{ item.name }}
+        </button>
+      </sky-dropdown-item>
+    </sky-dropdown-menu>
+  </sky-dropdown>
+  <br />
+
   <button
     class="sky-btn sky-btn-primary"
     type="button"

--- a/apps/playground/src/app/components/popovers/dropdown/dropdown.module.ts
+++ b/apps/playground/src/app/components/popovers/dropdown/dropdown.module.ts
@@ -1,12 +1,18 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
+import { SkyIconModule } from '@skyux/indicators';
 import { SkyDropdownModule } from '@skyux/popovers';
 
 import { DropdownRoutingModule } from './dropdown-routing.module';
 import { DropdownComponent } from './dropdown.component';
 
 @NgModule({
-  imports: [CommonModule, DropdownRoutingModule, SkyDropdownModule],
+  imports: [
+    CommonModule,
+    DropdownRoutingModule,
+    SkyDropdownModule,
+    SkyIconModule,
+  ],
   declarations: [DropdownComponent],
 })
 export class DropdownModule {

--- a/libs/components/action-bars/src/lib/modules/summary-action-bar/actions/summary-action-bar-secondary-actions.component.html
+++ b/libs/components/action-bars/src/lib/modules/summary-action-bar/actions/summary-action-bar-secondary-actions.component.html
@@ -20,6 +20,7 @@
   <sky-dropdown
     buttonType="select"
     [attr.title]="'skyux_summary_action_bar_open_secondary' | skyLibResources"
+    [label]="'skyux_summary_action_bar_open_secondary' | skyLibResources"
     [messageStream]="dropdownMessageStream"
   >
     <sky-dropdown-button>

--- a/libs/components/popovers/src/lib/modules/dropdown/dropdown.component.html
+++ b/libs/components/popovers/src/lib/modules/dropdown/dropdown.component.html
@@ -6,7 +6,10 @@
     [attr.aria-controls]="isOpen ? menuId : null"
     [attr.aria-haspopup]="menuAriaRole"
     [attr.aria-label]="
-      label || ('skyux_dropdown_context_menu_default_label' | skyLibResources)
+      label ||
+      (buttonType === 'context-menu'
+        ? ('skyux_dropdown_context_menu_default_label' | skyLibResources)
+        : undefined)
     "
     [attr.title]="title"
     [disabled]="disabled"

--- a/libs/components/popovers/src/lib/modules/dropdown/dropdown.component.spec.ts
+++ b/libs/components/popovers/src/lib/modules/dropdown/dropdown.component.spec.ts
@@ -1129,7 +1129,7 @@ describe('Dropdown component', function () {
   });
 
   describe('accessibility', function () {
-    it('should set default ARIA attributes', fakeAsync(() => {
+    it('should set default ARIA attributes - standard dropdown', fakeAsync(() => {
       detectChangesFakeAsync();
       const button = getButtonElement();
 
@@ -1142,7 +1142,28 @@ describe('Dropdown component', function () {
       expect(button?.getAttribute('aria-haspopup')).toEqual(
         menu?.getAttribute('role')
       );
-      expect(button?.getAttribute('aria-label')).toEqual('Context menu');
+      expect(button?.getAttribute('aria-label')).toBeNull();
+      expect(button?.getAttribute('aria-expanded')).toEqual('true');
+      expect(menu?.getAttribute('role')).toEqual('menu');
+      expect(menu?.getAttribute('aria-labelledby')).toBeNull();
+      expect(item?.getAttribute('role')).toEqual('menuitem');
+    }));
+
+    it('should set default ARIA attributes - context menu', fakeAsync(() => {
+      fixture.componentInstance.buttonType = 'context-menu';
+      detectChangesFakeAsync();
+      const button = getButtonElement();
+
+      button?.click();
+      detectChangesFakeAsync();
+
+      const menu = getMenuElement();
+      const item = getFirstMenuItem();
+
+      expect(button?.getAttribute('aria-haspopup')).toEqual(
+        menu?.getAttribute('role')
+      );
+      expect(button?.getAttribute('aria-label')).toBe('Context menu');
       expect(button?.getAttribute('aria-expanded')).toEqual('true');
       expect(menu?.getAttribute('role')).toEqual('menu');
       expect(menu?.getAttribute('aria-labelledby')).toBeNull();

--- a/libs/components/popovers/testing/src/dropdown/harness/dropdown-harness.spec.ts
+++ b/libs/components/popovers/testing/src/dropdown/harness/dropdown-harness.spec.ts
@@ -148,8 +148,9 @@ describe('Dropdown test harness', () => {
     await expectAsync(dropdownHarness.isDisabled()).toBeResolvedTo(false);
   });
 
-  it('should have default aria-label', async () => {
+  it('should have default aria-label for context menus', async () => {
     const { dropdownHarness, fixture } = await setupTest();
+    fixture.componentInstance.buttonType = 'context-menu';
 
     fixture.detectChanges();
 


### PR DESCRIPTION
[AB#2578214](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/2578214)