### PR TITLE
fix(components/core): prevent resize observer loop error (#1790)

### DIFF
--- a/apps/e2e/action-bars-storybook-e2e/src/e2e/summary-action-bar.component.cy.ts
+++ b/apps/e2e/action-bars-storybook-e2e/src/e2e/summary-action-bar.component.cy.ts
@@ -4,7 +4,6 @@ import { E2eVariations } from '@skyux-sdk/e2e-schematics';
 Cypress.on(
   'uncaught:exception',
   (err) =>
-    !err.message.includes('ResizeObserver loop limit exceeded') &&
     !err.message.includes(
       'ResizeObserver loop completed with undelivered notifications'
     )

--- a/apps/e2e/pages-storybook-e2e/src/e2e/page-layout-blocks.component.cy.ts
+++ b/apps/e2e/pages-storybook-e2e/src/e2e/page-layout-blocks.component.cy.ts
@@ -6,7 +6,6 @@ const ID = 'blockspagecomponent-blockspage--blocks-page';
 Cypress.on(
   'uncaught:exception',
   (err) =>
-    !err.message.includes('ResizeObserver loop limit exceeded') &&
     !err.message.includes(
       'ResizeObserver loop completed with undelivered notifications'
     )

--- a/libs/components/core/src/lib/modules/resize-observer/fixtures/resize-observer-mock.ts
+++ b/libs/components/core/src/lib/modules/resize-observer/fixtures/resize-observer-mock.ts
@@ -29,6 +29,11 @@ export const mockResizeObserverHandle = {
 };
 
 export function mockResizeObserver() {
+  (window as any).requestAnimationFrame = (callback: () => void): number => {
+    callback();
+    return 0;
+  };
+  (window as any).cancelAnimationFrame = (_: number): void => undefined;
   window.ResizeObserver = class {
     constructor(callback: ResizeObserverCallback) {
       mockResizeObserverHandle.callback = callback;

--- a/libs/components/core/src/lib/modules/resize-observer/resize-observer-media-query.service.spec.ts
+++ b/libs/components/core/src/lib/modules/resize-observer/resize-observer-media-query.service.spec.ts
@@ -1,4 +1,4 @@
-import { ElementRef, NgZone } from '@angular/core';
+import { ElementRef } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 
 import { SkyMediaBreakpoints } from '../media-query/media-breakpoints';
@@ -16,11 +16,14 @@ describe('SkyResizeObserverMediaQueryService service', async () => {
     mockResizeObserver();
   });
 
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [SkyResizeObserverService, SkyResizeObserverMediaQueryService],
+    });
+  });
+
   it('should return a new instance of a resize observer media query service', async () => {
-    const zone = TestBed.inject(NgZone);
-    const service = new SkyResizeObserverMediaQueryService(
-      new SkyResizeObserverService(zone)
-    );
+    const service = TestBed.inject(SkyResizeObserverMediaQueryService);
     expect(service).toBeTruthy();
     service.ngOnDestroy();
   });
@@ -32,10 +35,7 @@ describe('SkyResizeObserverMediaQueryService service', async () => {
 
     let result: SkyMediaBreakpoints | undefined;
 
-    const zone = TestBed.inject(NgZone);
-    const service = new SkyResizeObserverMediaQueryService(
-      new SkyResizeObserverService(zone)
-    );
+    const service = TestBed.inject(SkyResizeObserverMediaQueryService);
     service.observe(target);
     const subscription = service.subscribe((breakpoint) => {
       result = breakpoint;
@@ -69,10 +69,7 @@ describe('SkyResizeObserverMediaQueryService service', async () => {
     const testEl = document.createElement('div');
     const target = new ElementRef(testEl);
 
-    const zone = TestBed.inject(NgZone);
-    const service = new SkyResizeObserverMediaQueryService(
-      new SkyResizeObserverService(zone)
-    );
+    const service = TestBed.inject(SkyResizeObserverMediaQueryService);
 
     service.observe(target, { updateResponsiveClasses: true });
 
@@ -112,10 +109,7 @@ describe('SkyResizeObserverMediaQueryService service', async () => {
       nativeElement: { id: 'element2', offsetWidth: 220 },
     } as ElementRef;
     let result: SkyMediaBreakpoints | undefined;
-    const zone = TestBed.inject(NgZone);
-    const service = new SkyResizeObserverMediaQueryService(
-      new SkyResizeObserverService(zone)
-    );
+    const service = TestBed.inject(SkyResizeObserverMediaQueryService);
     service.observe(target1);
     const subscription = service.subscribe((breakpoint) => {
       result = breakpoint;

--- a/libs/components/core/src/lib/modules/resize-observer/resize-observer-media-query.service.ts
+++ b/libs/components/core/src/lib/modules/resize-observer/resize-observer-media-query.service.ts
@@ -1,4 +1,4 @@
-import { ElementRef, Injectable, OnDestroy } from '@angular/core';
+import { ElementRef, Injectable, OnDestroy, inject } from '@angular/core';
 
 import { ReplaySubject, Subject, Subscription } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
@@ -50,13 +50,9 @@ export class SkyResizeObserverMediaQueryService implements OnDestroy {
 
   #ngUnsubscribe = new Subject<void>();
 
-  #resizeObserverSvc: SkyResizeObserverService;
+  #resizeObserverSvc = inject(SkyResizeObserverService);
 
   #target: ElementRef | undefined;
-
-  constructor(resizeObserverSvc: SkyResizeObserverService) {
-    this.#resizeObserverSvc = resizeObserverSvc;
-  }
 
   public ngOnDestroy(): void {
     this.unobserve();

--- a/libs/components/core/src/lib/modules/resize-observer/resize-observer.service.spec.ts
+++ b/libs/components/core/src/lib/modules/resize-observer/resize-observer.service.spec.ts
@@ -1,4 +1,4 @@
-import { ElementRef, NgZone } from '@angular/core';
+import { ElementRef } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 
 import {
@@ -14,7 +14,7 @@ describe('ResizeObserver service', async () => {
   });
 
   it('should return a new instance of a resize observer', async () => {
-    const service = new SkyResizeObserverService(TestBed.inject(NgZone));
+    const service = TestBed.inject(SkyResizeObserverService);
     expect(service).toBeTruthy();
     service.ngOnDestroy();
   });
@@ -24,7 +24,7 @@ describe('ResizeObserver service', async () => {
       nativeElement: { id: 'element' },
     } as ElementRef;
     let result: ResizeObserverEntry | undefined;
-    const service = new SkyResizeObserverService(TestBed.inject(NgZone));
+    const service = TestBed.inject(SkyResizeObserverService);
     const subscription = service
       .observe(target)
       .subscribe((resizeObserverEntry) => {
@@ -49,7 +49,7 @@ describe('ResizeObserver service', async () => {
       nativeElement: { id: 'element' },
     } as ElementRef;
     let result: ResizeObserverEntry | undefined;
-    const service = new SkyResizeObserverService(TestBed.inject(NgZone));
+    const service = TestBed.inject(SkyResizeObserverService);
     const subscription1 = service
       .observe(target)
       .subscribe((resizeObserverEntry) => {

--- a/libs/components/core/src/lib/modules/resize-observer/resize-observer.service.ts
+++ b/libs/components/core/src/lib/modules/resize-observer/resize-observer.service.ts
@@ -1,7 +1,15 @@
-import { ElementRef, Injectable, NgZone, OnDestroy } from '@angular/core';
+import {
+  ElementRef,
+  Injectable,
+  NgZone,
+  OnDestroy,
+  inject,
+} from '@angular/core';
 
 import { Observable, Subject } from 'rxjs';
 import { finalize } from 'rxjs/operators';
+
+import { SkyAppWindowRef } from '../window/window-ref';
 
 type ResizeObserverTracking = {
   element: Element;
@@ -16,19 +24,22 @@ type ResizeObserverTracking = {
   providedIn: 'root',
 })
 export class SkyResizeObserverService implements OnDestroy {
-  #resizeObserver: ResizeObserver;
-
+  #next = new Map<Subject<ResizeObserverEntry>, number>();
+  #resizeObserver = new ResizeObserver((entries) => {
+    entries.forEach((entry) => this.#callback(entry));
+  });
   #tracking: ResizeObserverTracking[] = [];
-  #zone: NgZone;
-
-  constructor(zone: NgZone) {
-    this.#zone = zone;
-    this.#resizeObserver = new ResizeObserver((entries) => {
-      entries.forEach((entry) => this.#callback(entry));
-    });
-  }
+  #window = inject(SkyAppWindowRef);
+  #zone = inject(NgZone);
 
   public ngOnDestroy(): void {
+    this.#next.forEach((value) =>
+      this.#window.nativeWindow.cancelAnimationFrame(value)
+    );
+    this.#tracking.forEach((value) => {
+      value.subject.complete();
+      this.#resizeObserver.unobserve(value.element);
+    });
     this.#resizeObserver.disconnect();
   }
 
@@ -62,6 +73,12 @@ export class SkyResizeObserverService implements OnDestroy {
 
         if (checkTracking === -1) {
           this.#resizeObserver.unobserve(element.nativeElement);
+          const deleteTracking = this.#tracking.findIndex(
+            (value) => value.subject === subject
+          );
+          if (deleteTracking > -1) {
+            this.#tracking.splice(deleteTracking, 1);
+          }
         }
       })
     );
@@ -79,15 +96,25 @@ export class SkyResizeObserverService implements OnDestroy {
 
   #callback(entry: ResizeObserverEntry): void {
     this.#tracking
-      .filter((value) => !(value.subject.closed || value.subject.isStopped))
+      .filter((value) => !value.subject.closed)
       .forEach((value) => {
         /* istanbul ignore else */
         if (value.element === entry.target) {
           // Execute the callback within NgZone because Angular does not "monkey patch"
           // ResizeObserver like it does for other features in the DOM.
-          this.#zone.run(() => {
-            value.subject.next(entry);
-          });
+          if (this.#next.has(value.subject)) {
+            this.#window.nativeWindow.cancelAnimationFrame(
+              this.#next.get(value.subject)
+            );
+          }
+          this.#next.set(
+            value.subject,
+            (this.#window.nativeWindow as Window).requestAnimationFrame(() => {
+              this.#zone.run(() => {
+                value.subject.next(entry);
+              });
+            })
+          );
         }
       });
   }

--- a/libs/components/core/testing/src/resize-observer-mock.ts
+++ b/libs/components/core/testing/src/resize-observer-mock.ts
@@ -29,6 +29,11 @@ export const mockResizeObserverHandle = {
 };
 
 export function mockResizeObserver() {
+  (window as any).requestAnimationFrame = (callback: () => void): number => {
+    callback();
+    return 0;
+  };
+  (window as any).cancelAnimationFrame = (_: number): void => undefined;
   window.ResizeObserver = class {
     constructor(callback: ResizeObserverCallback) {
       mockResizeObserverHandle.callback = callback;


### PR DESCRIPTION
:cherries: Cherry picked from #1790 [fix(components/core): prevent resize observer loop error](https://github.com/blackbaud/skyux/pull/1790)

[AB#2698342](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/2698342) 