### PR TITLE
feat(components/forms): hide required asterisk from screen readers (#1982)

### DIFF
--- a/libs/components/theme/src/lib/styles/_public-api/_compat/_mixins.scss
+++ b/libs/components/theme/src/lib/styles/_public-api/_compat/_mixins.scss
@@ -141,7 +141,9 @@
 }
 
 @mixin sky-required-field {
+  /* TODO: remove this fallback `content` line, once support for content alt text is added to firefox & safari */
   content: '*';
+  content: '*' / '';
   color: var(--sky-highlight-color-danger);
   padding-left: compatVars.$sky-padding-half;
 }


### PR DESCRIPTION
:cherries: Cherry picked from #1982 [feat(components/forms): hide required asterisk from screen readers](https://github.com/blackbaud/skyux/pull/1982)