### PR TITLE
fix(components/datetime): timepicker overlay prevents unintended keyboard navigation from reaching parent components

### DIFF
--- a/libs/components/datetime/src/lib/modules/timepicker/timepicker.component.spec.ts
+++ b/libs/components/datetime/src/lib/modules/timepicker/timepicker.component.spec.ts
@@ -482,14 +482,15 @@ describe('Timepicker', () => {
     it('should close picker when `escape` key is pressed', fakeAsync(() => {
       detectChangesAndTick(fixture);
       openTimepicker(fixture);
+      let picker = getTimepicker();
 
-      SkyAppTestUtility.fireDomEvent(window.document, 'keydown', {
+      SkyAppTestUtility.fireDomEvent(picker, 'keyup', {
         customEventInit: {
           key: 'escape',
         },
       });
       detectChangesAndTick(fixture);
-      const picker = getTimepicker();
+      picker = getTimepicker();
 
       expect(picker).toBeNull();
     }));
@@ -497,12 +498,13 @@ describe('Timepicker', () => {
     it('should handle non-keyboard events', fakeAsync(() => {
       detectChangesAndTick(fixture);
       openTimepicker(fixture);
+      let picker = getTimepicker();
 
-      SkyAppTestUtility.fireDomEvent(window.document, 'keydown', {
+      SkyAppTestUtility.fireDomEvent(picker, 'keyup', {
         customEventInit: {}, // Don't pass in a key value.
       });
       detectChangesAndTick(fixture);
-      const picker = getTimepicker();
+      picker = getTimepicker();
 
       expect(picker).not.toBeNull();
     }));

--- a/libs/components/datetime/src/lib/modules/timepicker/timepicker.component.ts
+++ b/libs/components/datetime/src/lib/modules/timepicker/timepicker.component.ts
@@ -241,7 +241,7 @@ export class SkyTimepickerComponent implements OnInit, OnDestroy {
 
   #overlay: SkyOverlayInstance | undefined;
 
-  #overlayKeydownListener: Subscription | undefined;
+  #overlayKeyupListener: Subscription | undefined;
 
   #_disabled = false;
 
@@ -460,8 +460,6 @@ export class SkyTimepickerComponent implements OnInit, OnDestroy {
           }
         });
 
-      // this.#addKeyupListener();
-
       overlay.attachTemplate(this.timepickerTemplateRef);
 
       this.#overlay = overlay;
@@ -480,7 +478,7 @@ export class SkyTimepickerComponent implements OnInit, OnDestroy {
     const timepickerMenuElement = this.timepickerRef?.nativeElement;
 
     if (timepickerMenuElement) {
-      this.#overlayKeydownListener = fromEvent<KeyboardEvent>(
+      this.#overlayKeyupListener = fromEvent<KeyboardEvent>(
         timepickerMenuElement,
         'keyup',
       )
@@ -505,6 +503,6 @@ export class SkyTimepickerComponent implements OnInit, OnDestroy {
       this.#timepickerUnsubscribe = new Subject<void>();
     }
     /* istanbul ignore next */
-    this.#overlayKeydownListener?.unsubscribe();
+    this.#overlayKeyupListener?.unsubscribe();
   }
 }

--- a/libs/components/datetime/src/lib/modules/timepicker/timepicker.component.ts
+++ b/libs/components/datetime/src/lib/modules/timepicker/timepicker.component.ts
@@ -184,6 +184,8 @@ export class SkyTimepickerComponent implements OnInit, OnDestroy {
     if (value) {
       this.#_timepickerRef = value;
 
+      this.#addKeyupListener();
+
       // Wait for the timepicker component to render before gauging dimensions.
       setTimeout(() => {
         this.#destroyAffixer();
@@ -283,7 +285,7 @@ export class SkyTimepickerComponent implements OnInit, OnDestroy {
 
   public ngOnInit(): void {
     this.setFormat(this.timeFormat);
-    this.#addKeydownListener();
+    this.#addKeyupListener();
 
     if (this.inputBoxHostService && this.inputTemplateRef) {
       this.inputBoxHostService.populate({
@@ -381,7 +383,7 @@ export class SkyTimepickerComponent implements OnInit, OnDestroy {
     this.#openPicker();
   }
 
-  #closePicker() {
+  #closePicker(): void {
     this.#destroyAffixer();
     this.#destroyOverlay();
     this.#removePickerEventListeners();
@@ -458,7 +460,7 @@ export class SkyTimepickerComponent implements OnInit, OnDestroy {
           }
         });
 
-      this.#addKeydownListener();
+      // this.#addKeyupListener();
 
       overlay.attachTemplate(this.timepickerTemplateRef);
 
@@ -474,19 +476,25 @@ export class SkyTimepickerComponent implements OnInit, OnDestroy {
     }
   }
 
-  #addKeydownListener(): void {
-    this.#overlayKeydownListener = fromEvent<KeyboardEvent>(
-      window.document,
-      'keydown',
-    )
-      .pipe(takeUntil(this.#ngUnsubscribe))
-      .subscribe((event) => {
-        const key = event.key?.toLowerCase();
-        /* istanbul ignore else */
-        if (key === 'escape' && this.isOpen) {
-          this.#closePicker();
-        }
-      });
+  #addKeyupListener(): void {
+    const timepickerMenuElement = this.timepickerRef?.nativeElement;
+
+    if (timepickerMenuElement) {
+      this.#overlayKeydownListener = fromEvent<KeyboardEvent>(
+        timepickerMenuElement,
+        'keyup',
+      )
+        .pipe(takeUntil(this.#ngUnsubscribe))
+        .subscribe((event) => {
+          const key = event.key?.toLowerCase();
+          /* istanbul ignore else */
+          if (key === 'escape' && this.isOpen) {
+            this.#closePicker();
+            event.stopPropagation();
+            event.preventDefault();
+          }
+        });
+    }
   }
 
   #removePickerEventListeners(): void {


### PR DESCRIPTION
[AB#2012800](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/2012800)