### PR TITLE
feat(components/modals): add modal form errors code example (#2065)

### DIFF
--- a/apps/code-examples/src/app/code-examples/modals/modal-with-error/context.ts
+++ b/apps/code-examples/src/app/code-examples/modals/modal-with-error/context.ts
@@ -1,0 +1,5 @@
+import { ModalDemoData } from './data';
+
+export class ModalDemoContext {
+  constructor(public data: ModalDemoData) {}
+}

--- a/apps/code-examples/src/app/code-examples/modals/modal-with-error/data.service.ts
+++ b/apps/code-examples/src/app/code-examples/modals/modal-with-error/data.service.ts
@@ -1,0 +1,29 @@
+import { Injectable } from '@angular/core';
+
+import { Observable, of } from 'rxjs';
+import { delay } from 'rxjs/operators';
+
+import { ModalDemoData } from './data';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class ModalDemoDataService {
+  #data: ModalDemoData = {
+    value1: 'Hello world',
+  };
+
+  public load(): Observable<ModalDemoData> {
+    // Simulate a network request to get data.
+    return of(this.#data).pipe(delay(1000));
+  }
+
+  public save(data: ModalDemoData, error = false): Observable<ModalDemoData> {
+    if (!error) {
+      this.#data = data;
+    }
+
+    // Simulate a network request to save data.
+    return of(this.#data).pipe(delay(1000));
+  }
+}

--- a/apps/code-examples/src/app/code-examples/modals/modal-with-error/data.ts
+++ b/apps/code-examples/src/app/code-examples/modals/modal-with-error/data.ts
@@ -1,0 +1,3 @@
+export interface ModalDemoData {
+  value1?: string | null;
+}

--- a/apps/code-examples/src/app/code-examples/modals/modal-with-error/demo.component.html
+++ b/apps/code-examples/src/app/code-examples/modals/modal-with-error/demo.component.html
@@ -1,0 +1,8 @@
+<button
+  class="sky-btn sky-btn-default"
+  type="button"
+  (click)="onOpenModalClick()"
+>
+  Open modal demo
+</button>
+<div *ngIf="demoValue">The user entered {{ demoValue }}</div>

--- a/apps/code-examples/src/app/code-examples/modals/modal-with-error/demo.component.spec.ts
+++ b/apps/code-examples/src/app/code-examples/modals/modal-with-error/demo.component.spec.ts
@@ -1,0 +1,58 @@
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { SkyWaitService } from '@skyux/indicators';
+import { SkyModalHarness } from '@skyux/modals/testing';
+
+import { Observable, of } from 'rxjs';
+
+import { ModalDemoDataService } from './data.service';
+import { DemoComponent } from './demo.component';
+
+class mockWaitSvc {
+  public blockingWrap(data: unknown): Observable<unknown> {
+    return of(data);
+  }
+}
+
+describe('Basic modal', () => {
+  async function setupTest(): Promise<{
+    modalHarness: SkyModalHarness;
+    fixture: ComponentFixture<DemoComponent>;
+  }> {
+    const fixture = TestBed.createComponent(DemoComponent);
+    fixture.componentInstance.onOpenModalClick();
+    fixture.detectChanges();
+
+    const loader = TestbedHarnessEnvironment.documentRootLoader(fixture);
+    const modalHarness = await loader.getHarness(
+      SkyModalHarness.with({
+        dataSkyId: 'modal-demo',
+      }),
+    );
+
+    return { modalHarness, fixture };
+  }
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [DemoComponent],
+      providers: [
+        {
+          provide: SkyWaitService,
+          useClass: mockWaitSvc,
+        },
+        ModalDemoDataService,
+      ],
+    });
+  });
+
+  it('should open the correct modal', async () => {
+    const { modalHarness, fixture } = await setupTest();
+
+    fixture.detectChanges();
+
+    await expectAsync(modalHarness.getAriaRole()).toBeResolvedTo('dialog');
+    await expectAsync(modalHarness.getSize()).toBeResolvedTo('medium');
+    await expectAsync(modalHarness.isFullPage()).toBeResolvedTo(false);
+  });
+});

--- a/apps/code-examples/src/app/code-examples/modals/modal-with-error/demo.component.ts
+++ b/apps/code-examples/src/app/code-examples/modals/modal-with-error/demo.component.ts
@@ -1,0 +1,63 @@
+import { CommonModule } from '@angular/common';
+import { Component, OnDestroy, inject } from '@angular/core';
+import { SkyWaitService } from '@skyux/indicators';
+import { SkyModalConfigurationInterface, SkyModalService } from '@skyux/modals';
+
+import { Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
+
+import { ModalDemoContext } from './context';
+import { ModalDemoData } from './data';
+import { ModalDemoDataService } from './data.service';
+import { ModalComponent } from './modal.component';
+
+@Component({
+  standalone: true,
+  selector: 'app-demo',
+  templateUrl: './demo.component.html',
+  imports: [CommonModule],
+})
+export class DemoComponent implements OnDestroy {
+  protected modalSize = 'medium';
+  protected demoValue: string | null | undefined;
+
+  #ngUnsubscribe = new Subject<void>();
+
+  readonly #dataSvc = inject(ModalDemoDataService);
+  readonly #modalSvc = inject(SkyModalService);
+  readonly #waitSvc = inject(SkyWaitService);
+
+  public ngOnDestroy(): void {
+    this.#ngUnsubscribe.next();
+    this.#ngUnsubscribe.complete();
+  }
+
+  public onOpenModalClick(): void {
+    // Display a blocking wait while data is loaded from the data service.
+    this.#waitSvc
+      .blockingWrap(this.#dataSvc.load())
+      .pipe(takeUntil(this.#ngUnsubscribe))
+      .subscribe((data) => {
+        const options: SkyModalConfigurationInterface = {
+          providers: [
+            {
+              provide: ModalDemoContext,
+              useValue: new ModalDemoContext(data),
+            },
+          ],
+          size: this.modalSize,
+        };
+
+        // Show the modal after data is loaded.
+        const instance = this.#modalSvc.open(ModalComponent, options);
+
+        instance.closed.subscribe((result) => {
+          if (result.reason === 'save') {
+            // Display the updated value.
+            const data = result.data as ModalDemoData;
+            this.demoValue = data.value1;
+          }
+        });
+      });
+  }
+}

--- a/apps/code-examples/src/app/code-examples/modals/modal-with-error/modal.component.html
+++ b/apps/code-examples/src/app/code-examples/modals/modal-with-error/modal.component.html
@@ -1,0 +1,27 @@
+<form [formGroup]="demoForm" (submit)="saveForm()">
+  <sky-modal
+    data-sky-id="modal-demo"
+    [isDirty]="demoForm.dirty"
+    [formErrors]="errors"
+  >
+    <sky-modal-header> Modal title </sky-modal-header>
+    <sky-modal-content>
+      <sky-input-box labelText="An input inside a modal">
+        <input formControlName="value1" type="text" />
+      </sky-input-box>
+    </sky-modal-content>
+    <sky-modal-footer>
+      <button class="sky-btn sky-btn-primary" type="submit">Save</button>
+      <button
+        class="sky-btn sky-btn-link"
+        type="button"
+        (click)="saveFormWithFormError()"
+      >
+        Save form with an error
+      </button>
+      <button class="sky-btn sky-btn-link" type="button" (click)="cancelForm()">
+        Cancel
+      </button>
+    </sky-modal-footer>
+  </sky-modal>
+</form>

--- a/apps/code-examples/src/app/code-examples/modals/modal-with-error/modal.component.ts
+++ b/apps/code-examples/src/app/code-examples/modals/modal-with-error/modal.component.ts
@@ -1,0 +1,58 @@
+import { Component, inject } from '@angular/core';
+import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
+import { SkyInputBoxModule } from '@skyux/forms';
+import { SkyWaitService } from '@skyux/indicators';
+import { SkyModalError, SkyModalInstance, SkyModalModule } from '@skyux/modals';
+
+import { ModalDemoContext } from './context';
+import { ModalDemoDataService } from './data.service';
+
+@Component({
+  standalone: true,
+  selector: 'app-modal',
+  templateUrl: './modal.component.html',
+  imports: [ReactiveFormsModule, SkyInputBoxModule, SkyModalModule],
+})
+export class ModalComponent {
+  protected demoForm: FormGroup<{
+    value1: FormControl<string | null | undefined>;
+  }>;
+
+  readonly #context = inject(ModalDemoContext);
+  readonly #dataSvc = inject(ModalDemoDataService);
+  readonly #instance = inject(SkyModalInstance);
+  readonly #waitSvc = inject(SkyWaitService);
+
+  public errors: SkyModalError[] = [];
+
+  constructor() {
+    this.demoForm = new FormGroup({
+      value1: new FormControl(this.#context.data.value1),
+    });
+  }
+
+  protected saveForm(): void {
+    // Use the data service to save the data.
+
+    this.#waitSvc
+      .blockingWrap(this.#dataSvc.save(this.demoForm.value))
+      .subscribe((data) => {
+        // Notify the modal instance that data was saved and return the saved data.
+        this.#instance.save(data);
+      });
+  }
+
+  protected saveFormWithFormError(): void {
+    // Use the data service to save the data.
+
+    this.#waitSvc
+      .blockingWrap(this.#dataSvc.save(this.demoForm.value, true))
+      .subscribe((data) => {
+        this.errors = [{ message: 'There was an error saving the form.' }];
+      });
+  }
+
+  protected cancelForm(): void {
+    this.#instance.cancel();
+  }
+}

--- a/apps/code-examples/src/app/features/modals.module.ts
+++ b/apps/code-examples/src/app/features/modals.module.ts
@@ -23,6 +23,13 @@ const routes: Routes = [
         (c) => c.DemoComponent,
       ),
   },
+  {
+    path: 'modal-with-error',
+    loadComponent: () =>
+      import('../code-examples/modals/modal-with-error/demo.component').then(
+        (c) => c.DemoComponent,
+      ),
+  },
 ];
 
 @NgModule({

--- a/apps/code-examples/src/app/home/home.component.html
+++ b/apps/code-examples/src/app/home/home.component.html
@@ -527,6 +527,7 @@
       <li><a routerLink="modals/confirm">Confirm</a></li>
       <li><a routerLink="modals/modal">Modal</a></li>
       <li><a routerLink="modals/inline-help">Modal (inline-help)</a></li>
+      <li><a routerLink="modals/modal-with-error">Modal with form error</a></li>
     </ul>
   </li>
 


### PR DESCRIPTION
:cherries: Cherry picked from #2065 [feat(components/modals): add modal form errors code example](https://github.com/blackbaud/skyux/pull/2065)