### PR TITLE
feat(sdk/prettier-schematics)!: add support for `prettier@3`

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -4,5 +4,6 @@
   "importOrder": ["^@(.*)$", "^\\w(.*)$", "^(../)(.*)$", "^(./)(.*)$"],
   "importOrderSeparation": true,
   "importOrderSortSpecifiers": true,
-  "importOrderParserPlugins": ["typescript", "jsx", "decorators-legacy"]
+  "importOrderParserPlugins": ["typescript", "jsx", "decorators-legacy"],
+  "plugins": ["@trivago/prettier-plugin-sort-imports"]
 }

--- a/libs/components/packages/src/schematics/migrations/update-10/axe-core/axe-core.schematic.spec.ts
+++ b/libs/components/packages/src/schematics/migrations/update-10/axe-core/axe-core.schematic.spec.ts
@@ -46,15 +46,13 @@ describe('axe-core.schematic', () => {
 
     await runSchematic();
 
-    expect(tree.readText('package.json')).toMatchInlineSnapshot(`
-      "{
-        "dependencies": {},
-        "devDependencies": {
-          "@skyux-sdk/testing": "*",
-          "axe-core": "~4.8.3"
-        }
-      }"
-    `);
+    expect(JSON.parse(tree.readText('package.json'))).toEqual({
+      dependencies: {},
+      devDependencies: {
+        '@skyux-sdk/testing': '*',
+        'axe-core': '~4.8.3',
+      },
+    });
   });
 
   it('should abort if @skyux-sdk/testing not installed', async () => {
@@ -68,9 +66,9 @@ describe('axe-core.schematic', () => {
 
     await runSchematic();
 
-    expect(tree.readText('package.json')).toMatchInlineSnapshot(
-      `"{"devDependencies":{"axe-core":"*"}}"`,
-    );
+    expect(JSON.parse(tree.readText('package.json'))).toEqual({
+      devDependencies: { 'axe-core': '*' },
+    });
   });
 
   it('should install axe-core if @skyux-sdk/testing installed without', async () => {
@@ -84,13 +82,11 @@ describe('axe-core.schematic', () => {
 
     await runSchematic();
 
-    expect(tree.readText('package.json')).toMatchInlineSnapshot(`
-      "{
-        "devDependencies": {
-          "@skyux-sdk/testing": "*",
-          "axe-core": "~4.8.3"
-        }
-      }"
-    `);
+    expect(JSON.parse(tree.readText('package.json'))).toEqual({
+      devDependencies: {
+        '@skyux-sdk/testing': '*',
+        'axe-core': '~4.8.3',
+      },
+    });
   });
 });

--- a/libs/sdk/prettier-schematics/package.json
+++ b/libs/sdk/prettier-schematics/package.json
@@ -23,8 +23,9 @@
   "ng-update": {
     "migrations": "./src/schematics/migrations/migration-collection.json",
     "packageGroup": {
-      "eslint-config-prettier": "^8.7.0",
-      "prettier": "^2.8.0"
+      "@trivago/prettier-plugin-sort-imports": "^4.3.0",
+      "eslint-config-prettier": "^9.1.0",
+      "prettier": "^3.2.5"
     }
   },
   "peerDependencies": {

--- a/libs/sdk/prettier-schematics/src/schematics/migrations/migration-collection.json
+++ b/libs/sdk/prettier-schematics/src/schematics/migrations/migration-collection.json
@@ -4,6 +4,11 @@
       "version": "0.0.0-PLACEHOLDER",
       "factory": "./noop/noop.schematic",
       "description": "Update prettier dependencies"
+    },
+    "sort-imports-plugin": {
+      "version": "10.0.0-0",
+      "factory": "./update-10/sort-imports-plugin/sort-imports-plugin.schematic",
+      "description": "Update .prettierrc.json plugins"
     }
   }
 }

--- a/libs/sdk/prettier-schematics/src/schematics/migrations/update-10/sort-imports-plugin/sort-imports-plugin.schematic.spec.ts
+++ b/libs/sdk/prettier-schematics/src/schematics/migrations/update-10/sort-imports-plugin/sort-imports-plugin.schematic.spec.ts
@@ -4,6 +4,9 @@ import { resolve } from 'path';
 
 import { createTestLibrary } from '../../../testing/scaffold';
 
+// eslint-disable-next-line @cspell/spellchecker
+const PLUGIN_NAME = '@trivago/prettier-plugin-sort-imports';
+
 describe('fixSortImportsPlugin', () => {
   const runner = new SchematicTestRunner(
     'migrations',
@@ -37,14 +40,14 @@ describe('fixSortImportsPlugin', () => {
     jest.resetAllMocks();
   });
 
-  it('should add @trivago/prettier-plugin-sort-imports to plugins if installed', async () => {
+  it('should add prettier-plugin-sort-imports to plugins if installed', async () => {
     const { runSchematic, tree } = await setupTest({
       prettierConfig: {
         singleQuote: true,
       },
       packageJson: {
         devDependencies: {
-          '@trivago/prettier-plugin-sort-imports': '*',
+          PLUGIN_NAME: '*',
         },
       },
     });
@@ -53,11 +56,11 @@ describe('fixSortImportsPlugin', () => {
 
     expect(JSON.parse(tree.readText('/.prettierrc.json'))).toEqual({
       singleQuote: true,
-      plugins: ['@trivago/prettier-plugin-sort-imports'],
+      plugins: [PLUGIN_NAME],
     });
   });
 
-  it('should not add @trivago/prettier-plugin-sort-imports to plugins if uninstalled', async () => {
+  it('should not add prettier-plugin-sort-imports to plugins if uninstalled', async () => {
     const { runSchematic, tree } = await setupTest({
       prettierConfig: {
         singleQuote: true,
@@ -72,15 +75,15 @@ describe('fixSortImportsPlugin', () => {
     });
   });
 
-  it('should not add @trivago/prettier-plugin-sort-imports to plugins if already added', async () => {
+  it('should not add prettier-plugin-sort-imports to plugins if already added', async () => {
     const { runSchematic, tree } = await setupTest({
       prettierConfig: {
         singleQuote: true,
-        plugins: ['@trivago/prettier-plugin-sort-imports'],
+        plugins: [PLUGIN_NAME],
       },
       packageJson: {
         dependencies: {
-          '@trivago/prettier-plugin-sort-imports': '*',
+          PLUGIN_NAME: '*',
         },
       },
     });
@@ -89,7 +92,7 @@ describe('fixSortImportsPlugin', () => {
 
     expect(JSON.parse(tree.readText('/.prettierrc.json'))).toEqual({
       singleQuote: true,
-      plugins: ['@trivago/prettier-plugin-sort-imports'],
+      plugins: [PLUGIN_NAME],
     });
   });
 });

--- a/libs/sdk/prettier-schematics/src/schematics/migrations/update-10/sort-imports-plugin/sort-imports-plugin.schematic.spec.ts
+++ b/libs/sdk/prettier-schematics/src/schematics/migrations/update-10/sort-imports-plugin/sort-imports-plugin.schematic.spec.ts
@@ -1,0 +1,95 @@
+import { SchematicTestRunner } from '@angular-devkit/schematics/testing';
+
+import { resolve } from 'path';
+
+import { createTestLibrary } from '../../../testing/scaffold';
+
+describe('fixSortImportsPlugin', () => {
+  const runner = new SchematicTestRunner(
+    'migrations',
+    resolve(__dirname, '../../migration-collection.json'),
+  );
+
+  async function setupTest(options?: {
+    prettierConfig?: Record<string, unknown>;
+    packageJson?: {
+      dependencies?: Record<string, string>;
+      devDependencies?: Record<string, string>;
+    };
+  }) {
+    const tree = await createTestLibrary(runner, {
+      name: 'my-lib',
+    });
+
+    tree.overwrite('/package.json', JSON.stringify(options?.packageJson ?? {}));
+
+    if (options?.prettierConfig) {
+      tree.create('.prettierrc.json', JSON.stringify(options.prettierConfig));
+    }
+
+    return {
+      runSchematic: () => runner.runSchematic('sort-imports-plugin', {}, tree),
+      tree,
+    };
+  }
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('should add @trivago/prettier-plugin-sort-imports to plugins if installed', async () => {
+    const { runSchematic, tree } = await setupTest({
+      prettierConfig: {
+        singleQuote: true,
+      },
+      packageJson: {
+        devDependencies: {
+          '@trivago/prettier-plugin-sort-imports': '*',
+        },
+      },
+    });
+
+    await runSchematic();
+
+    expect(JSON.parse(tree.readText('/.prettierrc.json'))).toEqual({
+      singleQuote: true,
+      plugins: ['@trivago/prettier-plugin-sort-imports'],
+    });
+  });
+
+  it('should not add @trivago/prettier-plugin-sort-imports to plugins if uninstalled', async () => {
+    const { runSchematic, tree } = await setupTest({
+      prettierConfig: {
+        singleQuote: true,
+      },
+      packageJson: {},
+    });
+
+    await runSchematic();
+
+    expect(JSON.parse(tree.readText('/.prettierrc.json'))).toEqual({
+      singleQuote: true,
+    });
+  });
+
+  it('should not add @trivago/prettier-plugin-sort-imports to plugins if already added', async () => {
+    const { runSchematic, tree } = await setupTest({
+      prettierConfig: {
+        singleQuote: true,
+        plugins: ['@trivago/prettier-plugin-sort-imports'],
+      },
+      packageJson: {
+        dependencies: {
+          '@trivago/prettier-plugin-sort-imports': '*',
+        },
+      },
+    });
+
+    await runSchematic();
+
+    expect(JSON.parse(tree.readText('/.prettierrc.json'))).toEqual({
+      singleQuote: true,
+      plugins: ['@trivago/prettier-plugin-sort-imports'],
+    });
+  });
+});

--- a/libs/sdk/prettier-schematics/src/schematics/migrations/update-10/sort-imports-plugin/sort-imports-plugin.schematic.spec.ts
+++ b/libs/sdk/prettier-schematics/src/schematics/migrations/update-10/sort-imports-plugin/sort-imports-plugin.schematic.spec.ts
@@ -41,15 +41,17 @@ describe('fixSortImportsPlugin', () => {
   });
 
   it('should add prettier-plugin-sort-imports to plugins if installed', async () => {
+    const packageJson: { devDependencies: Record<string, string> } = {
+      devDependencies: {},
+    };
+
+    packageJson.devDependencies[PLUGIN_NAME] = '*';
+
     const { runSchematic, tree } = await setupTest({
       prettierConfig: {
         singleQuote: true,
       },
-      packageJson: {
-        devDependencies: {
-          PLUGIN_NAME: '*',
-        },
-      },
+      packageJson,
     });
 
     await runSchematic();
@@ -76,16 +78,18 @@ describe('fixSortImportsPlugin', () => {
   });
 
   it('should not add prettier-plugin-sort-imports to plugins if already added', async () => {
+    const packageJson: { dependencies: Record<string, string> } = {
+      dependencies: {},
+    };
+
+    packageJson.dependencies[PLUGIN_NAME] = '*';
+
     const { runSchematic, tree } = await setupTest({
       prettierConfig: {
         singleQuote: true,
         plugins: [PLUGIN_NAME],
       },
-      packageJson: {
-        dependencies: {
-          PLUGIN_NAME: '*',
-        },
-      },
+      packageJson,
     });
 
     await runSchematic();

--- a/libs/sdk/prettier-schematics/src/schematics/migrations/update-10/sort-imports-plugin/sort-imports-plugin.schematic.ts
+++ b/libs/sdk/prettier-schematics/src/schematics/migrations/update-10/sort-imports-plugin/sort-imports-plugin.schematic.ts
@@ -2,6 +2,7 @@ import { Rule } from '@angular-devkit/schematics';
 
 import { readJsonFile, writeJsonFile } from '../../../utility/tree';
 
+// eslint-disable-next-line @cspell/spellchecker
 const PLUGIN_NAME = '@trivago/prettier-plugin-sort-imports';
 
 export default function fixSortImportsPlugin(): Rule {

--- a/libs/sdk/prettier-schematics/src/schematics/migrations/update-10/sort-imports-plugin/sort-imports-plugin.schematic.ts
+++ b/libs/sdk/prettier-schematics/src/schematics/migrations/update-10/sort-imports-plugin/sort-imports-plugin.schematic.ts
@@ -1,0 +1,37 @@
+import { Rule } from '@angular-devkit/schematics';
+
+import { readJsonFile, writeJsonFile } from '../../../utility/tree';
+
+const PLUGIN_NAME = '@trivago/prettier-plugin-sort-imports';
+
+export default function fixSortImportsPlugin(): Rule {
+  return (tree) => {
+    const prettierConfigPath = '/.prettierrc.json';
+
+    const packageJson = readJsonFile<{
+      dependencies?: Record<string, string>;
+      devDependencies?: Record<string, string>;
+    }>(tree, '/package.json');
+
+    const dependencies = {
+      ...packageJson.dependencies,
+      ...packageJson.devDependencies,
+    };
+
+    if (tree.exists(prettierConfigPath) && PLUGIN_NAME in dependencies) {
+      const prettierConfig = readJsonFile<Record<string, unknown>>(
+        tree,
+        prettierConfigPath,
+      );
+
+      const plugins: string[] =
+        (prettierConfig['plugins'] as string[] | undefined) ?? [];
+
+      if (!plugins.includes(PLUGIN_NAME)) {
+        plugins.push(PLUGIN_NAME);
+        prettierConfig['plugins'] = plugins;
+        writeJsonFile(tree, prettierConfigPath, prettierConfig);
+      }
+    }
+  };
+}

--- a/libs/sdk/prettier-schematics/src/schematics/ng-add/ng-add.schematic.spec.ts
+++ b/libs/sdk/prettier-schematics/src/schematics/ng-add/ng-add.schematic.spec.ts
@@ -70,8 +70,8 @@ describe('ng-add.schematic', () => {
       'package.json',
       expect.objectContaining({
         devDependencies: expect.objectContaining({
-          prettier: '2.8.4',
-          'eslint-config-prettier': '8.7.0',
+          prettier: '3.2.5',
+          'eslint-config-prettier': '9.1.0',
         }),
       }),
     );

--- a/libs/sdk/prettier-schematics/src/schematics/ng-add/rules/add-prettier-dependencies.ts
+++ b/libs/sdk/prettier-schematics/src/schematics/ng-add/rules/add-prettier-dependencies.ts
@@ -11,14 +11,14 @@ export function addPrettierDependencies(): Rule {
     addPackageJsonDependency(tree, {
       name: 'prettier',
       type: NodeDependencyType.Dev,
-      version: '2.8.4',
+      version: '3.2.5',
       overwrite: true,
     });
 
     addPackageJsonDependency(tree, {
       name: 'eslint-config-prettier',
       type: NodeDependencyType.Dev,
-      version: '8.7.0',
+      version: '9.1.0',
       overwrite: true,
     });
   };

--- a/package-lock.json
+++ b/package-lock.json
@@ -132,7 +132,7 @@
         "postcss-import": "16.0.0",
         "postcss-preset-env": "9.3.0",
         "postcss-url": "10.1.3",
-        "prettier": "2.8.8",
+        "prettier": "3.2.5",
         "react": "18.2.0",
         "react-dom": "18.2.0",
         "resize-observer-polyfill": "1.5.1",
@@ -11154,6 +11154,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/@storybook/cli/node_modules/prettier": {
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
     "node_modules/@storybook/cli/node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -11203,6 +11218,21 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/codemod/node_modules/prettier": {
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/@storybook/components": {
@@ -28761,15 +28791,15 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
-      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.5.tgz",
+      "integrity": "sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==",
       "dev": true,
       "bin": {
-        "prettier": "bin-prettier.js"
+        "prettier": "bin/prettier.cjs"
       },
       "engines": {
-        "node": ">=10.13.0"
+        "node": ">=14"
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"

--- a/package.json
+++ b/package.json
@@ -208,7 +208,7 @@
     "postcss-import": "16.0.0",
     "postcss-preset-env": "9.3.0",
     "postcss-url": "10.1.3",
-    "prettier": "2.8.8",
+    "prettier": "3.2.5",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "resize-observer-polyfill": "1.5.1",


### PR DESCRIPTION
BREAKING CHANGE: Prettier 3 requires manually setting `plugins` in its configuration. This change will automatically add known plugins to `.prettierrc.json`, but there is a chance a plugin will be missed after the update.