### PR TITLE
fix(components/angular-tree-component): tree view code examples now use context specific accessibility labels and dropdown menu labels

### DIFF
--- a/apps/code-examples/src/app/code-examples/angular-tree-component/angular-tree/advanced/angular-tree-demo.component.html
+++ b/apps/code-examples/src/app/code-examples/angular-tree-component/angular-tree/advanced/angular-tree-demo.component.html
@@ -133,7 +133,10 @@
             >
               <sky-dropdown-menu>
                 <sky-dropdown-item *ngFor="let item of dropdownItems">
-                  <button type="button" (click)="actionClicked(item.name, node)">
+                  <button
+                    type="button"
+                    (click)="actionClicked(item.name, node)"
+                  >
                     <sky-format [text]="item.name" [args]="[itemName]" />
                   </button>
                   <ng-template #itemName>{{ node.data.name }}</ng-template>

--- a/apps/code-examples/src/app/code-examples/angular-tree-component/angular-tree/advanced/angular-tree-demo.component.html
+++ b/apps/code-examples/src/app/code-examples/angular-tree-component/angular-tree/advanced/angular-tree-demo.component.html
@@ -129,15 +129,14 @@
             <sky-dropdown
               *ngIf="demoOptions.value.showContextMenus"
               buttonType="context-menu"
+              [label]="'Context menu for ' + node.data.name"
             >
               <sky-dropdown-menu>
                 <sky-dropdown-item *ngFor="let item of dropdownItems">
-                  <button
-                    type="button"
-                    (click)="actionClicked(item.name, node)"
-                  >
-                    {{ item.name }}
+                  <button type="button" (click)="actionClicked(item.id, node)">
+                    <sky-format [text]="item.name" [args]="[itemName]" />
                   </button>
+                  <ng-template #itemName>{{ node.data.name }}</ng-template>
                 </sky-dropdown-item>
               </sky-dropdown-menu>
             </sky-dropdown>

--- a/apps/code-examples/src/app/code-examples/angular-tree-component/angular-tree/advanced/angular-tree-demo.component.html
+++ b/apps/code-examples/src/app/code-examples/angular-tree-component/angular-tree/advanced/angular-tree-demo.component.html
@@ -133,7 +133,7 @@
             >
               <sky-dropdown-menu>
                 <sky-dropdown-item *ngFor="let item of dropdownItems">
-                  <button type="button" (click)="actionClicked(item.id, node)">
+                  <button type="button" (click)="actionClicked(item.name, node)">
                     <sky-format [text]="item.name" [args]="[itemName]" />
                   </button>
                   <ng-template #itemName>{{ node.data.name }}</ng-template>

--- a/apps/code-examples/src/app/code-examples/angular-tree-component/angular-tree/advanced/angular-tree-demo.component.ts
+++ b/apps/code-examples/src/app/code-examples/angular-tree-component/angular-tree/advanced/angular-tree-demo.component.ts
@@ -71,14 +71,17 @@ export class AngularTreeDemoComponent implements OnInit {
   };
 
   public dropdownItems: { name: string; disabled: boolean }[] = [
-    { name: 'Insert an item at this level', disabled: false },
-    { name: 'Insert an item under this level', disabled: false },
-    { name: 'Move up', disabled: false },
-    { name: 'Move down', disabled: false },
-    { name: 'Move left', disabled: false },
-    { name: 'Move right', disabled: false },
-    { name: 'Edit', disabled: false },
-    { name: 'Delete', disabled: false },
+    {
+      name: 'Insert an item adjacent to {0}',
+      disabled: false,
+    },
+    { name: 'Insert an item under {0}', disabled: false },
+    { name: 'Move up {0}', disabled: false },
+    { name: 'Move down {0}', disabled: false },
+    { name: 'Move left {0}', disabled: false },
+    { name: 'Move right {0}', disabled: false },
+    { name: 'Edit {0}', disabled: false },
+    { name: 'Delete {0}', disabled: false },
   ];
 
   public nodes: AngularTreeDemoNode[] = [
@@ -183,7 +186,7 @@ export class AngularTreeDemoComponent implements OnInit {
 
   public actionClicked(name: string, node: TreeNode): void {
     // Add custom actions here.
-    alert(name + `: "${node.data.name}"`);
+    alert(name.replace('{0}', node.data.name) + ' clicked!');
   }
 
   public onTreeStateChange(treeModel: ITreeState): void {

--- a/apps/code-examples/src/app/code-examples/angular-tree-component/angular-tree/advanced/angular-tree-demo.module.ts
+++ b/apps/code-examples/src/app/code-examples/angular-tree-component/angular-tree/advanced/angular-tree-demo.module.ts
@@ -4,7 +4,7 @@ import { ReactiveFormsModule } from '@angular/forms';
 import { TreeModule } from '@blackbaud/angular-tree-component';
 import { SkyAngularTreeModule } from '@skyux/angular-tree-component';
 import { SkyCheckboxModule, SkyRadioModule } from '@skyux/forms';
-import { SkyFluidGridModule } from '@skyux/layout';
+import { SkyFluidGridModule, SkyFormatModule } from '@skyux/layout';
 import { SkyDropdownModule } from '@skyux/popovers';
 
 import { AngularTreeDemoComponent } from './angular-tree-demo.component';
@@ -17,6 +17,7 @@ import { AngularTreeDemoComponent } from './angular-tree-demo.component';
     SkyCheckboxModule,
     SkyDropdownModule,
     SkyFluidGridModule,
+    SkyFormatModule,
     SkyRadioModule,
     TreeModule,
   ],


### PR DESCRIPTION
[AB#2578237](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/2578237)