### PR TITLE
feat(components/forms): add labelText input to toggle switch (#2019)

### DIFF
--- a/apps/e2e/forms-storybook/src/app/toggle-switch/toggle-switch.component.html
+++ b/apps/e2e/forms-storybook/src/app/toggle-switch/toggle-switch.component.html
@@ -7,8 +7,7 @@
   </p>
 
   <p>
-    <sky-toggle-switch [checked]="false">
-      <sky-toggle-switch-label> Switch is "off" </sky-toggle-switch-label>
+    <sky-toggle-switch [checked]="false" labelText='Switch is "off"'>
     </sky-toggle-switch>
   </p>
 
@@ -21,10 +20,11 @@
   </p>
 
   <p>
-    <sky-toggle-switch [checked]="false" [disabled]="true">
-      <sky-toggle-switch-label>
-        Switch is "off", disabled
-      </sky-toggle-switch-label>
+    <sky-toggle-switch
+      [checked]="false"
+      [disabled]="true"
+      labelText='Switch is "off", disabled'
+    >
     </sky-toggle-switch>
   </p>
 </div>

--- a/apps/playground/src/app/components/forms/toggle-switch/toggle-switch.component.html
+++ b/apps/playground/src/app/components/forms/toggle-switch/toggle-switch.component.html
@@ -9,8 +9,10 @@
 </div>
 
 <div class="sky-padding-even-large">
-  <sky-toggle-switch class="sky-margin-inline-lg">
-    <sky-toggle-switch-label>Toggle switch label</sky-toggle-switch-label>
+  <sky-toggle-switch labelText="label text" class="sky-margin-inline-lg">
+    <sky-toggle-switch-label
+      >Overridden label component</sky-toggle-switch-label
+    >
     <sky-help-inline
       *ngIf="showInlineHelp"
       class="sky-control-help"
@@ -19,8 +21,8 @@
   <span>Text after switch</span>
 </div>
 <div class="sky-padding-even-large">
-  <sky-toggle-switch [disabled]="true">
-    <sky-toggle-switch-label>Disabled switch</sky-toggle-switch-label>
+  <sky-toggle-switch labelText="Disabled switch" [disabled]="true">
+    <sky-toggle-switch-label>Overridden label</sky-toggle-switch-label>
     <sky-help-inline
       *ngIf="showInlineHelp"
       class="sky-control-help"
@@ -52,7 +54,8 @@
 <div class="sky-padding-even-large">
   <sky-toggle-switch
     [disabled]="true"
-    ariaLabel="Disabled switch without visible label"
+    labelText="Disabled switch without visible label"
+    labelHidden="true"
   >
     <sky-help-inline
       *ngIf="showInlineHelp"

--- a/libs/components/forms/src/lib/modules/toggle-switch/fixtures/toggle-switch.component.fixture.html
+++ b/libs/components/forms/src/lib/modules/toggle-switch/fixtures/toggle-switch.component.fixture.html
@@ -2,6 +2,8 @@
   [ariaLabel]="ariaLabel"
   [checked]="isChecked"
   [disabled]="isDisabled"
+  [labelHidden]="labelHidden"
+  [labelText]="labelText"
   [tabIndex]="customTabIndex"
   (toggleChange)="checkChanged($event)"
 >

--- a/libs/components/forms/src/lib/modules/toggle-switch/fixtures/toggle-switch.component.fixture.ts
+++ b/libs/components/forms/src/lib/modules/toggle-switch/fixtures/toggle-switch.component.fixture.ts
@@ -12,6 +12,8 @@ export class SkyToggleSwitchFixtureComponent {
   public showLabel = true;
   public ariaLabel: string | undefined;
   public buttonLabel: string | undefined = 'Simple toggle';
+  public labelText: string | undefined;
+  public labelHidden = false;
 
   public checkChanged(event: { checked: boolean }): void {
     this.isChecked = event.checked;

--- a/libs/components/forms/src/lib/modules/toggle-switch/toggle-switch-label.component.ts
+++ b/libs/components/forms/src/lib/modules/toggle-switch/toggle-switch-label.component.ts
@@ -1,13 +1,23 @@
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { SkyLogService } from '@skyux/core';
 
 /**
  * Specifies the label to display beside the toggle switch. To display a help button beside the label, include a help
  * button element, such as `sky-help-inline`, in the `sky-toggle-switch` element and a `sky-control-help` CSS class on
  * that help button element.
+ * @deprecated Use the `labelText` input on the toggle switch component instead.
  */
 @Component({
   selector: 'sky-toggle-switch-label',
   templateUrl: './toggle-switch-label.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class SkyToggleSwitchLabelComponent {}
+export class SkyToggleSwitchLabelComponent {
+  constructor() {
+    inject(SkyLogService).deprecated('SkyToggleSwitchLabelComponent', {
+      deprecationMajorVersion: 9,
+      replacementRecommendation:
+        'To add a label to toggle switch, use the `labelText` input on the toggle switch component instead.',
+    });
+  }
+}

--- a/libs/components/forms/src/lib/modules/toggle-switch/toggle-switch.component.html
+++ b/libs/components/forms/src/lib/modules/toggle-switch/toggle-switch.component.html
@@ -1,7 +1,7 @@
 <span
   class="sky-toggle-switch"
   [ngClass]="{
-    'sky-toggle-switch-with-label': hasLabelComponent
+    'sky-toggle-switch-with-label': hasLabelComponent || labelText
   }"
 >
   <button
@@ -10,8 +10,10 @@
     type="button"
     skyId
     [attr.aria-checked]="checked"
-    [attr.aria-label]="ariaLabel"
-    [attr.aria-labelledby]="!ariaLabel && hasLabelComponent ? labelId : null"
+    [attr.aria-label]="labelText || ariaLabel || null"
+    [attr.aria-labelledby]="
+      !ariaLabel && (hasLabelComponent || labelText) ? labelId : null
+    "
     [disabled]="disabled"
     [ngClass]="{
       'sky-toggle-switch-checked': checked,
@@ -34,11 +36,13 @@
   </button>
   <span
     ><label
-      *ngIf="hasLabelComponent"
+      *ngIf="hasLabelComponent || labelText"
       [for]="toggle.id"
       [attr.id]="labelId"
       class="sky-toggle-switch-label"
-      ><ng-container *ngTemplateOutlet="labelContent"></ng-container></label
+      ><ng-container *ngIf="labelText; else labelContent">
+        <ng-container *ngIf="!labelHidden">{{ labelText }}</ng-container>
+      </ng-container></label
     ><span class="sky-control-help-container"
       ><ng-content select=".sky-control-help" /></span></span
 ></span>

--- a/libs/components/forms/src/lib/modules/toggle-switch/toggle-switch.component.spec.ts
+++ b/libs/components/forms/src/lib/modules/toggle-switch/toggle-switch.component.spec.ts
@@ -8,6 +8,7 @@ import {
 import { NgModel, UntypedFormControl } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 import { SkyAppTestUtility, expect, expectAsync } from '@skyux-sdk/testing';
+import { SkyLogService } from '@skyux/core';
 
 import { SkyToggleSwitchChangeEventFixtureComponent } from './fixtures/toggle-switch-change-event.component.fixture';
 import { SkyToggleSwitchFormDirectivesFixtureComponent } from './fixtures/toggle-switch-form-directives.component.fixture';
@@ -149,6 +150,29 @@ describe('Toggle switch component', () => {
       expect(label?.textContent?.trim()).toEqual('Simple toggle');
     });
 
+    it('should log a deprecation warning when aria label input is used', () => {
+      const logService = TestBed.inject(SkyLogService);
+      const spy = spyOn(logService, 'deprecated');
+
+      testComponent.ariaLabel = 'aria label';
+      fixture.detectChanges();
+
+      expect(spy).toHaveBeenCalledWith('SkyToggleSwitchComponent.ariaLabel', {
+        deprecationMajorVersion: 9,
+        replacementRecommendation:
+          'To add an ARIA label to the toggle switch, use the `labelText` input instead',
+      });
+    });
+
+    it('should not have `aria-label` if `ariaLabel` is empty', () => {
+      testComponent.ariaLabel = '';
+      fixture.detectChanges();
+
+      const button = getButtonElement(fixture);
+
+      expect(button?.getAttribute('aria-label')).toBeNull();
+    });
+
     it('should make the host element a tab stop', () => {
       expect(buttonElement?.tabIndex).toEqual(0);
     });
@@ -159,6 +183,85 @@ describe('Toggle switch component', () => {
       expect(
         toggleNativeElement.querySelector('.sky-help-inline'),
       ).toBeTruthy();
+    });
+
+    it('should pass accessibility with label text input and should set `aria-label` to label text', async () => {
+      testComponent.labelText = 'label text';
+      testComponent.buttonLabel = undefined;
+
+      fixture.detectChanges();
+      expect(buttonElement?.getAttribute('aria-labelledby')).toEqual(
+        getLabelElement(fixture).id,
+      );
+      expect(buttonElement?.getAttribute('aria-label')).toBe('label text');
+      await expectAsync(fixture.nativeElement).toBeAccessible();
+    });
+
+    it('should still have `aria-label` if `labelHidden` is true', async () => {
+      testComponent.labelText = 'label text';
+      testComponent.labelHidden = true;
+
+      fixture.detectChanges();
+      expect(buttonElement?.getAttribute('aria-label')).toBe('label text');
+    });
+
+    it('should render the `labelText` and not label element if `labelText` is set', async () => {
+      testComponent.labelText = 'label text';
+      testComponent.buttonLabel = 'label element';
+
+      fixture.detectChanges();
+
+      const label = getLabelElement(fixture);
+
+      expect(label?.textContent?.trim()).toBe('label text');
+    });
+
+    it('should not render the label or label element if `labelText` is set and `labelHidden` is true', async () => {
+      testComponent.labelText = 'label text';
+      testComponent.buttonLabel = 'label element';
+      testComponent.labelHidden = true;
+
+      fixture.detectChanges();
+
+      const label = getLabelElement(fixture);
+
+      expect(label?.textContent).toBe('');
+    });
+
+    it('should not render the label if `labelText` is set and `labelHidden` is true', async () => {
+      testComponent.labelText = 'label text';
+      testComponent.labelHidden = true;
+
+      fixture.detectChanges();
+
+      const label = getLabelElement(fixture);
+
+      expect(label?.textContent).toBe('');
+    });
+
+    it('should render the label if `labelText` is set', async () => {
+      testComponent.labelText = 'label text';
+
+      fixture.detectChanges();
+
+      const label = getLabelElement(fixture);
+
+      expect(label?.textContent).toBe('label text');
+    });
+
+    it('should render the label element regardless of `labelHidden` value if `labelText` is not set', async () => {
+      testComponent.buttonLabel = 'label element';
+
+      fixture.detectChanges();
+
+      const label = getLabelElement(fixture);
+
+      expect(label?.textContent).toBe('label element');
+
+      testComponent.labelHidden = true;
+      fixture.detectChanges();
+
+      expect(label?.textContent).toBe('label element');
     });
 
     it('should pass accessibility with label element and no `ariaLabel`', async () => {

--- a/libs/components/forms/src/lib/modules/toggle-switch/toggle-switch.component.ts
+++ b/libs/components/forms/src/lib/modules/toggle-switch/toggle-switch.component.ts
@@ -10,6 +10,7 @@ import {
   Output,
   QueryList,
   forwardRef,
+  inject,
 } from '@angular/core';
 import {
   AbstractControl,
@@ -19,7 +20,7 @@ import {
   ValidationErrors,
   Validator,
 } from '@angular/forms';
-import { SkyIdService } from '@skyux/core';
+import { SkyIdService, SkyLogService } from '@skyux/core';
 
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
@@ -57,9 +58,24 @@ export class SkyToggleSwitchComponent
    * Use a context-sensitive label, such as "Activate annual fundraiser" for a toggle switch that activates and deactivates an annual fundraiser. Context is especially important if multiple toggle switches are in close proximity.
    * When the `sky-toggle-switch-label` component displays a visible label, this property is only necessary if that label requires extra context.
    * For more information about the `aria-label` attribute, see the [WAI-ARIA definition](https://www.w3.org/TR/wai-aria/#aria-label).
+   * @deprecated Use the `labelText` input instead.
    */
   @Input()
-  public ariaLabel: string | undefined;
+  public set ariaLabel(value: string | undefined) {
+    this.#_ariaLabel = value;
+
+    if (value !== undefined) {
+      this.#logSvc.deprecated('SkyToggleSwitchComponent.ariaLabel', {
+        deprecationMajorVersion: 9,
+        replacementRecommendation:
+          'To add an ARIA label to the toggle switch, use the `labelText` input instead',
+      });
+    }
+  }
+
+  public get ariaLabel(): string | undefined {
+    return this.#_ariaLabel;
+  }
 
   /**
    * Whether the toggle switch is selected.
@@ -100,6 +116,18 @@ export class SkyToggleSwitchComponent
   public tabIndex: number | undefined = 0;
 
   /**
+   * The text to display as the toggle switch's label.
+   */
+  @Input()
+  public labelText: string | undefined;
+
+  /**
+   * Whether to hide `labelText` from view.
+   */
+  @Input()
+  public labelHidden = false;
+
+  /**
    * Fires when the checked state of a toggle switch changes.
    */
   @Output()
@@ -115,8 +143,10 @@ export class SkyToggleSwitchComponent
 
   #control: AbstractControl | undefined;
   #isFirstChange = true;
+  readonly #logSvc = inject(SkyLogService);
   #ngUnsubscribe = new Subject<void>();
 
+  #_ariaLabel: string | undefined;
   #_checked = false;
 
   #changeDetector: ChangeDetectorRef;


### PR DESCRIPTION
:cherries: Cherry picked from #2019 [feat(components/forms): add labelText input to toggle switch](https://github.com/blackbaud/skyux/pull/2019)