### PR TITLE
refactor(components/avatar): convert avatar to standalone

### DIFF
--- a/libs/components/avatar/src/index.ts
+++ b/libs/components/avatar/src/index.ts
@@ -1,7 +1,7 @@
-export { SkyAvatarSize } from './lib/modules/avatar/avatar-size';
-export { SkyAvatarSrc } from './lib/modules/avatar/avatar-src';
+export type { SkyAvatarSize } from './lib/modules/avatar/avatar-size';
+export type { SkyAvatarSrc } from './lib/modules/avatar/avatar-src';
 export { SkyAvatarModule } from './lib/modules/avatar/avatar.module';
 
-// Components and directives must be exported to support Angular's "partial" Ivy compiler.
-// Obscure names are used to indicate types are not part of public API.
-export { SkyAvatarComponent as λ1 } from './lib/modules/avatar/avatar.component';
+// Now that the SkyAutonumericDirective is standalone it can be exported directly thus removing the need to
+// import the SkyAvatarModule in the consuming application.
+export { SkyAvatarComponent } from './lib/modules/avatar/avatar.component';

--- a/libs/components/avatar/src/lib/modules/avatar/avatar.component.html
+++ b/libs/components/avatar/src/lib/modules/avatar/avatar.component.html
@@ -8,7 +8,6 @@
             ? ('skyux_avatar_upload_change_aria_label' | skyLibResources : name)
             : ('skyux_avatar_upload_new_aria_label' | skyLibResources : name)
         "
-        [multiple]="false"
         [maxFileSize]="maxFileSize"
         [multiple]="false"
         (filesChanged)="photoDrop($event)"

--- a/libs/components/avatar/src/lib/modules/avatar/avatar.component.ts
+++ b/libs/components/avatar/src/lib/modules/avatar/avatar.component.ts
@@ -1,3 +1,4 @@
+import { AsyncPipe, NgIf, NgTemplateOutlet } from '@angular/common';
 import {
   Component,
   EventEmitter,
@@ -8,13 +9,21 @@ import {
 } from '@angular/core';
 import { SkyDefaultInputProvider } from '@skyux/core';
 import { ErrorModalConfig, SkyErrorModalService } from '@skyux/errors';
-import { SkyFileDropChange, SkyFileItem, SkyFileSizePipe } from '@skyux/forms';
+import {
+  SkyFileAttachmentsModule,
+  SkyFileDropChange,
+  SkyFileItem,
+  SkyFileSizePipe,
+} from '@skyux/forms';
 import { SkyLibResourcesService } from '@skyux/i18n';
 
 import { Observable } from 'rxjs';
 
+import { SkyAvatarResourcesModule } from '../shared/sky-avatar-resources.module';
+
 import { SkyAvatarSize } from './avatar-size';
 import { SkyAvatarSrc } from './avatar-src';
+import { SkyAvatarInnerComponent } from './avatar.inner.component';
 
 const MAX_FILE_SIZE_DEFAULT = 500000;
 
@@ -23,6 +32,15 @@ const MAX_FILE_SIZE_DEFAULT = 500000;
   templateUrl: './avatar.component.html',
   styleUrls: ['./avatar.component.scss'],
   encapsulation: ViewEncapsulation.None,
+  standalone: true,
+  imports: [
+    AsyncPipe,
+    NgIf,
+    NgTemplateOutlet,
+    SkyAvatarInnerComponent,
+    SkyAvatarResourcesModule,
+    SkyFileAttachmentsModule,
+  ],
 })
 export class SkyAvatarComponent {
   /**

--- a/libs/components/avatar/src/lib/modules/avatar/avatar.inner.component.ts
+++ b/libs/components/avatar/src/lib/modules/avatar/avatar.inner.component.ts
@@ -1,3 +1,4 @@
+import { NgClass, NgIf } from '@angular/common';
 import {
   AfterViewInit,
   Component,
@@ -6,6 +7,9 @@ import {
   OnDestroy,
   ViewEncapsulation,
 } from '@angular/core';
+import { SkyThemeModule } from '@skyux/theme';
+
+import { SkyAvatarResourcesModule } from '../shared/sky-avatar-resources.module';
 
 import { SkyAvatarAdapterService } from './avatar-adapter.service';
 import { SkyAvatarSize } from './avatar-size';
@@ -20,6 +24,8 @@ import { SkyAvatarSrc } from './avatar-src';
   styleUrls: ['./avatar.inner.component.scss'],
   providers: [SkyAvatarAdapterService],
   encapsulation: ViewEncapsulation.None,
+  imports: [NgClass, SkyAvatarResourcesModule, NgIf, SkyThemeModule],
+  standalone: true,
 })
 export class SkyAvatarInnerComponent implements AfterViewInit, OnDestroy {
   public get src(): SkyAvatarSrc | undefined {

--- a/libs/components/avatar/src/lib/modules/avatar/avatar.module.ts
+++ b/libs/components/avatar/src/lib/modules/avatar/avatar.module.ts
@@ -1,23 +1,11 @@
-import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
-import { SkyErrorModule } from '@skyux/errors';
-import { SkyFileAttachmentsModule, SkyFileSizePipe } from '@skyux/forms';
-import { SkyThemeModule } from '@skyux/theme';
-
-import { SkyAvatarResourcesModule } from '../shared/sky-avatar-resources.module';
+import { SkyFileSizePipe } from '@skyux/forms';
 
 import { SkyAvatarComponent } from './avatar.component';
 import { SkyAvatarInnerComponent } from './avatar.inner.component';
 
 @NgModule({
-  declarations: [SkyAvatarInnerComponent, SkyAvatarComponent],
-  imports: [
-    CommonModule,
-    SkyAvatarResourcesModule,
-    SkyErrorModule,
-    SkyFileAttachmentsModule,
-    SkyThemeModule,
-  ],
+  imports: [SkyAvatarInnerComponent, SkyAvatarComponent],
   providers: [SkyFileSizePipe],
   exports: [SkyAvatarComponent],
 })


### PR DESCRIPTION
Converts the avatar project to standalone.

1. Makes the component(s) standalone (one public one private)
2. Updates Module to import and export instead of declare and export (does not export the inner component)
3. Removes the dependency imports in the modules
4. Does not export the component as an obscure name as now it can be imported directly
5. Removes a duplicate `[multiple]` input in the component html