### PR TITLE
feat(components/tabs): add keyboard navigation to vertical tabset (#1978)

### DIFF
--- a/apps/playground/src/app/components/tabs/vertical-tabset/vertical-tabset.component.html
+++ b/apps/playground/src/app/components/tabs/vertical-tabset/vertical-tabset.component.html
@@ -54,6 +54,9 @@
         Group 3 Tab 2 content
       </sky-vertical-tab>
     </sky-vertical-tabset-group>
+    <sky-vertical-tab tabHeading="Ungrouped Tab" tabHeaderCount="2">
+      Ungrouped tab content
+    </sky-vertical-tab>
   </sky-vertical-tabset>
 </div>
 

--- a/libs/components/tabs/src/lib/modules/vertical-tabset/vertical-tab.component.html
+++ b/libs/components/tabs/src/lib/modules/vertical-tabset/vertical-tab.component.html
@@ -1,18 +1,22 @@
 <a
-  class="sky-vertical-tab"
+  class="sky-vertical-tab sky-vertical-tabset-button"
   [attr.aria-controls]="isMobile ? null : ariaControls || tabContentPane.id"
+  [attr.aria-disabled]="disabled || undefined"
   [attr.aria-selected]="active"
   [attr.id]="tabId"
   [attr.role]="isMobile ? undefined : ariaRole"
   [ngClass]="{
     'sky-vertical-tab-active': active,
-    'sky-vertical-tab-disabled': disabled,
+    'sky-vertical-tabset-button-disabled': disabled,
     'sky-font-deemphasized': disabled,
     'sky-deemphasized': disabled
   }"
-  [tabIndex]="tabIndex()"
+  [tabIndex]="-1"
   (click)="activateTab()"
-  (keyup)="onTabButtonKeyUp($event)"
+  (keyup.arrowleft)="tabButtonArrowLeft($event)"
+  (keyup.enter)="tabButtonActivate($event)"
+  (keyup.space)="tabButtonActivate($event)"
+  #tabButton
 >
   <div class="sky-vertical-tab-display">
     <div class="sky-vertical-tab-heading">

--- a/libs/components/tabs/src/lib/modules/vertical-tabset/vertical-tab.component.scss
+++ b/libs/components/tabs/src/lib/modules/vertical-tabset/vertical-tab.component.scss
@@ -50,7 +50,7 @@
   margin-left: $sky-margin-half;
 }
 
-.sky-vertical-tab-disabled {
+.sky-vertical-tabset-button-disabled {
   cursor: not-allowed;
   pointer-events: none;
 }
@@ -58,6 +58,13 @@
 .sky-vertical-tab-right-arrow {
   padding: 3px $sky-padding 0 0;
   color: $sky-text-color-icon-borderless;
+}
+
+.sky-vertical-tab-content-pane {
+  &:focus-visible {
+    outline: none;
+    border: none;
+  }
 }
 
 @include mixins.sky-theme-modern {

--- a/libs/components/tabs/src/lib/modules/vertical-tabset/vertical-tab.component.ts
+++ b/libs/components/tabs/src/lib/modules/vertical-tabset/vertical-tab.component.ts
@@ -9,6 +9,7 @@ import {
   OnInit,
   Optional,
   ViewChild,
+  inject,
 } from '@angular/core';
 import { SkyMediaQueryService } from '@skyux/core';
 
@@ -19,6 +20,7 @@ import { SkyTabIdService } from '../shared/tab-id.service';
 
 import { SkyVerticalTabMediaQueryService } from './vertical-tab-media-query.service';
 import { SkyVerticalTabsetAdapterService } from './vertical-tabset-adapter.service';
+import { SkyVerticalTabsetGroupService } from './vertical-tabset-group.service';
 import { SkyVerticalTabsetService } from './vertical-tabset.service';
 
 let nextId = 0;
@@ -140,8 +142,15 @@ export class SkyVerticalTabComponent implements OnInit, OnDestroy {
 
   public isMobile = false;
 
+  @ViewChild('tabButton')
+  public tabButton: ElementRef | undefined;
+
   @ViewChild('tabContentWrapper')
   public tabContent: ElementRef | undefined;
+
+  public groupService = inject(SkyVerticalTabsetGroupService, {
+    optional: true,
+  });
 
   #_ariaRole = 'tab';
 
@@ -210,14 +219,6 @@ export class SkyVerticalTabComponent implements OnInit, OnDestroy {
     this.#tabsetService.destroyTab(this);
   }
 
-  public tabIndex(): number {
-    if (!this.disabled) {
-      return 0;
-    } else {
-      return -1;
-    }
-  }
-
   public activateTab(): void {
     if (!this.disabled) {
       this.active = true;
@@ -227,19 +228,22 @@ export class SkyVerticalTabComponent implements OnInit, OnDestroy {
     }
   }
 
-  public onTabButtonKeyUp(event: KeyboardEvent): void {
-    /*istanbul ignore else */
-    if (event.key) {
-      switch (event.key.toUpperCase()) {
-        case ' ':
-        case 'ENTER':
-          this.activateTab();
-          event.stopPropagation();
-          break;
-        /* istanbul ignore next */
-        default:
-          break;
-      }
+  public focusButton(): void {
+    this.#adapterService.focusButton(this.tabButton);
+  }
+
+  public tabButtonActivate(event: Event): void {
+    this.activateTab();
+    event.stopPropagation();
+  }
+
+  public tabButtonArrowLeft(event: Event): void {
+    if (this.groupService) {
+      this.groupService.messageStream.next({
+        messageType: 'focus',
+      });
+
+      event.preventDefault();
     }
   }
 

--- a/libs/components/tabs/src/lib/modules/vertical-tabset/vertical-tabset-adapter.service.ts
+++ b/libs/components/tabs/src/lib/modules/vertical-tabset/vertical-tabset-adapter.service.ts
@@ -1,14 +1,20 @@
+import { DOCUMENT } from '@angular/common';
 import {
   ElementRef,
   Injectable,
   Renderer2,
   RendererFactory2,
+  inject,
 } from '@angular/core';
 import { SkyMediaBreakpoints } from '@skyux/core';
+
+const VERTICAL_TABSET_BUTTON_SELECTOR = '.sky-vertical-tabset-button';
+const VERTICAL_TABSET_BUTTON_DISABLED_SELECTOR = `${VERTICAL_TABSET_BUTTON_SELECTOR}-disabled`;
 
 @Injectable()
 export class SkyVerticalTabsetAdapterService {
   #renderer: Renderer2;
+  #document = inject(DOCUMENT);
 
   constructor(rendererFactory: RendererFactory2) {
     this.#renderer = rendererFactory.createRenderer(undefined, null);
@@ -55,5 +61,80 @@ export class SkyVerticalTabsetAdapterService {
     }
 
     this.#renderer.addClass(nativeEl, newClass);
+  }
+
+  public focusButton(elRef: ElementRef<HTMLElement> | undefined): boolean {
+    return this.#focusButtonEl(elRef?.nativeElement);
+  }
+
+  public focusFirstButton(
+    tabGroups: ElementRef<HTMLElement> | undefined,
+  ): void {
+    const tabGroupsEl = tabGroups?.nativeElement;
+
+    if (tabGroupsEl) {
+      const firstButtonEl = tabGroupsEl.querySelector(
+        VERTICAL_TABSET_BUTTON_SELECTOR,
+      ) as HTMLElement | null;
+
+      if (firstButtonEl) {
+        firstButtonEl.focus();
+      }
+    }
+  }
+
+  public focusNextButton(tabGroups: ElementRef | undefined): void {
+    this.#focusSiblingButton(tabGroups);
+  }
+
+  public focusPreviousButton(tabGroups: ElementRef | undefined): void {
+    this.#focusSiblingButton(tabGroups, true);
+  }
+
+  #focusSiblingButton(
+    tabGroups: ElementRef<HTMLElement> | undefined,
+    previous?: boolean,
+  ): void {
+    if (tabGroups) {
+      const focusedEl = this.#document.activeElement as HTMLElement | null;
+
+      if (focusedEl?.matches(VERTICAL_TABSET_BUTTON_SELECTOR)) {
+        const tabGroupsEl = tabGroups.nativeElement;
+
+        const buttonEls = Array.from(
+          tabGroupsEl.querySelectorAll(VERTICAL_TABSET_BUTTON_SELECTOR),
+        ) as HTMLElement[];
+
+        if (previous) {
+          buttonEls.reverse();
+        }
+
+        const focusedIndex = buttonEls.indexOf(focusedEl);
+
+        for (let i = 1, n = buttonEls.length; i < n; i++) {
+          // Offset the index of the next button from the index of the
+          // currently focused button, circling back to the first button
+          // when the end of the list is reached.
+          const offset = (i + focusedIndex) % n;
+
+          if (this.#focusButtonEl(buttonEls[offset])) {
+            break;
+          }
+        }
+      }
+    }
+  }
+
+  #focusButtonEl(el: HTMLElement | null | undefined): boolean {
+    if (el && !el.matches(VERTICAL_TABSET_BUTTON_DISABLED_SELECTOR)) {
+      el.focus();
+      return this.#elHasFocus(el);
+    }
+
+    return false;
+  }
+
+  #elHasFocus(el: HTMLElement | null | undefined): boolean {
+    return !!el && el === this.#document.activeElement;
   }
 }

--- a/libs/components/tabs/src/lib/modules/vertical-tabset/vertical-tabset-group-message.ts
+++ b/libs/components/tabs/src/lib/modules/vertical-tabset/vertical-tabset-group-message.ts
@@ -1,0 +1,3 @@
+export interface SkyVerticalTabsetGroupMessage {
+  messageType: 'focus';
+}

--- a/libs/components/tabs/src/lib/modules/vertical-tabset/vertical-tabset-group.component.html
+++ b/libs/components/tabs/src/lib/modules/vertical-tabset/vertical-tabset-group.component.html
@@ -3,21 +3,28 @@
   <div
     class="sky-vertical-tabset-group-header"
     [ngClass]="{
-      'sky-vertical-tabset-group-header-sub-open sky-font-emphasized':
-        subMenuOpen(),
+      'sky-vertical-tabset-group-header-active sky-font-emphasized':
+        isActive(),
+      'sky-vertical-tabset-group-header-sub-open': open,
       'sky-font-deemphasized': disabled,
       'sky-deemphasized': disabled,
-      'sky-vertical-tabset-disabled': disabled
     }"
-    [tabIndex]="-1"
   >
     <button
-      class="sky-padding-even-default"
+      class="sky-padding-even-default sky-vertical-tabset-button"
+      role="tab"
       type="button"
-      skyId
       [attr.aria-controls]="groupContent.id"
+      [attr.aria-disabled]="disabled || undefined"
       [attr.aria-expanded]="!disabled && open"
+      [id]="groupId"
+      [ngClass]="{
+        'sky-vertical-tabset-button-disabled': disabled
+      }"
+      [tabIndex]="-1"
       (click)="toggleMenuOpen()"
+      (keyup.arrowleft)="groupButtonArrowLeft($event)"
+      (keyup.arrowright)="groupButtonArrowRight($event)"
       #groupHeadingButton
     >
       {{ groupHeading }}
@@ -31,7 +38,7 @@
   <div
     class="sky-vertical-tabset-group-content"
     skyId
-    [attr.labelledby]="groupHeadingButton.id"
+    [attr.labelledby]="groupId"
     [@.disabled]="animationDisabled"
     [@skyAnimationSlide]="slideDirection"
     (@skyAnimationSlide.done)="updateSlideDirection($event)"

--- a/libs/components/tabs/src/lib/modules/vertical-tabset/vertical-tabset-group.component.scss
+++ b/libs/components/tabs/src/lib/modules/vertical-tabset/vertical-tabset-group.component.scss
@@ -27,7 +27,7 @@
   font-size: 14px !important;
 }
 
-.sky-vertical-tabset-disabled {
+.sky-vertical-tabset-button-disabled {
   cursor: not-allowed;
   pointer-events: none;
 }

--- a/libs/components/tabs/src/lib/modules/vertical-tabset/vertical-tabset-group.component.ts
+++ b/libs/components/tabs/src/lib/modules/vertical-tabset/vertical-tabset-group.component.ts
@@ -3,17 +3,25 @@ import {
   ChangeDetectorRef,
   Component,
   ContentChildren,
+  ElementRef,
   Input,
   OnDestroy,
   OnInit,
   QueryList,
+  ViewChild,
+  inject,
 } from '@angular/core';
 import { skyAnimationSlide } from '@skyux/animations';
+import { SkyIdService } from '@skyux/core';
 
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 
+import { SkyTabIdService } from '../shared/tab-id.service';
+
 import { SkyVerticalTabComponent } from './vertical-tab.component';
+import { SkyVerticalTabsetAdapterService } from './vertical-tabset-adapter.service';
+import { SkyVerticalTabsetGroupService } from './vertical-tabset-group.service';
 import { SkyVerticalTabsetService } from './vertical-tabset.service';
 
 @Component({
@@ -22,6 +30,7 @@ import { SkyVerticalTabsetService } from './vertical-tabset.service';
   styleUrls: ['./vertical-tabset-group.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
   animations: [skyAnimationSlide],
+  providers: [SkyVerticalTabsetGroupService],
 })
 export class SkyVerticalTabsetGroupComponent implements OnInit, OnDestroy {
   /**
@@ -61,13 +70,22 @@ export class SkyVerticalTabsetGroupComponent implements OnInit, OnDestroy {
   @ContentChildren(SkyVerticalTabComponent)
   public tabs: QueryList<SkyVerticalTabComponent> | undefined;
 
+  @ViewChild('groupHeadingButton')
+  public groupHeadingButton: ElementRef | undefined;
+
   public animationDisabled = false;
   public slideDirection: 'down' | 'up' | 'void' = 'up';
+
+  protected groupId: string;
 
   #ngUnsubscribe = new Subject<void>();
 
   #tabService: SkyVerticalTabsetService;
   #changeRef: ChangeDetectorRef;
+  #adapterService = inject(SkyVerticalTabsetAdapterService);
+  #idService = inject(SkyIdService);
+  #tabIdService = inject(SkyTabIdService);
+  #groupService = inject(SkyVerticalTabsetGroupService);
 
   #_disabled: boolean | undefined;
   #_open: boolean | undefined;
@@ -78,25 +96,42 @@ export class SkyVerticalTabsetGroupComponent implements OnInit, OnDestroy {
   ) {
     this.#tabService = tabService;
     this.#changeRef = changeRef;
+
+    this.groupId = this.#idService.generateId();
+
+    this.#groupService.messageStream.subscribe((message) => {
+      switch (message.messageType) {
+        case 'focus':
+          this.#focusButton();
+      }
+    });
   }
 
   public ngOnInit(): void {
+    this.#tabIdService.register(this.groupId, this.groupId);
+
+    this.#tabService.addGroup(this);
+
     this.#tabService.hidingTabs
       .pipe(takeUntil(this.#ngUnsubscribe))
-      .subscribe(this.tabsHidden);
+      .subscribe(() => this.#tabsHidden());
 
     this.#tabService.showingTabs
       .pipe(takeUntil(this.#ngUnsubscribe))
-      .subscribe(this.tabsShown);
+      .subscribe(() => this.#tabsShown());
 
     this.#tabService.tabClicked
       .pipe(takeUntil(this.#ngUnsubscribe))
-      .subscribe(this.tabClicked);
+      .subscribe(() => this.#tabClicked());
   }
 
   public ngOnDestroy(): void {
+    this.#tabService.destroyGroup(this);
+
     this.#ngUnsubscribe.next();
     this.#ngUnsubscribe.complete();
+
+    this.#tabIdService.unregister(this.groupId);
   }
 
   public updateSlideDirection(event: any): void {
@@ -112,29 +147,51 @@ export class SkyVerticalTabsetGroupComponent implements OnInit, OnDestroy {
     this.#changeRef.markForCheck();
   }
 
-  public subMenuOpen(): boolean {
+  protected groupButtonArrowLeft(event: Event): void {
+    if (this.open) {
+      this.toggleMenuOpen();
+    }
+
+    event.preventDefault();
+  }
+
+  protected groupButtonArrowRight(event: Event): void {
+    if (this.open) {
+      this.tabs?.get(0)?.focusButton();
+    } else {
+      this.toggleMenuOpen();
+    }
+
+    event.preventDefault();
+  }
+
+  public isActive(): boolean {
     return !!this.tabs && this.tabs.find((t) => !!t.active) !== undefined;
   }
 
-  public tabClicked = () => {
+  #tabClicked(): void {
     this.#changeRef.markForCheck();
-  };
+  }
 
-  public tabsHidden = () => {
+  #tabsHidden(): void {
     // Angular will sometimes place the animation into the "void" state when tabs are hidden. Update our internal variable to reflect that.
     this.slideDirection = 'void';
     this.#changeRef.markForCheck();
-  };
+  }
 
-  public tabsShown = () => {
+  #tabsShown(): void {
     // Set the animation back up so that the "void" state is returned to where it was prior to the tabs being hidden.
     // This will be instantaneous due to there not being a "void -> *" state on the slide animation.
     this.#updateSlideDirection(true);
     this.#changeRef.markForCheck();
-  };
+  }
 
   #updateSlideDirection(animate: boolean): void {
     this.animationDisabled = !animate;
     this.slideDirection = this.open && !this.disabled ? 'down' : 'up';
+  }
+
+  #focusButton(): void {
+    this.#adapterService.focusButton(this.groupHeadingButton);
   }
 }

--- a/libs/components/tabs/src/lib/modules/vertical-tabset/vertical-tabset-group.service.ts
+++ b/libs/components/tabs/src/lib/modules/vertical-tabset/vertical-tabset-group.service.ts
@@ -1,0 +1,13 @@
+import { Injectable } from '@angular/core';
+
+import { Subject } from 'rxjs';
+
+import { SkyVerticalTabsetGroupMessage } from './vertical-tabset-group-message';
+
+/**
+ * @internal
+ */
+@Injectable()
+export class SkyVerticalTabsetGroupService {
+  public messageStream = new Subject<SkyVerticalTabsetGroupMessage>();
+}

--- a/libs/components/tabs/src/lib/modules/vertical-tabset/vertical-tabset.component.html
+++ b/libs/components/tabs/src/lib/modules/vertical-tabset/vertical-tabset.component.html
@@ -1,4 +1,8 @@
-<div class="sky-vertical-tabset">
+<div
+  class="sky-vertical-tabset"
+  [tabIndex]="tablistHasFocus ? -1 : 0"
+  (focus)="tabsetFocus()"
+>
   <!--
     ARIA rules do not allow tabpanel elements to be children of a tablist element.
     However, the markup for each sky-vertical-tab component includes both the tab button
@@ -15,7 +19,7 @@
     class="sky-vertical-tabset-tablist"
     [attr.aria-label]="ariaLabel"
     [attr.aria-labelledby]="ariaLabelledBy"
-    [attr.aria-owns]="ariaOwns"
+    [attr.aria-owns]="(tabIdSvc.ids | async)?.join(' ') || undefined"
     [attr.role]="isMobile ? undefined : ariaRole"
   ></span>
   <div
@@ -23,6 +27,11 @@
     class="sky-vertical-tabset-group-container"
     [@tabGroupEnter]="tabService.animationTabsVisibleState"
     [ngClass]="{ 'sky-vertical-tabset-hidden': !tabService.tabsVisible() }"
+    (keydown.arrowdown)="tabGroupsArrowDown(); $event.preventDefault()"
+    (keydown.arrowup)="tabGroupsArrowUp(); $event.preventDefault()"
+    (focusin)="tabGroupsFocusIn()"
+    (focusout)="tabGroupsFocusOut()"
+    #groupContainerWrapper
   >
     <ng-content />
   </div>

--- a/libs/components/tabs/src/lib/modules/vertical-tabset/vertical-tabset.component.spec.ts
+++ b/libs/components/tabs/src/lib/modules/vertical-tabset/vertical-tabset.component.spec.ts
@@ -22,65 +22,104 @@ import { SkyVerticalTabsetComponent } from './vertical-tabset.component';
 let mockQueryService: MockSkyMediaQueryService;
 
 function getVisibleTabContentPane(
-  fixture: ComponentFixture<any>,
+  fixture: ComponentFixture<unknown>,
 ): HTMLElement[] {
-  return fixture.nativeElement.querySelectorAll(
-    '.sky-vertical-tab-content-pane:not(.sky-vertical-tab-hidden)',
+  return Array.from(
+    fixture.nativeElement.querySelectorAll(
+      '.sky-vertical-tab-content-pane:not(.sky-vertical-tab-hidden)',
+    ),
   );
 }
 
-function getTabContentPanes(fixture: ComponentFixture<any>): HTMLElement[] {
-  return fixture.nativeElement.querySelectorAll(
-    '.sky-vertical-tab-content-pane',
+function getTabset(fixture: ComponentFixture<unknown>): HTMLElement {
+  return (fixture.nativeElement as HTMLElement).querySelector(
+    '.sky-vertical-tabset',
+  ) as HTMLElement;
+}
+
+function getTabContentPanes(fixture: ComponentFixture<unknown>): HTMLElement[] {
+  return Array.from(
+    fixture.nativeElement.querySelectorAll('.sky-vertical-tab-content-pane'),
   );
 }
 
 function getVisibleTabsetContent(
-  fixture: ComponentFixture<any>,
+  fixture: ComponentFixture<unknown>,
 ): HTMLElement[] {
-  return fixture.nativeElement.querySelectorAll(
-    '.sky-vertical-tabset-content:not(.sky-vertical-tabset-content-hidden)',
+  return Array.from(
+    fixture.nativeElement.querySelectorAll(
+      '.sky-vertical-tabset-content:not(.sky-vertical-tabset-content-hidden)',
+    ),
   );
 }
 
-function getTabsContainer(fixture: ComponentFixture<any>): HTMLElement[] {
-  return fixture.nativeElement.querySelectorAll(
+function getTabsContainer(fixture: ComponentFixture<unknown>): HTMLElement {
+  return fixture.nativeElement.querySelector(
     '.sky-vertical-tabset-group-container:not(.sky-vertical-tabset-hidden)',
   );
 }
 
-function getTabs(fixture: ComponentFixture<any>): HTMLElement[] {
-  return fixture.nativeElement.querySelectorAll('.sky-vertical-tab');
+function getTabs(fixture: ComponentFixture<unknown>): HTMLElement[] {
+  return Array.from(
+    fixture.nativeElement.querySelectorAll('.sky-vertical-tab'),
+  );
 }
 
-function getTabGroups(fixture: ComponentFixture<any>): HTMLElement[] {
-  return fixture.nativeElement.querySelectorAll('.sky-vertical-tabset-group');
+function getTabGroups(fixture: ComponentFixture<unknown>): HTMLElement[] {
+  return Array.from(
+    fixture.nativeElement.querySelectorAll('.sky-vertical-tabset-group'),
+  );
 }
 
-function getOpenTabGroups(fixture: ComponentFixture<any>): HTMLElement[] {
-  return fixture.nativeElement.querySelectorAll('.sky-expansion-indicator-up');
+function getOpenTabGroups(fixture: ComponentFixture<unknown>): HTMLElement[] {
+  return Array.from(
+    fixture.nativeElement.querySelectorAll('.sky-expansion-indicator-up'),
+  );
 }
 
-function clickGroupButton(fixture: ComponentFixture<any>, index: number): void {
-  getTabGroups(fixture)[index].querySelector('button')?.click();
+function getAllTabButtons(fixture: ComponentFixture<unknown>): HTMLElement[] {
+  return Array.from(
+    fixture.nativeElement.querySelectorAll('.sky-vertical-tabset-button'),
+  );
+}
+
+function getGroupButton(
+  fixture: ComponentFixture<unknown>,
+  index: number,
+): HTMLButtonElement | null {
+  return getTabGroups(fixture)[index].querySelector('button');
+}
+
+function clickGroupButton(
+  fixture: ComponentFixture<unknown>,
+  index: number,
+): void {
+  getGroupButton(fixture, index)?.click();
   fixture.detectChanges();
   tick();
 }
 
+function getTab(
+  fixture: ComponentFixture<unknown>,
+  groupIndex: number,
+  tabIndex: number,
+): HTMLElement {
+  return getTabGroups(fixture)[groupIndex].querySelectorAll(
+    '.sky-vertical-tab',
+  )[tabIndex] as HTMLElement;
+}
+
 function clickTab(
-  fixture: ComponentFixture<any>,
+  fixture: ComponentFixture<unknown>,
   groupIndex: number,
   tabIndex: number,
 ): void {
-  const tab = getTabGroups(fixture)[groupIndex].querySelectorAll(
-    '.sky-vertical-tab',
-  )[tabIndex] as HTMLElement;
-  tab.click();
+  getTab(fixture, groupIndex, tabIndex).click();
   fixture.detectChanges();
 }
 
 function expectGroupTabsAreVisible(
-  fixture: ComponentFixture<any>,
+  fixture: ComponentFixture<unknown>,
   index: number,
 ): void {
   const groupContent = getTabGroups(fixture)[index].querySelector(
@@ -92,7 +131,7 @@ function expectGroupTabsAreVisible(
 }
 
 function expectGroupTabsAreNotVisible(
-  fixture: ComponentFixture<any>,
+  fixture: ComponentFixture<unknown>,
   index: number,
 ): void {
   const groupContent = getTabGroups(fixture)[index].querySelector(
@@ -102,24 +141,77 @@ function expectGroupTabsAreNotVisible(
   expect(['0', '0px']).toContain(groupContent.style.height);
 }
 
-function expectOpenGroup(
-  fixture: ComponentFixture<any>,
+function expectActiveGroup(
+  fixture: ComponentFixture<unknown>,
   innerText: string,
 ): void {
-  const openGroupEl = fixture.nativeElement.querySelectorAll(
+  const openGroupEl = fixture.nativeElement.querySelector(
+    '.sky-vertical-tabset-group-header-active',
+  ) as HTMLElement | null;
+
+  expect(openGroupEl).toBeTruthy();
+  expect(openGroupEl?.textContent?.trim()).toBe(innerText);
+}
+
+function expectOpenGroup(
+  fixture: ComponentFixture<unknown>,
+  innerText: string,
+  open = true,
+): void {
+  const openGroupEl = fixture.nativeElement.querySelector(
     '.sky-vertical-tabset-group-header-sub-open',
-  );
-  expect(openGroupEl.length).toBe(1);
-  expect(openGroupEl[0].textContent.trim()).toBe(innerText);
+  ) as HTMLElement | null;
+
+  if (open) {
+    expect(openGroupEl).toBeTruthy();
+    expect(openGroupEl?.textContent?.trim()).toBe(innerText);
+  } else {
+    expect(openGroupEl?.textContent?.trim() === innerText).toBe(false);
+  }
 }
 
 function expectVisibleTabContentPane(
-  fixture: ComponentFixture<any>,
+  fixture: ComponentFixture<unknown>,
   innerText: string,
 ): void {
   const visibleTabContent = getVisibleTabContentPane(fixture);
   expect(visibleTabContent.length).toBe(1);
   expect(visibleTabContent[0]).toHaveText(innerText);
+}
+
+function elementHasFocus(el: HTMLElement | null): boolean {
+  return !!el && document.activeElement === el;
+}
+
+function fireKeyEvent(
+  el: HTMLElement | null,
+  eventName: 'keydown' | 'keyup',
+  key: string,
+): void {
+  SkyAppTestUtility.fireDomEvent(el, eventName, {
+    keyboardEventInit: {
+      key,
+    },
+  });
+}
+
+function fireTabsContainerKeydown(
+  fixture: ComponentFixture<unknown>,
+  key: string,
+): void {
+  fireKeyEvent(getTabsContainer(fixture), 'keydown', key);
+}
+
+function validateTabsKeyboardNav(
+  fixture: ComponentFixture<unknown>,
+  key: 'ArrowDown' | 'ArrowUp',
+  expectedActiveIndex: number,
+): void {
+  fireTabsContainerKeydown(fixture, key);
+
+  expect(
+    elementHasFocus(getAllTabButtons(fixture)[expectedActiveIndex]),
+  ).toBeTrue();
 }
 // #endregion
 
@@ -138,7 +230,7 @@ describe('Vertical tabset component', () => {
     });
   });
 
-  function createTestComponent() {
+  function createTestComponent(): ComponentFixture<VerticalTabsetTestComponent> {
     const fixture = TestBed.overrideComponent(SkyVerticalTabsetComponent, {
       add: {
         providers: [
@@ -187,8 +279,8 @@ describe('Vertical tabset component', () => {
     // check open tab
     expectVisibleTabContentPane(fixture, 'Group 2 Tab 2 content');
 
-    // check if parent group of selected tab has "open" CSS class
-    expectOpenGroup(fixture, 'Group 2');
+    // check if parent group of selected tab has "active" CSS class
+    expectActiveGroup(fixture, 'Group 2');
 
     flush();
   }));
@@ -201,11 +293,7 @@ describe('Vertical tabset component', () => {
     const tabs = getTabs(fixture);
 
     // open second tab
-    SkyAppTestUtility.fireDomEvent(tabs[1], 'keyup', {
-      keyboardEventInit: {
-        key: 'enter',
-      },
-    });
+    fireKeyEvent(tabs[1], 'keyup', 'enter');
     fixture.detectChanges();
 
     // check open tab
@@ -222,15 +310,169 @@ describe('Vertical tabset component', () => {
     const tabs = getTabs(fixture);
 
     // open second tab
-    SkyAppTestUtility.fireDomEvent(tabs[1], 'keyup', {
-      keyboardEventInit: {
-        key: ' ',
-      },
-    });
+    fireKeyEvent(tabs[1], 'keyup', ' ');
     fixture.detectChanges();
 
     // check open tab
     expectVisibleTabContentPane(fixture, 'Group 1 Tab 2 content');
+
+    flush();
+  }));
+
+  it('should expand and collapse groups with the left and right arrow keys', () => {
+    mockQueryService.fire(SkyMediaBreakpoints.lg);
+    const fixture = createTestComponent();
+    fixture.detectChanges();
+
+    const groupButton = getGroupButton(fixture, 0);
+
+    expectOpenGroup(fixture, 'Group 1');
+
+    fireKeyEvent(groupButton, 'keyup', 'ArrowLeft');
+    fixture.detectChanges();
+
+    expectOpenGroup(fixture, 'Group 1', false);
+
+    fireKeyEvent(groupButton, 'keyup', 'ArrowRight');
+    fixture.detectChanges();
+
+    expectOpenGroup(fixture, 'Group 1');
+  });
+
+  it('should move to the first item in a group with the right arrow key', () => {
+    mockQueryService.fire(SkyMediaBreakpoints.lg);
+    const fixture = createTestComponent();
+    fixture.detectChanges();
+
+    const groupButton = getGroupButton(fixture, 0);
+
+    expectOpenGroup(fixture, 'Group 1');
+
+    fireKeyEvent(groupButton, 'keyup', 'ArrowRight');
+    fixture.detectChanges();
+
+    expect(elementHasFocus(getTab(fixture, 0, 0))).toBeTrue();
+  });
+
+  it('should focus parent group when left arrow is pressed', fakeAsync(() => {
+    mockQueryService.fire(SkyMediaBreakpoints.lg);
+    const fixture = createTestComponent();
+    fixture.detectChanges();
+
+    clickGroupButton(fixture, 1);
+
+    // click second tab in second group
+    clickTab(fixture, 1, 1);
+
+    fireKeyEvent(getTab(fixture, 1, 1), 'keyup', 'ArrowLeft');
+
+    expect(elementHasFocus(getGroupButton(fixture, 1))).toBeTrue();
+
+    flush();
+  }));
+
+  it('should navigate between tabs when up and down arrow keys are pressed', () => {
+    mockQueryService.fire(SkyMediaBreakpoints.lg);
+    const fixture = createTestComponent();
+    fixture.detectChanges();
+
+    const tabsContainer = getTabsContainer(fixture);
+    const allButtons = getAllTabButtons(fixture);
+    const groups = getTabGroups(fixture);
+
+    // This will focus the active tab, which is the second tab button
+    // (the first being its group button)
+    SkyAppTestUtility.fireDomEvent(tabsContainer, 'focus');
+
+    // The last group is disabled, so get the penultimate group.
+    const lastEnabledGroupButton = getGroupButton(
+      fixture,
+      groups.length - 2,
+    ) as HTMLButtonElement;
+
+    validateTabsKeyboardNav(fixture, 'ArrowDown', 2);
+    validateTabsKeyboardNav(fixture, 'ArrowDown', 3);
+    validateTabsKeyboardNav(fixture, 'ArrowUp', 2);
+    validateTabsKeyboardNav(fixture, 'ArrowUp', 1);
+    validateTabsKeyboardNav(fixture, 'ArrowUp', 0);
+
+    // Validate focus circles back to the top or bottom.
+    validateTabsKeyboardNav(
+      fixture,
+      'ArrowUp',
+      allButtons.indexOf(lastEnabledGroupButton),
+    );
+    validateTabsKeyboardNav(fixture, 'ArrowDown', 0);
+  });
+
+  it('should focus the active tab when the tabs container is focused', fakeAsync(() => {
+    mockQueryService.fire(SkyMediaBreakpoints.lg);
+    const fixture = createTestComponent();
+    fixture.detectChanges();
+
+    const tabset = getTabset(fixture);
+    const tabsContainer = getTabsContainer(fixture);
+
+    clickGroupButton(fixture, 1);
+
+    // click second tab in second group
+    clickTab(fixture, 1, 1);
+
+    // Disallow tabbing to the tabset while focus is in the tabs container.
+    SkyAppTestUtility.fireDomEvent(tabsContainer, 'focusin');
+    fixture.detectChanges();
+    expect(tabset.tabIndex).toBe(-1);
+
+    SkyAppTestUtility.fireDomEvent(tabsContainer, 'focus');
+
+    expect(elementHasFocus(getTab(fixture, 1, 1))).toBeTrue();
+
+    // Enable tabbing to the tabset when focus leaves the tabs container.
+    SkyAppTestUtility.fireDomEvent(tabsContainer, 'focusout');
+    fixture.detectChanges();
+    expect(tabset.tabIndex).toBe(0);
+
+    flush();
+  }));
+
+  it('should focus the first tab when the tabs container is focused and no tab is active', () => {
+    mockQueryService.fire(SkyMediaBreakpoints.lg);
+    const fixture = createTestComponent();
+
+    fixture.componentInstance.active = false;
+    fixture.detectChanges();
+
+    const tabsContainer = getTabsContainer(fixture);
+
+    const tabButtons = getAllTabButtons(fixture);
+
+    expect(elementHasFocus(tabButtons[0])).toBeFalse();
+
+    SkyAppTestUtility.fireDomEvent(tabsContainer, 'focus');
+
+    expect(elementHasFocus(tabButtons[0])).toBeTrue();
+  });
+
+  it("should focus the active tab's group when the tabs container is focused and the tab's group is collapsed", fakeAsync(() => {
+    mockQueryService.fire(SkyMediaBreakpoints.lg);
+    const fixture = createTestComponent();
+    fixture.detectChanges();
+
+    const tabsContainer = getTabsContainer(fixture);
+
+    clickGroupButton(fixture, 1);
+
+    // click second tab in second group
+    clickTab(fixture, 1, 1);
+
+    clickGroupButton(fixture, 1);
+
+    expectOpenGroup(fixture, 'Group 2', false);
+    expect(elementHasFocus(getGroupButton(fixture, 1))).toBeFalse();
+
+    SkyAppTestUtility.fireDomEvent(tabsContainer, 'focus');
+
+    expect(elementHasFocus(getGroupButton(fixture, 1))).toBeTrue();
 
     flush();
   }));
@@ -335,7 +577,7 @@ describe('Vertical tabset component', () => {
 
     // check tabs are not visible
     const tabs = getTabsContainer(fixture);
-    expect(tabs.length).toBe(0);
+    expect(tabs).toBeFalsy();
   });
 
   it('show tabs button should show tabs on mobile', () => {
@@ -347,7 +589,7 @@ describe('Vertical tabset component', () => {
 
     // check tabs are not visible
     const tabs = getTabsContainer(fixture);
-    expect(tabs.length).toBe(0);
+    expect(tabs).toBeFalsy();
 
     // check content is visible
     let visibleTabs = getVisibleTabContentPane(fixture);
@@ -364,7 +606,7 @@ describe('Vertical tabset component', () => {
 
     // check tabs are visible
     const tabsUpdated = getTabsContainer(fixture);
-    expect(tabsUpdated.length).toBe(1);
+    expect(tabsUpdated).toBeTruthy();
 
     // check content is not visible
     visibleTabs = getVisibleTabsetContent(fixture);
@@ -394,7 +636,7 @@ describe('Vertical tabset component', () => {
 
     // check tabs are not visible
     const tabs = getTabsContainer(fixture);
-    expect(tabs.length).toBe(0);
+    expect(tabs).toBeFalsy();
 
     // check content is visible
     const visibleTabs = getVisibleTabContentPane(fixture);
@@ -436,7 +678,7 @@ describe('Vertical tabset component', () => {
 
     // check tabs are not visible
     const tabs = getTabsContainer(fixture);
-    expect(tabs.length).toBe(0);
+    expect(tabs).toBeFalsy();
 
     // check content is visible
     const visibleTabs = getVisibleTabContentPane(fixture);
@@ -464,7 +706,7 @@ describe('Vertical tabset component', () => {
 
     // check tabs are visible
     const tabs = getTabsContainer(fixture);
-    expect(tabs.length).toBe(1);
+    expect(tabs).toBeTruthy();
 
     // check content is visible
     const visibleTabs = getVisibleTabContentPane(fixture);
@@ -632,8 +874,8 @@ describe('Vertical tabset component', () => {
     expect(visibleTabs.length).toBe(1);
     expect(visibleTabs[0]).toHaveText('Group 2 Tab 2 content');
 
-    // check open group
-    expectOpenGroup(fixture, 'Group 2');
+    // check active group
+    expectActiveGroup(fixture, 'Group 2');
 
     fixture.detectChanges();
 

--- a/libs/components/tabs/src/lib/modules/vertical-tabset/vertical-tabset.component.ts
+++ b/libs/components/tabs/src/lib/modules/vertical-tabset/vertical-tabset.component.ts
@@ -121,36 +121,32 @@ export class SkyVerticalTabsetComponent
   public ariaOwns: string | undefined;
 
   public isMobile = false;
+
+  protected tablistHasFocus = false;
+
   #ngUnsubscribe = new Subject<void>();
   #_ariaRole = 'tablist';
 
   #resources: SkyLibResourcesService;
   #changeRef: ChangeDetectorRef;
-  #tabIdSvc: SkyTabIdService;
 
   constructor(
     public adapterService: SkyVerticalTabsetAdapterService,
     public tabService: SkyVerticalTabsetService,
     resources: SkyLibResourcesService,
     changeRef: ChangeDetectorRef,
-    tabIdSvc: SkyTabIdService,
+    public tabIdSvc: SkyTabIdService,
   ) {
     this.#resources = resources;
     this.#changeRef = changeRef;
-    this.#tabIdSvc = tabIdSvc;
-
-    this.#tabIdSvc.ids.pipe(takeUntil(this.#ngUnsubscribe)).subscribe((ids) => {
-      this.ariaOwns = ids.join(' ') || undefined;
-      this.#changeRef.markForCheck();
-    });
   }
 
-  public ngOnInit() {
+  public ngOnInit(): void {
     this.tabService.maintainTabContent = this.maintainTabContent;
 
     this.tabService.indexChanged
       .pipe(takeUntil(this.#ngUnsubscribe))
-      .subscribe((index: any) => {
+      .subscribe((index) => {
         this.activeChange.emit(index);
         if (this.contentWrapper) {
           this.adapterService.scrollToContentTop(this.contentWrapper);
@@ -184,13 +180,37 @@ export class SkyVerticalTabsetComponent
     }
   }
 
-  public ngAfterViewChecked() {
+  public ngAfterViewChecked(): void {
     this.tabService.content = this.content;
     this.tabService.updateContent();
   }
 
-  public ngOnDestroy() {
+  public ngOnDestroy(): void {
     this.#ngUnsubscribe.next();
     this.#ngUnsubscribe.complete();
+  }
+
+  protected tabsetFocus(): void {
+    this.tabService.focusActiveTab(this.tabGroups);
+  }
+
+  protected tabGroupsFocusIn(): void {
+    // This will set the tab index of the the vertical tabset element to -1
+    // while focus is inside the tab list, allowing Shift+Tab to move
+    // to the next element above the tab list element. Otherwise focus would
+    // be trapped on the currently focused tab.
+    this.tablistHasFocus = true;
+  }
+
+  protected tabGroupsFocusOut(): void {
+    this.tablistHasFocus = false;
+  }
+
+  protected tabGroupsArrowDown(): void {
+    this.adapterService.focusNextButton(this.tabGroups);
+  }
+
+  protected tabGroupsArrowUp(): void {
+    this.adapterService.focusPreviousButton(this.tabGroups);
   }
 }

--- a/libs/components/tabs/src/lib/modules/vertical-tabset/vertical-tabset.service.spec.ts
+++ b/libs/components/tabs/src/lib/modules/vertical-tabset/vertical-tabset.service.spec.ts
@@ -1,5 +1,8 @@
+import { TestBed } from '@angular/core/testing';
+import { SkyMediaQueryService } from '@skyux/core';
 import { MockSkyMediaQueryService } from '@skyux/core/testing';
 
+import { SkyVerticalTabsetAdapterService } from './vertical-tabset-adapter.service';
 import { SkyVerticalTabsetService } from './vertical-tabset.service';
 
 describe('Vertical tabset service', () => {
@@ -7,7 +10,18 @@ describe('Vertical tabset service', () => {
   const mockQueryService = new MockSkyMediaQueryService();
 
   beforeEach(() => {
-    service = new SkyVerticalTabsetService(mockQueryService as any);
+    TestBed.configureTestingModule({
+      providers: [
+        SkyVerticalTabsetService,
+        SkyVerticalTabsetAdapterService,
+        {
+          provide: SkyMediaQueryService,
+          useValue: mockQueryService,
+        },
+      ],
+    });
+
+    service = TestBed.inject(SkyVerticalTabsetService);
   });
 
   it('should add two non active tabs', () => {


### PR DESCRIPTION
:cherries: Cherry picked from #1978 [feat(components/tabs): add keyboard navigation to vertical tabset](https://github.com/blackbaud/skyux/pull/1978)

[AB#2599941](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/2599941) 