### PR TITLE
feat(components/core): add `VERSION` to public exports API; update to `@skyux/icons@6.3.0`

### DIFF
--- a/libs/components/core/src/index.ts
+++ b/libs/components/core/src/index.ts
@@ -100,6 +100,8 @@ export { SkyViewkeeperService } from './lib/modules/viewkeeper/viewkeeper.servic
 
 export { SkyAppWindowRef } from './lib/modules/window/window-ref';
 
+export { VERSION } from './version';
+
 // Components and directives must be exported to support Angular's "partial" Ivy compiler.
 // Obscure names are used to indicate types are not part of the public API.
 export { SkyAffixDirective as λ1 } from './lib/modules/affix/affix.directive';

--- a/libs/components/core/src/version.ts
+++ b/libs/components/core/src/version.ts
@@ -1,0 +1,23 @@
+// Taken from Angular's version.ts file.
+// See: https://github.com/angular/angular/blob/16.2.x/packages/core/src/version.ts
+
+/**
+ * Represents the version of a package.
+ * @internal
+ */
+export class Version {
+  public readonly major: string;
+  public readonly minor: string;
+  public readonly patch: string;
+
+  constructor(public readonly full: string) {
+    this.major = full.split('.')[0];
+    this.minor = full.split('.')[1];
+    this.patch = full.split('.').slice(2).join('.');
+  }
+}
+
+/**
+ * Represents the version of @skyux/core.
+ */
+export const VERSION = new Version('0.0.0-PLACEHOLDER');

--- a/libs/components/packages/package.json
+++ b/libs/components/packages/package.json
@@ -59,6 +59,7 @@
       "@skyux/grids": "0.0.0-PLACEHOLDER",
       "@skyux/http": "0.0.0-PLACEHOLDER",
       "@skyux/i18n": "0.0.0-PLACEHOLDER",
+      "@skyux/icons": "^6.0.0",
       "@skyux/indicators": "0.0.0-PLACEHOLDER",
       "@skyux/inline-form": "0.0.0-PLACEHOLDER",
       "@skyux/layout": "0.0.0-PLACEHOLDER",

--- a/libs/components/packages/package.json
+++ b/libs/components/packages/package.json
@@ -59,7 +59,7 @@
       "@skyux/grids": "0.0.0-PLACEHOLDER",
       "@skyux/http": "0.0.0-PLACEHOLDER",
       "@skyux/i18n": "0.0.0-PLACEHOLDER",
-      "@skyux/icons": "^6.0.0",
+      "@skyux/icons": "^6.3.0",
       "@skyux/indicators": "0.0.0-PLACEHOLDER",
       "@skyux/inline-form": "0.0.0-PLACEHOLDER",
       "@skyux/layout": "0.0.0-PLACEHOLDER",

--- a/libs/components/packages/package.json
+++ b/libs/components/packages/package.json
@@ -59,7 +59,6 @@
       "@skyux/grids": "0.0.0-PLACEHOLDER",
       "@skyux/http": "0.0.0-PLACEHOLDER",
       "@skyux/i18n": "0.0.0-PLACEHOLDER",
-      "@skyux/icons": "^6.3.0",
       "@skyux/indicators": "0.0.0-PLACEHOLDER",
       "@skyux/inline-form": "0.0.0-PLACEHOLDER",
       "@skyux/layout": "0.0.0-PLACEHOLDER",

--- a/libs/components/theme/package.json
+++ b/libs/components/theme/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@blackbaud/skyux-design-tokens": "0.0.27",
-    "@skyux/icons": "6.2.4",
+    "@skyux/icons": "6.3.0",
     "fontfaceobserver": "2.3.0",
     "tslib": "^2.6.2"
   }

--- a/libs/components/theme/src/lib/styles/sky.scss
+++ b/libs/components/theme/src/lib/styles/sky.scss
@@ -23,4 +23,4 @@
 @forward 'type';
 
 @import url('https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css');
-@import url('https://sky.blackbaudcdn.net/static/skyux-icons/6.2.4/assets/css/skyux-icons.min.css');
+@import url('https://sky.blackbaudcdn.net/static/skyux-icons/6.3.0/assets/css/skyux-icons.min.css');

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "@blackbaud/skyux-design-tokens": "0.0.27",
         "@nx/angular": "16.8.1",
         "@skyux/auth-client-factory": "1.2.0",
-        "@skyux/icons": "6.2.4",
+        "@skyux/icons": "6.3.0",
         "ag-grid-angular": "29.3.5",
         "ag-grid-community": "29.3.5",
         "autonumeric": "4.9.0",
@@ -8704,9 +8704,9 @@
       }
     },
     "node_modules/@skyux/icons": {
-      "version": "6.2.4",
-      "resolved": "https://registry.npmjs.org/@skyux/icons/-/icons-6.2.4.tgz",
-      "integrity": "sha512-1qU1voTq+ltymO0VO3rMYsJ1AJWOXf0DGUA/U74ck0fbgQ7ks5WOUFlx+ByCu2nx1OQ7htDvyta6a3xQMZ/48A=="
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@skyux/icons/-/icons-6.3.0.tgz",
+      "integrity": "sha512-wD4s/DcwFpebaKLACXH0VkPnAnKg26L91VmCjjbuHCwoq5z5urmfDU31aWzfC8Q+UNGCoBMU+hHuLc7KMlVB/A=="
     },
     "node_modules/@socket.io/component-emitter": {
       "version": "3.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -78,7 +78,7 @@
         "@ryansonshine/commitizen": "4.2.8",
         "@ryansonshine/cz-conventional-changelog": "3.3.4",
         "@schematics/angular": "16.2.0",
-        "@skyux/dev-infra-private": "github:blackbaud/skyux-dev-infra-private-builds#9.0.0-alpha.9",
+        "@skyux/dev-infra-private": "github:blackbaud/skyux-dev-infra-private-builds#9.0.0-alpha.10",
         "@storybook/addon-a11y": "7.4.1",
         "@storybook/addon-actions": "7.4.1",
         "@storybook/addon-controls": "7.4.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -78,7 +78,7 @@
         "@ryansonshine/commitizen": "4.2.8",
         "@ryansonshine/cz-conventional-changelog": "3.3.4",
         "@schematics/angular": "16.2.0",
-        "@skyux/dev-infra-private": "github:blackbaud/skyux-dev-infra-private-builds#9.0.0-alpha.10",
+        "@skyux/dev-infra-private": "github:blackbaud/skyux-dev-infra-private-builds#9.0.0-alpha.11",
         "@storybook/addon-a11y": "7.4.1",
         "@storybook/addon-actions": "7.4.1",
         "@storybook/addon-controls": "7.4.1",
@@ -173,17 +173,47 @@
       }
     },
     "node_modules/@angular-devkit/architect": {
-      "version": "0.1602.2",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1602.2.tgz",
-      "integrity": "sha512-JFIeKKW7V2+/C8+pTReM6gfQkVU9l1IR1OCb9vvHWTRvuTr7E5h2L1rUInnmLiRWkEvkYfG29B+UPpYlkVl9oQ==",
+      "version": "0.1602.3",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1602.3.tgz",
+      "integrity": "sha512-7f4U5LzAYRcQcOvRJwunSwLd5/nwbNxY/E4jTgwFxCNvCBSMysNJBi3g9v0t8zm2XYOv4ok5eYqIwriXVypRBg==",
+      "dev": true,
+      "peer": true,
       "dependencies": {
-        "@angular-devkit/core": "16.2.2",
+        "@angular-devkit/core": "16.2.3",
         "rxjs": "7.8.1"
       },
       "engines": {
         "node": "^16.14.0 || >=18.10.0",
         "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
         "yarn": ">= 1.13.0"
+      }
+    },
+    "node_modules/@angular-devkit/architect/node_modules/@angular-devkit/core": {
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-16.2.3.tgz",
+      "integrity": "sha512-oZLdg2XTx7likYAXRj1CU0XmrsCfe5f2grj3iwuI3OB1LXwwpdbHBztruj03y3yHES+TnO+dIbkvRnvMXs7uAA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "ajv": "8.12.0",
+        "ajv-formats": "2.1.1",
+        "jsonc-parser": "3.2.0",
+        "picomatch": "2.3.1",
+        "rxjs": "7.8.1",
+        "source-map": "0.7.4"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.10.0",
+        "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
+        "yarn": ">= 1.13.0"
+      },
+      "peerDependencies": {
+        "chokidar": "^3.5.2"
+      },
+      "peerDependenciesMeta": {
+        "chokidar": {
+          "optional": true
+        }
       }
     },
     "node_modules/@angular-devkit/build-angular": {
@@ -305,6 +335,20 @@
         "tailwindcss": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@angular-devkit/build-angular/node_modules/@angular-devkit/architect": {
+      "version": "0.1602.2",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1602.2.tgz",
+      "integrity": "sha512-JFIeKKW7V2+/C8+pTReM6gfQkVU9l1IR1OCb9vvHWTRvuTr7E5h2L1rUInnmLiRWkEvkYfG29B+UPpYlkVl9oQ==",
+      "dependencies": {
+        "@angular-devkit/core": "16.2.2",
+        "rxjs": "7.8.1"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.10.0",
+        "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
+        "yarn": ">= 1.13.0"
       }
     },
     "node_modules/@angular-devkit/build-angular/node_modules/@babel/core": {
@@ -761,6 +805,20 @@
         "webpack-dev-server": "^4.0.0"
       }
     },
+    "node_modules/@angular-devkit/build-webpack/node_modules/@angular-devkit/architect": {
+      "version": "0.1602.2",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1602.2.tgz",
+      "integrity": "sha512-JFIeKKW7V2+/C8+pTReM6gfQkVU9l1IR1OCb9vvHWTRvuTr7E5h2L1rUInnmLiRWkEvkYfG29B+UPpYlkVl9oQ==",
+      "dependencies": {
+        "@angular-devkit/core": "16.2.2",
+        "rxjs": "7.8.1"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.10.0",
+        "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
+        "yarn": ">= 1.13.0"
+      }
+    },
     "node_modules/@angular-devkit/core": {
       "version": "16.2.2",
       "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-16.2.2.tgz",
@@ -927,6 +985,21 @@
       },
       "bin": {
         "ng": "bin/ng.js"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.10.0",
+        "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
+        "yarn": ">= 1.13.0"
+      }
+    },
+    "node_modules/@angular/cli/node_modules/@angular-devkit/architect": {
+      "version": "0.1602.2",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1602.2.tgz",
+      "integrity": "sha512-JFIeKKW7V2+/C8+pTReM6gfQkVU9l1IR1OCb9vvHWTRvuTr7E5h2L1rUInnmLiRWkEvkYfG29B+UPpYlkVl9oQ==",
+      "dev": true,
+      "dependencies": {
+        "@angular-devkit/core": "16.2.2",
+        "rxjs": "7.8.1"
       },
       "engines": {
         "node": "^16.14.0 || >=18.10.0",
@@ -1174,27 +1247,27 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.22.9",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.22.9.tgz",
-      "integrity": "sha512-5UamI7xkUcJ3i9qVDS+KFDEK8/7oJ55/sJMB1Ge7IEapr7KfdfV/HErR+koZwOfd+SgtFKOKRhRakdg++DcJpQ==",
+      "version": "7.22.20",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.22.20.tgz",
+      "integrity": "sha512-BQYjKbpXjoXwFW5jGqiizJQQT/aC7pFm9Ok1OWssonuguICi264lbgMzRp2ZMmRSlfkX6DsWDDcsrctK8Rwfiw==",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.22.19",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.22.19.tgz",
-      "integrity": "sha512-Q8Yj5X4LHVYTbLCKVz0//2D2aDmHF4xzCdEttYvKOnWvErGsa6geHXD6w46x64n5tP69VfeH+IfSrdyH3MLhwA==",
+      "version": "7.22.20",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.22.20.tgz",
+      "integrity": "sha512-Y6jd1ahLubuYweD/zJH+vvOY141v4f9igNQAQ+MBgq9JlHS2iTsZKn1aMsb3vGccZsXI16VzTBw52Xx0DWmtnA==",
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.22.13",
         "@babel/generator": "^7.22.15",
         "@babel/helper-compilation-targets": "^7.22.15",
-        "@babel/helper-module-transforms": "^7.22.19",
+        "@babel/helper-module-transforms": "^7.22.20",
         "@babel/helpers": "^7.22.15",
         "@babel/parser": "^7.22.16",
         "@babel/template": "^7.22.15",
-        "@babel/traverse": "^7.22.19",
+        "@babel/traverse": "^7.22.20",
         "@babel/types": "^7.22.19",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
@@ -1374,9 +1447,9 @@
       }
     },
     "node_modules/@babel/helper-environment-visitor": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.5.tgz",
-      "integrity": "sha512-XGmhECfVA/5sAt+H+xpSg0mfrHq6FzNr9Oxh7PSEBBRUb/mL7Kz3NICXb194rCqAEdxkhPT1a88teizAFyvk8Q==",
+      "version": "7.22.20",
+      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.20.tgz",
+      "integrity": "sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -1427,15 +1500,15 @@
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.22.19",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.22.19.tgz",
-      "integrity": "sha512-m6h1cJvn+OJ+R3jOHp30faq5xKJ7VbjwDj5RGgHuRlU9hrMeKsGC+JpihkR5w1g7IfseCPPtZ0r7/hB4UKaYlA==",
+      "version": "7.22.20",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.22.20.tgz",
+      "integrity": "sha512-dLT7JVWIUUxKOs1UnJUBR3S70YK+pKX6AbJgB2vMIvEkZkrfJDbYDJesnPshtKV4LhDOR3Oc5YULeDizRek+5A==",
       "dependencies": {
-        "@babel/helper-environment-visitor": "^7.22.5",
+        "@babel/helper-environment-visitor": "^7.22.20",
         "@babel/helper-module-imports": "^7.22.15",
         "@babel/helper-simple-access": "^7.22.5",
         "@babel/helper-split-export-declaration": "^7.22.6",
-        "@babel/helper-validator-identifier": "^7.22.19"
+        "@babel/helper-validator-identifier": "^7.22.20"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1464,13 +1537,13 @@
       }
     },
     "node_modules/@babel/helper-remap-async-to-generator": {
-      "version": "7.22.17",
-      "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.22.17.tgz",
-      "integrity": "sha512-bxH77R5gjH3Nkde6/LuncQoLaP16THYPscurp1S8z7S9ZgezCyV3G8Hc+TZiCmY8pz4fp8CvKSgtJMW0FkLAxA==",
+      "version": "7.22.20",
+      "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.22.20.tgz",
+      "integrity": "sha512-pBGyV4uBqOns+0UvhsTO8qgl8hO89PmiDYv+/COyp1aeMcmfrfruz+/nCMFiYyFF/Knn0yfrC85ZzNFjembFTw==",
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.22.5",
-        "@babel/helper-environment-visitor": "^7.22.5",
-        "@babel/helper-wrap-function": "^7.22.17"
+        "@babel/helper-environment-visitor": "^7.22.20",
+        "@babel/helper-wrap-function": "^7.22.20"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1480,12 +1553,12 @@
       }
     },
     "node_modules/@babel/helper-replace-supers": {
-      "version": "7.22.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.22.9.tgz",
-      "integrity": "sha512-LJIKvvpgPOPUThdYqcX6IXRuIcTkcAub0IaDRGCZH0p5GPUp7PhRU9QVgFcDDd51BaPkk77ZjqFwh6DZTAEmGg==",
+      "version": "7.22.20",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.22.20.tgz",
+      "integrity": "sha512-qsW0In3dbwQUbK8kejJ4R7IHVGwHJlV6lpG6UA7a9hSa2YEiAib+N1T2kr6PEeUT+Fl7najmSOS6SmAwCHK6Tw==",
       "dependencies": {
-        "@babel/helper-environment-visitor": "^7.22.5",
-        "@babel/helper-member-expression-to-functions": "^7.22.5",
+        "@babel/helper-environment-visitor": "^7.22.20",
+        "@babel/helper-member-expression-to-functions": "^7.22.15",
         "@babel/helper-optimise-call-expression": "^7.22.5"
       },
       "engines": {
@@ -1537,9 +1610,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.22.19",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.19.tgz",
-      "integrity": "sha512-Tinq7ybnEPFFXhlYOYFiSjespWQk0dq2dRNAiMdRTOYQzEGqnnNyrTxPYHP5r6wGjlF1rFgABdDV0g8EwD6Qbg==",
+      "version": "7.22.20",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
+      "integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -1553,13 +1626,13 @@
       }
     },
     "node_modules/@babel/helper-wrap-function": {
-      "version": "7.22.17",
-      "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.22.17.tgz",
-      "integrity": "sha512-nAhoheCMlrqU41tAojw9GpVEKDlTS8r3lzFmF0lP52LwblCPbuFSO7nGIZoIcoU5NIm1ABrna0cJExE4Ay6l2Q==",
+      "version": "7.22.20",
+      "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.22.20.tgz",
+      "integrity": "sha512-pms/UwkOpnQe/PDAEdV/d7dVCoBbB+R4FvYoHGZz+4VPcg7RtYy2KP7S2lbuWM6FCSgob5wshfGESbC/hzNXZw==",
       "dependencies": {
         "@babel/helper-function-name": "^7.22.5",
         "@babel/template": "^7.22.15",
-        "@babel/types": "^7.22.17"
+        "@babel/types": "^7.22.19"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1605,11 +1678,11 @@
       }
     },
     "node_modules/@babel/highlight": {
-      "version": "7.22.13",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.13.tgz",
-      "integrity": "sha512-C/BaXcnnvBCmHTpz/VGZ8jgtE2aYlW4hxDhseJAWZb7gqGM/qtCK6iZUb0TyKFf7BOUsBH7Q7fkRsDRhg1XklQ==",
+      "version": "7.22.20",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.20.tgz",
+      "integrity": "sha512-dkdMCN3py0+ksCgYmGG8jKeGA/8Tk+gJwSYYlFGxG5lmhfKNoAy004YpLxpS1W2J8m/EK2Ew+yOs9pVRwO89mg==",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.22.5",
+        "@babel/helper-validator-identifier": "^7.22.20",
         "chalk": "^2.4.2",
         "js-tokens": "^4.0.0"
       },
@@ -3159,13 +3232,13 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.22.19",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.22.19.tgz",
-      "integrity": "sha512-ZCcpVPK64krfdScRbpxF6xA5fz7IOsfMwx1tcACvCzt6JY+0aHkBk7eIU8FRDSZRU5Zei6Z4JfgAxN1bqXGECg==",
+      "version": "7.22.20",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.22.20.tgz",
+      "integrity": "sha512-eU260mPZbU7mZ0N+X10pxXhQFMGTeLb9eFS0mxehS8HZp9o1uSnFeWQuG1UPrlxgA7QoUzFhOnilHDp0AXCyHw==",
       "dependencies": {
         "@babel/code-frame": "^7.22.13",
         "@babel/generator": "^7.22.15",
-        "@babel/helper-environment-visitor": "^7.22.5",
+        "@babel/helper-environment-visitor": "^7.22.20",
         "@babel/helper-function-name": "^7.22.5",
         "@babel/helper-hoist-variables": "^7.22.5",
         "@babel/helper-split-export-declaration": "^7.22.6",
@@ -3757,9 +3830,9 @@
       "dev": true
     },
     "node_modules/@cspell/dict-php": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-php/-/dict-php-4.0.2.tgz",
-      "integrity": "sha512-7yglcmMoFHDPQXHW+9QAl8YjAToMm1qOi+4x/yGY1FSIEjZbCpjeDgyKMGg/NgpooQQceEN38AR59Pn23EDriA==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-php/-/dict-php-4.0.3.tgz",
+      "integrity": "sha512-PxtSmWJCDEB4M8R9ER9ijxBum/tvUqYT26QeuV58q2IFs5IrPZ6hocQKvnFGXItjCWH4oYXyAEAAzINlBC4Opg==",
       "dev": true
     },
     "node_modules/@cspell/dict-powershell": {
@@ -3808,9 +3881,9 @@
       "dev": true
     },
     "node_modules/@cspell/dict-software-terms": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-software-terms/-/dict-software-terms-3.2.3.tgz",
-      "integrity": "sha512-L1Fjkt+Q5MnjEOGPXQxdT4+8ieDBcaHSjh1gHzxdqFXTOnnfvsLUa5ykuv/fG06b/G/yget1066ftKosMaPcXA==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-software-terms/-/dict-software-terms-3.2.4.tgz",
+      "integrity": "sha512-ECb02otzD2LDm+h+EM5S2SNSozRoSU/oyuT3IfYv9RVBsuM3v2XjSyZD5rfiyhZkpAhJM9tXV8pdF6pfvrJktg==",
       "dev": true
     },
     "node_modules/@cspell/dict-sql": {
@@ -4775,9 +4848,9 @@
       "dev": true
     },
     "node_modules/@floating-ui/core": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.4.2.tgz",
-      "integrity": "sha512-olUakR5nr9v2ueVr1yomoJnBTkHGqHzL/iK4AhforiJS/wKJgFphAYpZHZzADLv/zNUFuQwqLH3bcoUhFh2E1Q==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.5.0.tgz",
+      "integrity": "sha512-kK1h4m36DQ0UHGj5Ah4db7R0rHemTqqO0QLvUqi1/mUUp3LuAWbWxdxSIf/XsnH9VS6rRVPLJCncjRzUvyCLXg==",
       "dev": true,
       "dependencies": {
         "@floating-ui/utils": "^0.1.3"
@@ -4807,9 +4880,9 @@
       }
     },
     "node_modules/@floating-ui/utils": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.1.3.tgz",
-      "integrity": "sha512-uvnFKtPgzLnpzzTRfhDlvXX0kLYi9lDRQbcDmT8iXl71Rx+uwSuaUIQl3DNC7w5OweAQ7XQMDObML+KaYDQfng==",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.1.4.tgz",
+      "integrity": "sha512-qprfWkn82Iw821mcKofJ5Pk9wgioHicxcQMxx+5zt5GSKoqdWvgG5AxVmpmUUjzTLPVSH5auBrhI93Deayn/DA==",
       "dev": true
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -8578,8 +8651,8 @@
       }
     },
     "node_modules/@skyux/dev-infra-private": {
-      "version": "9.0.0-alpha.9",
-      "resolved": "git+ssh://git@github.com/blackbaud/skyux-dev-infra-private-builds.git#63ce25298b909c31426a2ef58d30ae469ef0dd9b",
+      "version": "9.0.0-alpha.11",
+      "resolved": "git+ssh://git@github.com/blackbaud/skyux-dev-infra-private-builds.git#93afda52d7aca2809ac31d7b987bcb8dcbc6b489",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8990,9 +9063,9 @@
       }
     },
     "node_modules/@storybook/angular/node_modules/@types/node": {
-      "version": "16.18.50",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.50.tgz",
-      "integrity": "sha512-OiDU5xRgYTJ203v4cprTs0RwOCd5c5Zjv+K5P8KSqfiCsB1W3LcamTUMcnQarpq5kOYbhHfSOgIEJvdPyb5xyw==",
+      "version": "16.18.53",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.53.tgz",
+      "integrity": "sha512-vVmHeo4tpF8zsknALU90Hh24VueYdu45ZlXzYWFbom61YR4avJqTFDC3QlWzjuTdAv6/3xHaxiO9NrtVZXrkmw==",
       "dev": true
     },
     "node_modules/@storybook/angular/node_modules/ansi-styles": {
@@ -9623,9 +9696,9 @@
       }
     },
     "node_modules/@storybook/builder-webpack5/node_modules/@types/node": {
-      "version": "16.18.50",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.50.tgz",
-      "integrity": "sha512-OiDU5xRgYTJ203v4cprTs0RwOCd5c5Zjv+K5P8KSqfiCsB1W3LcamTUMcnQarpq5kOYbhHfSOgIEJvdPyb5xyw==",
+      "version": "16.18.53",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.53.tgz",
+      "integrity": "sha512-vVmHeo4tpF8zsknALU90Hh24VueYdu45ZlXzYWFbom61YR4avJqTFDC3QlWzjuTdAv6/3xHaxiO9NrtVZXrkmw==",
       "dev": true
     },
     "node_modules/@storybook/builder-webpack5/node_modules/ajv": {
@@ -10418,9 +10491,9 @@
       }
     },
     "node_modules/@storybook/core-common/node_modules/@types/node": {
-      "version": "16.18.50",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.50.tgz",
-      "integrity": "sha512-OiDU5xRgYTJ203v4cprTs0RwOCd5c5Zjv+K5P8KSqfiCsB1W3LcamTUMcnQarpq5kOYbhHfSOgIEJvdPyb5xyw==",
+      "version": "16.18.53",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.53.tgz",
+      "integrity": "sha512-vVmHeo4tpF8zsknALU90Hh24VueYdu45ZlXzYWFbom61YR4avJqTFDC3QlWzjuTdAv6/3xHaxiO9NrtVZXrkmw==",
       "dev": true
     },
     "node_modules/@storybook/core-common/node_modules/ansi-styles": {
@@ -10594,9 +10667,9 @@
       }
     },
     "node_modules/@storybook/core-server/node_modules/@types/node": {
-      "version": "16.18.50",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.50.tgz",
-      "integrity": "sha512-OiDU5xRgYTJ203v4cprTs0RwOCd5c5Zjv+K5P8KSqfiCsB1W3LcamTUMcnQarpq5kOYbhHfSOgIEJvdPyb5xyw==",
+      "version": "16.18.53",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.53.tgz",
+      "integrity": "sha512-vVmHeo4tpF8zsknALU90Hh24VueYdu45ZlXzYWFbom61YR4avJqTFDC3QlWzjuTdAv6/3xHaxiO9NrtVZXrkmw==",
       "dev": true
     },
     "node_modules/@storybook/core-server/node_modules/ansi-styles": {
@@ -10683,9 +10756,9 @@
       }
     },
     "node_modules/@storybook/core-webpack/node_modules/@types/node": {
-      "version": "16.18.50",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.50.tgz",
-      "integrity": "sha512-OiDU5xRgYTJ203v4cprTs0RwOCd5c5Zjv+K5P8KSqfiCsB1W3LcamTUMcnQarpq5kOYbhHfSOgIEJvdPyb5xyw==",
+      "version": "16.18.53",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.53.tgz",
+      "integrity": "sha512-vVmHeo4tpF8zsknALU90Hh24VueYdu45ZlXzYWFbom61YR4avJqTFDC3QlWzjuTdAv6/3xHaxiO9NrtVZXrkmw==",
       "dev": true
     },
     "node_modules/@storybook/csf": {
@@ -11005,9 +11078,9 @@
       }
     },
     "node_modules/@swc/core": {
-      "version": "1.3.84",
-      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.3.84.tgz",
-      "integrity": "sha512-UPKUiDwG7HOdPfOb1VFeEJ76JDgU2w80JLewzx6tb0fk9TIjhr9yxKBzPbzc/QpjGHDu5iaEuNeZcu27u4j63g==",
+      "version": "1.3.86",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.3.86.tgz",
+      "integrity": "sha512-bEXUtm37bcmJ3q+geG7Zy4rJNUzpxalXQUrrqX1ZoGj3HRtzdeVZ0L/um3fG2j16qe61t8TX/OIZ2G6j6dkG/w==",
       "devOptional": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -11021,16 +11094,16 @@
         "url": "https://opencollective.com/swc"
       },
       "optionalDependencies": {
-        "@swc/core-darwin-arm64": "1.3.84",
-        "@swc/core-darwin-x64": "1.3.84",
-        "@swc/core-linux-arm-gnueabihf": "1.3.84",
-        "@swc/core-linux-arm64-gnu": "1.3.84",
-        "@swc/core-linux-arm64-musl": "1.3.84",
-        "@swc/core-linux-x64-gnu": "1.3.84",
-        "@swc/core-linux-x64-musl": "1.3.84",
-        "@swc/core-win32-arm64-msvc": "1.3.84",
-        "@swc/core-win32-ia32-msvc": "1.3.84",
-        "@swc/core-win32-x64-msvc": "1.3.84"
+        "@swc/core-darwin-arm64": "1.3.86",
+        "@swc/core-darwin-x64": "1.3.86",
+        "@swc/core-linux-arm-gnueabihf": "1.3.86",
+        "@swc/core-linux-arm64-gnu": "1.3.86",
+        "@swc/core-linux-arm64-musl": "1.3.86",
+        "@swc/core-linux-x64-gnu": "1.3.86",
+        "@swc/core-linux-x64-musl": "1.3.86",
+        "@swc/core-win32-arm64-msvc": "1.3.86",
+        "@swc/core-win32-ia32-msvc": "1.3.86",
+        "@swc/core-win32-x64-msvc": "1.3.86"
       },
       "peerDependencies": {
         "@swc/helpers": "^0.5.0"
@@ -11042,9 +11115,9 @@
       }
     },
     "node_modules/@swc/core-darwin-arm64": {
-      "version": "1.3.84",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.3.84.tgz",
-      "integrity": "sha512-mqK0buOo+toF2HoJ/gWj2ApZbvbIiNq3mMwSTHCYJHlQFQfoTWnl9aaD5GSO4wfNFVYfEZ1R259o5uv5NlVtoA==",
+      "version": "1.3.86",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.3.86.tgz",
+      "integrity": "sha512-hMvSDms0sJJHNtRa3Vhmr9StWN1vmikbf5VE0IZUYGnF1/JZTkXU1h6CdNUY4Hr6i7uCZjH6BEhxFHX1JtKV4w==",
       "cpu": [
         "arm64"
       ],
@@ -11057,9 +11130,9 @@
       }
     },
     "node_modules/@swc/core-darwin-x64": {
-      "version": "1.3.84",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.3.84.tgz",
-      "integrity": "sha512-cyuQZz62C43EDZqtnptUTlfDvAjgG3qu139m5zsfIK6ltXA5inKFbDWV3a/M5c18dFzA2Xh21Q46XZezmtQ9Tg==",
+      "version": "1.3.86",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.3.86.tgz",
+      "integrity": "sha512-Jro6HVH4uSOBM7tTDaQNKLNc8BJV7n+SO+Ft2HAZINyeKJS/8MfEYneG7Vmqg18gv00c6dz9AOCcyz+BR7BFkQ==",
       "cpu": [
         "x64"
       ],
@@ -11072,9 +11145,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm-gnueabihf": {
-      "version": "1.3.84",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.3.84.tgz",
-      "integrity": "sha512-dmt/ECQrp3ZPWnK27p4E4xRIRHOoJhgGvxC5t5YaWzN20KcxE9ykEY2oLGSoeceM/A+4D11aRYGwF/EM7yOkvA==",
+      "version": "1.3.86",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.3.86.tgz",
+      "integrity": "sha512-wYB9m0pzXJVSzedXSl4JwS3gKtvcPinpe9MbkddezpqL7OjyDP6pHHW9qIucsfgCrtMtbPC2nqulXLPtAAyIjw==",
       "cpu": [
         "arm"
       ],
@@ -11087,9 +11160,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm64-gnu": {
-      "version": "1.3.84",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.3.84.tgz",
-      "integrity": "sha512-PgVfrI3NVg2z/oeg3GWLb9rFLMqidbdPwVH5nRyHVP2RX/BWP6qfnYfG+gJv4qrKzIldb9TyCGH7y8VWctKLxw==",
+      "version": "1.3.86",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.3.86.tgz",
+      "integrity": "sha512-fR44IyK5cdCaO8cC++IEH0Jn03tWnunJnjzA99LxlE5TRInSIOvFm+g5OSUQZDAvEXmQ38sd31LO2HOoDS1Edw==",
       "cpu": [
         "arm64"
       ],
@@ -11102,9 +11175,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm64-musl": {
-      "version": "1.3.84",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.3.84.tgz",
-      "integrity": "sha512-hcuEa8/vin4Ns0P+FpcDHQ4f3jmhgGKQhqw0w+TovPSVTIXr+nrFQ2AGhs9nAxS6tSQ77C53Eb5YRpK8ToFo1A==",
+      "version": "1.3.86",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.3.86.tgz",
+      "integrity": "sha512-EUPfdbK4dUk/nkX3Vmv/47XH+DqHOa9JI0CTthvJ8/ZXei1MKDUsUc+tI1zMQX2uCuSkSWsEIEpCmA0tMwFhtw==",
       "cpu": [
         "arm64"
       ],
@@ -11117,9 +11190,9 @@
       }
     },
     "node_modules/@swc/core-linux-x64-gnu": {
-      "version": "1.3.84",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.3.84.tgz",
-      "integrity": "sha512-IvyimSbwGdu21jBBEqR1Up8Jhvl8kIAf1k3e5Oy8oRfgojdUfmW1EIwgGdoUeyQ1VHlfquiWaRGfsnHQUKl35g==",
+      "version": "1.3.86",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.3.86.tgz",
+      "integrity": "sha512-snVZZWv8XgNVaKrTxtO3rUN+BbbB6I8Fqwe8zM/DWGJ096J13r89doQ48x5ZyO+bW4D48eZIWP5pdfSW7oBE3w==",
       "cpu": [
         "x64"
       ],
@@ -11132,9 +11205,9 @@
       }
     },
     "node_modules/@swc/core-linux-x64-musl": {
-      "version": "1.3.84",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.3.84.tgz",
-      "integrity": "sha512-hdgVU/O5ufDCe+p5RtCjU7PRNwd0WM+eWJS+GNY4QWL6O8y2VLM+i4+6YzwSUjeBk0xd+1YElMxbqz7r5tSZhw==",
+      "version": "1.3.86",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.3.86.tgz",
+      "integrity": "sha512-PnnksUJymEJkdnbV2orOSOSB441UqsxYbJge9zbr5UTRXUfWO3eFRV0iTBegjTlOQGbW6yN+YRSDkenTbmCI6g==",
       "cpu": [
         "x64"
       ],
@@ -11147,9 +11220,9 @@
       }
     },
     "node_modules/@swc/core-win32-arm64-msvc": {
-      "version": "1.3.84",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.3.84.tgz",
-      "integrity": "sha512-rzH6k2BF0BFOFhUTD+bh0oCiUCZjFfDfoZoYNN/CM0qbtjAcFH21hzMh/EH8ZaXq8k/iQmUNNa5MPNPZ4SOMNw==",
+      "version": "1.3.86",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.3.86.tgz",
+      "integrity": "sha512-XlGEGyHwLndm08VvgeAPGj40L+Hx575MQC+2fsyB1uSNUN+uf7fvke+wc7k50a92CaQe/8foLyIR5faayozEJA==",
       "cpu": [
         "arm64"
       ],
@@ -11162,9 +11235,9 @@
       }
     },
     "node_modules/@swc/core-win32-ia32-msvc": {
-      "version": "1.3.84",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.3.84.tgz",
-      "integrity": "sha512-Y+Dk7VLLVwwsAzoDmjkNW/sTmSPl9PGr4Mj1nhc5A2NNxZ+hz4SxFMclacDI03SC5ikK8Qh6WOoE/+nwUDa3uA==",
+      "version": "1.3.86",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.3.86.tgz",
+      "integrity": "sha512-U1BhZa1x9yn+wZGTQmt1cYR79a0FzW/wL6Jas1Pn0bykKLxdRU4mCeZt2P+T3buLm8jr8LpPWiCrbvr658PzwA==",
       "cpu": [
         "ia32"
       ],
@@ -11177,9 +11250,9 @@
       }
     },
     "node_modules/@swc/core-win32-x64-msvc": {
-      "version": "1.3.84",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.3.84.tgz",
-      "integrity": "sha512-WmpaosqCWMX7DArLdU8AJcj96hy0PKlYh1DaMVikSrrDHbJm2dZ8rd27IK3qUB8DgPkrDYHmLAKNZ+z3gWXgRQ==",
+      "version": "1.3.86",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.3.86.tgz",
+      "integrity": "sha512-wRoQUajqpE3wITHhZVj/6BPu/QwHriFHLHuJA+9y6PeGtUtTmntL42aBKXIFhfL767dYFtohyNg1uZ9eqbGyGQ==",
       "cpu": [
         "x64"
       ],
@@ -11192,9 +11265,9 @@
       }
     },
     "node_modules/@swc/types": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.4.tgz",
-      "integrity": "sha512-z/G02d+59gyyUb7KYhKi9jOhicek6QD2oMaotUyG+lUkybpXoV49dY9bj7Ah5Q+y7knK2jU67UTX9FyfGzaxQg==",
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.5.tgz",
+      "integrity": "sha512-myfUej5naTBWnqOCc/MdVOLVjXUXtIA+NpDrDBKJtLLg2shUjBu3cZmB/85RyitKc55+lUUyl7oRfLOvkr2hsw==",
       "devOptional": true
     },
     "node_modules/@szmarczak/http-timer": {
@@ -11371,9 +11444,9 @@
       }
     },
     "node_modules/@types/babel__core": {
-      "version": "7.20.1",
-      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.1.tgz",
-      "integrity": "sha512-aACu/U/omhdk15O4Nfb+fHgH/z3QsfQzpnvRZhYhThms83ZnAOZz7zZAWO7mn2yyNQaA4xTO8GLK3uqFU4bYYw==",
+      "version": "7.20.2",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.2.tgz",
+      "integrity": "sha512-pNpr1T1xLUc2l3xJKuPtsEky3ybxN3m4fJkknfIpTCTfIZCDW57oAg+EfCgIIp2rvCe0Wn++/FfodDS4YXxBwA==",
       "dependencies": {
         "@babel/parser": "^7.20.7",
         "@babel/types": "^7.20.7",
@@ -11383,43 +11456,43 @@
       }
     },
     "node_modules/@types/babel__generator": {
-      "version": "7.6.4",
-      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.4.tgz",
-      "integrity": "sha512-tFkciB9j2K755yrTALxD44McOrk+gfpIpvC3sxHjRawj6PfnQxrse4Clq5y/Rq+G3mrBurMax/lG8Qn2t9mSsg==",
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.5.tgz",
+      "integrity": "sha512-h9yIuWbJKdOPLJTbmSpPzkF67e659PbQDba7ifWm5BJ8xTv+sDmS7rFmywkWOvXedGTivCdeGSIIX8WLcRTz8w==",
       "dependencies": {
         "@babel/types": "^7.0.0"
       }
     },
     "node_modules/@types/babel__template": {
-      "version": "7.4.1",
-      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.1.tgz",
-      "integrity": "sha512-azBFKemX6kMg5Io+/rdGT0dkGreboUVR0Cdm3fz9QJWpaQGJRQXl7C+6hOTCZcMll7KFyEQpgbYI2lHdsS4U7g==",
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.2.tgz",
+      "integrity": "sha512-/AVzPICMhMOMYoSx9MoKpGDKdBRsIXMNByh1PXSZoa+v6ZoLa8xxtsT/uLQ/NJm0XVAWl/BvId4MlDeXJaeIZQ==",
       "dependencies": {
         "@babel/parser": "^7.1.0",
         "@babel/types": "^7.0.0"
       }
     },
     "node_modules/@types/babel__traverse": {
-      "version": "7.20.1",
-      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.20.1.tgz",
-      "integrity": "sha512-MitHFXnhtgwsGZWtT68URpOvLN4EREih1u3QtQiN4VdAxWKRVvGCSvw/Qth0M0Qq3pJpnGOu5JaM/ydK7OGbqg==",
+      "version": "7.20.2",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.20.2.tgz",
+      "integrity": "sha512-ojlGK1Hsfce93J0+kn3H5R73elidKUaZonirN33GSmgTUMpzI/MIFfSpF3haANe3G1bEBS9/9/QEqwTzwqFsKw==",
       "dependencies": {
         "@babel/types": "^7.20.7"
       }
     },
     "node_modules/@types/body-parser": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.2.tgz",
-      "integrity": "sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==",
+      "version": "1.19.3",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.3.tgz",
+      "integrity": "sha512-oyl4jvAfTGX9Bt6Or4H9ni1Z447/tQuxnZsytsCaExKlmJiU8sFgnIBRzJUpKwB5eWn9HuBYlUlVA74q/yN0eQ==",
       "dependencies": {
         "@types/connect": "*",
         "@types/node": "*"
       }
     },
     "node_modules/@types/bonjour": {
-      "version": "3.5.10",
-      "resolved": "https://registry.npmjs.org/@types/bonjour/-/bonjour-3.5.10.tgz",
-      "integrity": "sha512-p7ienRMiS41Nu2/igbJxxLDWrSZ0WxM8UQgCeO9KhoVF7cOVFkrKsiDr1EsJIla8vV3oEEjGcz11jc5yimhzZw==",
+      "version": "3.5.11",
+      "resolved": "https://registry.npmjs.org/@types/bonjour/-/bonjour-3.5.11.tgz",
+      "integrity": "sha512-isGhjmBtLIxdHBDl2xGwUzEM8AOyOvWsADWq7rqirdi/ZQoHnLWErHvsThcEzTX8juDRiZtzp2Qkv5bgNh6mAg==",
       "dependencies": {
         "@types/node": "*"
       }
@@ -11617,19 +11690,19 @@
       "devOptional": true
     },
     "node_modules/@types/http-cache-semantics": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.1.tgz",
-      "integrity": "sha512-SZs7ekbP8CN0txVG2xVRH6EgKmEm31BOxA07vkFaETzZz1xh+cbt8BcI0slpymvwhx5dlFnQG2rTlPVQn+iRPQ=="
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.2.tgz",
+      "integrity": "sha512-FD+nQWA2zJjh4L9+pFXqWOi0Hs1ryBCfI+985NjluQ1p8EYtoLvjLOKidXBtZ4/IcxDX4o8/E8qDS3540tNliw=="
     },
     "node_modules/@types/http-errors": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.1.tgz",
-      "integrity": "sha512-/K3ds8TRAfBvi5vfjuz8y6+GiAYBZ0x4tXv1Av6CWBWn0IlADc+ZX9pMq7oU0fNQPnBwIZl3rmeLp6SBApbxSQ=="
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.2.tgz",
+      "integrity": "sha512-lPG6KlZs88gef6aD85z3HNkztpj7w2R7HmR3gygjfXCQmsLloWNARFkMuzKiiY8FGdh1XDpgBdrSf4aKDiA7Kg=="
     },
     "node_modules/@types/http-proxy": {
-      "version": "1.17.11",
-      "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.11.tgz",
-      "integrity": "sha512-HC8G7c1WmaF2ekqpnFq626xd3Zz0uvaqFmBJNRZCGEZCXkvSdJoNFn/8Ygbd9fKNQj8UzLdCETaI0UWPAjK7IA==",
+      "version": "1.17.12",
+      "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.12.tgz",
+      "integrity": "sha512-kQtujO08dVtQ2wXAuSFfk9ASy3sug4+ogFR8Kd8UgP8PEuc1/G/8yjYRmp//PcDNJEUKOza/MrQu15bouEUCiw==",
       "dependencies": {
         "@types/node": "*"
       }
@@ -11683,9 +11756,9 @@
       }
     },
     "node_modules/@types/json-schema": {
-      "version": "7.0.12",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.12.tgz",
-      "integrity": "sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA=="
+      "version": "7.0.13",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.13.tgz",
+      "integrity": "sha512-RbSSoHliUbnXj3ny0CNFOoxrIDV6SUGyStHsvDqosw6CkdPV8TtWGlfecuK4ToyMEAql6pzNxgCFKanovUzlgQ=="
     },
     "node_modules/@types/jwt-decode": {
       "version": "2.2.1",
@@ -11762,9 +11835,9 @@
       "dev": true
     },
     "node_modules/@types/prop-types": {
-      "version": "15.7.5",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
-      "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==",
+      "version": "15.7.6",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.6.tgz",
+      "integrity": "sha512-RK/kBbYOQQHLYj9Z95eh7S6t7gq4Ojt/NT8HTk8bWVhA5DaF+5SMnxHKkP4gPNN3wAZkKP+VjAf0ebtYzf+fxg==",
       "dev": true
     },
     "node_modules/@types/qs": {
@@ -14035,9 +14108,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001534",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001534.tgz",
-      "integrity": "sha512-vlPVrhsCS7XaSh2VvWluIQEzVhefrUQcEsQWSS5A5V+dM07uv1qHeQzAOTGIMy9i3e9bH15+muvI/UHojVgS/Q==",
+      "version": "1.0.30001538",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001538.tgz",
+      "integrity": "sha512-HWJnhnID+0YMtGlzcp3T9drmBJUVDchPJ08tpUGFLs9CYlwWPH2uLgpHn8fND5pCgXVtnGS3H4QR9XLMHVNkHw==",
       "funding": [
         {
           "type": "opencollective",
@@ -16337,9 +16410,9 @@
       }
     },
     "node_modules/dayjs": {
-      "version": "1.11.9",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.9.tgz",
-      "integrity": "sha512-QvzAURSbQ0pKdIye2txOzNaHmxtUBXerpY0FJsFXUMKbIZeFm5ht1LS/jFsrncjnmtv8HsG0W2g6c0zUjZWmpA==",
+      "version": "1.11.10",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.10.tgz",
+      "integrity": "sha512-vjAczensTgRcqDERK0SR2XMwsF/tSvnvlv6VcF2GIhg6Sx4yOIt/irsr1RDJsKiIyBzJDpCoXiWWq28MqH2cnQ==",
       "devOptional": true
     },
     "node_modules/debug": {
@@ -17247,9 +17320,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.520",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.520.tgz",
-      "integrity": "sha512-Frfus2VpYADsrh1lB3v/ft/WVFlVzOIm+Q0p7U7VqHI6qr7NWHYKe+Wif3W50n7JAFoBsWVsoU0+qDks6WQ60g=="
+      "version": "1.4.525",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.525.tgz",
+      "integrity": "sha512-GIZ620hDK4YmIqAWkscG4W6RwY6gOx1y5J6f4JUQwctiJrqH2oxZYU4mXHi35oV32tr630UcepBzSBGJ/WYcZA=="
     },
     "node_modules/emittery": {
       "version": "0.13.1",
@@ -18588,9 +18661,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
-      "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ=="
+      "version": "3.2.9",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.9.tgz",
+      "integrity": "sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ=="
     },
     "node_modules/flow-parser": {
       "version": "0.216.1",
@@ -18602,9 +18675,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
-      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
+      "version": "1.15.3",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.3.tgz",
+      "integrity": "sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==",
       "funding": [
         {
           "type": "individual",
@@ -29036,9 +29109,9 @@
       "integrity": "sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A=="
     },
     "node_modules/regenerate-unicode-properties": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-10.1.0.tgz",
-      "integrity": "sha512-d1VudCLoIGitcU/hEg2QqvyGZQmdC0Lf8BqdOMXGFSvJP4bNV1+XqbPQeHHLD51Jh4QJJ225dlIFvY4Ly6MXmQ==",
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-10.1.1.tgz",
+      "integrity": "sha512-X007RyZLsCJVVrjgEFVpLUTZwyOZk3oiL75ZcuYjlIWd6rNJtOjkBwQc5AsRrpbKVkxN6sklw/k/9m2jJYOf8Q==",
       "dependencies": {
         "regenerate": "^1.4.2"
       },
@@ -29541,9 +29614,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "3.29.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.29.1.tgz",
-      "integrity": "sha512-c+ebvQz0VIH4KhhCpDsI+Bik0eT8ZFEVZEYw0cGMVqIP8zc+gnwl7iXCamTw7vzv2MeuZFZfdx5JJIq+ehzDlg==",
+      "version": "3.29.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.29.2.tgz",
+      "integrity": "sha512-CJouHoZ27v6siztc21eEQGo0kIcE5D1gVPA571ez0mMYb25LGYGKnVNXpEj5MGlepmDWGXNjDB5q7uNiPHC11A==",
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -30332,9 +30405,9 @@
       }
     },
     "node_modules/spdx-license-ids": {
-      "version": "3.0.13",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.13.tgz",
-      "integrity": "sha512-XkD+zwiqXHikFZm4AX/7JSCXA98U5Db4AFd5XUg/+9UNtnH75+Z9KxtpYiJZx36mUDVOwH83pl7yvCer6ewM3w==",
+      "version": "3.0.15",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.15.tgz",
+      "integrity": "sha512-lpT8hSQp9jAKp9mhtBU4Xjon8LPGBvLIuBiSVhMEtmLecTh2mO0tlqrAMp47tBXzMr13NJMQ2lf7RpQGLJ3HsQ==",
       "dev": true
     },
     "node_modules/spdy": {
@@ -32186,9 +32259,9 @@
       }
     },
     "node_modules/url": {
-      "version": "0.11.2",
-      "resolved": "https://registry.npmjs.org/url/-/url-0.11.2.tgz",
-      "integrity": "sha512-7yIgNnrST44S7PJ5+jXbdIupfU1nWUdQJBFBeJRclPXiWgCvrSq5Frw8lr/i//n5sqDfzoKmBymMS81l4U/7cg==",
+      "version": "0.11.3",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.11.3.tgz",
+      "integrity": "sha512-6hxOLGfZASQK/cijlZnZJTq8OXAkt/3YGfQX45vvMYXpZoo8NdWZcY73K108Jf759lS1Bv/8wXnHDTSz17dSRw==",
       "dev": true,
       "dependencies": {
         "punycode": "^1.4.1",
@@ -33449,9 +33522,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.14.1.tgz",
-      "integrity": "sha512-4OOseMUq8AzRBI/7SLMUwO+FEDnguetSk7KMb1sHwvF2w2Wv5Hoj0nlifx8vtGsftE/jWHojPy8sMMzYLJ2G/A==",
+      "version": "8.14.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.14.2.tgz",
+      "integrity": "sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==",
       "engines": {
         "node": ">=10.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "@blackbaud/skyux-design-tokens": "0.0.27",
     "@nx/angular": "16.8.1",
     "@skyux/auth-client-factory": "1.2.0",
-    "@skyux/icons": "6.2.4",
+    "@skyux/icons": "6.3.0",
     "ag-grid-angular": "29.3.5",
     "ag-grid-community": "29.3.5",
     "autonumeric": "4.9.0",

--- a/package.json
+++ b/package.json
@@ -149,7 +149,7 @@
     "@ryansonshine/commitizen": "4.2.8",
     "@ryansonshine/cz-conventional-changelog": "3.3.4",
     "@schematics/angular": "16.2.0",
-    "@skyux/dev-infra-private": "github:blackbaud/skyux-dev-infra-private-builds#9.0.0-alpha.9",
+    "@skyux/dev-infra-private": "github:blackbaud/skyux-dev-infra-private-builds#9.0.0-alpha.10",
     "@storybook/addon-a11y": "7.4.1",
     "@storybook/addon-actions": "7.4.1",
     "@storybook/addon-controls": "7.4.1",

--- a/package.json
+++ b/package.json
@@ -149,7 +149,7 @@
     "@ryansonshine/commitizen": "4.2.8",
     "@ryansonshine/cz-conventional-changelog": "3.3.4",
     "@schematics/angular": "16.2.0",
-    "@skyux/dev-infra-private": "github:blackbaud/skyux-dev-infra-private-builds#9.0.0-alpha.10",
+    "@skyux/dev-infra-private": "github:blackbaud/skyux-dev-infra-private-builds#9.0.0-alpha.11",
     "@storybook/addon-a11y": "7.4.1",
     "@storybook/addon-actions": "7.4.1",
     "@storybook/addon-controls": "7.4.1",


### PR DESCRIPTION
[AB#2675743](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/2675743)

Allow for runtime access to SKY UX's version number.
```
import { VERSION } from '@skyux/core';
```