### PR TITLE
feat(components/forms): checkbox label deprecations (#2055)

### DIFF
--- a/libs/components/forms/src/lib/modules/checkbox/checkbox-label-text-label.component.html
+++ b/libs/components/forms/src/lib/modules/checkbox/checkbox-label-text-label.component.html
@@ -1,0 +1,1 @@
+<span *ngIf="!labelHidden" class="sky-switch-label">{{ labelText }}</span>

--- a/libs/components/forms/src/lib/modules/checkbox/checkbox-label-text-label.component.ts
+++ b/libs/components/forms/src/lib/modules/checkbox/checkbox-label-text-label.component.ts
@@ -1,0 +1,24 @@
+import { Component, Input } from '@angular/core';
+
+/**
+@internal
+ */
+@Component({
+  selector: 'sky-checkbox-label-text-label',
+  templateUrl: './checkbox-label-text-label.component.html',
+})
+export class SkyCheckboxLabelTextLabelComponent {
+  @Input()
+  public labelHidden = false;
+
+  @Input()
+  public set labelText(value: string) {
+    this.#_labelText = value.trim();
+  }
+
+  public get labelText(): string {
+    return this.#_labelText;
+  }
+
+  #_labelText = '';
+}

--- a/libs/components/forms/src/lib/modules/checkbox/checkbox-label.component.ts
+++ b/libs/components/forms/src/lib/modules/checkbox/checkbox-label.component.ts
@@ -4,6 +4,7 @@ import { Component } from '@angular/core';
  * Specifies a label for the checkbox. To display a help button beside the label, include a help button element, such as
  * `sky-help-inline`, in the `sky-checkbox-label` element and a `sky-control-help` CSS class on that help button
  * element.
+ * @deprecated Use `labelText` input on `sky-checkbox-component` instead.
  */
 @Component({
   selector: 'sky-checkbox-label',

--- a/libs/components/forms/src/lib/modules/checkbox/checkbox.component.html
+++ b/libs/components/forms/src/lib/modules/checkbox/checkbox.component.html
@@ -14,8 +14,8 @@
     [name]="name"
     [required]="required"
     [tabIndex]="tabindex"
-    [attr.aria-label]="label"
-    [attr.aria-labelledby]="labelledBy"
+    [attr.aria-label]="labelText || label"
+    [attr.aria-labelledby]="labelText ? undefined : labelledBy"
     [attr.aria-required]="required ? true : null"
     [attr.aria-invalid]="!!ngControl?.errors"
     [attr.aria-errormessage]="
@@ -55,8 +55,12 @@
       />
     </ng-template>
   </span>
+
   <ng-container *ngIf="labelText; else labelElement">
-    <sky-checkbox-label>{{ labelText }}</sky-checkbox-label>
+    <sky-checkbox-label-text-label
+      [labelText]="labelText"
+      [labelHidden]="labelHidden"
+    />
   </ng-container>
   <ng-template #labelElement>
     <ng-content select="sky-checkbox-label" />

--- a/libs/components/forms/src/lib/modules/checkbox/checkbox.component.ts
+++ b/libs/components/forms/src/lib/modules/checkbox/checkbox.component.ts
@@ -35,18 +35,44 @@ export class SkyCheckboxComponent implements ControlValueAccessor, OnInit {
    * [to support accessibility](https://developer.blackbaud.com/skyux/components/checkbox#accessibility)
    * when the checkbox does not include a visible label. You must set this property for icon
    * checkboxes. If the checkbox includes a visible label, use `labelledBy` instead.
+   * @deprecated Use `labelText` instead.
    */
   @Input()
-  public label: string | undefined;
+  public set label(value: string | undefined) {
+    this.#_label = value;
+
+    if (value) {
+      this.#logger.deprecated('SkyCheckboxComponent.label', {
+        deprecationMajorVersion: 9,
+      });
+    }
+  }
+
+  public get label(): string | undefined {
+    return this.#_label;
+  }
 
   /**
    * The HTML element ID of the element that labels the
    * checkbox. This sets the checkbox's `aria-labelledby` attribute
    * [to support accessibility](https://developer.blackbaud.com/skyux/components/checkbox#accessibility).
    * If the checkbox does not include a visible label, use `label` instead.
+   * @deprecated Use `labelText` instead.
    */
   @Input()
-  public labelledBy: string | undefined;
+  public set labelledBy(value: string | undefined) {
+    this.#_labelledBy = value;
+
+    if (value) {
+      this.#logger.deprecated('SkyCheckboxComponent.labelledBy', {
+        deprecationMajorVersion: 9,
+      });
+    }
+  }
+
+  public get labelledBy(): string | undefined {
+    return this.#_labelledBy;
+  }
 
   /**
    * The ID for the checkbox.
@@ -208,6 +234,12 @@ export class SkyCheckboxComponent implements ControlValueAccessor, OnInit {
   public labelText: string | undefined;
 
   /**
+   * Indicates whether to hide the `labelText`.
+   */
+  @Input()
+  public labelHidden: boolean = false;
+
+  /**
    * Fires when users select or deselect the checkbox.
    */
   @Output()
@@ -260,6 +292,8 @@ export class SkyCheckboxComponent implements ControlValueAccessor, OnInit {
   #_inputEl: ElementRef | undefined;
   #_name = '';
   #_required = false;
+  #_label: string | undefined;
+  #_labelledBy: string | undefined;
 
   #changeDetector = inject(ChangeDetectorRef);
   #idSvc = inject(SkyIdService);

--- a/libs/components/forms/src/lib/modules/checkbox/checkbox.component.ts
+++ b/libs/components/forms/src/lib/modules/checkbox/checkbox.component.ts
@@ -237,7 +237,7 @@ export class SkyCheckboxComponent implements ControlValueAccessor, OnInit {
    * Indicates whether to hide the `labelText`.
    */
   @Input()
-  public labelHidden: boolean = false;
+  public labelHidden = false;
 
   /**
    * Fires when users select or deselect the checkbox.

--- a/libs/components/forms/src/lib/modules/checkbox/checkbox.module.ts
+++ b/libs/components/forms/src/lib/modules/checkbox/checkbox.module.ts
@@ -8,11 +8,16 @@ import { SkyFormErrorModule } from '../form-error/form-error.module';
 import { SkyFormErrorsModule } from '../form-error/form-errors.module';
 import { SkyFormsResourcesModule } from '../shared/sky-forms-resources.module';
 
+import { SkyCheckboxLabelTextLabelComponent } from './checkbox-label-text-label.component';
 import { SkyCheckboxLabelComponent } from './checkbox-label.component';
 import { SkyCheckboxComponent } from './checkbox.component';
 
 @NgModule({
-  declarations: [SkyCheckboxComponent, SkyCheckboxLabelComponent],
+  declarations: [
+    SkyCheckboxComponent,
+    SkyCheckboxLabelComponent,
+    SkyCheckboxLabelTextLabelComponent,
+  ],
   imports: [
     CommonModule,
     FormsModule,

--- a/libs/components/forms/src/lib/modules/radio/radio-group.component.html
+++ b/libs/components/forms/src/lib/modules/radio/radio-group.component.html
@@ -1,15 +1,11 @@
-<label
-  *ngIf="labelText && !labelHidden"
-  [id]="labelId"
-  class="sky-control-label"
->
+<label *ngIf="labelText && !labelHidden" class="sky-control-label">
   {{ labelText }}
 </label>
 <div
   class="sky-radio-group"
   role="radiogroup"
-  [attr.aria-label]="labelText ? labelText : ariaLabel"
-  [attr.aria-labelledby]="labelText ? labelId : ariaLabelledBy"
+  [attr.aria-label]="labelText || ariaLabel"
+  [attr.aria-labelledby]="labelText ? undefined : ariaLabelledBy"
   [attr.aria-owns]="ariaOwns"
   [attr.aria-required]="required ? true : null"
   [attr.required]="required ? '' : null"

--- a/libs/components/forms/src/lib/modules/radio/radio-group.component.spec.ts
+++ b/libs/components/forms/src/lib/modules/radio/radio-group.component.spec.ts
@@ -569,7 +569,7 @@ describe('Radio group component (reactive)', function () {
       fixture.nativeElement.querySelector('.sky-radio-group');
 
     expect(radioGroupEl.getAttribute('aria-owns')).toEqual(
-      'sky-radio-MOCK_ID_3-input sky-radio-MOCK_ID_4-input sky-radio-MOCK_ID_5-input sky-radio-MOCK_ID_6-input',
+      'sky-radio-MOCK_ID_2-input sky-radio-MOCK_ID_3-input sky-radio-MOCK_ID_4-input sky-radio-MOCK_ID_5-input',
     );
   });
 
@@ -581,7 +581,7 @@ describe('Radio group component (reactive)', function () {
 
     const originalAriaOwns = radioGroupEl.getAttribute('aria-owns');
     expect(originalAriaOwns).toEqual(
-      'sky-radio-MOCK_ID_3-input sky-radio-MOCK_ID_4-input sky-radio-MOCK_ID_5-input sky-radio-MOCK_ID_6-input',
+      'sky-radio-MOCK_ID_2-input sky-radio-MOCK_ID_3-input sky-radio-MOCK_ID_4-input sky-radio-MOCK_ID_5-input',
     );
 
     // Change an existing ID to something else.
@@ -590,7 +590,7 @@ describe('Radio group component (reactive)', function () {
 
     const newAriaOwns = radioGroupEl.getAttribute('aria-owns');
     expect(newAriaOwns).toEqual(
-      'sky-radio-foobar-input sky-radio-MOCK_ID_4-input sky-radio-MOCK_ID_5-input sky-radio-MOCK_ID_6-input',
+      'sky-radio-foobar-input sky-radio-MOCK_ID_3-input sky-radio-MOCK_ID_4-input sky-radio-MOCK_ID_5-input',
     );
   });
 
@@ -627,7 +627,7 @@ describe('Radio group component (reactive)', function () {
 
     const radioGroup = fixture.nativeElement.querySelector('.sky-radio-group');
 
-    expect(radioGroup.getAttribute('aria-labelledBy')).toEqual('MOCK_ID_1');
+    expect(radioGroup.getAttribute('aria-labelledBy')).toBeNull();
     expect(radioGroup.getAttribute('aria-label')).toEqual(labelText);
   });
 

--- a/libs/components/forms/src/lib/modules/radio/radio-group.component.ts
+++ b/libs/components/forms/src/lib/modules/radio/radio-group.component.ts
@@ -216,10 +216,9 @@ export class SkyRadioGroupComponent
   #changeDetector: ChangeDetectorRef;
   #radioGroupIdSvc: SkyRadioGroupIdService;
 
-  readonly #idService = inject(SkyIdService);
   readonly #logger = inject(SkyLogService);
+  readonly #idService = inject(SkyIdService);
 
-  protected labelId = this.#idService.generateId();
   protected errorId = this.#idService.generateId();
   protected ngControl: NgControl | undefined;
 

--- a/libs/components/forms/testing/src/checkbox/checkbox-harness.spec.ts
+++ b/libs/components/forms/testing/src/checkbox/checkbox-harness.spec.ts
@@ -107,13 +107,52 @@ describe('Checkbox harness', () => {
     await expectAsync(checkboxHarness.getLabelText()).toBeResolvedTo(undefined);
   });
 
-  it('should get the label when specified via labelText input', async () => {
+  it('should get the label text when specified via `labelText` input', async () => {
     const { checkboxHarness } = await setupTest({
       dataSkyId: 'my-phone-checkbox',
-      hideEmailLabel: true,
     });
 
     await expectAsync(checkboxHarness.getLabelText()).toBeResolvedTo('Phone');
+  });
+
+  it('should get the label text when specified via `labelText` input and label is hidden', async () => {
+    const { checkboxHarness, fixture } = await setupTest({
+      dataSkyId: 'my-phone-checkbox',
+    });
+
+    fixture.componentInstance.hidePhoneLabel = true;
+    fixture.detectChanges();
+
+    await expectAsync(checkboxHarness.getLabelText()).toBeResolvedTo('Phone');
+  });
+
+  it('should indicate the label is not hidden when the label is specified via `labelText`', async () => {
+    const { checkboxHarness } = await setupTest({
+      dataSkyId: 'my-phone-checkbox',
+    });
+
+    await expectAsync(checkboxHarness.getLabelHidden()).toBeResolvedTo(false);
+  });
+
+  it('should indicate the label is hidden when the label is specified via `labelText`', async () => {
+    const { checkboxHarness, fixture } = await setupTest({
+      dataSkyId: 'my-phone-checkbox',
+    });
+
+    fixture.componentInstance.hidePhoneLabel = true;
+    fixture.detectChanges();
+
+    await expectAsync(checkboxHarness.getLabelHidden()).toBeResolvedTo(true);
+  });
+
+  it('should throw an error when getting `labelIsHidden` for a checkbox using `sky-checkbox-label`', async () => {
+    const { checkboxHarness } = await setupTest({
+      dataSkyId: 'my-email-checkbox',
+    });
+
+    await expectAsync(checkboxHarness.getLabelHidden()).toBeRejectedWithError(
+      '`labelIsHidden` is only supported when setting the checkbox label via the `labelText` input.',
+    );
   });
 
   it('should get the checkbox name and value', async () => {

--- a/libs/components/forms/testing/src/checkbox/checkbox-harness.ts
+++ b/libs/components/forms/testing/src/checkbox/checkbox-harness.ts
@@ -5,6 +5,7 @@ import { SkyFormErrorsHarness } from '../form-error/form-errors-harness';
 
 import { SkyCheckboxHarnessFilters } from './checkbox-harness-filters';
 import { SkyCheckboxLabelHarness } from './checkbox-label-harness';
+import { SkyCheckboxLabelTextLabelHarness } from './checkbox-label-text-label.harness';
 
 /**
  * Harness for interacting with a checkbox component in tests.
@@ -19,6 +20,10 @@ export class SkyCheckboxHarness extends SkyComponentHarness {
   #getInput = this.locatorFor('input.sky-checkbox-input');
 
   #getLabel = this.locatorForOptional(SkyCheckboxLabelHarness);
+
+  #getLabelTextLabel = this.locatorForOptional(
+    SkyCheckboxLabelTextLabelHarness,
+  );
 
   async #getFormErrors(): Promise<SkyFormErrorsHarness> {
     const harness = await this.locatorForOptional(SkyFormErrorsHarness)();
@@ -78,14 +83,38 @@ export class SkyCheckboxHarness extends SkyComponentHarness {
   }
 
   /**
-   * Gets the checkbox's label text.
+   * Gets the checkbox's label text. If the label is set via `labelText` and `labelHidden` is true,
+   * the text will still be returned.
    */
   public async getLabelText(): Promise<string | undefined> {
+    const labelTextLabel = await this.#getLabelTextLabel();
     const label = await this.#getLabel();
-    if (label) {
-      return label.getText();
+
+    if (labelTextLabel) {
+      const text = await labelTextLabel.getText();
+      const ariaLabel = await this.getAriaLabel();
+
+      // if labelText is set, ariaLabel will never return null
+      return text || ariaLabel!;
+    } else {
+      return label?.getText();
     }
-    return;
+  }
+
+  /**
+   * Whether the label is hidden. Only supported when using the `labelText` input to set the label.
+   */
+  public async getLabelHidden(): Promise<boolean> {
+    const labelTextLabel = await this.#getLabelTextLabel();
+    const label = await this.#getLabel();
+
+    if (label) {
+      throw new Error(
+        '`labelIsHidden` is only supported when setting the checkbox label via the `labelText` input.',
+      );
+    } else {
+      return !(await labelTextLabel?.getText());
+    }
   }
 
   /**

--- a/libs/components/forms/testing/src/checkbox/checkbox-label-text-label.harness.ts
+++ b/libs/components/forms/testing/src/checkbox/checkbox-label-text-label.harness.ts
@@ -1,0 +1,21 @@
+import { ComponentHarness } from '@angular/cdk/testing';
+
+/**
+ * Harness for interacting with a `labelText` checkbox label component in tests.
+ * @internal
+ */
+export class SkyCheckboxLabelTextLabelHarness extends ComponentHarness {
+  /**
+   * @internal
+   */
+  public static hostSelector = 'sky-checkbox-label-text-label';
+
+  #getLabelContent = this.locatorForOptional('.sky-switch-label');
+
+  /**
+   * Gets the text content of the `labelText` checkbox label.
+   */
+  public async getText(): Promise<string | undefined> {
+    return (await this.#getLabelContent())?.text();
+  }
+}

--- a/libs/components/forms/testing/src/checkbox/fixtures/checkbox-harness-test.component.html
+++ b/libs/components/forms/testing/src/checkbox/fixtures/checkbox-harness-test.component.html
@@ -16,10 +16,9 @@
       <li>
         <sky-checkbox
           [required]="true"
+          [labelHidden]="hidePhoneLabel"
           data-sky-id="my-phone-checkbox"
           formControlName="phone"
-          label="Your phone number"
-          labelledBy="foo-phone-id"
           labelText="Phone"
         />
       </li>

--- a/libs/components/forms/testing/src/checkbox/fixtures/checkbox-harness-test.component.ts
+++ b/libs/components/forms/testing/src/checkbox/fixtures/checkbox-harness-test.component.ts
@@ -15,6 +15,7 @@ export class CheckboxHarnessTestComponent {
   public myForm: UntypedFormGroup;
   public hideEmailLabel = false;
   public mailControl: UntypedFormControl;
+  public hidePhoneLabel = false;
 
   #formBuilder: UntypedFormBuilder;
 

--- a/libs/components/lists/src/lib/modules/repeater/repeater.component.spec.ts
+++ b/libs/components/lists/src/lib/modules/repeater/repeater.component.spec.ts
@@ -109,7 +109,7 @@ describe('Repeater item component', () => {
     expected: boolean,
   ): void {
     if (expected) {
-      expect(deprecatedSpy).toHaveBeenCalledOnceWith(
+      expect(deprecatedSpy).toHaveBeenCalledWith(
         'SkyRepeaterItemComponent without `itemName`',
         {
           deprecationMajorVersion: 8,
@@ -117,7 +117,13 @@ describe('Repeater item component', () => {
         },
       );
     } else {
-      expect(deprecatedSpy).not.toHaveBeenCalled();
+      expect(deprecatedSpy).not.toHaveBeenCalledWith(
+        'SkyRepeaterItemComponent without `itemName`',
+        {
+          deprecationMajorVersion: 8,
+          replacementRecommendation: 'Always specify an `itemName` property.',
+        },
+      );
     }
   }
 


### PR DESCRIPTION
:cherries: Cherry picked from #2055 [feat(components/forms): checkbox label deprecations](https://github.com/blackbaud/skyux/pull/2055)