### PR TITLE
fix(components/core): numeric pipe now handles undefined values (#1765)

### DIFF
--- a/libs/components/core/src/lib/modules/numeric/fixtures/numeric.pipe.fixture.html
+++ b/libs/components/core/src/lib/modules/numeric/fixtures/numeric.pipe.fixture.html
@@ -1,4 +1,4 @@
 <p>
-  {{ 1234567.89 | skyNumeric:{ truncate: false, minDigits:2, format: 'currency',
+  {{ value | skyNumeric:{ truncate: false, minDigits:2, format: 'currency',
   locale: locale } }}
 </p>

--- a/libs/components/core/src/lib/modules/numeric/fixtures/numeric.pipe.fixture.ts
+++ b/libs/components/core/src/lib/modules/numeric/fixtures/numeric.pipe.fixture.ts
@@ -22,6 +22,7 @@ class MockLocaleProvider extends SkyAppLocaleProvider {
 })
 export class NumericPipeFixtureComponent {
   public locale: string | undefined;
+  public value: number | undefined = 1234567.89;
 
   public updateLocaleProviderLocale(newLocale: string): void {
     providedLocale = newLocale;

--- a/libs/components/core/src/lib/modules/numeric/numeric.pipe.spec.ts
+++ b/libs/components/core/src/lib/modules/numeric/numeric.pipe.spec.ts
@@ -76,6 +76,21 @@ describe('Numeric pipe', () => {
     }).toThrowError();
   });
 
+  it('should handle undefined and null values', async () => {
+    const fixture = TestBed.createComponent(NumericPipeFixtureComponent);
+    const component = fixture.componentInstance;
+    // NOTE: We had a previous issue with change detection and undefined. This issue only appeared in unit tests when auto detecting changes.
+    fixture.autoDetectChanges();
+    component.value = undefined;
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    // Get formatted date.
+    const el = document.querySelector('p') as HTMLParagraphElement;
+
+    expect(el.innerHTML.trim()).toBe('');
+  });
+
   describe('locale support', () => {
     let fixture: ComponentFixture<NumericPipeFixtureComponent>;
     let component: NumericPipeFixtureComponent;

--- a/libs/components/core/src/lib/modules/numeric/numeric.pipe.ts
+++ b/libs/components/core/src/lib/modules/numeric/numeric.pipe.ts
@@ -61,7 +61,14 @@ export class SkyNumericPipe implements PipeTransform, OnDestroy {
   /**
    * Formats a number based on the provided options.
    */
-  public transform(value: number, config?: SkyNumericOptions): string {
+  public transform(
+    value: number | undefined | null,
+    config?: SkyNumericOptions
+  ): string {
+    if (value === undefined || value === null || isNaN(value)) {
+      return '';
+    }
+
     const newCacheKey =
       (config ? JSON.stringify(config, Object.keys(config).sort()) : '') +
       `${value}_${config?.locale || this.#providerLocale}`;

--- a/libs/components/core/src/lib/modules/numeric/numeric.service.ts
+++ b/libs/components/core/src/lib/modules/numeric/numeric.service.ts
@@ -41,8 +41,11 @@ export class SkyNumericService {
    * @param value The number to format.
    * @param options Format options.
    */
-  public formatNumber(value: number, options: SkyNumericOptions): string {
-    if (isNaN(value) || value === null) {
+  public formatNumber(
+    value: number | undefined | null,
+    options: SkyNumericOptions
+  ): string {
+    if (value === undefined || value === null || isNaN(value)) {
       return '';
     }
 


### PR DESCRIPTION
:cherries: Cherry picked from #1765 [fix(components/core): numeric pipe now handles undefined values](https://github.com/blackbaud/skyux/pull/1765)

[AB#2675313](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/2675313) 
[AB#2677934](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/2677934) 