### PR TITLE
fix(components/tiles): tile summary is not visible to screen readers when tile is expanded (#2002)

### DIFF
--- a/libs/components/tiles/src/lib/modules/tiles/tile/tile.component.scss
+++ b/libs/components/tiles/src/lib/modules/tiles/tile/tile.component.scss
@@ -26,7 +26,7 @@
 
 .sky-tile-summary {
   color: $sky-text-color-action-primary;
-  opacity: 0;
+  display: none;
   padding-right: $sky-tile-header-tool-padding;
   transition: opacity $sky-transition-time-medium;
   max-height: 30px;
@@ -35,7 +35,7 @@
 
 .sky-tile-collapsed {
   .sky-tile-summary {
-    opacity: 1;
+    display: block;
   }
 }
 


### PR DESCRIPTION
:cherries: Cherry picked from #2002 [fix(components/tiles): tile summary is not visible to screen readers when tile is expanded](https://github.com/blackbaud/skyux/pull/2002)

[AB#2599959](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/2599959) 