### PR TITLE
feat(components/forms): add labelText to single file attachment (#2059)

### DIFF
--- a/apps/e2e/forms-storybook/src/app/single-file-attachment/single-file-attachment.component.html
+++ b/apps/e2e/forms-storybook/src/app/single-file-attachment/single-file-attachment.component.html
@@ -2,11 +2,9 @@
   <div style="margin-bottom: 20px">
     <sky-file-attachment
       formControlName="attachment"
+      labelText="Single file attachment"
       (fileChange)="reactiveFileUpdated($event)"
     >
-      <sky-file-attachment-label>
-        Single file attachment
-      </sky-file-attachment-label>
     </sky-file-attachment>
   </div>
 </form>
@@ -28,6 +26,7 @@
   <div style="margin-bottom: 20px">
     <sky-file-attachment
       formControlName="fileAttachment"
+      labelText="Single file attachment with text file"
       (fileChange)="reactiveFileUpdated($event)"
     >
       <sky-file-attachment-label>

--- a/apps/playground/src/app/components/forms/single-file-attachment/single-file-attachment.component.html
+++ b/apps/playground/src/app/components/forms/single-file-attachment/single-file-attachment.component.html
@@ -2,6 +2,7 @@
   <div style="margin-bottom: 50px">
     <sky-file-attachment
       formControlName="attachment"
+      labelText="label text"
       [maxFileSize]="maxFileSize"
       [validateFn]="validateFile"
       (fileChange)="reactiveFileUpdated($event)"

--- a/libs/components/forms/src/lib/modules/file-attachment/file-attachment-label.component.ts
+++ b/libs/components/forms/src/lib/modules/file-attachment/file-attachment-label.component.ts
@@ -1,9 +1,16 @@
-import { ChangeDetectionStrategy, Component, ViewChild } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  ViewChild,
+  inject,
+} from '@angular/core';
+import { SkyLogService } from '@skyux/core';
 
 /**
  * Displays a label above the file attachment element. To display a help button beside the label, include a help button
  * element, such as `sky-help-inline`, in the `sky-file-attachment-label` element and a `sky-control-help` CSS class on
  * that help button element.
+ * @deprecated use the `labelText` input on the single file attachment component instead.
  */
 @Component({
   selector: 'sky-file-attachment-label',
@@ -14,4 +21,11 @@ import { ChangeDetectionStrategy, Component, ViewChild } from '@angular/core';
 export class SkyFileAttachmentLabelComponent {
   @ViewChild('labelContentId')
   public labelContentId: { id: string } | undefined;
+  constructor() {
+    inject(SkyLogService).deprecated('SkyFileAttachmentLabelComponent', {
+      deprecationMajorVersion: 9,
+      replacementRecommendation:
+        'To add a label to single file attachment, use the `labelText` input on the `sky-file-attachment` component instead.',
+    });
+  }
 }

--- a/libs/components/forms/src/lib/modules/file-attachment/file-attachment.component.html
+++ b/libs/components/forms/src/lib/modules/file-attachment/file-attachment.component.html
@@ -2,9 +2,15 @@
   <div
     class="sky-file-attachment-label-wrapper"
     [attr.id]="labelElementId"
-    [ngClass]="{ 'sky-control-label-required': required && hasLabelComponent }"
+    [ngClass]="{
+      'sky-control-label-required': required && (hasLabelComponent || labelText)
+    }"
   >
-    <ng-container *ngTemplateOutlet="labelContent"></ng-container>
+    <ng-container *ngIf="labelText; else labelContent">
+      <span *ngIf="!labelHidden" class="sky-control-label">{{
+        labelText
+      }}</span>
+    </ng-container>
   </div>
   <div
     class="sky-file-attachment-upload sky-file-attachment sky-file-attachment-target"
@@ -52,7 +58,9 @@
         [attr.aria-labelledby]="
           attachButton.id +
           ' ' +
-          (hasLabelComponent
+          (labelText
+            ? labelElementId
+            : hasLabelComponent
             ? labelComponents?.get(0)?.labelContentId?.id
             : undefined)
         "

--- a/libs/components/forms/src/lib/modules/file-attachment/file-attachment.component.scss
+++ b/libs/components/forms/src/lib/modules/file-attachment/file-attachment.component.scss
@@ -67,6 +67,11 @@
 }
 
 @include mixins.sky-theme-modern {
+  .sky-control-label {
+    color: $sky-theme-modern-font-deemphasized-color;
+    font-size: 13px;
+  }
+
   .sky-file-attachment-none {
     font-size: $sky-theme-modern-text-size-125;
   }

--- a/libs/components/forms/src/lib/modules/file-attachment/file-attachment.component.spec.ts
+++ b/libs/components/forms/src/lib/modules/file-attachment/file-attachment.component.spec.ts
@@ -111,6 +111,11 @@ describe('File attachment', () => {
     );
   }
 
+  function validateLabelText(expectedLabel: string) {
+    const label = getLabelWrapper();
+    expect(label?.textContent?.trim()).toBe(expectedLabel);
+  }
+
   function getImage(): DebugElement | null {
     return fixture.debugElement.query(
       By.css('.sky-file-attachment-preview-img'),
@@ -433,6 +438,31 @@ describe('File attachment', () => {
     );
 
     fixture.componentInstance.showLabel = false;
+    fixture.detectChanges();
+
+    expect(labelWrapper?.classList.contains('sky-control-label-required')).toBe(
+      false,
+    );
+  }));
+
+  it('should handle removing the labelText', fakeAsync(() => {
+    fixture.componentInstance.required = true;
+    fixture.componentInstance.labelText = 'label text';
+    fixture.componentInstance.labelElementText = undefined;
+    fixture.componentInstance.showLabel = false;
+
+    fileAttachmentInstance.ngAfterViewInit();
+    fileAttachmentInstance.ngAfterContentInit();
+    tick();
+    fixture.detectChanges();
+
+    const labelWrapper = getLabelWrapper();
+
+    expect(labelWrapper?.classList.contains('sky-control-label-required')).toBe(
+      true,
+    );
+
+    fixture.componentInstance.labelText = undefined;
     fixture.detectChanges();
 
     expect(labelWrapper?.classList.contains('sky-control-label-required')).toBe(
@@ -1351,10 +1381,55 @@ describe('File attachment', () => {
   });
 
   it('should pass accessibility when label does not match the button text', async () => {
-    fixture.componentInstance.labelText = 'Something different';
+    fixture.componentInstance.labelElementText = 'Something different';
     fixture.detectChanges();
     await fixture.whenStable();
     await expectAsync(fixture.nativeElement).toBeAccessible();
+  });
+
+  it('should pass accessibility when `labelText` is set', async () => {
+    fixture.componentInstance.labelText = 'Attach file';
+    fixture.componentInstance.labelElementText = undefined;
+    fixture.detectChanges();
+
+    await expectAsync(fixture.nativeElement).toBeAccessible();
+  });
+
+  it('should render `labelText` and not label element if `labelText` is set', async () => {
+    fixture.componentInstance.labelElementText = 'label element';
+    fixture.componentInstance.labelText = 'label text';
+    fixture.detectChanges();
+
+    validateLabelText('label text');
+  });
+
+  it('should not render `labelText` or label element if `labelHidden` is set to true', async () => {
+    fixture.componentInstance.labelElementText = 'label element';
+    fixture.componentInstance.labelText = 'label text';
+    fixture.componentInstance.labelHidden = true;
+    fixture.detectChanges();
+
+    validateLabelText('');
+  });
+
+  it('should render label if `labelText` is set', async () => {
+    fixture.componentInstance.labelText = 'label text';
+    fixture.componentInstance.labelElementText = undefined;
+    fixture.detectChanges();
+
+    validateLabelText('label text');
+  });
+
+  it('should render label element regardless of `labelHidden` value if `labelText` is not set', async () => {
+    fixture.componentInstance.labelElementText = 'label element';
+    fixture.detectChanges();
+
+    validateLabelText('label element');
+
+    fixture.componentInstance.labelHidden = true;
+    fixture.detectChanges();
+
+    validateLabelText('label element');
   });
 });
 

--- a/libs/components/forms/src/lib/modules/file-attachment/file-attachment.component.ts
+++ b/libs/components/forms/src/lib/modules/file-attachment/file-attachment.component.ts
@@ -79,6 +79,18 @@ export class SkyFileAttachmentComponent
   }
 
   /**
+   * The text to display as the file attachment's label.
+   */
+  @Input()
+  public labelText: string | undefined;
+
+  /**
+   * Whether to hide `labelText` from view.
+   */
+  @Input()
+  public labelHidden = false;
+
+  /**
    * The maximum size in bytes for valid files.
    * @default 500000
    */

--- a/libs/components/forms/src/lib/modules/file-attachment/fixtures/file-attachment.component.fixture.html
+++ b/libs/components/forms/src/lib/modules/file-attachment/fixtures/file-attachment.component.fixture.html
@@ -1,7 +1,12 @@
 <form novalidate [formGroup]="fileForm">
-  <sky-file-attachment formControlName="attachment" [required]="required">
+  <sky-file-attachment
+    formControlName="attachment"
+    [required]="required"
+    [labelHidden]="labelHidden"
+    [labelText]="labelText"
+  >
     <sky-file-attachment-label *ngIf="showLabel">
-      {{ labelText }}
+      {{ labelElementText }}
       <sky-help-inline
         *ngIf="showInlineHelp"
         class="sky-control-help"

--- a/libs/components/forms/src/lib/modules/file-attachment/fixtures/file-attachment.component.fixture.ts
+++ b/libs/components/forms/src/lib/modules/file-attachment/fixtures/file-attachment.component.fixture.ts
@@ -16,7 +16,11 @@ export class FileAttachmentTestComponent {
 
   public fileForm: UntypedFormGroup;
 
-  public labelText = 'Choose file';
+  public labelElementText: string | undefined = 'Choose file';
+
+  public labelHidden = false;
+
+  public labelText: string | undefined;
 
   public required = false;
 


### PR DESCRIPTION
:cherries: Cherry picked from #2059 [feat(components/forms): add labelText to single file attachment](https://github.com/blackbaud/skyux/pull/2059)