### PR TITLE
feat(components/ag-grid): support custom label for row selector (#2029)

### DIFF
--- a/apps/code-examples/src/app/code-examples/ag-grid/data-entry-grid/basic/demo.component.ts
+++ b/apps/code-examples/src/app/code-examples/ag-grid/data-entry-grid/basic/demo.component.ts
@@ -17,9 +17,10 @@ import {
   GridReadyEvent,
   ValueFormatterParams,
 } from 'ag-grid-community';
+import { of } from 'rxjs';
 
 import { ContextMenuComponent } from './context-menu.component';
-import { AG_GRID_DEMO_DATA } from './data';
+import { AG_GRID_DEMO_DATA, AgGridDemoRow } from './data';
 import { EditModalContext } from './edit-modal-context';
 import { EditModalComponent } from './edit-modal.component';
 
@@ -40,6 +41,10 @@ export class DemoComponent {
     {
       field: 'selected',
       type: SkyCellType.RowSelector,
+      cellRendererParams: {
+        // Could be a SkyAppResourcesService.getString call that returns an observable.
+        label: (data: AgGridDemoRow) => of(`Select ${data.name}`),
+      },
     },
     {
       colId: 'context',

--- a/apps/code-examples/src/app/code-examples/ag-grid/data-entry-grid/data-manager-added/view-grid.component.ts
+++ b/apps/code-examples/src/app/code-examples/ag-grid/data-entry-grid/data-manager-added/view-grid.component.ts
@@ -24,7 +24,7 @@ import {
   RowSelectedEvent,
   ValueFormatterParams,
 } from 'ag-grid-community';
-import { Subject, takeUntil } from 'rxjs';
+import { Subject, of, takeUntil } from 'rxjs';
 
 import { ContextMenuComponent } from './context-menu.component';
 import { AgGridDemoRow } from './data';
@@ -54,6 +54,10 @@ export class ViewGridComponent implements OnInit, OnDestroy {
     {
       field: 'selected',
       type: SkyCellType.RowSelector,
+      cellRendererParams: {
+        // Could be a SkyAppResourcesService.getString call that returns an observable.
+        label: (data: AgGridDemoRow) => of(`Select ${data.name}`),
+      },
     },
     {
       colId: 'context',

--- a/apps/code-examples/src/app/code-examples/ag-grid/data-entry-grid/inline-help/demo.component.ts
+++ b/apps/code-examples/src/app/code-examples/ag-grid/data-entry-grid/inline-help/demo.component.ts
@@ -21,9 +21,10 @@ import {
   GridReadyEvent,
   ValueFormatterParams,
 } from 'ag-grid-community';
+import { of } from 'rxjs';
 
 import { ContextMenuComponent } from './context-menu.component';
-import { AG_GRID_DEMO_DATA } from './data';
+import { AG_GRID_DEMO_DATA, AgGridDemoRow } from './data';
 import { EditModalContext } from './edit-modal-context';
 import { EditModalComponent } from './edit-modal.component';
 import { InlineHelpComponent } from './inline-help.component';
@@ -45,6 +46,10 @@ export class DemoComponent {
     {
       field: 'selected',
       type: SkyCellType.RowSelector,
+      cellRendererParams: {
+        // Could be a SkyAppResourcesService.getString call that returns an observable.
+        label: (data: AgGridDemoRow) => of(`Select ${data.name}`),
+      },
     },
     {
       colId: 'context',

--- a/apps/code-examples/src/app/code-examples/ag-grid/data-grid/basic-multiselect/demo.component.ts
+++ b/apps/code-examples/src/app/code-examples/ag-grid/data-grid/basic-multiselect/demo.component.ts
@@ -10,9 +10,10 @@ import {
   GridReadyEvent,
   ValueFormatterParams,
 } from 'ag-grid-community';
+import { of } from 'rxjs';
 
 import { ContextMenuComponent } from './context-menu.component';
-import { AG_GRID_DEMO_DATA } from './data';
+import { AG_GRID_DEMO_DATA, AgGridDemoRow } from './data';
 
 @Component({
   standalone: true,
@@ -30,6 +31,10 @@ export class DemoComponent {
     {
       field: 'selected',
       type: SkyCellType.RowSelector,
+      cellRendererParams: {
+        // Could be a SkyAppResourcesService.getString call that returns an observable.
+        label: (data: AgGridDemoRow) => of(`Select ${data.name}`),
+      },
     },
     {
       colId: 'context',

--- a/apps/code-examples/src/app/code-examples/ag-grid/data-grid/data-manager-multiselect/view-grid.component.ts
+++ b/apps/code-examples/src/app/code-examples/ag-grid/data-grid/data-manager-multiselect/view-grid.component.ts
@@ -27,7 +27,7 @@ import {
   RowSelectedEvent,
   ValueFormatterParams,
 } from 'ag-grid-community';
-import { Subject, takeUntil } from 'rxjs';
+import { Subject, of, takeUntil } from 'rxjs';
 
 import { ContextMenuComponent } from './context-menu.component';
 import { AgGridDemoRow } from './data';
@@ -54,6 +54,10 @@ export class ViewGridComponent implements OnInit, OnDestroy {
     {
       field: 'selected',
       type: SkyCellType.RowSelector,
+      cellRendererParams: {
+        // Could be a SkyAppResourcesService.getString call that returns an observable.
+        label: (data: AgGridDemoRow) => of(`Select ${data.name}`),
+      },
     },
     {
       colId: 'context',

--- a/apps/code-examples/src/app/code-examples/ag-grid/data-grid/inline-help/demo.component.ts
+++ b/apps/code-examples/src/app/code-examples/ag-grid/data-grid/inline-help/demo.component.ts
@@ -17,9 +17,10 @@ import {
   GridReadyEvent,
   ValueFormatterParams,
 } from 'ag-grid-community';
+import { of } from 'rxjs';
 
 import { ContextMenuComponent } from './context-menu.component';
-import { AG_GRID_DEMO_DATA } from './data';
+import { AG_GRID_DEMO_DATA, AgGridDemoRow } from './data';
 import { InlineHelpComponent } from './inline-help.component';
 
 @Component({
@@ -40,6 +41,10 @@ export class DemoComponent {
     {
       field: 'selected',
       type: SkyCellType.RowSelector,
+      cellRendererParams: {
+        // Could be a SkyAppResourcesService.getString call that returns an observable.
+        label: (data: AgGridDemoRow) => of(`Select ${data.name}`),
+      },
     },
     {
       colId: 'context',

--- a/apps/code-examples/src/app/code-examples/ag-grid/data-grid/top-scroll/demo.component.ts
+++ b/apps/code-examples/src/app/code-examples/ag-grid/data-grid/top-scroll/demo.component.ts
@@ -12,9 +12,10 @@ import {
   GridReadyEvent,
   ValueFormatterParams,
 } from 'ag-grid-community';
+import { of } from 'rxjs';
 
 import { ContextMenuComponent } from './context-menu.component';
-import { AG_GRID_DEMO_DATA } from './data';
+import { AG_GRID_DEMO_DATA, AgGridDemoRow } from './data';
 
 @Component({
   standalone: true,
@@ -40,6 +41,10 @@ export class DemoComponent {
     {
       field: 'selected',
       type: SkyCellType.RowSelector,
+      cellRendererParams: {
+        // Could be a SkyAppResourcesService.getString call that returns an observable.
+        label: (data: AgGridDemoRow) => of(`Select ${data.name}`),
+      },
     },
     {
       field: 'name',

--- a/apps/code-examples/src/app/code-examples/data-manager/data-manager/basic/view-grid.component.ts
+++ b/apps/code-examples/src/app/code-examples/data-manager/data-manager/basic/view-grid.component.ts
@@ -23,7 +23,7 @@ import {
   GridReadyEvent,
   RowSelectedEvent,
 } from 'ag-grid-community';
-import { Subject } from 'rxjs';
+import { Subject, of } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 
 import { DataManagerDemoRow } from './data';
@@ -57,6 +57,10 @@ export class ViewGridComponent implements OnInit, OnDestroy {
       suppressMovable: true,
       lockPosition: true,
       lockVisible: true,
+      cellRendererParams: {
+        // Could be a SkyAppResourcesService.getString call that returns an observable.
+        label: (data: DataManagerDemoRow) => of(`Select ${data.name}`),
+      },
     },
     {
       colId: 'name',

--- a/apps/playground/src/app/components/ag-grid/edit-complex-cells/edit-complex-cells.component.ts
+++ b/apps/playground/src/app/components/ag-grid/edit-complex-cells/edit-complex-cells.component.ts
@@ -92,6 +92,9 @@ export class EditComplexCellsComponent implements OnInit {
         field: 'selected',
         colId: 'selected',
         type: SkyCellType.RowSelector,
+        cellRendererParams: {
+          label: (data: any) => of(`Select ${data.name}`),
+        },
       },
       {
         colId: 'name',

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/cell-renderers/cell-renderer-row-selector/cell-renderer-row-selector.component.html
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/cell-renderers/cell-renderer-row-selector/cell-renderer-row-selector.component.html
@@ -1,11 +1,7 @@
 <sky-checkbox
   data-sky-id="row-checkbox"
   [tabindex]="-1"
-  [label]="'sky_ag_grid_row_selector_aria_label' | skyLibResources : rowNumber"
-  [attr.aria-label]="
-    'sky_ag_grid_row_selector_aria_label' | skyLibResources : rowNumber
-  "
+  [label]="(label | async) || ''"
   [(ngModel)]="checked"
   (change)="updateRow()"
->
-</sky-checkbox>
+/>

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/cell-renderers/cell-renderer-row-selector/cell-renderer-row-selector.component.spec.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/cell-renderers/cell-renderer-row-selector/cell-renderer-row-selector.component.spec.ts
@@ -15,6 +15,7 @@ import {
   RowClickedEvent,
   RowNode,
 } from 'ag-grid-community';
+import { Observable, of } from 'rxjs';
 
 import { SkyAgGridFixtureComponent } from '../../fixtures/ag-grid.component.fixture';
 import { SkyAgGridFixtureModule } from '../../fixtures/ag-grid.module.fixture';
@@ -45,6 +46,9 @@ describe('SkyCellRendererCheckboxComponent', () => {
     cellRendererParams = {
       colDef: {
         field: dataField,
+        cellRendererParams: {
+          label: 'Select',
+        },
       },
     };
   });
@@ -112,9 +116,14 @@ describe('SkyCellRendererCheckboxComponent', () => {
       expect(checkbox.selected).toBe(false);
       expect(rowSelectorCellComponent.rowNode).toBeUndefined();
 
-      rowSelectorCellComponent.agInit(
-        cellRendererParams as ICellRendererParams,
-      );
+      rowSelectorCellComponent.agInit({
+        ...cellRendererParams,
+        colDef: {
+          cellRendererParams: {
+            label: (): string => 'Select',
+          },
+        },
+      } as ICellRendererParams);
 
       rowSelectorCellFixture.detectChanges();
       tick();
@@ -298,6 +307,15 @@ describe('SkyCellRendererCheckboxComponent', () => {
   });
 
   it('should pass accessibility', async () => {
+    rowSelectorCellComponent.agInit({
+      ...cellRendererParams,
+      colDef: {
+        cellRendererParams: {
+          label: (): Observable<string> => of('Select'),
+        },
+      },
+    } as ICellRendererParams);
+
     rowSelectorCellFixture.detectChanges();
     await rowSelectorCellFixture.whenStable();
 

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/cell-renderers/cell-renderer-row-selector/cell-renderer-row-selector.component.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/cell-renderers/cell-renderer-row-selector/cell-renderer-row-selector.component.ts
@@ -2,8 +2,11 @@ import {
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
+  OnDestroy,
   ViewEncapsulation,
+  inject,
 } from '@angular/core';
+import { SkyLibResourcesService } from '@skyux/i18n';
 
 import { ICellRendererAngularComp } from 'ag-grid-angular';
 import {
@@ -12,6 +15,7 @@ import {
   RowNode,
   RowSelectedEvent,
 } from 'ag-grid-community';
+import { BehaviorSubject, Subscription } from 'rxjs';
 
 /**
  * @internal
@@ -24,18 +28,27 @@ import {
   encapsulation: ViewEncapsulation.None,
 })
 export class SkyAgGridCellRendererRowSelectorComponent
-  implements ICellRendererAngularComp
+  implements ICellRendererAngularComp, OnDestroy
 {
   public checked: boolean | undefined;
   public dataField: string | undefined;
   public rowNode: IRowNode | undefined;
   public rowNumber: number | undefined;
 
-  #params: ICellRendererParams | undefined;
-  #changeDetector: ChangeDetectorRef;
+  protected readonly label = new BehaviorSubject('');
 
-  constructor(changeDetector: ChangeDetectorRef) {
-    this.#changeDetector = changeDetector;
+  readonly #changeDetector = inject(ChangeDetectorRef);
+  readonly #labelResourceKey = 'sky_ag_grid_row_selector_aria_label';
+  #params: ICellRendererParams | undefined;
+  readonly #resources = inject(SkyLibResourcesService);
+  #subscription = new Subscription();
+
+  constructor() {
+    this.#setDefaultLabel();
+  }
+
+  public ngOnDestroy(): void {
+    this.#subscription.unsubscribe();
   }
 
   /**
@@ -83,7 +96,28 @@ export class SkyAgGridCellRendererRowSelectorComponent
     this.dataField = this.#params.colDef?.field;
     this.rowNode = this.#params?.node as IRowNode | undefined;
     this.rowNumber = this.#params.rowIndex + 1;
-    const rowSelected = this.#params.node.isSelected();
+
+    this.#subscription.unsubscribe();
+    this.#subscription = new Subscription();
+    this.#subscription.add(
+      this.label.subscribe(() => this.#changeDetector.markForCheck()),
+    );
+    if (typeof params.colDef?.cellRendererParams?.label === 'string') {
+      this.label.next(params.colDef.cellRendererParams.label);
+    } else if (typeof params.colDef?.cellRendererParams?.label === 'function') {
+      const label = params.colDef.cellRendererParams.label(params.data);
+      if (label.subscribe) {
+        this.#subscription.add(
+          label.subscribe((value: string) => this.label.next(value)),
+        );
+      } else {
+        this.label.next(label);
+      }
+    } else {
+      this.#setDefaultLabel();
+    }
+
+    const rowSelected = !!this.#params.node?.isSelected();
 
     if (this.dataField) {
       this.checked = !!this.#params.value;
@@ -95,6 +129,14 @@ export class SkyAgGridCellRendererRowSelectorComponent
     }
 
     this.#changeDetector.markForCheck();
+  }
+
+  #setDefaultLabel(): void {
+    this.#subscription.add(
+      this.#resources
+        .getString(this.#labelResourceKey, this.rowNumber ?? '')
+        .subscribe((value) => this.label.next(value)),
+    );
   }
 
   #rowSelectedListener(event: RowSelectedEvent): void {

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/cell-renderers/cell-renderer-row-selector/cell-renderer-row-selector.module.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/cell-renderers/cell-renderer-row-selector/cell-renderer-row-selector.module.ts
@@ -1,3 +1,4 @@
+import { AsyncPipe } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { SkyCheckboxModule } from '@skyux/forms';
@@ -6,7 +7,12 @@ import { SkyAgGridResourcesModule } from '../../../shared/sky-ag-grid-resources.
 import { SkyAgGridCellRendererRowSelectorComponent } from '../cell-renderer-row-selector/cell-renderer-row-selector.component';
 
 @NgModule({
-  imports: [SkyAgGridResourcesModule, SkyCheckboxModule, FormsModule],
+  imports: [
+    AsyncPipe,
+    SkyAgGridResourcesModule,
+    SkyCheckboxModule,
+    FormsModule,
+  ],
   declarations: [SkyAgGridCellRendererRowSelectorComponent],
   exports: [SkyAgGridCellRendererRowSelectorComponent],
 })


### PR DESCRIPTION
:cherries: Cherry picked from #2029 [feat(components/ag-grid): support custom label for row selector](https://github.com/blackbaud/skyux/pull/2029)

[AB#2588291](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/2588291) 