### PR TITLE
feat(components/datetime): add aria labels to datepicker calendar navigation buttons (#2033)

### DIFF
--- a/libs/components/datetime/src/assets/locales/resources_en_US.json
+++ b/libs/components/datetime/src/assets/locales/resources_en_US.json
@@ -7,6 +7,30 @@
     "_description": "Label for the trigger button of the datepicker when context is available",
     "message": "Open calendar for {0}"
   },
+  "skyux_datepicker_move_calendar_previous_day": {
+    "_description": "ARIA label for the previous month calendar button in 'day' mode",
+    "message": "Previous month"
+  },
+  "skyux_datepicker_move_calendar_next_day": {
+    "_description": "ARIA label for the next month calendar button in 'day' mode",
+    "message": "Next month"
+  },
+  "skyux_datepicker_move_calendar_previous_month": {
+    "_description": "ARIA label for the previous year calendar button in 'month' mode",
+    "message": "Previous year"
+  },
+  "skyux_datepicker_move_calendar_next_month": {
+    "_description": "ARIA label for the next year calendar button in 'month' mode",
+    "message": "Next year"
+  },
+  "skyux_datepicker_move_calendar_previous_year": {
+    "_description": "ARIA label for the previous page calendar button in 'year' mode",
+    "message": "Previous page"
+  },
+  "skyux_datepicker_move_calendar_next_year": {
+    "_description": "ARIA label for the next page calendar button in 'year' mode",
+    "message": "Next page"
+  },
   "skyux_timepicker_button_label": {
     "_description": "Screen reader text for the timepicker trigger button",
     "message": "Choose time"

--- a/libs/components/datetime/src/lib/modules/datepicker/datepicker-calendar-inner.component.html
+++ b/libs/components/datetime/src/lib/modules/datepicker/datepicker-calendar-inner.component.html
@@ -4,6 +4,7 @@
       <button
         type="button"
         class="sky-btn sky-btn-default sky-btn-sm sky-datepicker-btn-previous"
+        [attr.aria-label]="previousLabel"
         (click)="moveCalendar($event, -1)"
       >
         <sky-icon class="sky-datepicker-chevron" icon="chevron-left" />
@@ -27,6 +28,7 @@
       <button
         type="button"
         class="sky-btn sky-btn-default sky-btn-sm sky-datepicker-btn-next"
+        [attr.aria-label]="nextLabel"
         (click)="moveCalendar($event, 1)"
       >
         <sky-icon class="sky-datepicker-chevron" icon="chevron-right" />

--- a/libs/components/datetime/src/lib/modules/datepicker/datepicker-calendar-inner.component.ts
+++ b/libs/components/datetime/src/lib/modules/datepicker/datepicker-calendar-inner.component.ts
@@ -8,9 +8,11 @@ import {
   Output,
   SimpleChanges,
   ViewEncapsulation,
+  inject,
 } from '@angular/core';
+import { SkyLibResourcesService } from '@skyux/i18n';
 
-import { Subject } from 'rxjs';
+import { Subject, takeUntil } from 'rxjs';
 
 import { SkyDateFormatter } from './date-formatter';
 import { SkyDatepickerCustomDate } from './datepicker-custom-date';
@@ -94,6 +96,9 @@ export class SkyDatepickerCalendarInnerComponent
   public formatDayTitle = 'MMMM YYYY';
   public formatMonthTitle = 'YYYY';
 
+  public previousLabel: string | undefined;
+  public nextLabel: string | undefined;
+
   public datepickerId = `sky-datepicker-${++nextDatepickerId}`;
 
   public stepDay: any = {};
@@ -129,9 +134,17 @@ export class SkyDatepickerCalendarInnerComponent
   ];
 
   #ngUnsubscribe = new Subject<void>();
+  #prevDay: string | undefined;
+  #nextDay: string | undefined;
+  #prevMonth: string | undefined;
+  #nextMonth: string | undefined;
+  #prevYear: string | undefined;
+  #nextYear: string | undefined;
 
   #_selectedDate: Date | undefined;
   #_startingDay = 0;
+
+  readonly #resourcesSvc = inject(SkyLibResourcesService);
 
   public ngOnInit(): void {
     if (this.selectedDate) {
@@ -139,6 +152,27 @@ export class SkyDatepickerCalendarInnerComponent
     } else {
       this.activeDate = new Date();
     }
+
+    this.#resourcesSvc
+      .getStrings({
+        prevDay: 'skyux_datepicker_move_calendar_previous_day',
+        nextDay: 'skyux_datepicker_move_calendar_next_day',
+        prevMonth: 'skyux_datepicker_move_calendar_previous_month',
+        nextMonth: 'skyux_datepicker_move_calendar_next_month',
+        prevYear: 'skyux_datepicker_move_calendar_previous_year',
+        nextYear: 'skyux_datepicker_move_calendar_next_year',
+      })
+      .pipe(takeUntil(this.#ngUnsubscribe))
+      .subscribe((resources) => {
+        this.#prevDay = resources.prevDay;
+        this.#nextDay = resources.nextDay;
+        this.#prevMonth = resources.prevMonth;
+        this.#nextMonth = resources.nextMonth;
+        this.#prevYear = resources.prevYear;
+        this.#nextYear = resources.nextYear;
+
+        this.refreshView();
+      });
   }
 
   public ngOnChanges(changes: SimpleChanges): void {
@@ -207,14 +241,20 @@ export class SkyDatepickerCalendarInnerComponent
   public refreshView(): void {
     if (this.datepickerMode === 'day' && this.refreshViewHandlerDay) {
       this.title = this.refreshViewHandlerDay();
+      this.previousLabel = this.#prevDay;
+      this.nextLabel = this.#nextDay;
     }
 
     if (this.datepickerMode === 'month' && this.refreshViewHandlerMonth) {
       this.title = this.refreshViewHandlerMonth();
+      this.previousLabel = this.#prevMonth;
+      this.nextLabel = this.#nextMonth;
     }
 
     if (this.datepickerMode === 'year' && this.refreshViewHandlerYear) {
       this.title = this.refreshViewHandlerYear();
+      this.previousLabel = this.#prevYear;
+      this.nextLabel = this.#nextYear;
     }
   }
 

--- a/libs/components/datetime/src/lib/modules/datepicker/datepicker-calendar.component.spec.ts
+++ b/libs/components/datetime/src/lib/modules/datepicker/datepicker-calendar.component.spec.ts
@@ -66,19 +66,27 @@ describe('datepicker calendar', () => {
     fixture.detectChanges();
   }
 
-  function clickNextArrow(element: HTMLElement) {
-    const nextArrowEl = element.querySelector(
+  function getNextArrow(element: HTMLElement): HTMLButtonElement {
+    return element.querySelector(
       '.sky-datepicker-btn-next',
     ) as HTMLButtonElement;
+  }
+
+  function clickNextArrow(element: HTMLElement) {
+    const nextArrowEl = getNextArrow(element);
 
     nextArrowEl.click();
     fixture.detectChanges();
   }
 
-  function clickPreviousArrow(element: HTMLElement) {
-    const previousArrowEl = element.querySelector(
+  function getPreviousArrow(element: HTMLElement): HTMLButtonElement {
+    return element.querySelector(
       '.sky-datepicker-btn-previous',
     ) as HTMLButtonElement;
+  }
+
+  function clickPreviousArrow(element: HTMLElement) {
+    const previousArrowEl = getPreviousArrow(element);
 
     previousArrowEl.click();
     fixture.detectChanges();
@@ -505,6 +513,15 @@ describe('datepicker calendar', () => {
     });
 
     describe('daypicker accessibility', () => {
+      it('should have the correct aria labels for the previous and next buttons', () => {
+        component.selectedDate = new Date('4/4/2017');
+        fixture.detectChanges();
+        const nextArrowEl = getNextArrow(nativeElement);
+        expect(nextArrowEl.getAttribute('aria-label')).toBe('Next month');
+        const prevArrowEl = getPreviousArrow(nativeElement);
+        expect(prevArrowEl.getAttribute('aria-label')).toBe('Previous month');
+      });
+
       it('should move to the previous day when hitting left arrow key', () => {
         component.selectedDate = new Date('4/4/2017');
         fixture.detectChanges();
@@ -570,6 +587,16 @@ describe('datepicker calendar', () => {
     });
 
     describe('monthpicker accessibility', () => {
+      it('should have the correct aria labels for the previous and next buttons', () => {
+        component.selectedDate = new Date('4/4/2017');
+        fixture.detectChanges();
+        clickDatepickerTitle(nativeElement);
+        const nextArrowEl = getNextArrow(nativeElement);
+        expect(nextArrowEl.getAttribute('aria-label')).toBe('Next year');
+        const prevArrowEl = getPreviousArrow(nativeElement);
+        expect(prevArrowEl.getAttribute('aria-label')).toBe('Previous year');
+      });
+
       it('should move to the previous month with left arrow', () => {
         component.selectedDate = new Date('4/4/2017');
         fixture.detectChanges();
@@ -636,6 +663,17 @@ describe('datepicker calendar', () => {
     });
 
     describe('year accessibility', () => {
+      it('should have the correct aria labels for the previous and next buttons', () => {
+        component.selectedDate = new Date('4/4/2017');
+        fixture.detectChanges();
+        clickDatepickerTitle(nativeElement);
+        clickDatepickerTitle(nativeElement);
+        const nextArrowEl = getNextArrow(nativeElement);
+        expect(nextArrowEl.getAttribute('aria-label')).toBe('Next page');
+        const prevArrowEl = getPreviousArrow(nativeElement);
+        expect(prevArrowEl.getAttribute('aria-label')).toBe('Previous page');
+      });
+
       it('should move to the previous year with left arrow', () => {
         component.selectedDate = new Date('4/4/2017');
         fixture.detectChanges();

--- a/libs/components/datetime/src/lib/modules/shared/sky-datetime-resources.module.ts
+++ b/libs/components/datetime/src/lib/modules/shared/sky-datetime-resources.module.ts
@@ -56,6 +56,12 @@ const RESOURCES: Record<string, SkyLibResources> = {
     skyux_datepicker_trigger_button_label_context: {
       message: 'Open calendar for {0}',
     },
+    skyux_datepicker_move_calendar_previous_day: { message: 'Previous month' },
+    skyux_datepicker_move_calendar_next_day: { message: 'Next month' },
+    skyux_datepicker_move_calendar_previous_month: { message: 'Previous year' },
+    skyux_datepicker_move_calendar_next_month: { message: 'Next year' },
+    skyux_datepicker_move_calendar_previous_year: { message: 'Previous page' },
+    skyux_datepicker_move_calendar_next_year: { message: 'Next page' },
     skyux_timepicker_button_label: { message: 'Choose time' },
     skyux_timepicker_button_label_context: {
       message: 'Open time picker for {0}',


### PR DESCRIPTION
:cherries: Cherry picked from #2033 [feat(components/datetime): add aria labels to datepicker calendar navigation buttons](https://github.com/blackbaud/skyux/pull/2033)

[AB#2599956](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/2599956) 