### PR TITLE
fix(components/lookup): fit lookup dropdown to viewport (#1858)

### DIFF
--- a/libs/components/lookup/src/lib/modules/autocomplete/autocomplete.component.ts
+++ b/libs/components/lookup/src/lib/modules/autocomplete/autocomplete.component.ts
@@ -987,7 +987,7 @@ export class SkyAutocompleteComponent implements OnDestroy, AfterViewInit {
       );
 
       affixer.affixTo(this.#elementRef.nativeElement, {
-        autoFitContext: SkyAffixAutoFitContext.OverflowParent,
+        autoFitContext: SkyAffixAutoFitContext.Viewport,
         enableAutoFit: true,
         isSticky: true,
         placement: 'below',


### PR DESCRIPTION
:cherries: Cherry picked from #1858 [fix(components/lookup): fit lookup dropdown to viewport](https://github.com/blackbaud/skyux/pull/1858)