### PR TITLE
fix(components/packages): standardize how schematics visit project files (#1967)

### DIFF
--- a/libs/components/packages/src/schematics/migrations/update-9/ag-grid-29/ag-grid-29.schematic.ts
+++ b/libs/components/packages/src/schematics/migrations/update-9/ag-grid-29/ag-grid-29.schematic.ts
@@ -13,6 +13,8 @@ import {
 } from '@schematics/angular/utility/change';
 import { getPackageJsonDependency } from '@schematics/angular/utility/dependencies';
 
+import { visitProjectFiles } from '../../../utility/visit-project-files';
+
 const AG_GRID = 'ag-grid-community';
 const AG_GRID_ENT = 'ag-grid-enterprise';
 
@@ -133,9 +135,10 @@ function updateSourceFiles(): Rule {
   return async (tree: Tree): Promise<void> => {
     const workspace = await readWorkspace(tree);
     workspace.projects.forEach((project) => {
-      tree
-        .getDir(project.sourceRoot || project.root)
-        .visit((filePath: Path) => {
+      visitProjectFiles(
+        tree,
+        project.sourceRoot || project.root,
+        (filePath) => {
           // If the file is not a TypeScript file, we can skip it.
           if (!filePath.endsWith('.ts')) {
             return;
@@ -149,7 +152,8 @@ function updateSourceFiles(): Rule {
           const recorder = tree.beginUpdate(filePath);
           applyToUpdateRecorder(recorder, changes);
           tree.commitUpdate(recorder);
-        });
+        },
+      );
     });
   };
 }

--- a/libs/components/packages/src/schematics/migrations/update-9/i18n-resources-module/i18n-resources-module.schematic.ts
+++ b/libs/components/packages/src/schematics/migrations/update-9/i18n-resources-module/i18n-resources-module.schematic.ts
@@ -1,6 +1,7 @@
 import { Rule, chain, externalSchematic } from '@angular-devkit/schematics';
 
 import { readRequiredFile } from '../../../utility/tree';
+import { visitProjectFiles } from '../../../utility/visit-project-files';
 import { getWorkspace } from '../../../utility/workspace';
 
 const RESOURCES_MODULE_SUFFIX = '-resources.module.ts';
@@ -32,7 +33,7 @@ export default function (): Rule {
 
         const srcRootRegex = new RegExp(`^/${srcRoot}/`);
 
-        tree.getDir(srcRoot).visit((filePath) => {
+        visitProjectFiles(tree, srcRoot, (filePath) => {
           if (filePath.endsWith(RESOURCES_MODULE_SUFFIX)) {
             const content = readRequiredFile(tree, filePath);
 

--- a/libs/components/packages/src/schematics/migrations/update-9/legacy-services/legacy-services.schematic.ts
+++ b/libs/components/packages/src/schematics/migrations/update-9/legacy-services/legacy-services.schematic.ts
@@ -7,6 +7,7 @@ import { Rule, Tree, UpdateRecorder } from '@angular-devkit/schematics';
 import { readRequiredFile } from '../../../utility/tree';
 import { getImports, getUsages } from '../../../utility/typescript/imports';
 import { createSourceFile } from '../../../utility/typescript/source-file';
+import { visitProjectFiles } from '../../../utility/visit-project-files';
 import { getWorkspace } from '../../../utility/workspace';
 
 type RewriteFn = (startPos: number, origLength: number, text: string) => void;
@@ -95,8 +96,8 @@ export default function (): Rule {
     const { workspace } = await getWorkspace(tree);
 
     workspace.projects.forEach((project) => {
-      tree.getDir(project.root).visit((filePath) => {
-        if (filePath.endsWith('.ts') && !filePath.includes('node_modules')) {
+      visitProjectFiles(tree, project.root, (filePath) => {
+        if (filePath.endsWith('.ts')) {
           runLegacyServicesMigration(tree, filePath);
         }
       });

--- a/libs/components/packages/src/schematics/migrations/update-9/move-page-component/move-page-component.schematic.ts
+++ b/libs/components/packages/src/schematics/migrations/update-9/move-page-component/move-page-component.schematic.ts
@@ -9,6 +9,7 @@ import {
   getPackageJsonDependency,
 } from '@schematics/angular/utility/dependencies';
 
+import { visitProjectFiles } from '../../../utility/visit-project-files';
 import { getWorkspace } from '../../../utility/workspace';
 
 function getImportNames(importDeclaration: ts.ImportDeclaration): string[] {
@@ -27,7 +28,7 @@ export default function movePageComponent(): Rule {
       const source = project.sourceRoot || `${project.root}/src`;
 
       // Visit all TypeScript files in each project.
-      tree.getDir(source).visit((path) => {
+      visitProjectFiles(tree, source, (path) => {
         if (path.endsWith('.ts')) {
           // Parse the TypeScript file.
           const source = ts.createSourceFile(

--- a/libs/components/packages/src/schematics/migrations/update-9/update-angular-tree-component/update-angular-tree-component.schematic.ts
+++ b/libs/components/packages/src/schematics/migrations/update-9/update-angular-tree-component/update-angular-tree-component.schematic.ts
@@ -5,6 +5,7 @@ import { NodeDependencyType } from '@schematics/angular/utility/dependencies';
 import { getWorkspace } from '@schematics/angular/utility/workspace';
 
 import { ensurePeersInstalled } from '../../../rules/ensure-peers-installed';
+import { visitProjectFiles } from '../../../utility/visit-project-files';
 
 const OLD_PACKAGE = '@circlon/angular-tree-component';
 const NEW_PACKAGE = '@blackbaud/angular-tree-component';
@@ -14,7 +15,7 @@ function renameTypeScriptImportPaths(): Rule {
     const workspace = await getWorkspace(tree);
 
     for (const [, projectDefinition] of workspace.projects.entries()) {
-      tree.getDir(projectDefinition.root).visit((filePath) => {
+      visitProjectFiles(tree, projectDefinition.root, (filePath) => {
         if (filePath.match(/\.ts$/)) {
           const source = ts.createSourceFile(
             filePath,

--- a/libs/components/packages/src/schematics/utility/visit-project-files.ts
+++ b/libs/components/packages/src/schematics/utility/visit-project-files.ts
@@ -1,0 +1,22 @@
+import { Tree } from '@angular-devkit/schematics';
+import { FileVisitor } from '@angular-devkit/schematics/src/tree/interface';
+
+const rootIgnore = ['dist', 'coverage'];
+const alwaysIgnore = ['node_modules'];
+
+export function visitProjectFiles(
+  tree: Tree,
+  projectPath: string,
+  visitor: FileVisitor,
+): void {
+  tree.getDir(projectPath).visit((path, entry) => {
+    if (
+      path.includes('/.') ||
+      rootIgnore.some((i) => path.startsWith(`/${i}/`)) ||
+      alwaysIgnore.some((i) => path.includes(`/${i}/`))
+    ) {
+      return;
+    }
+    visitor(path, entry);
+  });
+}


### PR DESCRIPTION
:cherries: Cherry picked from #1967 [fix(components/packages): standardize how schematics visit project files](https://github.com/blackbaud/skyux/pull/1967)

[AB#2812991](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/2812991) 