### PR TITLE
feat(components/datetime): improve screen reader labels for values on datepicker calendar (#2051)

### DIFF
--- a/libs/components/datetime/src/lib/modules/datepicker/datepicker-calendar-inner.component.ts
+++ b/libs/components/datetime/src/lib/modules/datepicker/datepicker-calendar-inner.component.ts
@@ -10,6 +10,7 @@ import {
   ViewEncapsulation,
   inject,
 } from '@angular/core';
+import { SkyLiveAnnouncerService } from '@skyux/core';
 import { SkyLibResourcesService } from '@skyux/i18n';
 
 import { Subject, takeUntil } from 'rxjs';
@@ -95,6 +96,9 @@ export class SkyDatepickerCalendarInnerComponent
   public formatDayHeader = 'dd';
   public formatDayTitle = 'MMMM YYYY';
   public formatMonthTitle = 'YYYY';
+  public formatDayLabel = 'dddd, MMMM Do YYYY';
+  public formatMonthLabel = 'MMMM YYYY';
+  public formatYearLabel = 'YYYY';
 
   public previousLabel: string | undefined;
   public nextLabel: string | undefined;
@@ -145,6 +149,7 @@ export class SkyDatepickerCalendarInnerComponent
   #_startingDay = 0;
 
   readonly #resourcesSvc = inject(SkyLibResourcesService);
+  readonly #liveAnnouncerSvc = inject(SkyLiveAnnouncerService);
 
   public ngOnInit(): void {
     if (this.selectedDate) {
@@ -302,7 +307,7 @@ export class SkyDatepickerCalendarInnerComponent
   public onKeydown(event: KeyboardEvent): void {
     const key = event.key?.toLowerCase();
 
-    if (!this.keys.includes(key) || event.shiftKey || event.altKey) {
+    if (!this.keys.includes(key) || event.shiftKey) {
       return;
     }
 
@@ -455,6 +460,11 @@ export class SkyDatepickerCalendarInnerComponent
       this.calendarModeChange.emit(this.datepickerMode);
       this.refreshView();
     }
+  }
+
+  public announceDate(date: Date, format: string): void {
+    const caption = this.dateFilter(date, format);
+    this.#liveAnnouncerSvc.announce(caption);
   }
 
   /**

--- a/libs/components/datetime/src/lib/modules/datepicker/datepicker-calendar-label.pipe.spec.ts
+++ b/libs/components/datetime/src/lib/modules/datepicker/datepicker-calendar-label.pipe.spec.ts
@@ -1,0 +1,75 @@
+import { CommonModule } from '@angular/common';
+import { Component, Input } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { expect } from '@skyux-sdk/testing';
+
+import { SkyDatepickerCalendarInnerComponent } from './datepicker-calendar-inner.component';
+import { SkyDatepickerCalendarLabelPipe } from './datepicker-calendar-label.pipe';
+
+@Component({
+  standalone: true,
+  selector: 'sky-datepicker-calendar-label-pipe-test',
+  template: '{{ value | skyDatepickerCalendarLabel : format }}',
+  imports: [SkyDatepickerCalendarLabelPipe],
+})
+export class SkyDatepickerCalendarLabelPipeTestComponent {
+  @Input() public value: any;
+  @Input() public format: string | undefined;
+}
+
+class MockSkyCalendarInnerComponent {
+  public isActive(value: any): boolean {
+    return false;
+  }
+
+  public dateFilter(value: Date, format: string): string {
+    return 'Formatted date';
+  }
+}
+
+function setupTest(
+  component: SkyDatepickerCalendarLabelPipeTestComponent,
+  args?: { value?: Date; format?: string },
+): void {
+  if (args) {
+    component.value = args.value;
+    component.format = args.format;
+  }
+}
+
+describe('Datepicker calendar label pipe', () => {
+  let fixture: ComponentFixture<SkyDatepickerCalendarLabelPipeTestComponent>;
+  let component: SkyDatepickerCalendarLabelPipeTestComponent;
+  const calendarInnerComponent = new MockSkyCalendarInnerComponent();
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [CommonModule],
+      providers: [
+        {
+          provide: SkyDatepickerCalendarInnerComponent,
+          useValue: calendarInnerComponent,
+        },
+      ],
+    });
+
+    fixture = TestBed.createComponent(
+      SkyDatepickerCalendarLabelPipeTestComponent,
+    );
+    component = fixture.componentInstance;
+  });
+
+  it('should display a formatted date object', () => {
+    setupTest(component, { value: new Date(2000, 0, 1) });
+    fixture.detectChanges();
+    const value = fixture.nativeElement.textContent.trim();
+    expect(value).toBe('Formatted date');
+  });
+
+  it('should display nothing when given an invalid date', () => {
+    setupTest(component);
+    fixture.detectChanges();
+    const value = fixture.nativeElement.textContent.trim();
+    expect(value).toBe('');
+  });
+});

--- a/libs/components/datetime/src/lib/modules/datepicker/datepicker-calendar-label.pipe.ts
+++ b/libs/components/datetime/src/lib/modules/datepicker/datepicker-calendar-label.pipe.ts
@@ -1,0 +1,40 @@
+import { Pipe, PipeTransform, inject } from '@angular/core';
+
+import { SkyDatepickerCalendarInnerComponent } from './datepicker-calendar-inner.component';
+
+/**
+ * Formats date values according to formatting rules.
+ * @example
+ * ```markup
+ * {{ myDate | skyDatepickerCalendarLabel }}
+ * {{ myDate | skyDatepickerCalendarLabel:'YYYY' }}
+ * ```
+ * @internal
+ */
+@Pipe({
+  name: 'skyDatepickerCalendarLabel',
+  standalone: true,
+})
+export class SkyDatepickerCalendarLabelPipe implements PipeTransform {
+  #datepicker = inject(SkyDatepickerCalendarInnerComponent);
+  #defaultFormat = this.#datepicker.formatDayLabel;
+
+  /**
+   * Transforms a date value using locale and format rules.
+   * @param value Specifies the date value to transform.
+   * @param format Specifies the format to apply to the transform. The format string is
+   * constructed by a series of symbols that represent date-time values.
+   */
+  public transform(value: unknown, format?: string): string {
+    let formattedValue = '';
+
+    if (value && value instanceof Date) {
+      formattedValue = this.#datepicker.dateFilter(
+        value,
+        format || this.#defaultFormat,
+      );
+    }
+
+    return formattedValue;
+  }
+}

--- a/libs/components/datetime/src/lib/modules/datepicker/datepicker.module.ts
+++ b/libs/components/datetime/src/lib/modules/datepicker/datepicker.module.ts
@@ -10,6 +10,7 @@ import { SkyThemeModule } from '@skyux/theme';
 import { SkyDatetimeResourcesModule } from '../shared/sky-datetime-resources.module';
 
 import { SkyDatepickerCalendarInnerComponent } from './datepicker-calendar-inner.component';
+import { SkyDatepickerCalendarLabelPipe } from './datepicker-calendar-label.pipe';
 import { SkyDatepickerCalendarComponent } from './datepicker-calendar.component';
 import { SkyFuzzyDatepickerInputDirective } from './datepicker-input-fuzzy.directive';
 import { SkyDatepickerInputDirective } from './datepicker-input.directive';
@@ -39,6 +40,7 @@ import { SkyYearPickerComponent } from './yearpicker.component';
     CommonModule,
     FormsModule,
     SkyIconModule,
+    SkyDatepickerCalendarLabelPipe,
     SkyDatetimeResourcesModule,
     SkyAffixModule,
     SkyThemeModule,

--- a/libs/components/datetime/src/lib/modules/datepicker/daypicker-button.component.html
+++ b/libs/components/datetime/src/lib/modules/datepicker/daypicker-button.component.html
@@ -11,6 +11,7 @@
     'sky-datepicker-btn-disabled': date.disabled,
     'sky-datepicker-btn-key-date': date.keyDate
   }"
+  [attr.aria-label]="date.date | skyDatepickerCalendarLabel"
   (click)="datepicker.selectCalendar($event, date.date, true)"
 >
   <span [ngClass]="{ 'sky-datepicker-secondary': date.secondary }">

--- a/libs/components/datetime/src/lib/modules/datepicker/daypicker-cell.component.spec.ts
+++ b/libs/components/datetime/src/lib/modules/datepicker/daypicker-cell.component.spec.ts
@@ -39,6 +39,10 @@ class MockSkyCalendarInnerComponent {
   public isActive(value: any): boolean {
     return false;
   }
+
+  public dateFilter(value: Date, format: string): string {
+    return 'Formatted date';
+  }
 }
 
 describe('daypicker cell', () => {

--- a/libs/components/datetime/src/lib/modules/datepicker/daypicker.component.ts
+++ b/libs/components/datetime/src/lib/modules/datepicker/daypicker.component.ts
@@ -208,6 +208,10 @@ export class SkyDayPickerComponent implements OnDestroy, OnInit {
       );
     }
     this.datepicker.activeDate.setDate(date);
+    this.datepicker.announceDate(
+      this.datepicker.activeDate,
+      this.datepicker.formatDayLabel,
+    );
   }
 
   #getDaysInMonth(year: number, month: number): number {

--- a/libs/components/datetime/src/lib/modules/datepicker/monthpicker.component.html
+++ b/libs/components/datetime/src/lib/modules/datepicker/monthpicker.component.html
@@ -15,6 +15,9 @@
             'sky-btn-disabled': date.disabled,
             'sky-btn-active': datepicker.isActive(date)
           }"
+          [attr.aria-label]="
+            date.date | skyDatepickerCalendarLabel : datepicker.formatMonthLabel
+          "
           [disabled]="date.disabled"
           (click)="datepicker.selectCalendar($event, date.date)"
           tabindex="-1"

--- a/libs/components/datetime/src/lib/modules/datepicker/monthpicker.component.html
+++ b/libs/components/datetime/src/lib/modules/datepicker/monthpicker.component.html
@@ -16,7 +16,7 @@
             'sky-btn-active': datepicker.isActive(date)
           }"
           [attr.aria-label]="
-            date.date | skyDatepickerCalendarLabel : datepicker.formatMonthLabel
+            date.date | skyDatepickerCalendarLabel: datepicker.formatMonthLabel
           "
           [disabled]="date.disabled"
           (click)="datepicker.selectCalendar($event, date.date)"

--- a/libs/components/datetime/src/lib/modules/datepicker/monthpicker.component.ts
+++ b/libs/components/datetime/src/lib/modules/datepicker/monthpicker.component.ts
@@ -96,5 +96,9 @@ export class SkyMonthPickerComponent implements OnInit {
       date = 11;
     }
     this.datepicker.activeDate.setMonth(date);
+    this.datepicker.announceDate(
+      this.datepicker.activeDate,
+      this.datepicker.formatMonthLabel,
+    );
   }
 }

--- a/libs/components/datetime/src/lib/modules/datepicker/yearpicker.component.html
+++ b/libs/components/datetime/src/lib/modules/datepicker/yearpicker.component.html
@@ -10,6 +10,9 @@
             'sky-btn-disabled': date.disabled,
             'sky-btn-active': datepicker.isActive(date)
           }"
+          [attr.aria-label]="
+            date.date | skyDatepickerCalendarLabel : datepicker.formatYearLabel
+          "
           [disabled]="date.disabled"
           (click)="datepicker.selectCalendar($event, date.date)"
           tabindex="-1"

--- a/libs/components/datetime/src/lib/modules/datepicker/yearpicker.component.html
+++ b/libs/components/datetime/src/lib/modules/datepicker/yearpicker.component.html
@@ -11,7 +11,7 @@
             'sky-btn-active': datepicker.isActive(date)
           }"
           [attr.aria-label]="
-            date.date | skyDatepickerCalendarLabel : datepicker.formatYearLabel
+            date.date | skyDatepickerCalendarLabel: datepicker.formatYearLabel
           "
           [disabled]="date.disabled"
           (click)="datepicker.selectCalendar($event, date.date)"

--- a/libs/components/datetime/src/lib/modules/datepicker/yearpicker.component.ts
+++ b/libs/components/datetime/src/lib/modules/datepicker/yearpicker.component.ts
@@ -105,5 +105,9 @@ export class SkyYearPickerComponent implements OnInit {
         1;
     }
     this.datepicker.activeDate.setFullYear(date);
+    this.datepicker.announceDate(
+      this.datepicker.activeDate,
+      this.datepicker.formatYearLabel,
+    );
   }
 }


### PR DESCRIPTION
:cherries: Cherry picked from #2051 [feat(components/datetime): improve screen reader labels for values on datepicker calendar](https://github.com/blackbaud/skyux/pull/2051)

[AB#2599977](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/2599977) 