### PR TITLE
fix(components/datetime): keep date consistent when switching meridies (#2034)

### DIFF
--- a/libs/components/datetime/src/lib/modules/timepicker/timepicker.component.spec.ts
+++ b/libs/components/datetime/src/lib/modules/timepicker/timepicker.component.spec.ts
@@ -703,6 +703,29 @@ describe('Timepicker', () => {
       fixture.destroy();
     });
 
+    it('should not change date when switching meridies', fakeAsync(() => {
+      detectChangesAndTick(fixture);
+      openTimepicker(fixture);
+      detectChangesAndTick(fixture);
+
+      const meridieButtons = getMeridieButtons();
+      const date = component.timepickerComponent.selectedTime?.iso8601.getDay;
+
+      meridieButtons.item(1).click();
+
+      expect(component.timepickerComponent.selectedTime?.meridie).toBe('PM');
+      expect(component.timepickerComponent.selectedTime?.iso8601.getDay).toBe(
+        date,
+      );
+
+      meridieButtons.item(0).click();
+
+      expect(component.timepickerComponent.selectedTime?.meridie).toBe('AM');
+      expect(component.timepickerComponent.selectedTime?.iso8601.getDay).toBe(
+        date,
+      );
+    }));
+
     it('should set the initial value correctly', fakeAsync(() => {
       detectChangesAndTick(fixture);
 

--- a/libs/components/datetime/src/lib/modules/timepicker/timepicker.component.ts
+++ b/libs/components/datetime/src/lib/modules/timepicker/timepicker.component.ts
@@ -97,12 +97,21 @@ export class SkyTimepickerComponent implements OnInit, OnDestroy {
   }
 
   public set selectedMeridies(meridies: string) {
+    meridies = meridies.trim();
     /* istanbul ignore else */
-    if (!this.is8601) {
-      if (meridies.trim() !== this.selectedMeridies) {
-        this.activeTime = moment(this.activeTime).add(12, 'hours').toDate();
-        this.selectedTimeChanged.emit(this.selectedTime);
+    if (meridies !== this.selectedMeridies) {
+      switch (meridies) {
+        case 'AM':
+          this.activeTime = moment(this.activeTime)
+            .subtract(12, 'hours')
+            .toDate();
+          break;
+
+        case 'PM':
+          this.activeTime = moment(this.activeTime).add(12, 'hours').toDate();
+          break;
       }
+      this.selectedTimeChanged.emit(this.selectedTime);
     }
   }
 


### PR DESCRIPTION
:cherries: Cherry picked from #2034 [fix(components/datetime): keep date consistent when switching meridies](https://github.com/blackbaud/skyux/pull/2034)