### PR TITLE
fix(components/popovers): dropdown position not working in firefox (#1869)

### DIFF
--- a/libs/components/core/src/lib/modules/affix/affix.directive.spec.ts
+++ b/libs/components/core/src/lib/modules/affix/affix.directive.spec.ts
@@ -272,6 +272,26 @@ describe('Affix directive', () => {
       expect(getRecentPlacementChange()).toEqual('left');
     });
 
+    it('should adjust to a positioned parent offset', async () => {
+      const { fixture, getAffixedOffset } = await setupTest();
+      const componentInstance = fixture.componentInstance;
+
+      componentInstance.enablePositionedParent = true;
+      fixture.detectChanges();
+
+      const affixedOffset = getAffixedOffset();
+
+      if (position === 'absolute') {
+        // Absolute position is relative to the positioned parent.
+        expect(affixedOffset.top).toEqual(195);
+        expect(affixedOffset.left).toEqual(225);
+      } else {
+        // Fixed position is relative to the viewport.
+        expect(affixedOffset.top).toEqual(295);
+        expect(affixedOffset.left).toEqual(325);
+      }
+    });
+
     it('should affix element using vertical alignments', async () => {
       const { fixture, getAffixedOffset } = await setupTest();
       const componentInstance = fixture.componentInstance;

--- a/libs/components/core/src/lib/modules/affix/affixer.ts
+++ b/libs/components/core/src/lib/modules/affix/affixer.ts
@@ -211,7 +211,11 @@ export class SkyAffixer {
   }
 
   #getOffsetParentRect(): AffixRect {
-    if (this.#affixedElement.offsetParent) {
+    // Firefox sets the offsetParent to document.body if the element uses fixed positioning.
+    if (
+      this.#config.position === 'absolute' &&
+      this.#affixedElement.offsetParent
+    ) {
       return getOuterRect(this.#affixedElement.offsetParent as HTMLElement);
     } else {
       const layoutRect = getOuterRect(this.#layoutViewport);

--- a/libs/components/core/src/lib/modules/affix/fixtures/affix.component.fixture.html
+++ b/libs/components/core/src/lib/modules/affix/fixtures/affix.component.fixture.html
@@ -1,7 +1,8 @@
 <div
   class="canvas"
   [ngClass]="{
-    'canvas-overflow': enableOverflowParent
+    'canvas-overflow': enableOverflowParent,
+    'canvas-positioned': enablePositionedParent
   }"
   #overflowParentRef
 >

--- a/libs/components/core/src/lib/modules/affix/fixtures/affix.component.fixture.scss
+++ b/libs/components/core/src/lib/modules/affix/fixtures/affix.component.fixture.scss
@@ -14,6 +14,12 @@
   display: flex;
   align-items: center;
   justify-content: center;
+
+  &.canvas-positioned {
+    position: absolute;
+    top: 100px;
+    left: 100px;
+  }
 }
 
 .canvas-overflow {

--- a/libs/components/core/src/lib/modules/affix/fixtures/affix.component.fixture.ts
+++ b/libs/components/core/src/lib/modules/affix/fixtures/affix.component.fixture.ts
@@ -63,6 +63,8 @@ export class AffixFixtureComponent {
 
   public enableOverflowParent = false;
 
+  public enablePositionedParent = false;
+
   public onAffixOffsetChange(): void {}
 
   public onAffixOverflowScroll(): void {}


### PR DESCRIPTION
:cherries: Cherry picked from #1869 [fix(components/popovers): dropdown position not working in firefox](https://github.com/blackbaud/skyux/pull/1869)

[AB#2727256](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/2727256) 