### PR TITLE
refactor(components/autonumeric): convert autonumeric to standalone

### DIFF
--- a/libs/components/autonumeric/src/index.ts
+++ b/libs/components/autonumeric/src/index.ts
@@ -2,6 +2,6 @@ export { SkyAutonumericOptionsProvider } from './lib/modules/autonumeric/autonum
 export { SkyAutonumericOptions } from './lib/modules/autonumeric/autonumeric-options';
 export { SkyAutonumericModule } from './lib/modules/autonumeric/autonumeric.module';
 
-// Components and directives must be exported to support Angular's "partial" Ivy compiler.
-// Obscure names are used to indicate types are not part of the public API.
-export { SkyAutonumericDirective as λ1 } from './lib/modules/autonumeric/autonumeric.directive';
+// Now that the SkyAutonumericDirective is standalone it can be exported directly thus removing the need to
+// import the SkyAutonumericModule in the consuming application.
+export { SkyAutonumericDirective } from './lib/modules/autonumeric/autonumeric.directive';

--- a/libs/components/autonumeric/src/lib/modules/autonumeric/autonumeric.directive.ts
+++ b/libs/components/autonumeric/src/lib/modules/autonumeric/autonumeric.directive.ts
@@ -44,6 +44,7 @@ const SKY_AUTONUMERIC_VALIDATOR = {
 @Directive({
   selector: 'input[skyAutonumeric]',
   providers: [SKY_AUTONUMERIC_VALUE_ACCESSOR, SKY_AUTONUMERIC_VALIDATOR],
+  standalone: true,
 })
 export class SkyAutonumericDirective
   implements OnInit, OnDestroy, ControlValueAccessor, Validator

--- a/libs/components/autonumeric/src/lib/modules/autonumeric/autonumeric.module.ts
+++ b/libs/components/autonumeric/src/lib/modules/autonumeric/autonumeric.module.ts
@@ -1,12 +1,9 @@
-import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
-import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 
 import { SkyAutonumericDirective } from './autonumeric.directive';
 
 @NgModule({
-  declarations: [SkyAutonumericDirective],
-  imports: [CommonModule, FormsModule, ReactiveFormsModule],
+  imports: [SkyAutonumericDirective],
   exports: [SkyAutonumericDirective],
 })
 export class SkyAutonumericModule {}


### PR DESCRIPTION
Converts the `autonumeric` project to standalone.

1. Makes the directive standalone
2. Updates Module to import and export instead of declare and export
3. Removes the dependency imports in the module (Directives do not directly need the dependency imports as can be seen by the tests passing and the fact standalone directives do not have an `imports` array)
4. Does not export the directive as an obscure name as now it can be imported directly