### PR TITLE
chore(components/theme): update @skyux/icons to 6.9.0 (#1987)

### DIFF
--- a/libs/components/theme/package.json
+++ b/libs/components/theme/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@blackbaud/skyux-design-tokens": "0.0.28",
-    "@skyux/icons": "6.8.0",
+    "@skyux/icons": "6.9.0",
     "fontfaceobserver": "2.3.0",
     "tslib": "^2.6.2"
   }

--- a/libs/components/theme/src/lib/styles/sky.scss
+++ b/libs/components/theme/src/lib/styles/sky.scss
@@ -23,4 +23,4 @@
 @forward 'type';
 
 @import url('https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css');
-@import url('https://sky.blackbaudcdn.net/static/skyux-icons/6.8.0/assets/css/skyux-icons.min.css');
+@import url('https://sky.blackbaudcdn.net/static/skyux-icons/6.9.0/assets/css/skyux-icons.min.css');

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "@blackbaud/skyux-design-tokens": "0.0.28",
         "@nx/angular": "17.2.8",
         "@skyux/auth-client-factory": "1.2.0",
-        "@skyux/icons": "6.8.0",
+        "@skyux/icons": "6.9.0",
         "ag-grid-angular": "29.3.5",
         "ag-grid-community": "29.3.5",
         "autonumeric": "4.10.4",
@@ -10068,9 +10068,9 @@
       }
     },
     "node_modules/@skyux/icons": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/@skyux/icons/-/icons-6.8.0.tgz",
-      "integrity": "sha512-dCw9Nde20gcvQ1EFTtOUdUwMS7yAnP7bBZ0d14+/YXREQYPf/Kk+P5r2XI+z7KtzODf+NFw1RNbtsP0ulq9+pw=="
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@skyux/icons/-/icons-6.9.0.tgz",
+      "integrity": "sha512-28dxsCj68Ti2jO11+KwdDtGILEgekynQo1kKowCU20iTKP/N+n0ZZta6nGksXTOZiduBCdN8rjjiGPGJvGZnww=="
     },
     "node_modules/@socket.io/component-emitter": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "@blackbaud/skyux-design-tokens": "0.0.28",
     "@nx/angular": "17.2.8",
     "@skyux/auth-client-factory": "1.2.0",
-    "@skyux/icons": "6.8.0",
+    "@skyux/icons": "6.9.0",
     "ag-grid-angular": "29.3.5",
     "ag-grid-community": "29.3.5",
     "autonumeric": "4.10.4",


### PR DESCRIPTION
:cherries: Cherry picked from #1987 [chore(components/theme): update @skyux/icons to 6.9.0](https://github.com/blackbaud/skyux/pull/1987)