### PR TITLE
feat(components/lookup): lookup show more modal native picker configurations include a `selectionDescriptor` which passes context to aria labels and the modal title

### DIFF
--- a/apps/code-examples/src/app/code-examples/lookup/lookup/add-item/demo.component.html
+++ b/apps/code-examples/src/app/code-examples/lookup/lookup/add-item/demo.component.html
@@ -16,6 +16,7 @@
         [enableShowMore]="true"
         (searchAsync)="searchAsync($event)"
         [showAddButton]="true"
+        [showMoreConfig]="showMoreConfig"
         (addClick)="addClick($event)"
       />
     </sky-input-box>

--- a/apps/code-examples/src/app/code-examples/lookup/lookup/add-item/demo.component.spec.ts
+++ b/apps/code-examples/src/app/code-examples/lookup/lookup/add-item/demo.component.spec.ts
@@ -83,4 +83,32 @@ describe('Lookup asynchronous search demo', () => {
       ]
     );
   });
+
+  it('should respect the selection descriptor', async () => {
+    const { lookupHarness } = await setupTest();
+
+    mockSvc.search.and.callFake(() =>
+      of({
+        hasMore: false,
+        people: [
+          {
+            id: '21',
+            name: 'Bernard',
+          },
+        ],
+        totalCount: 1,
+      })
+    );
+
+    await lookupHarness?.clickShowMoreButton();
+
+    const picker = await lookupHarness?.getShowMorePicker();
+
+    await expectAsync(picker?.getSearchAriaLabel()).toBeResolvedTo(
+      'Search names'
+    );
+    await expectAsync(picker?.getSaveButtonAriaLabel()).toBeResolvedTo(
+      'Select names'
+    );
+  });
 });

--- a/apps/code-examples/src/app/code-examples/lookup/lookup/add-item/demo.component.ts
+++ b/apps/code-examples/src/app/code-examples/lookup/lookup/add-item/demo.component.ts
@@ -14,6 +14,7 @@ import {
   SkyAutocompleteSearchAsyncArgs,
   SkyLookupAddClickEventArgs,
   SkyLookupModule,
+  SkyLookupShowMoreConfig,
 } from '@skyux/lookup';
 import { SkyModalCloseArgs, SkyModalService } from '@skyux/modals';
 
@@ -42,6 +43,12 @@ export class DemoComponent implements OnInit, OnDestroy {
   public favoritesForm: FormGroup<{
     favoriteNames: FormControl<Person[] | null>;
   }>;
+
+  public showMoreConfig: SkyLookupShowMoreConfig = {
+    nativePickerConfig: {
+      selectionDescriptor: 'names',
+    },
+  };
 
   #subscriptions = new Subscription();
 

--- a/apps/code-examples/src/app/code-examples/lookup/lookup/async/demo.component.html
+++ b/apps/code-examples/src/app/code-examples/lookup/lookup/async/demo.component.html
@@ -16,6 +16,7 @@
         [enableShowMore]="true"
         (searchAsync)="searchAsync($event)"
         [showAddButton]="true"
+        [showMoreConfig]="showMoreConfig"
         (addClick)="addClick($event)"
       />
     </sky-input-box>

--- a/apps/code-examples/src/app/code-examples/lookup/lookup/async/demo.component.spec.ts
+++ b/apps/code-examples/src/app/code-examples/lookup/lookup/async/demo.component.spec.ts
@@ -79,4 +79,32 @@ describe('Lookup asynchronous search demo', () => {
       [{ name: 'Shirley' }, { name: 'Bernard' }]
     );
   });
+
+  it('should respect the selection descriptor', async () => {
+    const { lookupHarness } = await setupTest();
+
+    mockSvc.search.and.callFake(() =>
+      of({
+        hasMore: false,
+        people: [
+          {
+            id: '21',
+            name: 'Bernard',
+          },
+        ],
+        totalCount: 1,
+      })
+    );
+
+    await lookupHarness?.clickShowMoreButton();
+
+    const picker = await lookupHarness?.getShowMorePicker();
+
+    await expectAsync(picker?.getSearchAriaLabel()).toBeResolvedTo(
+      'Search names'
+    );
+    await expectAsync(picker?.getSaveButtonAriaLabel()).toBeResolvedTo(
+      'Select names'
+    );
+  });
 });

--- a/apps/code-examples/src/app/code-examples/lookup/lookup/async/demo.component.ts
+++ b/apps/code-examples/src/app/code-examples/lookup/lookup/async/demo.component.ts
@@ -13,6 +13,7 @@ import {
   SkyAutocompleteSearchAsyncArgs,
   SkyLookupAddClickEventArgs,
   SkyLookupModule,
+  SkyLookupShowMoreConfig,
 } from '@skyux/lookup';
 
 import { map } from 'rxjs/operators';
@@ -37,6 +38,12 @@ export class DemoComponent implements OnInit {
   public favoritesForm: FormGroup<{
     favoriteNames: FormControl<Person[] | null>;
   }>;
+
+  public showMoreConfig: SkyLookupShowMoreConfig = {
+    nativePickerConfig: {
+      selectionDescriptor: 'names',
+    },
+  };
 
   readonly #svc = inject(DemoService);
   readonly #waitSvc = inject(SkyWaitService);

--- a/apps/code-examples/src/app/code-examples/lookup/lookup/multi-select/demo.component.html
+++ b/apps/code-examples/src/app/code-examples/lookup/lookup/multi-select/demo.component.html
@@ -17,6 +17,7 @@
         [enableShowMore]="true"
         [searchFilters]="searchFilters"
         [showAddButton]="true"
+        [showMoreConfig]="showMoreConfig"
       />
     </sky-input-box>
   </div>

--- a/apps/code-examples/src/app/code-examples/lookup/lookup/multi-select/demo.component.spec.ts
+++ b/apps/code-examples/src/app/code-examples/lookup/lookup/multi-select/demo.component.spec.ts
@@ -49,4 +49,19 @@ describe('Lookup multi-select demo', () => {
       fixture.componentInstance.favoritesForm.controls.favoriteNames.value
     ).toEqual([{ name: 'Shirley' }, { name: 'Ben' }]);
   });
+
+  it('should respect the selection descriptor', async () => {
+    const { lookupHarness } = await setupTest();
+
+    await lookupHarness?.clickShowMoreButton();
+
+    const picker = await lookupHarness?.getShowMorePicker();
+
+    await expectAsync(picker?.getSearchAriaLabel()).toBeResolvedTo(
+      'Search names'
+    );
+    await expectAsync(picker?.getSaveButtonAriaLabel()).toBeResolvedTo(
+      'Select names'
+    );
+  });
 });

--- a/apps/code-examples/src/app/code-examples/lookup/lookup/multi-select/demo.component.ts
+++ b/apps/code-examples/src/app/code-examples/lookup/lookup/multi-select/demo.component.ts
@@ -11,6 +11,7 @@ import { SkyInputBoxModule } from '@skyux/forms';
 import {
   SkyAutocompleteSearchFunctionFilter,
   SkyLookupModule,
+  SkyLookupShowMoreConfig,
 } from '@skyux/lookup';
 
 import { Person } from './person';
@@ -32,6 +33,12 @@ export class DemoComponent implements OnInit {
   public favoritesForm: FormGroup<{
     favoriteNames: FormControl<Person[] | null>;
   }>;
+
+  public showMoreConfig: SkyLookupShowMoreConfig = {
+    nativePickerConfig: {
+      selectionDescriptor: 'names',
+    },
+  };
 
   protected searchFilters: SkyAutocompleteSearchFunctionFilter[] = [];
 

--- a/apps/code-examples/src/app/code-examples/lookup/lookup/result-templates/demo.component.spec.ts
+++ b/apps/code-examples/src/app/code-examples/lookup/lookup/result-templates/demo.component.spec.ts
@@ -87,4 +87,19 @@ describe('Lookup result templates demo', () => {
       { name: 'Abed', formal: 'Mr. Nadir' },
     ]);
   });
+
+  it('should respect the selection descriptor', async () => {
+    const { lookupHarness } = await setupTest();
+
+    await lookupHarness?.clickShowMoreButton();
+
+    const picker = await lookupHarness?.getShowMorePicker();
+
+    await expectAsync(picker?.getSearchAriaLabel()).toBeResolvedTo(
+      'Search names'
+    );
+    await expectAsync(picker?.getSaveButtonAriaLabel()).toBeResolvedTo(
+      'Select names'
+    );
+  });
 });

--- a/apps/code-examples/src/app/code-examples/lookup/lookup/result-templates/demo.component.ts
+++ b/apps/code-examples/src/app/code-examples/lookup/lookup/result-templates/demo.component.ts
@@ -126,7 +126,9 @@ export class DemoComponent implements OnInit {
   ];
 
   protected showMoreConfig: SkyLookupShowMoreConfig = {
-    nativePickerConfig: {},
+    nativePickerConfig: {
+      selectionDescriptor: 'names',
+    },
   };
 
   @ViewChild('modalItemTemplate')

--- a/apps/code-examples/src/app/code-examples/lookup/lookup/single-select/demo.component.html
+++ b/apps/code-examples/src/app/code-examples/lookup/lookup/single-select/demo.component.html
@@ -18,6 +18,7 @@
         [enableShowMore]="true"
         [searchFilters]="searchFilters"
         [showAddButton]="true"
+        [showMoreConfig]="showMoreConfig"
       />
     </sky-input-box>
   </div>

--- a/apps/code-examples/src/app/code-examples/lookup/lookup/single-select/demo.component.spec.ts
+++ b/apps/code-examples/src/app/code-examples/lookup/lookup/single-select/demo.component.spec.ts
@@ -47,4 +47,19 @@ describe('Lookup single select demo', () => {
       { name: 'Ben' },
     ]);
   });
+
+  it('should respect the selection descriptor', async () => {
+    const { lookupHarness } = await setupTest();
+
+    await lookupHarness?.clickShowMoreButton();
+
+    const picker = await lookupHarness?.getShowMorePicker();
+
+    await expectAsync(picker?.getSearchAriaLabel()).toBeResolvedTo(
+      'Search name'
+    );
+    await expectAsync(picker?.getSaveButtonAriaLabel()).toBeResolvedTo(
+      'Select name'
+    );
+  });
 });

--- a/apps/code-examples/src/app/code-examples/lookup/lookup/single-select/demo.component.ts
+++ b/apps/code-examples/src/app/code-examples/lookup/lookup/single-select/demo.component.ts
@@ -11,6 +11,7 @@ import { SkyInputBoxModule } from '@skyux/forms';
 import {
   SkyAutocompleteSearchFunctionFilter,
   SkyLookupModule,
+  SkyLookupShowMoreConfig,
 } from '@skyux/lookup';
 
 import { Person } from './person';
@@ -32,6 +33,12 @@ export class DemoComponent implements OnInit {
   public favoritesForm: FormGroup<{
     favoriteName: FormControl<Person[] | null>;
   }>;
+
+  public showMoreConfig: SkyLookupShowMoreConfig = {
+    nativePickerConfig: {
+      selectionDescriptor: 'name',
+    },
+  };
 
   protected searchFilters: SkyAutocompleteSearchFunctionFilter[];
 

--- a/apps/code-examples/tsconfig.editor.json
+++ b/apps/code-examples/tsconfig.editor.json
@@ -1,9 +1,6 @@
 {
   "extends": "./tsconfig.json",
-  "include": [
-    "**/*.ts",
-    "../../libs/components/lookup/src/lib/modules/selection-modal/fixtures/search-results.ts"
-  ],
+  "include": ["**/*.ts"],
   "compilerOptions": {
     "types": ["jasmine", "node"]
   }

--- a/libs/components/data-manager/src/lib/modules/data-manager/models/data-manager-config.ts
+++ b/libs/components/data-manager/src/lib/modules/data-manager/models/data-manager-config.ts
@@ -20,7 +20,7 @@ export interface SkyDataManagerConfig {
   filterModalComponent?: any;
   /**
    * A descriptor for the data that the data manager manipulates. Use a plural term. The descriptor helps set the data manager's `aria-label` attributes for multiselect toolbars, search inputs, sort buttons, and filter buttons to provide text equivalents for screen readers [to support accessibility](https://developer.blackbaud.com/skyux/components/checkbox#accessibility).
-   * For example, when the descriptor is “constituents,” the search input’s `aria-label` is “Search constituents.” For more information about the `aria-label` attribute, see the [WAI-ARIA definition](https://www.w3.org/TR/wai-aria/#aria-label).
+   * For example, when the descriptor is "constituents," the search input's `aria-label` is "Search constituents." For more information about the `aria-label` attribute, see the [WAI-ARIA definition](https://www.w3.org/TR/wai-aria/#aria-label).
    */
   listDescriptor?: string;
   /**

--- a/libs/components/layout/src/lib/modules/toolbar/toolbar.component.ts
+++ b/libs/components/layout/src/lib/modules/toolbar/toolbar.component.ts
@@ -29,8 +29,8 @@ export class SkyToolbarComponent {
   }
 
   /**
-   * A descriptor for the items that the toolbar manipulates. Use a plural term. The descriptor helps set the toolbar’s `aria-label` attributes for search inputs, sort buttons, and filter buttons to provide text equivalents for screen readers [to support accessibility](https://developer.blackbaud.com/skyux/components/checkbox#accessibility).
-   * For example, when the descriptor is “constituents,” the search input’s `aria-label` is “Search constituents.” For more information about the `aria-label` attribute, see the [WAI-ARIA definition](https://www.w3.org/TR/wai-aria/#aria-label).
+   * A descriptor for the items that the toolbar manipulates. Use a plural term. The descriptor helps set the toolbar's `aria-label` attributes for search inputs, sort buttons, and filter buttons to provide text equivalents for screen readers [to support accessibility](https://developer.blackbaud.com/skyux/components/checkbox#accessibility).
+   * For example, when the descriptor is "constituents," the search input's `aria-label` is "Search constituents." For more information about the `aria-label` attribute, see the [WAI-ARIA definition](https://www.w3.org/TR/wai-aria/#aria-label).
    */
   @Input()
   public set listDescriptor(value: string | undefined) {

--- a/libs/components/lookup/src/assets/locales/resources_en_US.json
+++ b/libs/components/lookup/src/assets/locales/resources_en_US.json
@@ -63,14 +63,6 @@
     "_description": "Default show more modal title using selection context",
     "message": "Select {0}"
   },
-  "skyux_lookup_show_more_modal_title_single": {
-    "_description": "Default show more modal title for single select mode",
-    "message": "Select an option"
-  },
-  "skyux_lookup_show_more_modal_title_multiple": {
-    "_description": "Default show more modal title for multiple select mode",
-    "message": "Select options"
-  },
   "skyux_lookup_show_more_no_results": {
     "_description": "Placeholder text for lookup's show more modal when no results are found",
     "message": "No matches found"

--- a/libs/components/lookup/src/lib/modules/lookup/lookup-show-more-modal.component.html
+++ b/libs/components/lookup/src/lib/modules/lookup/lookup-show-more-modal.component.html
@@ -12,7 +12,10 @@
     [skyViewkeeper]="['.sky-lookup-show-more-toolbar-wrapper']"
   >
     <div class="sky-lookup-show-more-toolbar-wrapper">
-      <sky-toolbar class="sky-lookup-show-more-modal-toolbar">
+      <sky-toolbar
+        [listDescriptor]="context.userConfig.selectionDescriptor"
+        class="sky-lookup-show-more-modal-toolbar"
+      >
         <sky-toolbar-section>
           <sky-toolbar-item>
             <sky-search
@@ -44,6 +47,10 @@
             <button
               class="sky-btn sky-btn-link sky-lookup-show-more-modal-select-all-btn"
               type="button"
+              [attr.aria-label]="
+                'skyux_lookup_show_more_select_all_button_aria_label'
+                  | skyLibResources : context.userConfig.selectionDescriptor
+              "
               (click)="selectAll()"
             >
               {{
@@ -56,6 +63,10 @@
             <button
               class="sky-btn sky-btn-link sky-lookup-show-more-modal-clear-all-btn"
               type="button"
+              [attr.aria-label]="
+                'skyux_lookup_show_more_clear_all_button_aria_label'
+                  | skyLibResources : context.userConfig.selectionDescriptor
+              "
               (click)="clearAll()"
             >
               {{
@@ -67,6 +78,10 @@
           <sky-toolbar-view-actions>
             <sky-checkbox
               [(checked)]="onlyShowSelected"
+              [label]="
+                'skyux_lookup_show_more_show_selected_option_aria_label'
+                  | skyLibResources : context.userConfig.selectionDescriptor
+              "
               (change)="updateDataState()"
             >
               <sky-checkbox-label>
@@ -117,6 +132,10 @@
     <button
       class="sky-btn sky-btn-primary sky-margin-inline-compact sky-lookup-show-more-modal-save"
       type="button"
+      [attr.aria-label]="
+        'skyux_lookup_show_more_select_context'
+          | skyLibResources : context.userConfig.selectionDescriptor
+      "
       (click)="modalInstance.save(selectedItems)"
     >
       {{ 'skyux_lookup_show_more_select' | skyLibResources }}
@@ -136,10 +155,8 @@
 </ng-template>
 
 <ng-template #defaultTitle>
-  <ng-container *ngIf="context.selectMode === 'single'">
-    {{ 'skyux_lookup_show_more_modal_title_single' | skyLibResources }}
-  </ng-container>
-  <ng-container *ngIf="context.selectMode === 'multiple'">
-    {{ 'skyux_lookup_show_more_modal_title_multiple' | skyLibResources }}
-  </ng-container>
+  {{
+    'skyux_lookup_show_more_modal_title'
+      | skyLibResources : context.userConfig.selectionDescriptor
+  }}
 </ng-template>

--- a/libs/components/lookup/src/lib/modules/lookup/lookup.component.spec.ts
+++ b/libs/components/lookup/src/lib/modules/lookup/lookup.component.spec.ts
@@ -81,20 +81,12 @@ describe('Lookup component', function () {
   }
 
   function clickShowMoreClearAll(fixture: ComponentFixture<any>): void {
-    (
-      document.querySelector(
-        '.sky-lookup-show-more-modal-clear-all-btn'
-      ) as HTMLElement
-    ).click();
+    getModalClearAllButton().click();
     fixture.detectChanges();
   }
 
   function clickShowMoreSelectAll(fixture: ComponentFixture<any>): void {
-    (
-      document.querySelector(
-        '.sky-lookup-show-more-modal-select-all-btn'
-      ) as HTMLElement
-    ).click();
+    getModalSelectAllButton().click();
     fixture.detectChanges();
   }
 
@@ -226,8 +218,22 @@ describe('Lookup component', function () {
     ) as HTMLElement;
   }
 
+  function getModalClearAllButton(): HTMLButtonElement | null {
+    return document.querySelector('.sky-lookup-show-more-modal-clear-all-btn');
+  }
+
   function getModalContentScrollTop(): number | undefined {
     return getModalEl().querySelector('.sky-modal-content')?.scrollTop;
+  }
+
+  function getModalOnlyShowSelectedInput(): HTMLInputElement | null {
+    return document.querySelector(
+      'sky-toolbar-view-actions sky-checkbox input'
+    );
+  }
+
+  function getModalSaveButton(): HTMLButtonElement | null {
+    return document.querySelector('.sky-lookup-show-more-modal-save');
   }
 
   function getModalSearchButton(): HTMLButtonElement | null {
@@ -245,6 +251,10 @@ describe('Lookup component', function () {
   function getModalSearchInputValue(): string {
     const modalSearchInput = getModalSearchInput();
     return modalSearchInput?.value ?? '';
+  }
+
+  function getModalSelectAllButton(): HTMLButtonElement | null {
+    return document.querySelector('.sky-lookup-show-more-modal-select-all-btn');
   }
 
   function getRepeaterItemCount(): number {
@@ -370,9 +380,7 @@ describe('Lookup component', function () {
     // Ensure the search async timer in the lookup fixture component is cleared
     // before saving the form.
     tick(200);
-    (
-      document.querySelector('.sky-lookup-show-more-modal-save') as HTMLElement
-    ).click();
+    getModalSaveButton().click();
     fixture.detectChanges();
   }
 
@@ -2299,19 +2307,6 @@ describe('Lookup component', function () {
               closeModalBase();
             });
 
-            it('the default modal title should be correct', fakeAsync(() => {
-              component.enableShowMore = true;
-              fixture.detectChanges();
-              expect(lookupComponent.value).toEqual([]);
-
-              performSearch('s', fixture);
-              clickShowMore(fixture);
-
-              expect(getShowMoreModalTitle()).toBe('Select options');
-
-              closeModal(fixture);
-            }));
-
             it('should respect a custom modal title', fakeAsync(() => {
               component.enableShowMore = true;
               component.setShowMoreNativePickerConfig({
@@ -2324,6 +2319,97 @@ describe('Lookup component', function () {
               clickShowMore(fixture);
 
               expect(getShowMoreModalTitle()).toBe('Custom title');
+
+              closeModal(fixture);
+            }));
+
+            it('should set default title and aria labels without a selection descriptor', fakeAsync(() => {
+              component.enableShowMore = true;
+              fixture.detectChanges();
+              expect(lookupComponent.value).toEqual([]);
+
+              performSearch('s', fixture);
+              clickShowMore(fixture);
+
+              const selectButton = getModalSaveButton();
+
+              expect(getShowMoreModalTitle()).toBe('Select items');
+
+              expect(getModalSearchInput()?.getAttribute('aria-label')).toBe(
+                'Search items'
+              );
+              // Test that button text isn't contextual and only the `aria-label`
+              expect(selectButton?.textContent.trim()).toBe('Select');
+              expect(selectButton?.getAttribute('aria-label')).toBe(
+                'Select items'
+              );
+
+              // Test that button text isn't contextual and only the `aria-label`
+              expect(getModalClearAllButton()?.textContent.trim()).toBe(
+                'Clear all'
+              );
+              expect(getModalClearAllButton().getAttribute('aria-label')).toBe(
+                'Clear all selected items'
+              );
+
+              // Test that button text isn't contextual and only the `aria-label`
+              expect(getModalSelectAllButton()?.textContent.trim()).toBe(
+                'Select all'
+              );
+              expect(getModalSelectAllButton().getAttribute('aria-label')).toBe(
+                'Select all items'
+              );
+
+              expect(
+                getModalOnlyShowSelectedInput().getAttribute('aria-label')
+              ).toBe('Show only selected items');
+
+              closeModal(fixture);
+            }));
+
+            it('should respect a selection descriptor', fakeAsync(() => {
+              component.enableShowMore = true;
+              component.setShowMoreNativePickerConfig({
+                selectionDescriptor: 'people',
+              });
+              fixture.detectChanges();
+              expect(lookupComponent.value).toEqual([]);
+
+              performSearch('s', fixture);
+              clickShowMore(fixture);
+
+              const selectButton = getModalSaveButton();
+
+              expect(getShowMoreModalTitle()).toBe('Select people');
+
+              expect(getModalSearchInput()?.getAttribute('aria-label')).toBe(
+                'Search people'
+              );
+              // Test that button text isn't contextual and only the `aria-label`
+              expect(selectButton?.textContent.trim()).toBe('Select');
+              expect(selectButton?.getAttribute('aria-label')).toBe(
+                'Select people'
+              );
+
+              // Test that button text isn't contextual and only the `aria-label`
+              expect(getModalClearAllButton()?.textContent.trim()).toBe(
+                'Clear all'
+              );
+              expect(getModalClearAllButton().getAttribute('aria-label')).toBe(
+                'Clear all selected people'
+              );
+
+              // Test that button text isn't contextual and only the `aria-label`
+              expect(getModalSelectAllButton()?.textContent.trim()).toBe(
+                'Select all'
+              );
+              expect(getModalSelectAllButton().getAttribute('aria-label')).toBe(
+                'Select all people'
+              );
+
+              expect(
+                getModalOnlyShowSelectedInput().getAttribute('aria-label')
+              ).toBe('Show only selected people');
 
               closeModal(fixture);
             }));
@@ -2706,19 +2792,6 @@ describe('Lookup component', function () {
               closeModal(fixture);
             }));
 
-            it('the default modal title should be correct', fakeAsync(() => {
-              component.enableShowMore = true;
-              fixture.detectChanges();
-              expect(asyncLookupComponent.value).toEqual([]);
-
-              performSearch('s', fixture, true);
-              clickShowMore(fixture);
-
-              expect(getShowMoreModalTitle()).toBe('Select items');
-
-              closeModal(fixture);
-            }));
-
             it('should respect a custom modal title', fakeAsync(() => {
               component.enableShowMore = true;
               component.setShowMoreNativePickerConfig({
@@ -2731,6 +2804,97 @@ describe('Lookup component', function () {
               clickShowMore(fixture);
 
               expect(getShowMoreModalTitle()).toBe('Custom title');
+
+              closeModal(fixture);
+            }));
+
+            it('should set default title and aria labels without a selection descriptor', fakeAsync(() => {
+              component.enableShowMore = true;
+              fixture.detectChanges();
+              expect(lookupComponent.value).toEqual([]);
+
+              performSearch('s', fixture);
+              clickShowMore(fixture);
+
+              const selectButton = getModalSaveButton();
+
+              expect(getShowMoreModalTitle()).toBe('Select items');
+
+              expect(getModalSearchInput()?.getAttribute('aria-label')).toBe(
+                'Search items'
+              );
+              // Test that button text isn't contextual and only the `aria-label`
+              expect(selectButton?.textContent.trim()).toBe('Select');
+              expect(selectButton?.getAttribute('aria-label')).toBe(
+                'Select items'
+              );
+
+              // Test that button text isn't contextual and only the `aria-label`
+              expect(getModalClearAllButton()?.textContent.trim()).toBe(
+                'Clear all'
+              );
+              expect(getModalClearAllButton().getAttribute('aria-label')).toBe(
+                'Clear all selected items'
+              );
+
+              // Test that button text isn't contextual and only the `aria-label`
+              expect(getModalSelectAllButton()?.textContent.trim()).toBe(
+                'Select all'
+              );
+              expect(getModalSelectAllButton().getAttribute('aria-label')).toBe(
+                'Select all items'
+              );
+
+              expect(
+                getModalOnlyShowSelectedInput().getAttribute('aria-label')
+              ).toBe('Show only selected items');
+
+              closeModal(fixture);
+            }));
+
+            it('should respect a selection descriptor', fakeAsync(() => {
+              component.enableShowMore = true;
+              component.setShowMoreNativePickerConfig({
+                selectionDescriptor: 'people',
+              });
+              fixture.detectChanges();
+              expect(lookupComponent.value).toEqual([]);
+
+              performSearch('s', fixture);
+              clickShowMore(fixture);
+
+              const selectButton = getModalSaveButton();
+
+              expect(getShowMoreModalTitle()).toBe('Select people');
+
+              expect(getModalSearchInput()?.getAttribute('aria-label')).toBe(
+                'Search people'
+              );
+              // Test that button text isn't contextual and only the `aria-label`
+              expect(selectButton?.textContent.trim()).toBe('Select');
+              expect(selectButton?.getAttribute('aria-label')).toBe(
+                'Select people'
+              );
+
+              // Test that button text isn't contextual and only the `aria-label`
+              expect(getModalClearAllButton()?.textContent.trim()).toBe(
+                'Clear all'
+              );
+              expect(getModalClearAllButton().getAttribute('aria-label')).toBe(
+                'Clear all selected people'
+              );
+
+              // Test that button text isn't contextual and only the `aria-label`
+              expect(getModalSelectAllButton()?.textContent.trim()).toBe(
+                'Select all'
+              );
+              expect(getModalSelectAllButton().getAttribute('aria-label')).toBe(
+                'Select all people'
+              );
+
+              expect(
+                getModalOnlyShowSelectedInput().getAttribute('aria-label')
+              ).toBe('Show only selected people');
 
               closeModal(fixture);
             }));
@@ -2963,19 +3127,6 @@ describe('Lookup component', function () {
               closeModal(fixture);
             }));
 
-            it('the default modal title should be correct', fakeAsync(() => {
-              component.enableShowMore = true;
-              fixture.detectChanges();
-              expect(lookupComponent.value).toEqual([]);
-
-              performSearch('s', fixture);
-              clickShowMore(fixture);
-
-              expect(getShowMoreModalTitle()).toBe('Select an option');
-
-              closeModal(fixture);
-            }));
-
             it('should respect a custom modal title', fakeAsync(() => {
               component.enableShowMore = true;
               component.setShowMoreNativePickerConfig({
@@ -2988,6 +3139,57 @@ describe('Lookup component', function () {
               clickShowMore(fixture);
 
               expect(getShowMoreModalTitle()).toBe('Custom title');
+
+              closeModal(fixture);
+            }));
+
+            it('should set default title and aria labels without a selection descriptor', fakeAsync(() => {
+              component.enableShowMore = true;
+              fixture.detectChanges();
+              expect(lookupComponent.value).toEqual([]);
+
+              performSearch('s', fixture);
+              clickShowMore(fixture);
+
+              const selectButton = getModalSaveButton();
+
+              expect(getShowMoreModalTitle()).toBe('Select item');
+
+              expect(getModalSearchInput()?.getAttribute('aria-label')).toBe(
+                'Search item'
+              );
+              // Test that button text isn't contextual and only the `aria-label`
+              expect(selectButton?.textContent.trim()).toBe('Select');
+              expect(selectButton?.getAttribute('aria-label')).toBe(
+                'Select item'
+              );
+
+              closeModal(fixture);
+            }));
+
+            it('should respect a selection descriptor', fakeAsync(() => {
+              component.enableShowMore = true;
+              component.setShowMoreNativePickerConfig({
+                selectionDescriptor: 'person',
+              });
+              fixture.detectChanges();
+              expect(lookupComponent.value).toEqual([]);
+
+              performSearch('s', fixture);
+              clickShowMore(fixture);
+
+              const selectButton = getModalSaveButton();
+
+              expect(getShowMoreModalTitle()).toBe('Select person');
+
+              expect(getModalSearchInput()?.getAttribute('aria-label')).toBe(
+                'Search person'
+              );
+              // Test that button text isn't contextual and only the `aria-label`
+              expect(selectButton?.textContent.trim()).toBe('Select');
+              expect(selectButton?.getAttribute('aria-label')).toBe(
+                'Select person'
+              );
 
               closeModal(fixture);
             }));
@@ -3159,19 +3361,6 @@ describe('Lookup component', function () {
               closeModal(fixture);
             }));
 
-            it('the default modal title should be correct', fakeAsync(() => {
-              component.enableShowMore = true;
-              fixture.detectChanges();
-              expect(asyncLookupComponent.value).toEqual([]);
-
-              performSearch('s', fixture, true);
-              clickShowMore(fixture);
-
-              expect(getShowMoreModalTitle()).toBe('Select item');
-
-              closeModal(fixture);
-            }));
-
             it('should respect a custom modal title', fakeAsync(() => {
               component.enableShowMore = true;
               component.setShowMoreNativePickerConfig({
@@ -3184,6 +3373,57 @@ describe('Lookup component', function () {
               clickShowMore(fixture);
 
               expect(getShowMoreModalTitle()).toBe('Custom title');
+
+              closeModal(fixture);
+            }));
+
+            it('should set default title and aria labels without a selection descriptor', fakeAsync(() => {
+              component.enableShowMore = true;
+              fixture.detectChanges();
+              expect(lookupComponent.value).toEqual([]);
+
+              performSearch('s', fixture);
+              clickShowMore(fixture);
+
+              const selectButton = getModalSaveButton();
+
+              expect(getShowMoreModalTitle()).toBe('Select item');
+
+              expect(getModalSearchInput()?.getAttribute('aria-label')).toBe(
+                'Search item'
+              );
+              // Test that button text isn't contextual and only the `aria-label`
+              expect(selectButton?.textContent.trim()).toBe('Select');
+              expect(selectButton?.getAttribute('aria-label')).toBe(
+                'Select item'
+              );
+
+              closeModal(fixture);
+            }));
+
+            it('should respect a selection descriptor', fakeAsync(() => {
+              component.enableShowMore = true;
+              component.setShowMoreNativePickerConfig({
+                selectionDescriptor: 'person',
+              });
+              fixture.detectChanges();
+              expect(lookupComponent.value).toEqual([]);
+
+              performSearch('s', fixture);
+              clickShowMore(fixture);
+
+              const selectButton = getModalSaveButton();
+
+              expect(getShowMoreModalTitle()).toBe('Select person');
+
+              expect(getModalSearchInput()?.getAttribute('aria-label')).toBe(
+                'Search person'
+              );
+              // Test that button text isn't contextual and only the `aria-label`
+              expect(selectButton?.textContent.trim()).toBe('Select');
+              expect(selectButton?.getAttribute('aria-label')).toBe(
+                'Select person'
+              );
 
               closeModal(fixture);
             }));
@@ -5485,19 +5725,6 @@ describe('Lookup component', function () {
               closeModalBase();
             });
 
-            it('the default modal title should be correct', fakeAsync(() => {
-              component.enableShowMore = true;
-              fixture.detectChanges();
-              expect(lookupComponent.value).toEqual([]);
-
-              performSearch('s', fixture);
-              clickShowMore(fixture);
-
-              expect(getShowMoreModalTitle()).toBe('Select options');
-
-              closeModal(fixture);
-            }));
-
             it('should respect a custom modal title', fakeAsync(() => {
               component.enableShowMore = true;
               component.setShowMoreNativePickerConfig({
@@ -5510,6 +5737,97 @@ describe('Lookup component', function () {
               clickShowMore(fixture);
 
               expect(getShowMoreModalTitle()).toBe('Custom title');
+
+              closeModal(fixture);
+            }));
+
+            it('should set default title and aria labels without a selection descriptor', fakeAsync(() => {
+              component.enableShowMore = true;
+              fixture.detectChanges();
+              expect(lookupComponent.value).toEqual([]);
+
+              performSearch('s', fixture);
+              clickShowMore(fixture);
+
+              const selectButton = getModalSaveButton();
+
+              expect(getShowMoreModalTitle()).toBe('Select items');
+
+              expect(getModalSearchInput()?.getAttribute('aria-label')).toBe(
+                'Search items'
+              );
+              // Test that button text isn't contextual and only the `aria-label`
+              expect(selectButton?.textContent.trim()).toBe('Select');
+              expect(selectButton?.getAttribute('aria-label')).toBe(
+                'Select items'
+              );
+
+              // Test that button text isn't contextual and only the `aria-label`
+              expect(getModalClearAllButton()?.textContent.trim()).toBe(
+                'Clear all'
+              );
+              expect(getModalClearAllButton().getAttribute('aria-label')).toBe(
+                'Clear all selected items'
+              );
+
+              // Test that button text isn't contextual and only the `aria-label`
+              expect(getModalSelectAllButton()?.textContent.trim()).toBe(
+                'Select all'
+              );
+              expect(getModalSelectAllButton().getAttribute('aria-label')).toBe(
+                'Select all items'
+              );
+
+              expect(
+                getModalOnlyShowSelectedInput().getAttribute('aria-label')
+              ).toBe('Show only selected items');
+
+              closeModal(fixture);
+            }));
+
+            it('should respect a selection descriptor', fakeAsync(() => {
+              component.enableShowMore = true;
+              component.setShowMoreNativePickerConfig({
+                selectionDescriptor: 'people',
+              });
+              fixture.detectChanges();
+              expect(lookupComponent.value).toEqual([]);
+
+              performSearch('s', fixture);
+              clickShowMore(fixture);
+
+              const selectButton = getModalSaveButton();
+
+              expect(getShowMoreModalTitle()).toBe('Select people');
+
+              expect(getModalSearchInput()?.getAttribute('aria-label')).toBe(
+                'Search people'
+              );
+              // Test that button text isn't contextual and only the `aria-label`
+              expect(selectButton?.textContent.trim()).toBe('Select');
+              expect(selectButton?.getAttribute('aria-label')).toBe(
+                'Select people'
+              );
+
+              // Test that button text isn't contextual and only the `aria-label`
+              expect(getModalClearAllButton()?.textContent.trim()).toBe(
+                'Clear all'
+              );
+              expect(getModalClearAllButton().getAttribute('aria-label')).toBe(
+                'Clear all selected people'
+              );
+
+              // Test that button text isn't contextual and only the `aria-label`
+              expect(getModalSelectAllButton()?.textContent.trim()).toBe(
+                'Select all'
+              );
+              expect(getModalSelectAllButton().getAttribute('aria-label')).toBe(
+                'Select all people'
+              );
+
+              expect(
+                getModalOnlyShowSelectedInput().getAttribute('aria-label')
+              ).toBe('Show only selected people');
 
               closeModal(fixture);
             }));
@@ -5880,19 +6198,6 @@ describe('Lookup component', function () {
               closeModal(fixture);
             }));
 
-            it('the default modal title should be correct', fakeAsync(() => {
-              component.enableShowMore = true;
-              fixture.detectChanges();
-              expect(asyncLookupComponent.value).toEqual([]);
-
-              performSearch('s', fixture, true);
-              clickShowMore(fixture);
-
-              expect(getShowMoreModalTitle()).toBe('Select items');
-
-              closeModal(fixture);
-            }));
-
             it('should respect a custom modal title', fakeAsync(() => {
               component.enableShowMore = true;
               component.setShowMoreNativePickerConfig({
@@ -5905,6 +6210,97 @@ describe('Lookup component', function () {
               clickShowMore(fixture);
 
               expect(getShowMoreModalTitle()).toBe('Custom title');
+
+              closeModal(fixture);
+            }));
+
+            it('should set default title and aria labels without a selection descriptor', fakeAsync(() => {
+              component.enableShowMore = true;
+              fixture.detectChanges();
+              expect(lookupComponent.value).toEqual([]);
+
+              performSearch('s', fixture);
+              clickShowMore(fixture);
+
+              const selectButton = getModalSaveButton();
+
+              expect(getShowMoreModalTitle()).toBe('Select items');
+
+              expect(getModalSearchInput()?.getAttribute('aria-label')).toBe(
+                'Search items'
+              );
+              // Test that button text isn't contextual and only the `aria-label`
+              expect(selectButton?.textContent.trim()).toBe('Select');
+              expect(selectButton?.getAttribute('aria-label')).toBe(
+                'Select items'
+              );
+
+              // Test that button text isn't contextual and only the `aria-label`
+              expect(getModalClearAllButton()?.textContent.trim()).toBe(
+                'Clear all'
+              );
+              expect(getModalClearAllButton().getAttribute('aria-label')).toBe(
+                'Clear all selected items'
+              );
+
+              // Test that button text isn't contextual and only the `aria-label`
+              expect(getModalSelectAllButton()?.textContent.trim()).toBe(
+                'Select all'
+              );
+              expect(getModalSelectAllButton().getAttribute('aria-label')).toBe(
+                'Select all items'
+              );
+
+              expect(
+                getModalOnlyShowSelectedInput().getAttribute('aria-label')
+              ).toBe('Show only selected items');
+
+              closeModal(fixture);
+            }));
+
+            it('should respect a selection descriptor', fakeAsync(() => {
+              component.enableShowMore = true;
+              component.setShowMoreNativePickerConfig({
+                selectionDescriptor: 'people',
+              });
+              fixture.detectChanges();
+              expect(lookupComponent.value).toEqual([]);
+
+              performSearch('s', fixture);
+              clickShowMore(fixture);
+
+              const selectButton = getModalSaveButton();
+
+              expect(getShowMoreModalTitle()).toBe('Select people');
+
+              expect(getModalSearchInput()?.getAttribute('aria-label')).toBe(
+                'Search people'
+              );
+              // Test that button text isn't contextual and only the `aria-label`
+              expect(selectButton?.textContent.trim()).toBe('Select');
+              expect(selectButton?.getAttribute('aria-label')).toBe(
+                'Select people'
+              );
+
+              // Test that button text isn't contextual and only the `aria-label`
+              expect(getModalClearAllButton()?.textContent.trim()).toBe(
+                'Clear all'
+              );
+              expect(getModalClearAllButton().getAttribute('aria-label')).toBe(
+                'Clear all selected people'
+              );
+
+              // Test that button text isn't contextual and only the `aria-label`
+              expect(getModalSelectAllButton()?.textContent.trim()).toBe(
+                'Select all'
+              );
+              expect(getModalSelectAllButton().getAttribute('aria-label')).toBe(
+                'Select all people'
+              );
+
+              expect(
+                getModalOnlyShowSelectedInput().getAttribute('aria-label')
+              ).toBe('Show only selected people');
 
               closeModal(fixture);
             }));
@@ -6143,19 +6539,6 @@ describe('Lookup component', function () {
               closeModal(fixture);
             }));
 
-            it('the default modal title should be correct', fakeAsync(() => {
-              component.enableShowMore = true;
-              fixture.detectChanges();
-              expect(lookupComponent.value).toEqual([]);
-
-              performSearch('s', fixture);
-              clickShowMore(fixture);
-
-              expect(getShowMoreModalTitle()).toBe('Select an option');
-
-              closeModal(fixture);
-            }));
-
             it('should respect a custom modal title', fakeAsync(() => {
               component.enableShowMore = true;
               component.setShowMoreNativePickerConfig({
@@ -6168,6 +6551,57 @@ describe('Lookup component', function () {
               clickShowMore(fixture);
 
               expect(getShowMoreModalTitle()).toBe('Custom title');
+
+              closeModal(fixture);
+            }));
+
+            it('should set default title and aria labels without a selection descriptor', fakeAsync(() => {
+              component.enableShowMore = true;
+              fixture.detectChanges();
+              expect(lookupComponent.value).toEqual([]);
+
+              performSearch('s', fixture);
+              clickShowMore(fixture);
+
+              const selectButton = getModalSaveButton();
+
+              expect(getShowMoreModalTitle()).toBe('Select item');
+
+              expect(getModalSearchInput()?.getAttribute('aria-label')).toBe(
+                'Search item'
+              );
+              // Test that button text isn't contextual and only the `aria-label`
+              expect(selectButton?.textContent.trim()).toBe('Select');
+              expect(selectButton?.getAttribute('aria-label')).toBe(
+                'Select item'
+              );
+
+              closeModal(fixture);
+            }));
+
+            it('should respect a selection descriptor', fakeAsync(() => {
+              component.enableShowMore = true;
+              component.setShowMoreNativePickerConfig({
+                selectionDescriptor: 'person',
+              });
+              fixture.detectChanges();
+              expect(lookupComponent.value).toEqual([]);
+
+              performSearch('s', fixture);
+              clickShowMore(fixture);
+
+              const selectButton = getModalSaveButton();
+
+              expect(getShowMoreModalTitle()).toBe('Select person');
+
+              expect(getModalSearchInput()?.getAttribute('aria-label')).toBe(
+                'Search person'
+              );
+              // Test that button text isn't contextual and only the `aria-label`
+              expect(selectButton?.textContent.trim()).toBe('Select');
+              expect(selectButton?.getAttribute('aria-label')).toBe(
+                'Select person'
+              );
 
               closeModal(fixture);
             }));
@@ -6316,19 +6750,6 @@ describe('Lookup component', function () {
               closeModal(fixture);
             }));
 
-            it('the default modal title should be correct', fakeAsync(() => {
-              component.enableShowMore = true;
-              fixture.detectChanges();
-              expect(asyncLookupComponent.value).toEqual([]);
-
-              performSearch('s', fixture, true);
-              clickShowMore(fixture);
-
-              expect(getShowMoreModalTitle()).toBe('Select item');
-
-              closeModal(fixture);
-            }));
-
             it('should respect a custom modal title', fakeAsync(() => {
               component.enableShowMore = true;
               component.setShowMoreNativePickerConfig({
@@ -6341,6 +6762,57 @@ describe('Lookup component', function () {
               clickShowMore(fixture);
 
               expect(getShowMoreModalTitle()).toBe('Custom title');
+
+              closeModal(fixture);
+            }));
+
+            it('should set default title and aria labels without a selection descriptor', fakeAsync(() => {
+              component.enableShowMore = true;
+              fixture.detectChanges();
+              expect(lookupComponent.value).toEqual([]);
+
+              performSearch('s', fixture);
+              clickShowMore(fixture);
+
+              const selectButton = getModalSaveButton();
+
+              expect(getShowMoreModalTitle()).toBe('Select item');
+
+              expect(getModalSearchInput()?.getAttribute('aria-label')).toBe(
+                'Search item'
+              );
+              // Test that button text isn't contextual and only the `aria-label`
+              expect(selectButton?.textContent.trim()).toBe('Select');
+              expect(selectButton?.getAttribute('aria-label')).toBe(
+                'Select item'
+              );
+
+              closeModal(fixture);
+            }));
+
+            it('should respect a selection descriptor', fakeAsync(() => {
+              component.enableShowMore = true;
+              component.setShowMoreNativePickerConfig({
+                selectionDescriptor: 'person',
+              });
+              fixture.detectChanges();
+              expect(lookupComponent.value).toEqual([]);
+
+              performSearch('s', fixture);
+              clickShowMore(fixture);
+
+              const selectButton = getModalSaveButton();
+
+              expect(getShowMoreModalTitle()).toBe('Select person');
+
+              expect(getModalSearchInput()?.getAttribute('aria-label')).toBe(
+                'Search person'
+              );
+              // Test that button text isn't contextual and only the `aria-label`
+              expect(selectButton?.textContent.trim()).toBe('Select');
+              expect(selectButton?.getAttribute('aria-label')).toBe(
+                'Select person'
+              );
 
               closeModal(fixture);
             }));

--- a/libs/components/lookup/src/lib/modules/lookup/lookup.component.ts
+++ b/libs/components/lookup/src/lib/modules/lookup/lookup.component.ts
@@ -686,6 +686,7 @@ export class SkyLookupComponent
       },
       initialSearch,
       itemTemplate: modalConfig.itemTemplate,
+      selectionDescriptor: modalConfig.selectionDescriptor,
       showAddButton: this.showAddButton,
       title: modalConfig.title,
       value: initialValue,
@@ -699,6 +700,11 @@ export class SkyLookupComponent
 
     if (!modalConfig.itemTemplate) {
       modalConfig.itemTemplate = this.searchResultTemplate;
+    }
+
+    if (!modalConfig.selectionDescriptor) {
+      modalConfig.selectionDescriptor =
+        this.selectMode === 'single' ? 'item' : 'items';
     }
 
     const contextProviderValue = new SkyLookupShowMoreNativePickerContext(

--- a/libs/components/lookup/src/lib/modules/lookup/types/lookup-show-more-native-picker-config.ts
+++ b/libs/components/lookup/src/lib/modules/lookup/types/lookup-show-more-native-picker-config.ts
@@ -16,6 +16,14 @@ export interface SkyLookupShowMoreNativePickerConfig {
   /**
    * The title for the picker.
    * @default "Select an option/Select options"
+   * @deprecated Use the `selectionDescriptor` input to give context to the title and accessibility labels instead.
    */
   title?: string;
+
+  /**
+   * A descriptor for the item or items being selected. Use a plural term when the lookup's `selectMode` is set to `multiple`; otherwise, use a singular term. The descriptor helps set the picker's `aria-label` attributes for the multiselect toolbar controls, the search input, and the save button to provide text equivalents for screen readers [to support accessibility](https://developer.blackbaud.com/skyux/components/checkbox#accessibility).
+   * For example, when the descriptor is “constituents,” the search input’s `aria-label` is “Search constituents.” For more information about the `aria-label` attribute, see the [WAI-ARIA definition](https://www.w3.org/TR/wai-aria/#aria-label).
+   * @default "item"/"items"
+   */
+  selectionDescriptor?: string;
 }

--- a/libs/components/lookup/src/lib/modules/lookup/types/lookup-show-more-native-picker-config.ts
+++ b/libs/components/lookup/src/lib/modules/lookup/types/lookup-show-more-native-picker-config.ts
@@ -21,8 +21,8 @@ export interface SkyLookupShowMoreNativePickerConfig {
   title?: string;
 
   /**
-   * A descriptor for the item or items being selected. Use a plural term when the lookup's `selectMode` is set to `multiple`; otherwise, use a singular term. The descriptor helps set the picker's `aria-label` attributes for the multiselect toolbar controls, the search input, and the save button to provide text equivalents for screen readers [to support accessibility](https://developer.blackbaud.com/skyux/components/checkbox#accessibility).
-   * For example, when the descriptor is “constituents,” the search input’s `aria-label` is “Search constituents.” For more information about the `aria-label` attribute, see the [WAI-ARIA definition](https://www.w3.org/TR/wai-aria/#aria-label).
+   * A descriptor for the item or items being selected. Use a plural term when the lookup's `selectMode` is set to `'multiple'`; otherwise, use a singular term. The descriptor helps set the picker's `aria-label` attributes for the multiselect toolbar controls, the search input, and the save button to provide text equivalents for screen readers [to support accessibility](https://developer.blackbaud.com/skyux/components/checkbox#accessibility).
+   * For example, when the descriptor is "constituents," the search input's `aria-label` is "Search constituents." For more information about the `aria-label` attribute, see the [WAI-ARIA definition](https://www.w3.org/TR/wai-aria/#aria-label).
    * @default "item"/"items"
    */
   selectionDescriptor?: string;

--- a/libs/components/lookup/src/lib/modules/selection-modal/types/selection-modal-open-args.ts
+++ b/libs/components/lookup/src/lib/modules/selection-modal/types/selection-modal-open-args.ts
@@ -80,7 +80,7 @@ export interface SkySelectionModalOpenArgs {
 
   /**
    * A descriptor for the item or items being selected. Use a plural term when `selectMode` is set to `multiple`; otherwise, use a singular term. The descriptor helps set the selection modal's `aria-label` attributes for the multiselect toolbar controls, the search input, and the save button to provide text equivalents for screen readers [to support accessibility](https://developer.blackbaud.com/skyux/components/checkbox#accessibility).
-   * For example, when the descriptor is “constituents,” the search input’s `aria-label` is “Search constituents.” For more information about the `aria-label` attribute, see the [WAI-ARIA definition](https://www.w3.org/TR/wai-aria/#aria-label).
+   * For example, when the descriptor is "constituents," the search input's `aria-label` is "Search constituents." For more information about the `aria-label` attribute, see the [WAI-ARIA definition](https://www.w3.org/TR/wai-aria/#aria-label).
    * @default "item"/"items"
    */
   selectionDescriptor?: string;

--- a/libs/components/lookup/src/lib/modules/shared/sky-lookup-resources.module.ts
+++ b/libs/components/lookup/src/lib/modules/shared/sky-lookup-resources.module.ts
@@ -45,8 +45,6 @@ const RESOURCES: { [locale: string]: SkyLibResources } = {
     },
     skyux_lookup_show_more_cancel: { message: 'Cancel' },
     skyux_lookup_show_more_modal_title: { message: 'Select {0}' },
-    skyux_lookup_show_more_modal_title_single: { message: 'Select an option' },
-    skyux_lookup_show_more_modal_title_multiple: { message: 'Select options' },
     skyux_lookup_show_more_no_results: { message: 'No matches found' },
     skyux_lookup_show_more_select: { message: 'Select' },
     skyux_lookup_show_more_select_context: { message: 'Select {0}' },

--- a/libs/components/lookup/testing/src/lookup/fixtures/lookup-harness-test.component.html
+++ b/libs/components/lookup/testing/src/lookup/fixtures/lookup-harness-test.component.html
@@ -25,6 +25,7 @@
         [enableShowMore]="true"
         [searchFilters]="getSearchFilters()"
         [showAddButton]="true"
+        [showMoreConfig]="showMoreConfig"
         (addClick)="onAddClick()"
       />
     </sky-input-box>
@@ -44,6 +45,7 @@
         [enableShowMore]="true"
         [searchFilters]="getSearchFilters()"
         [showAddButton]="true"
+        [showMoreConfig]="showMoreConfig"
         (addClick)="onAddClick()"
         (searchAsync)="onSearchAsync($event)"
       />
@@ -64,6 +66,7 @@
         [enableShowMore]="true"
         [searchFilters]="getSearchFilters()"
         [showAddButton]="true"
+        [showMoreConfig]="showMoreConfig"
       />
     </sky-input-box>
   </div>
@@ -80,6 +83,7 @@
         [ariaLabelledBy]="asyncNamesLabel.id"
         [enableShowMore]="true"
         [showAddButton]="true"
+        [showMoreConfig]="showMoreConfig"
         (addClick)="onAddClick()"
         (searchAsync)="onSearchAsync($event)"
       />

--- a/libs/components/lookup/testing/src/lookup/fixtures/lookup-harness-test.component.ts
+++ b/libs/components/lookup/testing/src/lookup/fixtures/lookup-harness-test.component.ts
@@ -1,9 +1,4 @@
-import {
-  AfterViewInit,
-  Component,
-  TemplateRef,
-  ViewChild,
-} from '@angular/core';
+import { Component, TemplateRef, ViewChild } from '@angular/core';
 import {
   UntypedFormBuilder,
   UntypedFormControl,
@@ -27,7 +22,7 @@ interface Person {
   selector: 'test-lookup-1',
   templateUrl: './lookup-harness-test.component.html',
 })
-export class LookupHarnessTestComponent implements AfterViewInit {
+export class LookupHarnessTestComponent {
   public myForm: UntypedFormGroup;
 
   public people: Person[] = [
@@ -132,14 +127,6 @@ export class LookupHarnessTestComponent implements AfterViewInit {
       multiselect: new UntypedFormControl(this.names),
       asyncNames: new UntypedFormControl(this.names),
     });
-  }
-
-  public ngAfterViewInit(): void {
-    /* istanbul ignore else */
-    if (this.showMoreConfig.nativePickerConfig) {
-      this.showMoreConfig.nativePickerConfig.itemTemplate =
-        this.showMoreSearchResultTemplate;
-    }
   }
 
   // Only show people in the search results that have not been chosen already.

--- a/libs/components/lookup/testing/src/lookup/lookup-harness.spec.ts
+++ b/libs/components/lookup/testing/src/lookup/lookup-harness.spec.ts
@@ -20,12 +20,14 @@ async function setupTest(options: {
     { selectionDescriptor: options.selectionDescriptor },
     fixture.componentInstance.showMoreConfig.nativePickerConfig
   );
+
   if (options.enableCustomTemplate) {
     fixture.componentInstance.showMoreConfig.nativePickerConfig = Object.assign(
       { itemTemplate: fixture.componentInstance.showMoreSearchResultTemplate },
       fixture.componentInstance.showMoreConfig.nativePickerConfig
     );
   }
+
   const loader = TestbedHarnessEnvironment.loader(fixture);
 
   let lookupHarness: SkyLookupHarness;

--- a/libs/components/lookup/testing/src/lookup/lookup-harness.spec.ts
+++ b/libs/components/lookup/testing/src/lookup/lookup-harness.spec.ts
@@ -6,12 +6,26 @@ import { LookupHarnessTestComponent } from './fixtures/lookup-harness-test.compo
 import { LookupHarnessTestModule } from './fixtures/lookup-harness-test.module';
 import { SkyLookupHarness } from './lookup-harness';
 
-async function setupTest(options: { dataSkyId: string }) {
+async function setupTest(options: {
+  dataSkyId: string;
+  selectionDescriptor?: string;
+  enableCustomTemplate?: boolean;
+}) {
   await TestBed.configureTestingModule({
     imports: [LookupHarnessTestModule],
   }).compileComponents();
 
   const fixture = TestBed.createComponent(LookupHarnessTestComponent);
+  fixture.componentInstance.showMoreConfig.nativePickerConfig = Object.assign(
+    { selectionDescriptor: options.selectionDescriptor },
+    fixture.componentInstance.showMoreConfig.nativePickerConfig
+  );
+  if (options.enableCustomTemplate) {
+    fixture.componentInstance.showMoreConfig.nativePickerConfig = Object.assign(
+      { itemTemplate: fixture.componentInstance.showMoreSearchResultTemplate },
+      fixture.componentInstance.showMoreConfig.nativePickerConfig
+    );
+  }
   const loader = TestbedHarnessEnvironment.loader(fixture);
 
   let lookupHarness: SkyLookupHarness;
@@ -116,6 +130,37 @@ function testSingleSelect(dataSkyId: string) {
 
     await expectAsync(picker?.clearAll()).toBeRejectedWithError(
       'Could not clear all selections because the "Clear all" button could not be found.'
+    );
+  });
+
+  it('should get accessibility labels', async () => {
+    const { lookupHarness } = await setupTest({
+      dataSkyId,
+      selectionDescriptor: 'person',
+    });
+
+    await lookupHarness.clickShowMoreButton();
+    const picker = await lookupHarness.getShowMorePicker();
+    await expectAsync(
+      picker.getClearAllButtonAriaLabel()
+    ).toBeRejectedWithError(
+      'Could not get the aria-label for the clear all button because the "Clear all" button could not be found.'
+    );
+    await expectAsync(
+      picker.getSelectAllButtonAriaLabel()
+    ).toBeRejectedWithError(
+      'Could not get the aria-label for the select all button because the "Select all" button could not be found.'
+    );
+    await expectAsync(
+      picker.getOnlyShowSelectedAriaLabel()
+    ).toBeRejectedWithError(
+      'Could not get the "Show only selected items" checkbox because it could not be found.'
+    );
+    await expectAsync(picker.getSearchAriaLabel()).toBeResolvedTo(
+      'Search person'
+    );
+    await expectAsync(picker.getSaveButtonAriaLabel()).toBeResolvedTo(
+      'Select person'
     );
   });
 }
@@ -287,6 +332,31 @@ function testMultiselect(dataSkyId: string) {
       'Cannot get the "Show more" picker because it is not open.'
     );
   });
+
+  it('should get accessibility labels', async () => {
+    const { lookupHarness } = await setupTest({
+      dataSkyId,
+      selectionDescriptor: 'people',
+    });
+
+    await lookupHarness.clickShowMoreButton();
+    const picker = await lookupHarness.getShowMorePicker();
+    await expectAsync(picker.getClearAllButtonAriaLabel()).toBeResolvedTo(
+      'Clear all selected people'
+    );
+    await expectAsync(picker.getSelectAllButtonAriaLabel()).toBeResolvedTo(
+      'Select all people'
+    );
+    await expectAsync(picker.getSearchAriaLabel()).toBeResolvedTo(
+      'Search people'
+    );
+    await expectAsync(picker.getSaveButtonAriaLabel()).toBeResolvedTo(
+      'Select people'
+    );
+    await expectAsync(picker.getOnlyShowSelectedAriaLabel()).toBeResolvedTo(
+      'Show only selected people'
+    );
+  });
 }
 
 describe('Lookup harness', () => {
@@ -305,6 +375,7 @@ describe('Lookup harness', () => {
     it('should get search result text and value', async () => {
       const { lookupHarness } = await setupTest({
         dataSkyId: 'my-custom-template-lookup',
+        enableCustomTemplate: true,
       });
 
       await lookupHarness.enterText('d');

--- a/libs/components/tiles/src/lib/modules/tiles/tile/tile.component.ts
+++ b/libs/components/tiles/src/lib/modules/tiles/tile/tile.component.ts
@@ -58,7 +58,7 @@ export class SkyTileComponent implements OnDestroy {
 
   /**
    * The human-readable name for the tile that is available to the tile controls for multiple purposes, such as accessibility and instrumentation. The component uses the name to construct ARIA labels for the help, expand/collapse, settings, and drag handle buttons to [support accessibility](https://developer.blackbaud.com/skyux/learn/accessibility).
-   * For example, if the tile name is “Constituents,” the help input’s `aria-label` is “Constituents help” and the drag handle’s `aria-label` is “Move Constituents.” For more information about the `aria-label` attribute, see the [WAI-ARIA definition](https://www.w3.org/TR/wai-aria/#aria-label).
+   * For example, if the tile name is "Constituents," the help input's `aria-label` is "Constituents help" and the drag handle's `aria-label` is "Move Constituents." For more information about the `aria-label` attribute, see the [WAI-ARIA definition](https://www.w3.org/TR/wai-aria/#aria-label).
    */
   @Input()
   public tileName: string | undefined;


### PR DESCRIPTION
[AB#2667980](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/2667980)