### PR TITLE
fix(components/ag-grid): fix height css expression for wrap-text

### DIFF
--- a/libs/components/ag-grid/src/lib/styles/_variables.scss
+++ b/libs/components/ag-grid/src/lib/styles/_variables.scss
@@ -14,6 +14,6 @@ $sky-cell-wrap-text-line-height-modern: variables.$sky-theme-modern-font-paragra
     line-height: #{$line-height};
     padding-top: $padding;
     padding-bottom: $padding;
-    min-height: var(--ag-row-height) - 2px;
+    min-height: calc(var(--ag-row-height) - 2px);
   }
 }


### PR DESCRIPTION
The wrap-text mixin included a CSS expression that should have been wrapped with `calc()`. Fixes #1830