### PR TITLE
ci: add retry option to cypress preset

### DIFF
--- a/apps/e2e/a11y-storybook-e2e/cypress.config.ts
+++ b/apps/e2e/a11y-storybook-e2e/cypress.config.ts
@@ -1,15 +1,13 @@
-import { nxE2EPreset } from '@nx/cypress/plugins/cypress-preset';
 import { sendCypressScreenshotsToPercy } from '@skyux-sdk/e2e-schematics';
+import { skyE2ePreset } from '@skyux-sdk/e2e-schematics/cypress-preset';
 
 import { defineConfig } from 'cypress';
 
 export default defineConfig({
   e2e: {
-    ...nxE2EPreset(__dirname),
-    video: false,
+    ...skyE2ePreset(__dirname),
     setupNodeEvents: (on, config) => {
       sendCypressScreenshotsToPercy(on, config);
     },
-    defaultCommandTimeout: 60000,
   },
 });

--- a/apps/e2e/action-bars-storybook-e2e/cypress.config.ts
+++ b/apps/e2e/action-bars-storybook-e2e/cypress.config.ts
@@ -1,15 +1,13 @@
-import { nxE2EPreset } from '@nx/cypress/plugins/cypress-preset';
 import { sendCypressScreenshotsToPercy } from '@skyux-sdk/e2e-schematics';
+import { skyE2ePreset } from '@skyux-sdk/e2e-schematics/cypress-preset';
 
 import { defineConfig } from 'cypress';
 
 export default defineConfig({
   e2e: {
-    ...nxE2EPreset(__dirname),
-    video: false,
+    ...skyE2ePreset(__dirname),
     setupNodeEvents: (on, config) => {
       sendCypressScreenshotsToPercy(on, config);
     },
-    defaultCommandTimeout: 60000,
   },
 });

--- a/apps/e2e/ag-grid-storybook-e2e/cypress.config.ts
+++ b/apps/e2e/ag-grid-storybook-e2e/cypress.config.ts
@@ -1,13 +1,11 @@
-import { nxE2EPreset } from '@nx/cypress/plugins/cypress-preset';
 import { sendCypressScreenshotsToPercy } from '@skyux-sdk/e2e-schematics';
+import { skyE2ePreset } from '@skyux-sdk/e2e-schematics/cypress-preset';
 
 import { defineConfig } from 'cypress';
 
 export default defineConfig({
   e2e: {
-    ...nxE2EPreset(__dirname),
-    video: false,
-    defaultCommandTimeout: 60000,
+    ...skyE2ePreset(__dirname),
     setupNodeEvents: (on, config) => {
       sendCypressScreenshotsToPercy(on, config);
     },

--- a/apps/e2e/angular-tree-component-storybook-e2e/cypress.config.ts
+++ b/apps/e2e/angular-tree-component-storybook-e2e/cypress.config.ts
@@ -1,11 +1,9 @@
-import { nxE2EPreset } from '@nx/cypress/plugins/cypress-preset';
+import { skyE2ePreset } from '@skyux-sdk/e2e-schematics/cypress-preset';
 
 import { defineConfig } from 'cypress';
 
 export default defineConfig({
   e2e: {
-    ...nxE2EPreset(__dirname),
-    video: false,
-    defaultCommandTimeout: 60000,
+    ...skyE2ePreset(__dirname),
   },
 });

--- a/apps/e2e/avatar-storybook-e2e/cypress.config.ts
+++ b/apps/e2e/avatar-storybook-e2e/cypress.config.ts
@@ -1,11 +1,9 @@
-import { nxE2EPreset } from '@nx/cypress/plugins/cypress-preset';
+import { skyE2ePreset } from '@skyux-sdk/e2e-schematics/cypress-preset';
 
 import { defineConfig } from 'cypress';
 
 export default defineConfig({
   e2e: {
-    ...nxE2EPreset(__dirname),
-    video: false,
-    defaultCommandTimeout: 60000,
+    ...skyE2ePreset(__dirname),
   },
 });

--- a/apps/e2e/colorpicker-storybook-e2e/cypress.config.ts
+++ b/apps/e2e/colorpicker-storybook-e2e/cypress.config.ts
@@ -1,11 +1,9 @@
-import { nxE2EPreset } from '@nx/cypress/plugins/cypress-preset';
+import { skyE2ePreset } from '@skyux-sdk/e2e-schematics/cypress-preset';
 
 import { defineConfig } from 'cypress';
 
 export default defineConfig({
   e2e: {
-    ...nxE2EPreset(__dirname),
-    video: false,
-    defaultCommandTimeout: 60000,
+    ...skyE2ePreset(__dirname),
   },
 });

--- a/apps/e2e/core-storybook-e2e/cypress.config.ts
+++ b/apps/e2e/core-storybook-e2e/cypress.config.ts
@@ -1,11 +1,9 @@
-import { nxE2EPreset } from '@nx/cypress/plugins/cypress-preset';
+import { skyE2ePreset } from '@skyux-sdk/e2e-schematics/cypress-preset';
 
 import { defineConfig } from 'cypress';
 
 export default defineConfig({
   e2e: {
-    ...nxE2EPreset(__dirname),
-    video: false,
-    defaultCommandTimeout: 60000,
+    ...skyE2ePreset(__dirname),
   },
 });

--- a/apps/e2e/data-manager-storybook-e2e/cypress.config.ts
+++ b/apps/e2e/data-manager-storybook-e2e/cypress.config.ts
@@ -1,11 +1,9 @@
-import { nxE2EPreset } from '@nx/cypress/plugins/cypress-preset';
+import { skyE2ePreset } from '@skyux-sdk/e2e-schematics/cypress-preset';
 
 import { defineConfig } from 'cypress';
 
 export default defineConfig({
   e2e: {
-    ...nxE2EPreset(__dirname),
-    video: false,
-    defaultCommandTimeout: 60000,
+    ...skyE2ePreset(__dirname),
   },
 });

--- a/apps/e2e/datetime-storybook-e2e/cypress.config.ts
+++ b/apps/e2e/datetime-storybook-e2e/cypress.config.ts
@@ -1,13 +1,11 @@
-import { nxE2EPreset } from '@nx/cypress/plugins/cypress-preset';
 import { sendCypressScreenshotsToPercy } from '@skyux-sdk/e2e-schematics';
+import { skyE2ePreset } from '@skyux-sdk/e2e-schematics/cypress-preset';
 
 import { defineConfig } from 'cypress';
 
 export default defineConfig({
   e2e: {
-    ...nxE2EPreset(__dirname),
-    video: false,
-    defaultCommandTimeout: 60000,
+    ...skyE2ePreset(__dirname),
     setupNodeEvents: (on, config) => {
       sendCypressScreenshotsToPercy(on, config);
     },

--- a/apps/e2e/errors-storybook-e2e/cypress.config.ts
+++ b/apps/e2e/errors-storybook-e2e/cypress.config.ts
@@ -1,11 +1,9 @@
-import { nxE2EPreset } from '@nx/cypress/plugins/cypress-preset';
+import { skyE2ePreset } from '@skyux-sdk/e2e-schematics/cypress-preset';
 
 import { defineConfig } from 'cypress';
 
 export default defineConfig({
   e2e: {
-    ...nxE2EPreset(__dirname),
-    video: false,
-    defaultCommandTimeout: 60000,
+    ...skyE2ePreset(__dirname),
   },
 });

--- a/apps/e2e/flyout-storybook-e2e/cypress.config.ts
+++ b/apps/e2e/flyout-storybook-e2e/cypress.config.ts
@@ -1,11 +1,9 @@
-import { nxE2EPreset } from '@nx/cypress/plugins/cypress-preset';
+import { skyE2ePreset } from '@skyux-sdk/e2e-schematics/cypress-preset';
 
 import { defineConfig } from 'cypress';
 
 export default defineConfig({
   e2e: {
-    ...nxE2EPreset(__dirname),
-    video: false,
-    defaultCommandTimeout: 60000,
+    ...skyE2ePreset(__dirname),
   },
 });

--- a/apps/e2e/forms-storybook-e2e/cypress.config.ts
+++ b/apps/e2e/forms-storybook-e2e/cypress.config.ts
@@ -1,11 +1,9 @@
-import { nxE2EPreset } from '@nx/cypress/plugins/cypress-preset';
+import { skyE2ePreset } from '@skyux-sdk/e2e-schematics/cypress-preset';
 
 import { defineConfig } from 'cypress';
 
 export default defineConfig({
   e2e: {
-    ...nxE2EPreset(__dirname),
-    video: false,
-    defaultCommandTimeout: 60000,
+    ...skyE2ePreset(__dirname),
   },
 });

--- a/apps/e2e/indicators-storybook-e2e/cypress.config.ts
+++ b/apps/e2e/indicators-storybook-e2e/cypress.config.ts
@@ -1,11 +1,9 @@
-import { nxE2EPreset } from '@nx/cypress/plugins/cypress-preset';
+import { skyE2ePreset } from '@skyux-sdk/e2e-schematics/cypress-preset';
 
 import { defineConfig } from 'cypress';
 
 export default defineConfig({
   e2e: {
-    ...nxE2EPreset(__dirname),
-    video: false,
-    defaultCommandTimeout: 60000,
+    ...skyE2ePreset(__dirname),
   },
 });

--- a/apps/e2e/inline-form-storybook-e2e/cypress.config.ts
+++ b/apps/e2e/inline-form-storybook-e2e/cypress.config.ts
@@ -1,11 +1,9 @@
-import { nxE2EPreset } from '@nx/cypress/plugins/cypress-preset';
+import { skyE2ePreset } from '@skyux-sdk/e2e-schematics/cypress-preset';
 
 import { defineConfig } from 'cypress';
 
 export default defineConfig({
   e2e: {
-    ...nxE2EPreset(__dirname),
-    video: false,
-    defaultCommandTimeout: 60000,
+    ...skyE2ePreset(__dirname),
   },
 });

--- a/apps/e2e/layout-storybook-e2e/cypress.config.ts
+++ b/apps/e2e/layout-storybook-e2e/cypress.config.ts
@@ -1,11 +1,9 @@
-import { nxE2EPreset } from '@nx/cypress/plugins/cypress-preset';
+import { skyE2ePreset } from '@skyux-sdk/e2e-schematics/cypress-preset';
 
 import { defineConfig } from 'cypress';
 
 export default defineConfig({
   e2e: {
-    ...nxE2EPreset(__dirname),
-    video: false,
-    defaultCommandTimeout: 60000,
+    ...skyE2ePreset(__dirname),
   },
 });

--- a/apps/e2e/lists-storybook-e2e/cypress.config.ts
+++ b/apps/e2e/lists-storybook-e2e/cypress.config.ts
@@ -1,11 +1,9 @@
-import { nxE2EPreset } from '@nx/cypress/plugins/cypress-preset';
+import { skyE2ePreset } from '@skyux-sdk/e2e-schematics/cypress-preset';
 
 import { defineConfig } from 'cypress';
 
 export default defineConfig({
   e2e: {
-    ...nxE2EPreset(__dirname),
-    video: false,
-    defaultCommandTimeout: 60000,
+    ...skyE2ePreset(__dirname),
   },
 });

--- a/apps/e2e/lookup-storybook-e2e/cypress.config.ts
+++ b/apps/e2e/lookup-storybook-e2e/cypress.config.ts
@@ -1,11 +1,9 @@
-import { nxE2EPreset } from '@nx/cypress/plugins/cypress-preset';
+import { skyE2ePreset } from '@skyux-sdk/e2e-schematics/cypress-preset';
 
 import { defineConfig } from 'cypress';
 
 export default defineConfig({
   e2e: {
-    ...nxE2EPreset(__dirname),
-    video: false,
-    defaultCommandTimeout: 60000,
+    ...skyE2ePreset(__dirname),
   },
 });

--- a/apps/e2e/modals-storybook-e2e/cypress.config.ts
+++ b/apps/e2e/modals-storybook-e2e/cypress.config.ts
@@ -1,11 +1,9 @@
-import { nxE2EPreset } from '@nx/cypress/plugins/cypress-preset';
+import { skyE2ePreset } from '@skyux-sdk/e2e-schematics/cypress-preset';
 
 import { defineConfig } from 'cypress';
 
 export default defineConfig({
   e2e: {
-    ...nxE2EPreset(__dirname),
-    video: false,
-    defaultCommandTimeout: 60000,
+    ...skyE2ePreset(__dirname),
   },
 });

--- a/apps/e2e/navbar-storybook-e2e/cypress.config.ts
+++ b/apps/e2e/navbar-storybook-e2e/cypress.config.ts
@@ -1,11 +1,9 @@
-import { nxE2EPreset } from '@nx/cypress/plugins/cypress-preset';
+import { skyE2ePreset } from '@skyux-sdk/e2e-schematics/cypress-preset';
 
 import { defineConfig } from 'cypress';
 
 export default defineConfig({
   e2e: {
-    ...nxE2EPreset(__dirname),
-    video: false,
-    defaultCommandTimeout: 60000,
+    ...skyE2ePreset(__dirname),
   },
 });

--- a/apps/e2e/pages-storybook-e2e/cypress.config.ts
+++ b/apps/e2e/pages-storybook-e2e/cypress.config.ts
@@ -1,11 +1,9 @@
-import { nxE2EPreset } from '@nx/cypress/plugins/cypress-preset';
+import { skyE2ePreset } from '@skyux-sdk/e2e-schematics/cypress-preset';
 
 import { defineConfig } from 'cypress';
 
 export default defineConfig({
   e2e: {
-    ...nxE2EPreset(__dirname),
-    video: false,
-    defaultCommandTimeout: 60000,
+    ...skyE2ePreset(__dirname),
   },
 });

--- a/apps/e2e/phone-field-storybook-e2e/cypress.config.ts
+++ b/apps/e2e/phone-field-storybook-e2e/cypress.config.ts
@@ -1,15 +1,13 @@
-import { nxE2EPreset } from '@nx/cypress/plugins/cypress-preset';
 import { sendCypressScreenshotsToPercy } from '@skyux-sdk/e2e-schematics';
+import { skyE2ePreset } from '@skyux-sdk/e2e-schematics/cypress-preset';
 
 import { defineConfig } from 'cypress';
 
 export default defineConfig({
   e2e: {
-    ...nxE2EPreset(__dirname),
-    video: false,
+    ...skyE2ePreset(__dirname),
     setupNodeEvents: (on, config) => {
       sendCypressScreenshotsToPercy(on, config);
     },
-    defaultCommandTimeout: 60000,
   },
 });

--- a/apps/e2e/popovers-storybook-e2e/cypress.config.ts
+++ b/apps/e2e/popovers-storybook-e2e/cypress.config.ts
@@ -1,11 +1,9 @@
-import { nxE2EPreset } from '@nx/cypress/plugins/cypress-preset';
+import { skyE2ePreset } from '@skyux-sdk/e2e-schematics/cypress-preset';
 
 import { defineConfig } from 'cypress';
 
 export default defineConfig({
   e2e: {
-    ...nxE2EPreset(__dirname),
-    video: false,
-    defaultCommandTimeout: 60000,
+    ...skyE2ePreset(__dirname),
   },
 });

--- a/apps/e2e/progress-indicator-storybook-e2e/cypress.config.ts
+++ b/apps/e2e/progress-indicator-storybook-e2e/cypress.config.ts
@@ -1,11 +1,9 @@
-import { nxE2EPreset } from '@nx/cypress/plugins/cypress-preset';
+import { skyE2ePreset } from '@skyux-sdk/e2e-schematics/cypress-preset';
 
 import { defineConfig } from 'cypress';
 
 export default defineConfig({
   e2e: {
-    ...nxE2EPreset(__dirname),
-    video: false,
-    defaultCommandTimeout: 60000,
+    ...skyE2ePreset(__dirname),
   },
 });

--- a/apps/e2e/split-view-storybook-e2e/cypress.config.ts
+++ b/apps/e2e/split-view-storybook-e2e/cypress.config.ts
@@ -1,11 +1,9 @@
-import { nxE2EPreset } from '@nx/cypress/plugins/cypress-preset';
+import { skyE2ePreset } from '@skyux-sdk/e2e-schematics/cypress-preset';
 
 import { defineConfig } from 'cypress';
 
 export default defineConfig({
   e2e: {
-    ...nxE2EPreset(__dirname),
-    video: false,
-    defaultCommandTimeout: 60000,
+    ...skyE2ePreset(__dirname),
   },
 });

--- a/apps/e2e/tabs-storybook-e2e/cypress.config.ts
+++ b/apps/e2e/tabs-storybook-e2e/cypress.config.ts
@@ -1,11 +1,9 @@
-import { nxE2EPreset } from '@nx/cypress/plugins/cypress-preset';
+import { skyE2ePreset } from '@skyux-sdk/e2e-schematics/cypress-preset';
 
 import { defineConfig } from 'cypress';
 
 export default defineConfig({
   e2e: {
-    ...nxE2EPreset(__dirname),
-    video: false,
-    defaultCommandTimeout: 60000,
+    ...skyE2ePreset(__dirname),
   },
 });

--- a/apps/e2e/text-editor-storybook-e2e/cypress.config.ts
+++ b/apps/e2e/text-editor-storybook-e2e/cypress.config.ts
@@ -1,11 +1,9 @@
-import { nxE2EPreset } from '@nx/cypress/plugins/cypress-preset';
+import { skyE2ePreset } from '@skyux-sdk/e2e-schematics/cypress-preset';
 
 import { defineConfig } from 'cypress';
 
 export default defineConfig({
   e2e: {
-    ...nxE2EPreset(__dirname),
-    video: false,
-    defaultCommandTimeout: 60000,
+    ...skyE2ePreset(__dirname),
   },
 });

--- a/apps/e2e/theme-storybook-e2e/cypress.config.ts
+++ b/apps/e2e/theme-storybook-e2e/cypress.config.ts
@@ -1,11 +1,9 @@
-import { nxE2EPreset } from '@nx/cypress/plugins/cypress-preset';
+import { skyE2ePreset } from '@skyux-sdk/e2e-schematics/cypress-preset';
 
 import { defineConfig } from 'cypress';
 
 export default defineConfig({
   e2e: {
-    ...nxE2EPreset(__dirname),
-    video: false,
-    defaultCommandTimeout: 60000,
+    ...skyE2ePreset(__dirname),
   },
 });

--- a/apps/e2e/tiles-storybook-e2e/cypress.config.ts
+++ b/apps/e2e/tiles-storybook-e2e/cypress.config.ts
@@ -1,11 +1,9 @@
-import { nxE2EPreset } from '@nx/cypress/plugins/cypress-preset';
+import { skyE2ePreset } from '@skyux-sdk/e2e-schematics/cypress-preset';
 
 import { defineConfig } from 'cypress';
 
 export default defineConfig({
   e2e: {
-    ...nxE2EPreset(__dirname),
-    video: false,
-    defaultCommandTimeout: 60000,
+    ...skyE2ePreset(__dirname),
   },
 });

--- a/apps/e2e/toast-storybook-e2e/cypress.config.ts
+++ b/apps/e2e/toast-storybook-e2e/cypress.config.ts
@@ -1,11 +1,9 @@
-import { nxE2EPreset } from '@nx/cypress/plugins/cypress-preset';
+import { skyE2ePreset } from '@skyux-sdk/e2e-schematics/cypress-preset';
 
 import { defineConfig } from 'cypress';
 
 export default defineConfig({
   e2e: {
-    ...nxE2EPreset(__dirname),
-    video: false,
-    defaultCommandTimeout: 60000,
+    ...skyE2ePreset(__dirname),
   },
 });

--- a/apps/integration-e2e/cypress.config.ts
+++ b/apps/integration-e2e/cypress.config.ts
@@ -1,13 +1,11 @@
-import { nxE2EPreset } from '@nx/cypress/plugins/cypress-preset';
 import { sendCypressScreenshotsToPercy } from '@skyux-sdk/e2e-schematics';
+import { skyE2ePreset } from '@skyux-sdk/e2e-schematics/cypress-preset';
 
 import { defineConfig } from 'cypress';
 
 export default defineConfig({
   e2e: {
-    ...nxE2EPreset(__dirname),
-    video: false,
-    defaultCommandTimeout: 60000,
+    ...skyE2ePreset(__dirname),
     setupNodeEvents: (on, config) => {
       sendCypressScreenshotsToPercy(on, config);
     },

--- a/libs/sdk/e2e-schematics/src/cypress-preset.ts
+++ b/libs/sdk/e2e-schematics/src/cypress-preset.ts
@@ -1,0 +1,24 @@
+import { nxE2EPreset } from '@nx/cypress/plugins/cypress-preset';
+import { joinPathFragments, offsetFromRoot } from '@nx/devkit';
+
+export function skyE2ePreset(
+  directory: string
+): Partial<Cypress.PluginConfigOptions> {
+  const offset = offsetFromRoot(directory);
+  return {
+    ...nxE2EPreset(directory),
+    downloadsFolder: joinPathFragments(
+      offset,
+      'dist',
+      'cypress',
+      directory,
+      'downloads'
+    ),
+    video: false,
+    defaultCommandTimeout: 60000,
+    retries: {
+      runMode: 2,
+      openMode: 0,
+    },
+  };
+}

--- a/libs/sdk/e2e-schematics/src/generators/configure-percy/__snapshots__/index.spec.ts.snap
+++ b/libs/sdk/e2e-schematics/src/generators/configure-percy/__snapshots__/index.spec.ts.snap
@@ -1,14 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`configure-percy should generate cypress.config.ts 1`] = `
-"import { nxE2EPreset } from '@nx/cypress/plugins/cypress-preset';
+"import { skyE2ePreset } from '@skyux-sdk/e2e-schematics/cypress-preset';
 import { defineConfig } from 'cypress';
 
 export default defineConfig({
   e2e: {
-    ...nxE2EPreset(__dirname),
-    video: false,
-    defaultCommandTimeout: 60000,
+    ...skyE2ePreset(__dirname),
   },
 });
 "

--- a/libs/sdk/e2e-schematics/src/generators/configure-percy/files/cypress.config.ts.template
+++ b/libs/sdk/e2e-schematics/src/generators/configure-percy/files/cypress.config.ts.template
@@ -1,10 +1,8 @@
 import { defineConfig } from 'cypress';
-import { nxE2EPreset } from '@nx/cypress/plugins/cypress-preset';
+import { skyE2ePreset } from '@skyux-sdk/e2e-schematics/cypress-preset';
 
 export default defineConfig({
   e2e: {
-    ...nxE2EPreset(__dirname),
-    video: false,
-    defaultCommandTimeout: 60000,
+    ...skyE2ePreset(__dirname),
   }
 });

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -26,6 +26,9 @@
     "paths": {
       "*": ["./vendor/types/*"],
       "@skyux-sdk/e2e-schematics": ["libs/sdk/e2e-schematics/src/index.ts"],
+      "@skyux-sdk/e2e-schematics/cypress-preset": [
+        "libs/sdk/e2e-schematics/src/cypress-preset.ts"
+      ],
       "@skyux-sdk/eslint-config": ["libs/sdk/eslint-config/src/index.ts"],
       "@skyux-sdk/prettier-schematics": [
         "libs/sdk/prettier-schematics/src/index.ts"


### PR DESCRIPTION
- [ ] Create `skyE2ePreset` to wrap shared Cypress settings
- [ ] New preset sets Cypress run retries to 2, which will immediately retry failed tests e.g. during CI and eliminate some noise from tests that fail due to transitory issues within the test environment