### PR TITLE
fix(components/forms): document form error inputs as required (#2011)

### DIFF
--- a/libs/components/forms/src/lib/modules/form-error/form-error.component.ts
+++ b/libs/components/forms/src/lib/modules/form-error/form-error.component.ts
@@ -42,12 +42,14 @@ import { SKY_FORM_ERRORS_ENABLED } from './form-errors-enabled-token';
 export class SkyFormErrorComponent {
   /**
    * The name of the error.
+   * @required
    */
   @Input({ required: true })
   public errorName!: string;
 
   /**
    * The error message to display.
+   * @required
    */
   @Input({ required: true })
   public errorText!: string;


### PR DESCRIPTION
:cherries: Cherry picked from #2011 [fix(components/forms): document form error inputs as required](https://github.com/blackbaud/skyux/pull/2011)