### PR TITLE
fix(components/colorpicker): updated color picker selection cursors to have accessible color contrast

### DIFF
--- a/libs/components/colorpicker/src/lib/modules/colorpicker/colorpicker.component.scss
+++ b/libs/components/colorpicker/src/lib/modules/colorpicker/colorpicker.component.scss
@@ -149,19 +149,13 @@
     position: absolute;
     z-index: 999999;
   }
-  div.cursor-sv {
-    cursor: default;
-    position: relative;
-    width: 14px;
-    height: 14px;
-    @include mixins.sky-border(dark, top, right, bottom, left);
-  }
   div.cursor {
     cursor: default;
     position: relative;
     width: 17px;
     height: 17px;
-    border: $sky-text-color-deemphasized solid 2px;
+    border: $sky-color-white solid 2px;
+    outline: thin solid;
   }
   .saturation-lightness {
     cursor: pointer;


### PR DESCRIPTION
[AB#2599940](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/2599940)