### PR TITLE
fix(components/toast): `SkyToastService` and `SkyToastLegacyService` add toast instances to the same pool

### DIFF
--- a/apps/code-examples/src/app/code-examples/angular-tree-component/angular-tree/advanced/demo.component.scss
+++ b/apps/code-examples/src/app/code-examples/angular-tree-component/angular-tree/advanced/demo.component.scss
@@ -1,8 +1,0 @@
-// .app-demo-container {
-//   border: 1px solid #cdcfd2;
-//   padding: 20px;
-
-//   .angular-tree-component {
-//     background: #fff;
-//   }
-// }

--- a/apps/code-examples/src/app/code-examples/angular-tree-component/angular-tree/advanced/demo.component.ts
+++ b/apps/code-examples/src/app/code-examples/angular-tree-component/angular-tree/advanced/demo.component.ts
@@ -33,7 +33,6 @@ import { AngularTreeDemoNode } from './node';
 @Component({
   standalone: true,
   selector: 'app-demo',
-  styleUrls: ['./demo.component.scss'],
   templateUrl: './demo.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [

--- a/libs/components/toast/src/lib/modules/toast/toast.service.ts
+++ b/libs/components/toast/src/lib/modules/toast/toast.service.ts
@@ -27,7 +27,7 @@ import { SkyToastConfig } from './types/toast-config';
 export class SkyToastService implements OnDestroy {
   private static host: ComponentRef<SkyToasterComponent> | undefined;
   private static toasts: SkyToast[] = [];
-  private static toastStream = new BehaviorSubject<SkyToast[]>([]);
+  private static toastStream: BehaviorSubject<SkyToast[]>;
 
   /**
    * @internal
@@ -41,6 +41,7 @@ export class SkyToastService implements OnDestroy {
 
   constructor(dynamicComponentService: SkyDynamicComponentService) {
     this.#dynamicComponentService = dynamicComponentService;
+    SkyToastService.toastStream = new BehaviorSubject<SkyToast[]>([]);
   }
 
   public ngOnDestroy(): void {
@@ -49,6 +50,7 @@ export class SkyToastService implements OnDestroy {
       this.#removeHostComponent();
     }
 
+    SkyToastService.toasts = [];
     SkyToastService.toastStream.complete();
   }
 

--- a/libs/components/toast/src/lib/modules/toast/toast.service.ts
+++ b/libs/components/toast/src/lib/modules/toast/toast.service.ts
@@ -26,18 +26,18 @@ import { SkyToastConfig } from './types/toast-config';
 })
 export class SkyToastService implements OnDestroy {
   private static host: ComponentRef<SkyToasterComponent> | undefined;
+  private static toasts: SkyToast[] = [];
+  private static toastStream = new BehaviorSubject<SkyToast[]>([]);
 
   /**
    * @internal
    */
   public get toastStream(): Observable<SkyToast[]> {
-    return this.#toastStream;
+    return SkyToastService.toastStream;
   }
 
   #dynamicComponentService: SkyDynamicComponentService;
   #environmentInjector = inject(EnvironmentInjector);
-  #toasts: SkyToast[] = [];
-  #toastStream = new BehaviorSubject<SkyToast[]>([]);
 
   constructor(dynamicComponentService: SkyDynamicComponentService) {
     this.#dynamicComponentService = dynamicComponentService;
@@ -49,7 +49,7 @@ export class SkyToastService implements OnDestroy {
       this.#removeHostComponent();
     }
 
-    this.#toastStream.complete();
+    SkyToastService.toastStream.complete();
   }
 
   /**
@@ -115,18 +115,18 @@ export class SkyToastService implements OnDestroy {
       SkyToastService.host = this.#createHostComponent();
     }
 
-    this.#toasts.push(toast);
-    this.#toastStream.next(this.#toasts);
+    SkyToastService.toasts.push(toast);
+    SkyToastService.toastStream.next(SkyToastService.toasts);
     instance.closed.subscribe(() => {
       this.#removeToast(toast);
     });
   }
 
   #removeToast(toast: SkyToast): void {
-    this.#toasts = this.#toasts.filter((t) => t !== toast);
-    this.#toastStream.next(this.#toasts);
+    SkyToastService.toasts = SkyToastService.toasts.filter((t) => t !== toast);
+    SkyToastService.toastStream.next(SkyToastService.toasts);
 
-    if (this.#toasts.length === 0) {
+    if (SkyToastService.toasts.length === 0) {
       this.#removeHostComponent();
     }
   }

--- a/libs/components/toast/src/lib/modules/toast/toaster.component.spec.ts
+++ b/libs/components/toast/src/lib/modules/toast/toaster.component.spec.ts
@@ -22,7 +22,7 @@ import { SkyToastContainerOptions } from './types/toast-container-options';
 import { SkyToastDisplayDirection } from './types/toast-display-direction';
 import { SkyToastType } from './types/toast-type';
 
-describe('Toast component', () => {
+describe('Toaster component', () => {
   let fixture: ComponentFixture<SkyToasterTestComponent>;
   let toastService: SkyToastService;
   let toasterService: SkyToasterService;


### PR DESCRIPTION
`SkyToastLegacyService` and `SkyToastService` have their own copies of toast instances and toast streams. This fix makes sure both services contribute to the same pool of toast instances, and emit a single stream for consumers.