### PR TITLE
feat(components/data-manager): data managers include a listDescriptor which passes context to standard items aria labels

### DIFF
--- a/libs/components/data-manager/src/assets/locales/resources_en_US.json
+++ b/libs/components/data-manager/src/assets/locales/resources_en_US.json
@@ -12,7 +12,7 @@
     "message": "Cancel"
   },
   "skyux_data_manager_select_all_button_aria_label": {
-    "_description": "Default aria-label text for the select all button in the data manager multiselect toolbar",
+    "_description": "Aria-label text for the select all button in the data manager multiselect toolbar",
     "message": "Select all {0}"
   },
   "skyux_data_manager_select_all_button_title": {
@@ -20,7 +20,7 @@
     "message": "Select all"
   },
   "skyux_data_manager_clear_all_button_aria_label": {
-    "_description": "Default aria-label text for the clear all button in the data manager multiselect toolbar",
+    "_description": "Aria-label text for the clear all button in the data manager multiselect toolbar",
     "message": "Clear all selected {0}"
   },
   "skyux_data_manager_clear_all_button_title": {
@@ -28,7 +28,7 @@
     "message": "Clear all"
   },
   "skyux_data_manager_show_selected_option_aria_label": {
-    "_description": "Default aria-label text for the show selected checkbox in the data manager multiselect toolbar",
+    "_description": "Aria-label text for the show selected checkbox in the data manager multiselect toolbar",
     "message": "Show only selected {0}"
   },
   "skyux_data_manager_show_selected_option_title": {
@@ -36,7 +36,7 @@
     "message": "Show only selected items"
   },
   "skyux_data_manager_columns_button_aria_label": {
-    "_description": "Default text for the column picker button's aria label in the data manager toolbar",
+    "_description": "Aria-label text for the column picker button's aria label in the data manager toolbar",
     "message": "Choose columns for {0}"
   },
   "skyux_data_manager_columns_button_title": {

--- a/libs/components/data-manager/src/assets/locales/resources_en_US.json
+++ b/libs/components/data-manager/src/assets/locales/resources_en_US.json
@@ -11,17 +11,33 @@
     "_description": "Text for the clear button in the data manager column picker",
     "message": "Cancel"
   },
+  "skyux_data_manager_select_all_button_aria_label": {
+    "_description": "Default aria-label text for the select all button in the data manager multiselect toolbar",
+    "message": "Select all {0}"
+  },
   "skyux_data_manager_select_all_button_title": {
     "_description": "Text for the select all button in the data manager multiselect toolbar",
     "message": "Select all"
+  },
+  "skyux_data_manager_clear_all_button_aria_label": {
+    "_description": "Default aria-label text for the clear all button in the data manager multiselect toolbar",
+    "message": "Clear all selected {0}"
   },
   "skyux_data_manager_clear_all_button_title": {
     "_description": "Text for the clear all button in the data manager multiselect toolbar",
     "message": "Clear all"
   },
+  "skyux_data_manager_show_selected_option_aria_label": {
+    "_description": "Default aria-label text for the show selected checkbox in the data manager multiselect toolbar",
+    "message": "Show only selected {0}"
+  },
   "skyux_data_manager_show_selected_option_title": {
     "_description": "Text for the show selected checkbox in the data manager multiselect toolbar",
     "message": "Show only selected items"
+  },
+  "skyux_data_manager_columns_button_aria_label": {
+    "_description": "Default text for the column picker button's aria label in the data manager toolbar",
+    "message": "Choose columns for {0}"
   },
   "skyux_data_manager_columns_button_title": {
     "_description": "Text for the column picker button in the data manager toolbar",

--- a/libs/components/data-manager/src/lib/modules/data-manager/data-manager-toolbar/data-manager-toolbar.component.html
+++ b/libs/components/data-manager/src/lib/modules/data-manager/data-manager-toolbar/data-manager-toolbar.component.html
@@ -1,5 +1,5 @@
 <div class="sky-data-manager-toolbar">
-  <sky-toolbar>
+  <sky-toolbar [listDescriptor]="dataManagerConfig?.listDescriptor">
     <sky-toolbar-section>
       <ng-content select="sky-data-manager-toolbar-primary-item" />
 
@@ -28,7 +28,10 @@
           class="sky-btn sky-btn-default sky-col-picker-btn"
           type="button"
           [attr.aria-label]="
-            'skyux_data_manager_columns_button_title' | skyLibResources
+            dataManagerConfig?.listDescriptor
+              ? ('skyux_data_manager_columns_button_aria_label'
+                | skyLibResources : dataManagerConfig.listDescriptor)
+              : ('skyux_data_manager_columns_button_title' | skyLibResources)
           "
           [attr.title]="
             'skyux_data_manager_columns_button_title' | skyLibResources
@@ -86,6 +89,12 @@
         <button
           class="sky-btn sky-btn-link sky-data-manager-select-all-btn"
           type="button"
+          [attr.aria-label]="
+            dataManagerConfig?.listDescriptor
+              ? ('skyux_data_manager_select_all_button_aria_label'
+                | skyLibResources : dataManagerConfig.listDescriptor)
+              : undefined
+          "
           (click)="selectAll()"
         >
           {{ 'skyux_data_manager_select_all_button_title' | skyLibResources }}
@@ -95,6 +104,12 @@
         <button
           class="sky-btn sky-btn-link sky-data-manager-clear-all-btn"
           type="button"
+          [attr.aria-label]="
+            dataManagerConfig?.listDescriptor
+              ? ('skyux_data_manager_clear_all_button_aria_label'
+                | skyLibResources : dataManagerConfig.listDescriptor)
+              : undefined
+          "
           (click)="clearAll()"
         >
           {{ 'skyux_data_manager_clear_all_button_title' | skyLibResources }}
@@ -103,6 +118,12 @@
       <sky-toolbar-view-actions>
         <sky-checkbox
           [checked]="onlyShowSelected"
+          [label]="
+            dataManagerConfig?.listDescriptor
+              ? ('skyux_data_manager_show_selected_option_aria_label'
+                | skyLibResources : dataManagerConfig.listDescriptor)
+              : undefined
+          "
           (change)="onOnlyShowSelected($event)"
         >
           <sky-checkbox-label>

--- a/libs/components/data-manager/src/lib/modules/data-manager/data-manager-toolbar/data-manager-toolbar.component.html
+++ b/libs/components/data-manager/src/lib/modules/data-manager/data-manager-toolbar/data-manager-toolbar.component.html
@@ -30,7 +30,7 @@
           [attr.aria-label]="
             dataManagerConfig?.listDescriptor
               ? ('skyux_data_manager_columns_button_aria_label'
-                | skyLibResources : dataManagerConfig.listDescriptor)
+                | skyLibResources : dataManagerConfig?.listDescriptor)
               : ('skyux_data_manager_columns_button_title' | skyLibResources)
           "
           [attr.title]="
@@ -92,7 +92,7 @@
           [attr.aria-label]="
             dataManagerConfig?.listDescriptor
               ? ('skyux_data_manager_select_all_button_aria_label'
-                | skyLibResources : dataManagerConfig.listDescriptor)
+                | skyLibResources : dataManagerConfig?.listDescriptor)
               : undefined
           "
           (click)="selectAll()"
@@ -107,7 +107,7 @@
           [attr.aria-label]="
             dataManagerConfig?.listDescriptor
               ? ('skyux_data_manager_clear_all_button_aria_label'
-                | skyLibResources : dataManagerConfig.listDescriptor)
+                | skyLibResources : dataManagerConfig?.listDescriptor)
               : undefined
           "
           (click)="clearAll()"
@@ -121,7 +121,7 @@
           [label]="
             dataManagerConfig?.listDescriptor
               ? ('skyux_data_manager_show_selected_option_aria_label'
-                | skyLibResources : dataManagerConfig.listDescriptor)
+                | skyLibResources : dataManagerConfig?.listDescriptor)
               : undefined
           "
           (change)="onOnlyShowSelected($event)"

--- a/libs/components/data-manager/src/lib/modules/data-manager/data-manager-toolbar/data-manager-toolbar.component.spec.ts
+++ b/libs/components/data-manager/src/lib/modules/data-manager/data-manager-toolbar/data-manager-toolbar.component.spec.ts
@@ -7,6 +7,7 @@ import {
 } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { SkyAppTestUtility, expect, expectAsync } from '@skyux-sdk/testing';
+import { SkyContentInfoProvider } from '@skyux/core';
 import { SkyModalConfigurationInterface, SkyModalService } from '@skyux/modals';
 
 import { Subject } from 'rxjs';
@@ -62,6 +63,32 @@ describe('SkyDataManagerToolbarComponent', () => {
   let dataManagerService: SkyDataManagerService;
   let modalServiceInstance: MockModalService;
   let viewConfig: SkyDataViewConfig;
+
+  function getClearAllButton(): HTMLButtonElement | undefined {
+    return dataManagerToolbarFixture.debugElement.query(
+      By.css('.sky-data-manager-clear-all-btn')
+    ).nativeElement;
+  }
+
+  function getColumnPickerButton(): HTMLButtonElement | undefined {
+    return dataManagerToolbarFixture.debugElement.query(
+      By.css('.sky-col-picker-btn')
+    ).nativeElement;
+  }
+
+  function getSelectAllButton(): HTMLButtonElement | undefined {
+    return dataManagerToolbarFixture.debugElement.query(
+      By.css('.sky-data-manager-select-all-btn')
+    ).nativeElement;
+  }
+
+  function getSectionFilterCheckbox(): HTMLInputElement | undefined {
+    return dataManagerToolbarFixture.debugElement.query(
+      By.css(
+        '.sky-data-manager-multiselect-toolbar sky-toolbar-view-actions input'
+      )
+    ).nativeElement;
+  }
 
   function setSearchInput(text: string): void {
     const inputEl = dataManagerToolbarFixture.debugElement.query(
@@ -807,7 +834,74 @@ describe('SkyDataManagerToolbarComponent', () => {
     expect(dataManagerService.updateDataState).not.toHaveBeenCalled();
   });
 
-  it('should pass accessibility', async () => {
-    await expectAsync(dataManagerToolbarNativeElement).toBeAccessible();
+  describe('a11y', () => {
+    it('should set accessibility labels correctly when no list descriptor is given', async () => {
+      const patchInfoSpy = spyOn(
+        SkyContentInfoProvider.prototype,
+        'patchInfo'
+      ).and.stub();
+
+      spyOn(dataManagerService, 'getViewById').and.returnValue({
+        ...(dataManagerToolbarComponent.activeView as SkyDataViewConfig),
+        multiselectToolbarEnabled: true,
+        columnPickerEnabled: true,
+      });
+      dataManagerToolbarFixture.detectChanges();
+
+      expect(patchInfoSpy.calls.count()).toBe(1);
+      expect(patchInfoSpy.calls.all()[0].args).toEqual([
+        { descriptor: undefined },
+      ]);
+
+      expect(getClearAllButton()?.getAttribute('aria-label')).toBeNull();
+      expect(getColumnPickerButton()?.getAttribute('aria-label')).toBe(
+        'Columns'
+      );
+      expect(getSectionFilterCheckbox()?.getAttribute('aria-label')).toBeNull();
+      expect(getSelectAllButton()?.getAttribute('aria-label')).toBeNull();
+    });
+
+    it('should set accessibility labels correctly when a list descriptor is given', async () => {
+      const patchInfoSpy = spyOn(
+        SkyContentInfoProvider.prototype,
+        'patchInfo'
+      ).and.stub();
+
+      const dataManagerFixture = TestBed.createComponent(
+        DataManagerFixtureComponent
+      );
+      dataManagerFixture.componentInstance.dataManagerConfig.listDescriptor =
+        'constituents';
+      dataManagerFixture.detectChanges();
+
+      expect(patchInfoSpy.calls.count()).toBe(1);
+      expect(patchInfoSpy.calls.all()[0].args).toEqual([
+        { descriptor: 'constituents' },
+      ]);
+
+      spyOn(dataManagerService, 'getViewById').and.returnValue({
+        ...(dataManagerToolbarComponent.activeView as SkyDataViewConfig),
+        multiselectToolbarEnabled: true,
+        columnPickerEnabled: true,
+      });
+      dataManagerToolbarFixture.detectChanges();
+
+      expect(getClearAllButton()?.getAttribute('aria-label')).toBe(
+        'Clear all selected constituents'
+      );
+      expect(getColumnPickerButton()?.getAttribute('aria-label')).toBe(
+        'Choose columns for constituents'
+      );
+      expect(getSectionFilterCheckbox()?.getAttribute('aria-label')).toBe(
+        'Show only selected constituents'
+      );
+      expect(getSelectAllButton()?.getAttribute('aria-label')).toBe(
+        'Select all constituents'
+      );
+    });
+
+    it('should pass accessibility', async () => {
+      await expectAsync(dataManagerToolbarNativeElement).toBeAccessible();
+    });
   });
 });

--- a/libs/components/data-manager/src/lib/modules/data-manager/fixtures/data-manager.component.fixture.ts
+++ b/libs/components/data-manager/src/lib/modules/data-manager/fixtures/data-manager.component.fixture.ts
@@ -7,6 +7,7 @@ import {
 
 import { SkyDataManagerComponent } from '../data-manager.component';
 import { SkyDataManagerService } from '../data-manager.service';
+import { SkyDataManagerConfig } from '../models/data-manager-config';
 import { SkyDataManagerState } from '../models/data-manager-state';
 
 import { DataViewRepeaterFixtureComponent } from './data-manager-repeater-view.component.fixture';
@@ -26,7 +27,7 @@ export class DataManagerFixtureComponent implements OnInit {
 
   public activeViewId = 'repeaterView';
 
-  public dataManagerConfig = {
+  public dataManagerConfig: SkyDataManagerConfig = {
     sortOptions: [
       {
         id: 'az',

--- a/libs/components/data-manager/src/lib/modules/data-manager/models/data-manager-config.ts
+++ b/libs/components/data-manager/src/lib/modules/data-manager/models/data-manager-config.ts
@@ -19,7 +19,7 @@ export interface SkyDataManagerConfig {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   filterModalComponent?: any;
   /**
-   * A descriptor for the items that the data manager is managing. Use a plural term. The descriptor helps set the data manager's `aria-label` attributes for multiselect toolbars, search inputs, sort buttons, and filter buttons to provide text equivalents for screen readers [to support accessibility](https://developer.blackbaud.com/skyux/components/checkbox#accessibility).
+   * A descriptor for the data that the data manager manipulates. Use a plural term. The descriptor helps set the data manager's `aria-label` attributes for multiselect toolbars, search inputs, sort buttons, and filter buttons to provide text equivalents for screen readers [to support accessibility](https://developer.blackbaud.com/skyux/components/checkbox#accessibility).
    * For example, when the descriptor is “constituents,” the search input’s `aria-label` is “Search constituents.” For more information about the `aria-label` attribute, see the [WAI-ARIA definition](https://www.w3.org/TR/wai-aria/#aria-label).
    */
   listDescriptor?: string;

--- a/libs/components/data-manager/src/lib/modules/data-manager/models/data-manager-config.ts
+++ b/libs/components/data-manager/src/lib/modules/data-manager/models/data-manager-config.ts
@@ -19,6 +19,11 @@ export interface SkyDataManagerConfig {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   filterModalComponent?: any;
   /**
+   * A descriptor for the items that the data manager is managing. Use a plural term. The descriptor helps set the data manager's `aria-label` attributes for multiselect toolbars, search inputs, sort buttons, and filter buttons to provide text equivalents for screen readers [to support accessibility](https://developer.blackbaud.com/skyux/components/checkbox#accessibility).
+   * For example, when the descriptor is “constituents,” the search input’s `aria-label` is “Search constituents.” For more information about the `aria-label` attribute, see the [WAI-ARIA definition](https://www.w3.org/TR/wai-aria/#aria-label).
+   */
+  listDescriptor?: string;
+  /**
    * The sort options displayed in the sort dropdown. The same sort options are used for all views,
    * but views can use `SkyDataViewConfig` to indicate whether to display the sort button.
    */

--- a/libs/components/data-manager/src/lib/modules/shared/sky-data-manager-resources.module.ts
+++ b/libs/components/data-manager/src/lib/modules/shared/sky-data-manager-resources.module.ts
@@ -24,10 +24,22 @@ const RESOURCES: { [locale: string]: SkyLibResources } = {
     },
     skyux_data_manager_apply_changes_button_title: { message: 'Apply changes' },
     skyux_data_manager_cancel_button_title: { message: 'Cancel' },
+    skyux_data_manager_select_all_button_aria_label: {
+      message: 'Select all {0}',
+    },
     skyux_data_manager_select_all_button_title: { message: 'Select all' },
+    skyux_data_manager_clear_all_button_aria_label: {
+      message: 'Clear all selected {0}',
+    },
     skyux_data_manager_clear_all_button_title: { message: 'Clear all' },
+    skyux_data_manager_show_selected_option_aria_label: {
+      message: 'Show only selected {0}',
+    },
     skyux_data_manager_show_selected_option_title: {
       message: 'Show only selected items',
+    },
+    skyux_data_manager_columns_button_aria_label: {
+      message: 'Choose columns for {0}',
     },
     skyux_data_manager_columns_button_title: { message: 'Columns' },
     skyux_data_manager_select_column_status_indicator_title: {


### PR DESCRIPTION
[AB#2652385](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/2652385)