### PR TITLE
feat(components/router): add `queryParams` to `skyHref` directive (#1800)

### DIFF
--- a/libs/components/config/src/index.ts
+++ b/libs/components/config/src/index.ts
@@ -31,6 +31,7 @@ export {
   SkyAppConfig,
 } from './lib/config';
 
-export { SkyAppRuntimeConfigParamsGetLinkUrlOptions } from './lib/params-get-link-url-options';
+export { SkyConfigGetLinkUrlOptions } from './lib/types/get-link-url-options';
+export { SkyConfigQueryParams } from './lib/types/query-params';
 export { SkyAppRuntimeConfigParamsProvider } from './lib/params-provider';
 export { SkyAppRuntimeConfigParams } from './lib/params';

--- a/libs/components/config/src/index.ts
+++ b/libs/components/config/src/index.ts
@@ -31,5 +31,6 @@ export {
   SkyAppConfig,
 } from './lib/config';
 
+export { SkyAppRuntimeConfigParamsGetLinkUrlOptions } from './lib/params-get-link-url-options';
 export { SkyAppRuntimeConfigParamsProvider } from './lib/params-provider';
 export { SkyAppRuntimeConfigParams } from './lib/params';

--- a/libs/components/config/src/lib/params-get-link-url-options.ts
+++ b/libs/components/config/src/lib/params-get-link-url-options.ts
@@ -1,0 +1,6 @@
+/**
+ * Options used to create link URLs.
+ */
+export type SkyAppRuntimeConfigParamsGetLinkUrlOptions = {
+  queryParams: Record<string, string | number | boolean | null | undefined>;
+};

--- a/libs/components/config/src/lib/params-get-link-url-options.ts
+++ b/libs/components/config/src/lib/params-get-link-url-options.ts
@@ -1,6 +1,0 @@
-/**
- * Options used to create link URLs.
- */
-export type SkyAppRuntimeConfigParamsGetLinkUrlOptions = {
-  queryParams: Record<string, string | number | boolean | null | undefined>;
-};

--- a/libs/components/config/src/lib/params.spec.ts
+++ b/libs/components/config/src/lib/params.spec.ts
@@ -278,6 +278,47 @@ describe('SkyAppRuntimeConfigParams', () => {
     expect(params.getAllKeys()).toEqual([]);
   });
 
+  it('should add provided params to a url link', () => {
+    const params: SkyAppRuntimeConfigParams = new SkyAppRuntimeConfigParams(
+      '',
+      allowed
+    );
+    expect(params.getLinkUrl('https://mysite.com', { q1: 5 })).toEqual(
+      'https://mysite.com?q1=5'
+    );
+  });
+
+  it('should ignore null, undefined, or empty provided params to a url link', () => {
+    const params: SkyAppRuntimeConfigParams = new SkyAppRuntimeConfigParams(
+      '',
+      allowed
+    );
+    expect(params.getLinkUrl('https://mysite.com', undefined)).toEqual(
+      'https://mysite.com'
+    );
+    expect(params.getLinkUrl('https://mysite.com', {})).toEqual(
+      'https://mysite.com'
+    );
+  });
+
+  it('should add provided params to a url link with a query string', () => {
+    const params: SkyAppRuntimeConfigParams = new SkyAppRuntimeConfigParams(
+      '',
+      {
+        q3: { value: 3 },
+        q4: { value: 4, excludeFromLinks: true },
+      }
+    );
+    expect(
+      params.getLinkUrl('https://mysite.com?q1=1&q2=2', {
+        q1: 5,
+        q5: null,
+        q6: undefined,
+        q7: '',
+      })
+    ).toEqual('https://mysite.com?q1=5&q2=2&q3=3');
+  });
+
   it("should exclude certain parameters from being added to a link's querystring", () => {
     const params = new SkyAppRuntimeConfigParams('https://mysite.com?a=1&b=2', {
       a: true,
@@ -296,10 +337,40 @@ describe('SkyAppRuntimeConfigParams', () => {
       },
     });
 
-    // Parameter 'f' should remain in the link because it already exists in the URL.
-    expect(params.getLinkUrl('https://mysite.com?c=3&f=6#foobar')).toEqual(
-      'https://mysite.com?c=3&f=6&a=1&b=2#foobar'
+    expect(params.getLinkUrl('https://mysite.com?c=3&f=6&g=9#foobar')).toEqual(
+      'https://mysite.com?c=3&g=9&a=1&b=2#foobar'
     );
+  });
+
+  it('should combine app config params, provided params, and url params', () => {
+    const params = new SkyAppRuntimeConfigParams(
+      'https://mysite.com?a=1&b=2&c=3',
+      {
+        b: {
+          excludeFromRequests: true,
+        },
+        c: {
+          value: 42,
+        },
+        d: {
+          value: 43,
+        },
+        m: {
+          excludeFromRequests: true,
+        },
+        n: {
+          excludeFromLinks: true,
+        },
+      }
+    );
+
+    expect(
+      params.getLinkUrl('https://mysite.com?a=10&c=13&f=6&m=14#foobar', {
+        a: 5,
+        m: 10,
+        n: 11,
+      })
+    ).toEqual('https://mysite.com?a=5&c=13&f=6&m=10&n=11&d=43#foobar');
   });
 
   it('should support query params with multiple values', () => {
@@ -320,5 +391,17 @@ describe('SkyAppRuntimeConfigParams', () => {
     expect(
       params.getLinkUrl('https://mysite.com?foobar=Robert+Hernandez')
     ).toEqual('https://mysite.com?foobar=Robert+Hernandez&a1=%20');
+  });
+
+  it('should validate query string encoding', () => {
+    const params = new SkyAppRuntimeConfigParams('?a1=str+1', {
+      a4: {
+        value: 'str+4',
+      },
+    });
+
+    expect(
+      params.getLinkUrl('https://mysite.com?a2=str+2', { a3: 'str+3' })
+    ).toEqual('https://mysite.com?a2=str+2&a3=str%2B3&a4=str%2B4');
   });
 });

--- a/libs/components/config/src/lib/params.spec.ts
+++ b/libs/components/config/src/lib/params.spec.ts
@@ -315,8 +315,9 @@ describe('SkyAppRuntimeConfigParams', () => {
         q5: null,
         q6: undefined,
         q7: '',
+        q8: false,
       })
-    ).toEqual('https://mysite.com?q1=5&q2=2&q3=3');
+    ).toEqual('https://mysite.com?q1=5&q2=2&q7=&q8=false&q3=3');
   });
 
   it("should exclude certain parameters from being added to a link's querystring", () => {

--- a/libs/components/config/src/lib/params.spec.ts
+++ b/libs/components/config/src/lib/params.spec.ts
@@ -236,7 +236,7 @@ describe('SkyAppRuntimeConfigParams', () => {
   it('should add provided params to a url link', () => {
     const params = new SkyAppRuntimeConfigParams('', allowed);
     expect(
-      params.getLinkUrl('https://mysite.com', { queryParams: { q1: 5 } })
+      params.getLinkUrl('https://mysite.com', { queryParams: { q1: '5' } })
     ).toEqual('https://mysite.com?q1=5');
   });
 
@@ -248,9 +248,9 @@ describe('SkyAppRuntimeConfigParams', () => {
     expect(
       params.getLinkUrl('https://mysite.com?q1=1&q2=2', {
         queryParams: {
-          q1: 5,
+          q1: '5',
           q7: '',
-          q8: false,
+          q8: 'false',
         },
       })
     ).toEqual('https://mysite.com?q1=5&q2=2&q7=&q8=false&q3=3');
@@ -304,9 +304,9 @@ describe('SkyAppRuntimeConfigParams', () => {
     expect(
       params.getLinkUrl('https://mysite.com?a=10&c=13&f=6&m=14#foobar', {
         queryParams: {
-          a: 5,
-          m: 10,
-          n: 11,
+          a: '5',
+          m: '10',
+          n: '11',
         },
       })
     ).toEqual('https://mysite.com?a=5&c=13&f=6&m=10&n=11&d=43#foobar');

--- a/libs/components/config/src/lib/params.spec.ts
+++ b/libs/components/config/src/lib/params.spec.ts
@@ -249,8 +249,6 @@ describe('SkyAppRuntimeConfigParams', () => {
       params.getLinkUrl('https://mysite.com?q1=1&q2=2', {
         queryParams: {
           q1: 5,
-          q5: null,
-          q6: undefined,
           q7: '',
           q8: false,
         },

--- a/libs/components/config/src/lib/params.spec.ts
+++ b/libs/components/config/src/lib/params.spec.ts
@@ -7,7 +7,7 @@ describe('SkyAppRuntimeConfigParams', () => {
   };
 
   it('should parse allowed params from a url', () => {
-    const params: SkyAppRuntimeConfigParams = new SkyAppRuntimeConfigParams(
+    const params = new SkyAppRuntimeConfigParams(
       'https://example.com/?a1=a&b2=jkl&a3=b',
       allowed
     );
@@ -23,37 +23,28 @@ describe('SkyAppRuntimeConfigParams', () => {
   });
 
   it('should only let allowed params be set', () => {
-    const params: SkyAppRuntimeConfigParams = new SkyAppRuntimeConfigParams(
-      '?a1=b&b2=c',
-      allowed
-    );
+    const params = new SkyAppRuntimeConfigParams('?a1=b&b2=c', allowed);
     expect(params.get('a1')).toEqual('b');
     expect(params.get('b2')).not.toEqual('c');
   });
 
   it('should add the current params to a url with a querystring', () => {
-    const params: SkyAppRuntimeConfigParams = new SkyAppRuntimeConfigParams(
-      '?a1=b',
-      allowed
-    );
+    const params = new SkyAppRuntimeConfigParams('?a1=b', allowed);
     expect(params.getUrl('https://mysite.com?c=d')).toEqual(
       'https://mysite.com?c=d&a1=b'
     );
   });
 
   it("should exclude certain parameters from being added to a url's querystring", () => {
-    const params: SkyAppRuntimeConfigParams = new SkyAppRuntimeConfigParams(
-      '?a1=b&b2=c3&z4=y',
-      {
-        a1: true,
-        b2: {
-          required: true,
-        },
-        z4: {
-          excludeFromRequests: true,
-        },
-      }
-    );
+    const params = new SkyAppRuntimeConfigParams('?a1=b&b2=c3&z4=y', {
+      a1: true,
+      b2: {
+        required: true,
+      },
+      z4: {
+        excludeFromRequests: true,
+      },
+    });
 
     expect(params.getUrl('https://mysite.com?c=d')).toEqual(
       'https://mysite.com?c=d&a1=b&b2=c3'
@@ -61,81 +52,60 @@ describe('SkyAppRuntimeConfigParams', () => {
   });
 
   it('should not add a current param if the url already has it', () => {
-    const params: SkyAppRuntimeConfigParams = new SkyAppRuntimeConfigParams(
-      '?a1=b',
-      allowed
-    );
+    const params = new SkyAppRuntimeConfigParams('?a1=b', allowed);
     expect(params.getUrl('https://mysite.com?a1=c&a3=e')).toEqual(
       'https://mysite.com?a1=c&a3=e'
     );
   });
 
   it('should add the current params to a url without a querystring', () => {
-    const params: SkyAppRuntimeConfigParams = new SkyAppRuntimeConfigParams(
-      '?a1=b',
-      allowed
-    );
+    const params = new SkyAppRuntimeConfigParams('?a1=b', allowed);
     expect(params.getUrl('https://mysite.com')).toEqual(
       'https://mysite.com?a1=b'
     );
   });
 
   it('should return the current url if no params set (do not add ?)', () => {
-    const params: SkyAppRuntimeConfigParams = new SkyAppRuntimeConfigParams(
-      '',
-      allowed
-    );
+    const params = new SkyAppRuntimeConfigParams('', allowed);
     expect(params.getUrl('https://mysite.com')).toEqual('https://mysite.com');
   });
 
   it('should not add double-encoded params to a url', () => {
-    const params: SkyAppRuntimeConfigParams = new SkyAppRuntimeConfigParams(
-      '?a1=%2F',
-      allowed
-    );
+    const params = new SkyAppRuntimeConfigParams('?a1=%2F', allowed);
     expect(params.getUrl('https://mysite.com')).toEqual(
       'https://mysite.com?a1=%2F'
     );
   });
 
   it('should allow querystring param keys to be case insensitive', () => {
-    const params: SkyAppRuntimeConfigParams = new SkyAppRuntimeConfigParams(
-      '?A1=b&A3=c',
-      allowed
-    );
+    const params = new SkyAppRuntimeConfigParams('?A1=b&A3=c', allowed);
     expect(params.get('a1')).toEqual('b');
     expect(params.get('a3')).toEqual('c');
   });
 
   it('should expose a `has` method for testing if a param exists', () => {
-    const params: SkyAppRuntimeConfigParams = new SkyAppRuntimeConfigParams(
-      '?a1=b&a2=c',
-      allowed
-    );
+    const params = new SkyAppRuntimeConfigParams('?a1=b&a2=c', allowed);
     expect(params.has('a1')).toEqual(true);
     expect(params.has('a2')).toEqual(false);
     expect(params.has('a3')).toEqual(false);
   });
 
   it('should allow default values to be specified', () => {
-    const params: SkyAppRuntimeConfigParams = new SkyAppRuntimeConfigParams(
-      '?a1=b&a2=c&a4=x',
-      {
-        // Allowed with simple boolean flag
-        a1: true,
-        // Disallowed but present in the query string
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        a2: undefined as any,
-        // Allowed with explicit default value
-        a3: {
-          value: 'd',
-        },
-        // Allowed with explicit default value of undefined
-        a4: {
-          value: undefined,
-        },
-      }
-    );
+    const params = new SkyAppRuntimeConfigParams('?a1=b&a2=c&a4=x', {
+      // Allowed with simple boolean flag
+      a1: true,
+      // Disallowed but present in the query string
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      a2: undefined as any,
+      // Allowed with explicit default value
+      a3: {
+        value: 'd',
+      },
+      // Allowed with explicit default value of undefined
+      a4: {
+        value: undefined,
+      },
+    });
 
     expect(params.get('a1')).toBe('b');
     expect(params.get('a2')).toBe(undefined);
@@ -145,22 +115,19 @@ describe('SkyAppRuntimeConfigParams', () => {
   });
 
   it('should allow default values to be overridden by the query string', () => {
-    const params: SkyAppRuntimeConfigParams = new SkyAppRuntimeConfigParams(
-      '?a1=b&a2=c',
-      {
-        a1: {
-          value: 'x',
-        },
-        a2: {},
-      }
-    );
+    const params = new SkyAppRuntimeConfigParams('?a1=b&a2=c', {
+      a1: {
+        value: 'x',
+      },
+      a2: {},
+    });
 
     expect(params.get('a1')).toBe('b');
     expect(params.get('a2')).toBe('c');
   });
 
   it('should support excluding default values in getAll() if specified', () => {
-    const params: SkyAppRuntimeConfigParams = new SkyAppRuntimeConfigParams(
+    const params = new SkyAppRuntimeConfigParams(
       '?a2=a2Value&a3=a3CustomValue',
       {
         // Allowed with simple boolean flag
@@ -193,63 +160,51 @@ describe('SkyAppRuntimeConfigParams', () => {
   });
 
   it('should allow queryParam values to be required', () => {
-    const params: SkyAppRuntimeConfigParams = new SkyAppRuntimeConfigParams(
-      '',
-      {
-        a1: {
-          value: 'test',
-          required: true,
-        },
-      }
-    );
+    const params = new SkyAppRuntimeConfigParams('', {
+      a1: {
+        value: 'test',
+        required: true,
+      },
+    });
 
     expect(params.isRequired('a1')).toEqual(true);
     expect(params.hasAllRequiredParams()).toBe(true);
   });
 
   it('should expose a `hasAllRequiredParams` method for testing if all required params are defined', () => {
-    const params: SkyAppRuntimeConfigParams = new SkyAppRuntimeConfigParams(
-      '',
-      {
-        a1: {
-          required: true,
-        },
-      }
-    );
+    const params = new SkyAppRuntimeConfigParams('', {
+      a1: {
+        required: true,
+      },
+    });
 
     expect(params.hasAllRequiredParams()).toBe(false);
   });
 
   it('should expose a `hasAllRequiredParams` method that returns true if no required params are defined', () => {
-    const params: SkyAppRuntimeConfigParams = new SkyAppRuntimeConfigParams(
-      '',
-      {
-        a1: true,
-      }
-    );
+    const params = new SkyAppRuntimeConfigParams('', {
+      a1: true,
+    });
 
     expect(params.hasAllRequiredParams()).toBe(true);
   });
 
   it('should expose a `hasAllRequiredParams` method that returns false if any required params are undefined', () => {
-    const params: SkyAppRuntimeConfigParams = new SkyAppRuntimeConfigParams(
-      '',
-      {
-        a1: {
-          value: '1',
-          required: true,
-        },
-        a2: {
-          required: true,
-        },
-      }
-    );
+    const params = new SkyAppRuntimeConfigParams('', {
+      a1: {
+        value: '1',
+        required: true,
+      },
+      a2: {
+        required: true,
+      },
+    });
 
     expect(params.hasAllRequiredParams()).toBe(false);
   });
 
   it('should handle a url with a querystring and fragment (#)', () => {
-    const params: SkyAppRuntimeConfigParams = new SkyAppRuntimeConfigParams(
+    const params = new SkyAppRuntimeConfigParams(
       '?A1=b&A3=c#hash-better=have-my-money',
       allowed
     );
@@ -261,7 +216,7 @@ describe('SkyAppRuntimeConfigParams', () => {
   });
 
   it('should ignore params in a fragment', () => {
-    const params: SkyAppRuntimeConfigParams = new SkyAppRuntimeConfigParams(
+    const params = new SkyAppRuntimeConfigParams(
       'https://example.com#A1=b',
       allowed
     );
@@ -270,7 +225,7 @@ describe('SkyAppRuntimeConfigParams', () => {
   });
 
   it('should handle a url without a querystring', () => {
-    const params: SkyAppRuntimeConfigParams = new SkyAppRuntimeConfigParams(
+    const params = new SkyAppRuntimeConfigParams(
       'https://example.com',
       allowed
     );
@@ -279,43 +234,26 @@ describe('SkyAppRuntimeConfigParams', () => {
   });
 
   it('should add provided params to a url link', () => {
-    const params: SkyAppRuntimeConfigParams = new SkyAppRuntimeConfigParams(
-      '',
-      allowed
-    );
-    expect(params.getLinkUrl('https://mysite.com', { q1: 5 })).toEqual(
-      'https://mysite.com?q1=5'
-    );
-  });
-
-  it('should ignore null, undefined, or empty provided params to a url link', () => {
-    const params: SkyAppRuntimeConfigParams = new SkyAppRuntimeConfigParams(
-      '',
-      allowed
-    );
-    expect(params.getLinkUrl('https://mysite.com', undefined)).toEqual(
-      'https://mysite.com'
-    );
-    expect(params.getLinkUrl('https://mysite.com', {})).toEqual(
-      'https://mysite.com'
-    );
+    const params = new SkyAppRuntimeConfigParams('', allowed);
+    expect(
+      params.getLinkUrl('https://mysite.com', { queryParams: { q1: 5 } })
+    ).toEqual('https://mysite.com?q1=5');
   });
 
   it('should add provided params to a url link with a query string', () => {
-    const params: SkyAppRuntimeConfigParams = new SkyAppRuntimeConfigParams(
-      '',
-      {
-        q3: { value: 3 },
-        q4: { value: 4, excludeFromLinks: true },
-      }
-    );
+    const params = new SkyAppRuntimeConfigParams('', {
+      q3: { value: 3 },
+      q4: { value: 4, excludeFromLinks: true },
+    });
     expect(
       params.getLinkUrl('https://mysite.com?q1=1&q2=2', {
-        q1: 5,
-        q5: null,
-        q6: undefined,
-        q7: '',
-        q8: false,
+        queryParams: {
+          q1: 5,
+          q5: null,
+          q6: undefined,
+          q7: '',
+          q8: false,
+        },
       })
     ).toEqual('https://mysite.com?q1=5&q2=2&q7=&q8=false&q3=3');
   });
@@ -367,9 +305,11 @@ describe('SkyAppRuntimeConfigParams', () => {
 
     expect(
       params.getLinkUrl('https://mysite.com?a=10&c=13&f=6&m=14#foobar', {
-        a: 5,
-        m: 10,
-        n: 11,
+        queryParams: {
+          a: 5,
+          m: 10,
+          n: 11,
+        },
       })
     ).toEqual('https://mysite.com?a=5&c=13&f=6&m=10&n=11&d=43#foobar');
   });
@@ -402,7 +342,9 @@ describe('SkyAppRuntimeConfigParams', () => {
     });
 
     expect(
-      params.getLinkUrl('https://mysite.com?a2=str+2', { a3: 'str+3' })
+      params.getLinkUrl('https://mysite.com?a2=str+2', {
+        queryParams: { a3: 'str+3' },
+      })
     ).toEqual('https://mysite.com?a2=str+2&a3=str%2B3&a4=str%2B4');
   });
 });

--- a/libs/components/config/src/lib/params.ts
+++ b/libs/components/config/src/lib/params.ts
@@ -2,6 +2,9 @@ import { HttpParams, HttpUrlEncodingCodec } from '@angular/common/http';
 
 import { SkyuxConfigParams } from './config-params';
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type QueryParams = Record<string, any>;
+
 /**
  * Override Angular's default encoder because it excludes certain characters.
  * @see https://github.com/angular/angular/blob/cb31dbc75ca4141d61cec3ba6e60505198208a0a/packages/common/http/src/params.ts#L96-L111
@@ -181,11 +184,7 @@ export class SkyAppRuntimeConfigParams {
    * @param url The url to update
    * @param queryParams Optional query parameters to include in the constructed url
    */
-  public getLinkUrl(
-    url: string,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    queryParams?: Record<string, any>
-  ): string {
+  public getLinkUrl(url: string, queryParams?: QueryParams): string {
     return this.#buildUrlWithParams(
       url,
       new Set([
@@ -199,8 +198,7 @@ export class SkyAppRuntimeConfigParams {
   #buildUrlWithParams(
     url: string,
     excludeParams: Set<string>,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    queryParams?: Record<string, any>
+    queryParams?: QueryParams
   ): string {
     const [beforeFragment, fragment] = url.split('#', 2);
     const urlParams = getUrlSearchParams(url);

--- a/libs/components/config/src/lib/params.ts
+++ b/libs/components/config/src/lib/params.ts
@@ -178,44 +178,89 @@ export class SkyAppRuntimeConfigParams {
 
   /**
    * Adds the current params to the supplied link URL.
+   * @param url The url to update
+   * @param queryParams Optional query parameters to include in the constructed url
    */
-  public getLinkUrl(url: string): string {
+  public getLinkUrl(
+    url: string,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    queryParams?: Record<string, any>
+  ): string {
     return this.#buildUrlWithParams(
       url,
       new Set([
         ...this.#excludeFromRequestsParams,
         ...this.#excludeFromLinksParams,
-      ])
+      ]),
+      queryParams
     );
   }
 
-  #buildUrlWithParams(url: string, excludeParams: Set<string>): string {
-    const existingParams = getUrlSearchParams(url);
+  #buildUrlWithParams(
+    url: string,
+    excludeParams: Set<string>,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    queryParams?: Record<string, any>
+  ): string {
+    const [beforeFragment, fragment] = url.split('#', 2);
+    const urlParams = getUrlSearchParams(url);
 
-    // When encoding the params, keep the requested params separate so that
-    // we can leave the existing params as-is.
-    let requestedParams = getUrlSearchParams('');
+    // Determine if the url params need to be modified
+    const urlParamsRequireModification = !!urlParams
+      .keys()
+      .find(
+        (key) => excludeParams.has(key) || (queryParams && queryParams[key])
+      );
 
-    // Add requested parameters to the URL.
+    const root = urlParamsRequireModification
+      ? beforeFragment.split('?')[0]
+      : beforeFragment;
+
+    let unifiedParams = urlParamsRequireModification
+      ? urlParams
+      : getUrlSearchParams('');
+
+    // Remove excluded params
+    if (urlParamsRequireModification) {
+      for (const paramName of excludeParams.keys()) {
+        unifiedParams = unifiedParams.delete(paramName);
+      }
+    }
+
+    // Add provided parameters to the URL which are not on the exclusion list
+    // Respect pre-existing params which already have values
+    if (queryParams) {
+      for (const [paramName, decodedValue] of Object.entries(queryParams)) {
+        if (decodedValue) {
+          unifiedParams = unifiedParams.set(paramName, decodedValue);
+        }
+      }
+    }
+
+    // Add default parameters to the URL which are not on the exclusion list
+    // Respect pre-existing params which already have values
     for (const key of this.getAllKeys()) {
-      if (!excludeParams.has(key) && !existingParams.has(key)) {
+      if (
+        !excludeParams.has(key) &&
+        !urlParams.has(key) &&
+        !unifiedParams.has(key)
+      ) {
         const decodedValue = this.get(key);
         if (decodedValue) {
-          requestedParams = requestedParams.set(key, decodedValue);
+          unifiedParams = unifiedParams.append(key, decodedValue);
         }
       }
     }
 
     // Combine all requested parameters and their values, e.g. 'a=b'.
-    const joinedParams = requestedParams.toString();
+    const joinedParams = unifiedParams.toString();
+    const delimiter = root.includes('?') ? '&' : '?';
 
     // Build and return the final URL.
-    const [beforeFragment, fragment] = url.split('#', 2);
-    const delimiter = url.includes('?') ? '&' : '?';
-
-    return joinedParams.length === 0
-      ? url
-      : `${beforeFragment}${delimiter}${joinedParams}` +
-          (fragment ? `#${fragment}` : '');
+    return (
+      root +
+      (joinedParams.length === 0 ? '' : `${delimiter}${joinedParams}`) +
+      (fragment ? `#${fragment}` : '')
+    );
   }
 }

--- a/libs/components/config/src/lib/params.ts
+++ b/libs/components/config/src/lib/params.ts
@@ -1,9 +1,8 @@
 import { HttpParams, HttpUrlEncodingCodec } from '@angular/common/http';
 
 import { SkyuxConfigParams } from './config-params';
-import { SkyAppRuntimeConfigParamsGetLinkUrlOptions } from './params-get-link-url-options';
-
-type QueryParams = Record<string, string | number | boolean>;
+import { SkyConfigGetLinkUrlOptions } from './types/get-link-url-options';
+import { SkyConfigQueryParams } from './types/query-params';
 
 /**
  * Override Angular's default encoder because it excludes certain characters.
@@ -35,26 +34,6 @@ function getUrlSearchParams(url: string): HttpParams {
     encoder: new UrlEncoder(),
     fromString: qs,
   });
-}
-
-/**
- * Removes undefined and null values from an object.
- */
-function filterUndefined(
-  obj: Record<string, unknown>
-): Record<string, unknown> {
-  // Clone the object to avoid modifying the original.
-  const clone = { ...obj };
-
-  for (const key in clone) {
-    const value = clone[key];
-
-    if (value === undefined || value === null) {
-      delete clone[key];
-    }
-  }
-
-  return clone;
 }
 
 export class SkyAppRuntimeConfigParams {
@@ -204,27 +183,21 @@ export class SkyAppRuntimeConfigParams {
    * @param url The url to update.
    * @param queryParams Optional query parameters to include in the constructed url.
    */
-  public getLinkUrl(
-    url: string,
-    options?: SkyAppRuntimeConfigParamsGetLinkUrlOptions
-  ): string {
-    const filteredParams = (options?.queryParams &&
-      filterUndefined(options.queryParams)) as QueryParams | undefined;
-
+  public getLinkUrl(url: string, options?: SkyConfigGetLinkUrlOptions): string {
     return this.#buildUrlWithParams(
       url,
       new Set([
         ...this.#excludeFromRequestsParams,
         ...this.#excludeFromLinksParams,
       ]),
-      filteredParams
+      options?.queryParams
     );
   }
 
   #buildUrlWithParams(
     url: string,
     excludeParams: Set<string>,
-    queryParams?: QueryParams
+    queryParams?: SkyConfigQueryParams
   ): string {
     const urlParams = getUrlSearchParams(url);
 

--- a/libs/components/config/src/lib/params.ts
+++ b/libs/components/config/src/lib/params.ts
@@ -265,10 +265,16 @@ export class SkyAppRuntimeConfigParams {
   #convertToCleanMap(
     obj: Record<string, string | number | boolean | null | undefined>
   ): Map<string, string | number | boolean> {
+    for (const key in obj) {
+      const value = obj[key];
+
+      if (value === undefined || value === null) {
+        delete obj[key];
+      }
+    }
+
     return new Map(
-      Object.entries(obj).filter(
-        ([, value]) => value !== undefined && value !== null
-      ) as [string, string | number | boolean][]
+      Object.entries(obj) as [string, string | number | boolean][]
     );
   }
 }

--- a/libs/components/config/src/lib/types/get-link-url-options.ts
+++ b/libs/components/config/src/lib/types/get-link-url-options.ts
@@ -1,0 +1,8 @@
+import { SkyConfigQueryParams } from './query-params';
+
+/**
+ * Options used to create link URLs.
+ */
+export type SkyConfigGetLinkUrlOptions = {
+  queryParams: SkyConfigQueryParams;
+};

--- a/libs/components/config/src/lib/types/query-params.ts
+++ b/libs/components/config/src/lib/types/query-params.ts
@@ -1,0 +1,4 @@
+/**
+ * A collection of query URL parameters.
+ */
+export type SkyConfigQueryParams = Record<string, string | number | boolean>;

--- a/libs/components/config/src/lib/types/query-params.ts
+++ b/libs/components/config/src/lib/types/query-params.ts
@@ -1,4 +1,4 @@
 /**
  * A collection of query URL parameters.
  */
-export type SkyConfigQueryParams = Record<string, string | number | boolean>;
+export type SkyConfigQueryParams = Record<string, string>;

--- a/libs/components/router/src/index.ts
+++ b/libs/components/router/src/index.ts
@@ -1,10 +1,12 @@
 export { SkyAppLinkQueryParams } from './lib/modules/link/link-query-params';
 export { SkyAppLinkModule } from './lib/modules/link/link.module';
+
 export { SkyHrefModule } from './lib/modules/href/href.module';
 export { SkyHrefResolver } from './lib/modules/href/href-resolver';
 export { SkyHrefResolverService } from './lib/modules/href/href-resolver.service';
 export { SkyHref } from './lib/modules/href/types/href';
 export { SkyHrefChange } from './lib/modules/href/types/href-change';
+export { SkyHrefQueryParams } from './lib/modules/href/types/href-query-params';
 export { SkyHrefResolverArgs } from './lib/modules/href/types/href-resolver.args';
 
 export { SkyRecentlyAccessedAddLinkArgs } from './lib/modules/recently-accessed/recently-accessed-add-link-args';

--- a/libs/components/router/src/lib/modules/href/fixtures/href-fixture.component.html
+++ b/libs/components/router/src/lib/modules/href/fixtures/href-fixture.component.html
@@ -29,3 +29,10 @@
 <p class="fragmentLink">
   <a skyHref="test://simple-app/example/page#foobar">Example</a>
 </p>
+
+<a
+  data-sky-id="query-params"
+  skyHref="test://simple-app/example/page#foobar"
+  [queryParams]="queryParams"
+  >Example</a
+>

--- a/libs/components/router/src/lib/modules/href/fixtures/href-fixture.component.ts
+++ b/libs/components/router/src/lib/modules/href/fixtures/href-fixture.component.ts
@@ -7,6 +7,7 @@ import {
 } from '@angular/core';
 
 import { SkyHrefModule } from '../href.module';
+import { SkyHrefQueryParams } from '../types/href-query-params';
 
 @Component({
   selector: 'sky-smart-link-fixture',
@@ -34,6 +35,7 @@ export class HrefDirectiveFixtureComponent {
     return this.#_dynamicElse;
   }
 
+  public queryParams: SkyHrefQueryParams | undefined;
   public testSlowLink = false;
 
   #_dynamicElse: 'hide' | 'unlink' = 'hide';

--- a/libs/components/router/src/lib/modules/href/fixtures/href-resolver-fixture.service.ts
+++ b/libs/components/router/src/lib/modules/href/fixtures/href-resolver-fixture.service.ts
@@ -25,7 +25,11 @@ export class HrefResolverFixtureService implements SkyHrefResolver {
       });
     } else if (url.startsWith('1bb-nav://')) {
       return Promise.resolve<SkyHref>({
-        url: 'https://example.com' + path + '?query=param',
+        url:
+          'https://example.com' +
+          path +
+          (path.includes('?') ? '&' : '?') +
+          'query=param',
         userHasAccess: true,
       });
     } else if (url.startsWith('nope://')) {

--- a/libs/components/router/src/lib/modules/href/href-query-params.ts
+++ b/libs/components/router/src/lib/modules/href/href-query-params.ts
@@ -1,1 +1,0 @@
-export type SkyHrefQueryParams = { [k: string]: any };

--- a/libs/components/router/src/lib/modules/href/href.directive.spec.ts
+++ b/libs/components/router/src/lib/modules/href/href.directive.spec.ts
@@ -109,7 +109,7 @@ describe('SkyHref Directive', () => {
     tick();
 
     const links = Array.from(el.querySelectorAll('a'));
-    expect(links.filter((e) => e.offsetParent).length).toEqual(6);
+    expect(links.filter((e) => e.offsetParent).length).toEqual(7);
   }));
 
   it('should hide links that the user cannot access', fakeAsync(() => {
@@ -328,6 +328,34 @@ describe('SkyHref Directive', () => {
 
     expect(element?.getAttribute('href')).toEqual(
       'https://success/example/page#foobar'
+    );
+  }));
+
+  it('should append additional query params', fakeAsync(() => {
+    const { el, fixture } = setupTest({
+      params: {
+        envid: {
+          value: 'abc123',
+        },
+      },
+    });
+
+    fixture.componentInstance.queryParams = {
+      a: 'foo',
+      b: '',
+      c: 0,
+      d: false,
+      e: null,
+      f: undefined,
+    };
+
+    fixture.detectChanges();
+    tick();
+
+    const element = el.querySelector('a[data-sky-id="query-params"]');
+
+    expect(element?.getAttribute('href')).toEqual(
+      'https://success/example/page?a=foo&b=&c=0&d=false&envid=abc123#foobar'
     );
   }));
 

--- a/libs/components/router/src/lib/modules/href/href.directive.spec.ts
+++ b/libs/components/router/src/lib/modules/href/href.directive.spec.ts
@@ -343,10 +343,8 @@ describe('SkyHref Directive', () => {
     fixture.componentInstance.queryParams = {
       a: 'foo',
       b: '',
-      c: 0,
-      d: false,
-      e: null,
-      f: undefined,
+      c: '0',
+      d: 'false',
     };
 
     fixture.detectChanges();

--- a/libs/components/router/src/lib/modules/href/href.directive.spec.ts
+++ b/libs/components/router/src/lib/modules/href/href.directive.spec.ts
@@ -197,7 +197,7 @@ describe('SkyHref Directive', () => {
 
     const element: HTMLElement | null = el.querySelector('.dynamicLink a');
     expect(element?.getAttribute('href')).toEqual(
-      'https://example.com/example/page?foo=override?query=param'
+      'https://example.com/example/page?foo=override&query=param'
     );
   }));
 

--- a/libs/components/router/src/lib/modules/href/href.directive.ts
+++ b/libs/components/router/src/lib/modules/href/href.directive.ts
@@ -11,7 +11,11 @@ import {
   Renderer2,
 } from '@angular/core';
 import { Router, UrlTree } from '@angular/router';
-import { SkyAppConfig, SkyAppRuntimeConfigParamsProvider } from '@skyux/config';
+import {
+  SkyAppConfig,
+  SkyAppRuntimeConfigParamsProvider,
+  SkyConfigQueryParams,
+} from '@skyux/config';
 
 import { SkyHrefResolverService } from './href-resolver.service';
 import { SkyHref } from './types/href';
@@ -19,6 +23,24 @@ import { SkyHrefChange } from './types/href-change';
 import { SkyHrefQueryParams } from './types/href-query-params';
 
 type HrefChanges = { href: string; hidden: boolean };
+
+/**
+ * Transforms SkyHrefQueryParams into SkyConfigQueryParams.
+ */
+function toConfigQueryParams(params: SkyHrefQueryParams): SkyConfigQueryParams {
+  // Clone the object to avoid modifying the original.
+  const clone = { ...params };
+
+  for (const key in clone) {
+    const value = clone[key];
+
+    if (value === undefined || value === null) {
+      delete clone[key];
+    }
+  }
+
+  return clone as SkyConfigQueryParams;
+}
 
 @Directive({
   selector: '[skyHref]',
@@ -218,7 +240,7 @@ export class SkyHrefDirective {
         this.#skyAppConfig?.runtime.params ?? this.#paramsProvider!.params;
 
       this.#href = params.getLinkUrl(this.#route.url, {
-        queryParams: this.queryParams ?? {},
+        queryParams: toConfigQueryParams(this.queryParams ?? {}),
       });
 
       return {

--- a/libs/components/router/src/lib/modules/href/href.directive.ts
+++ b/libs/components/router/src/lib/modules/href/href.directive.ts
@@ -10,12 +10,13 @@ import {
   Output,
   Renderer2,
 } from '@angular/core';
-import { Params, Router, UrlTree } from '@angular/router';
+import { Router, UrlTree } from '@angular/router';
 import { SkyAppConfig, SkyAppRuntimeConfigParamsProvider } from '@skyux/config';
 
 import { SkyHrefResolverService } from './href-resolver.service';
 import { SkyHref } from './types/href';
 import { SkyHrefChange } from './types/href-change';
+import { SkyHrefQueryParams } from './types/href-query-params';
 
 type HrefChanges = { href: string; hidden: boolean };
 
@@ -44,8 +45,20 @@ export class SkyHrefDirective {
     return this.#_skyHref;
   }
 
+  /**
+   * A collection of query URL parameters.
+   */
   @Input()
-  public queryParams: Params | undefined;
+  public set queryParams(value: SkyHrefQueryParams | undefined) {
+    if (value !== this.#_queryParams) {
+      this.#_queryParams = value;
+      this.#applyChanges(this.#getChanges());
+    }
+  }
+
+  public get queryParams(): SkyHrefQueryParams | undefined {
+    return this.#_queryParams;
+  }
 
   /**
    * Set the behavior for when the link is not available to either hide the link or display unlinked text.
@@ -72,8 +85,8 @@ export class SkyHrefDirective {
 
   #href = '';
 
+  #_queryParams: SkyHrefQueryParams | undefined;
   #_skyHref = '';
-
   #_skyHrefElse: 'hide' | 'unlink' | undefined = 'hide';
 
   #router: Router;

--- a/libs/components/router/src/lib/modules/href/href.directive.ts
+++ b/libs/components/router/src/lib/modules/href/href.directive.ts
@@ -11,11 +11,7 @@ import {
   Renderer2,
 } from '@angular/core';
 import { Router, UrlTree } from '@angular/router';
-import {
-  SkyAppConfig,
-  SkyAppRuntimeConfigParamsProvider,
-  SkyConfigQueryParams,
-} from '@skyux/config';
+import { SkyAppConfig, SkyAppRuntimeConfigParamsProvider } from '@skyux/config';
 
 import { SkyHrefResolverService } from './href-resolver.service';
 import { SkyHref } from './types/href';
@@ -23,24 +19,6 @@ import { SkyHrefChange } from './types/href-change';
 import { SkyHrefQueryParams } from './types/href-query-params';
 
 type HrefChanges = { href: string; hidden: boolean };
-
-/**
- * Transforms SkyHrefQueryParams into SkyConfigQueryParams.
- */
-function toConfigQueryParams(params: SkyHrefQueryParams): SkyConfigQueryParams {
-  // Clone the object to avoid modifying the original.
-  const clone = { ...params };
-
-  for (const key in clone) {
-    const value = clone[key];
-
-    if (value === undefined || value === null) {
-      delete clone[key];
-    }
-  }
-
-  return clone as SkyConfigQueryParams;
-}
 
 @Directive({
   selector: '[skyHref]',
@@ -240,7 +218,7 @@ export class SkyHrefDirective {
         this.#skyAppConfig?.runtime.params ?? this.#paramsProvider!.params;
 
       this.#href = params.getLinkUrl(this.#route.url, {
-        queryParams: toConfigQueryParams(this.queryParams ?? {}),
+        queryParams: this.queryParams ?? {},
       });
 
       return {

--- a/libs/components/router/src/lib/modules/href/href.directive.ts
+++ b/libs/components/router/src/lib/modules/href/href.directive.ts
@@ -217,7 +217,9 @@ export class SkyHrefDirective {
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         this.#skyAppConfig?.runtime.params ?? this.#paramsProvider!.params;
 
-      this.#href = params.getLinkUrl(this.#route.url, this.queryParams);
+      this.#href = params.getLinkUrl(this.#route.url, {
+        queryParams: this.queryParams ?? {},
+      });
 
       return {
         href: this.#href,

--- a/libs/components/router/src/lib/modules/href/href.directive.ts
+++ b/libs/components/router/src/lib/modules/href/href.directive.ts
@@ -10,7 +10,7 @@ import {
   Output,
   Renderer2,
 } from '@angular/core';
-import { Router, UrlTree } from '@angular/router';
+import { Params, Router, UrlTree } from '@angular/router';
 import { SkyAppConfig, SkyAppRuntimeConfigParamsProvider } from '@skyux/config';
 
 import { SkyHrefResolverService } from './href-resolver.service';
@@ -43,6 +43,9 @@ export class SkyHrefDirective {
   public get skyHref(): string {
     return this.#_skyHref;
   }
+
+  @Input()
+  public queryParams: Params | undefined;
 
   /**
    * Set the behavior for when the link is not available to either hide the link or display unlinked text.
@@ -137,7 +140,7 @@ export class SkyHrefDirective {
     return true;
   }
 
-  #applyChanges(change: HrefChanges) {
+  #applyChanges(change: HrefChanges): void {
     this.#renderer.addClass(this.#element.nativeElement, 'sky-href');
     if (change.hidden) {
       this.#renderer.setAttribute(
@@ -160,7 +163,7 @@ export class SkyHrefDirective {
     this.skyHrefChange.emit({ userHasAccess: !change.hidden });
   }
 
-  #checkRouteAccess() {
+  #checkRouteAccess(): void {
     this.#route = {
       url: this.skyHref,
       userHasAccess: false,
@@ -201,7 +204,7 @@ export class SkyHrefDirective {
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         this.#skyAppConfig?.runtime.params ?? this.#paramsProvider!.params;
 
-      this.#href = params.getLinkUrl(this.#route.url);
+      this.#href = params.getLinkUrl(this.#route.url, this.queryParams);
 
       return {
         href: this.#href,

--- a/libs/components/router/src/lib/modules/href/types/href-query-params.ts
+++ b/libs/components/router/src/lib/modules/href/types/href-query-params.ts
@@ -1,0 +1,7 @@
+/**
+ * A collection of query URL parameters.
+ */
+export type SkyHrefQueryParams = Record<
+  string,
+  string | number | boolean | null | undefined
+>;

--- a/libs/components/router/src/lib/modules/href/types/href-query-params.ts
+++ b/libs/components/router/src/lib/modules/href/types/href-query-params.ts
@@ -1,7 +1,4 @@
 /**
  * A collection of query URL parameters.
  */
-export type SkyHrefQueryParams = Record<
-  string,
-  string | number | boolean | null | undefined
->;
+export type SkyHrefQueryParams = Record<string, string>;


### PR DESCRIPTION
Original contribution: https://github.com/blackbaud/skyux/pull/1800
by @Blackbaud-TomRamsey

[AB#2704591](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/2704591)