### PR TITLE
refactor(components/colorpicker): convert colorpicker to standalone

### DIFF
--- a/libs/components/colorpicker/src/index.ts
+++ b/libs/components/colorpicker/src/index.ts
@@ -10,7 +10,7 @@ export { SkyColorpickerOutput } from './lib/modules/colorpicker/types/colorpicke
 export { SkyColorpickerResult } from './lib/modules/colorpicker/types/colorpicker-result';
 export { SkyColorpickerRgba } from './lib/modules/colorpicker/types/colorpicker-rgba';
 
-// Components and directives must be exported to support Angular's "partial" Ivy compiler.
-// Obscure names are used to indicate types are not part of the public API.
-export { SkyColorpickerComponent as λ1 } from './lib/modules/colorpicker/colorpicker.component';
-export { SkyColorpickerInputDirective as λ2 } from './lib/modules/colorpicker/colorpicker-input.directive';
+// Now that these are standalone they can be exported directly thus removing the need to
+// import the SkyColorpickerModule in the consuming application.
+export { SkyColorpickerComponent } from './lib/modules/colorpicker/colorpicker.component';
+export { SkyColorpickerInputDirective } from './lib/modules/colorpicker/colorpicker-input.directive';

--- a/libs/components/colorpicker/src/lib/modules/colorpicker/colorpicker-input.directive.ts
+++ b/libs/components/colorpicker/src/lib/modules/colorpicker/colorpicker-input.directive.ts
@@ -47,6 +47,7 @@ const SKY_COLORPICKER_DEFAULT_COLOR = '#FFFFFF';
 @Directive({
   selector: '[skyColorpickerInput]',
   providers: [SKY_COLORPICKER_VALUE_ACCESSOR, SKY_COLORPICKER_VALIDATOR],
+  standalone: true,
 })
 export class SkyColorpickerInputDirective
   implements OnInit, OnChanges, ControlValueAccessor, Validator, OnDestroy

--- a/libs/components/colorpicker/src/lib/modules/colorpicker/colorpicker-slider.directive.ts
+++ b/libs/components/colorpicker/src/lib/modules/colorpicker/colorpicker-slider.directive.ts
@@ -14,6 +14,7 @@ import { SkyColorpickerChangeAxis } from './types/colorpicker-axis';
  */
 @Directive({
   selector: '[skyColorpickerSlider]',
+  standalone: true,
 })
 export class SkyColorpickerSliderDirective {
   @Output()

--- a/libs/components/colorpicker/src/lib/modules/colorpicker/colorpicker-text.directive.ts
+++ b/libs/components/colorpicker/src/lib/modules/colorpicker/colorpicker-text.directive.ts
@@ -13,6 +13,7 @@ import { SkyColorpickerChangeColor } from './types/colorpicker-color';
  */
 @Directive({
   selector: '[skyColorpickerText]',
+  standalone: true,
 })
 export class SkyColorpickerTextDirective {
   @Output()

--- a/libs/components/colorpicker/src/lib/modules/colorpicker/colorpicker.component.ts
+++ b/libs/components/colorpicker/src/lib/modules/colorpicker/colorpicker.component.ts
@@ -1,3 +1,4 @@
+import { NgClass, NgForOf, NgIf, SlicePipe } from '@angular/common';
 import {
   ChangeDetectorRef,
   Component,
@@ -22,13 +23,18 @@ import {
   SkyOverlayInstance,
   SkyOverlayService,
 } from '@skyux/core';
-import { SkyIconType } from '@skyux/indicators';
-import { SkyThemeService } from '@skyux/theme';
+import { SkyInputBoxModule } from '@skyux/forms';
+import { SkyIconModule, SkyIconType } from '@skyux/indicators';
+import { SkyThemeModule, SkyThemeService } from '@skyux/theme';
 
 import { Subject, fromEvent } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 
+import { SkyColorpickerResourcesModule } from '../shared/sky-colorpicker-resources.module';
+
 import { SliderDimension, SliderPosition } from './colorpicker-classes';
+import { SkyColorpickerSliderDirective } from './colorpicker-slider.directive';
+import { SkyColorpickerTextDirective } from './colorpicker-text.directive';
 import { SkyColorpickerService } from './colorpicker.service';
 import { SkyColorpickerChangeAxis } from './types/colorpicker-axis';
 import { SkyColorpickerChangeColor } from './types/colorpicker-color';
@@ -52,6 +58,19 @@ let componentIdIndex = 0;
   styleUrls: ['./colorpicker.component.scss'],
   providers: [SkyColorpickerService],
   encapsulation: ViewEncapsulation.None,
+  standalone: true,
+  imports: [
+    NgClass,
+    NgForOf,
+    NgIf,
+    SkyColorpickerResourcesModule,
+    SkyColorpickerSliderDirective,
+    SkyColorpickerTextDirective,
+    SkyIconModule,
+    SkyInputBoxModule,
+    SkyThemeModule,
+    SlicePipe,
+  ],
 })
 export class SkyColorpickerComponent implements OnInit, OnDestroy {
   /**

--- a/libs/components/colorpicker/src/lib/modules/colorpicker/colorpicker.module.ts
+++ b/libs/components/colorpicker/src/lib/modules/colorpicker/colorpicker.module.ts
@@ -1,11 +1,4 @@
-import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
-import { SkyAffixModule } from '@skyux/core';
-import { SkyInputBoxModule } from '@skyux/forms';
-import { SkyIconModule } from '@skyux/indicators';
-import { SkyThemeModule } from '@skyux/theme';
-
-import { SkyColorpickerResourcesModule } from '../shared/sky-colorpicker-resources.module';
 
 import { SkyColorpickerInputDirective } from './colorpicker-input.directive';
 import { SkyColorpickerSliderDirective } from './colorpicker-slider.directive';
@@ -13,19 +6,11 @@ import { SkyColorpickerTextDirective } from './colorpicker-text.directive';
 import { SkyColorpickerComponent } from './colorpicker.component';
 
 @NgModule({
-  declarations: [
+  imports: [
     SkyColorpickerComponent,
     SkyColorpickerInputDirective,
-    SkyColorpickerTextDirective,
     SkyColorpickerSliderDirective,
-  ],
-  imports: [
-    CommonModule,
-    SkyAffixModule,
-    SkyColorpickerResourcesModule,
-    SkyIconModule,
-    SkyInputBoxModule,
-    SkyThemeModule,
+    SkyColorpickerTextDirective,
   ],
   exports: [SkyColorpickerComponent, SkyColorpickerInputDirective],
 })


### PR DESCRIPTION
Converts the colorpicker project to standalone.

1. Makes the component and directives standalone (one public one private of each)
2. Updates Module to import and export instead of declare and export (Only exports what was exported before)
3. Removes the dependency imports in the modules
4. Does not export the component and directive as an obscure name as now it can be imported directly