### PR TITLE
feat(components/tiles): use tile ID for region and help inline aria label attributes

### DIFF
--- a/apps/code-examples/src/app/code-examples/tiles/tiles/inline-help/tile1.component.html
+++ b/apps/code-examples/src/app/code-examples/tiles/tiles/inline-help/tile1.component.html
@@ -3,7 +3,6 @@
     Tile 1
     <sky-help-inline
       class="sky-control-help"
-      ariaLabel="Information about Tile 1"
       (actionClick)="onActionClick()"
       (click)="onHelpClick($event)"
     />

--- a/apps/code-examples/src/app/code-examples/tiles/tiles/inline-help/tile2.component.html
+++ b/apps/code-examples/src/app/code-examples/tiles/tiles/inline-help/tile2.component.html
@@ -1,9 +1,8 @@
-<sky-tile tileName="Tile 2">
+<sky-tile>
   <sky-tile-title>
     Tile 2
     <sky-help-inline
       class="sky-control-help"
-      ariaLabel="Information about Tile 2"
       (actionClick)="onActionClick()"
       (click)="onHelpClick($event)"
     />

--- a/libs/components/indicators/src/assets/locales/resources_en_US.json
+++ b/libs/components/indicators/src/assets/locales/resources_en_US.json
@@ -43,6 +43,14 @@
     "_description": "The title for the help button.",
     "message": "Show help content"
   },
+  "skyux_help_inline_button_title_with_descriptor_text": {
+    "_description": "The title for the help button.",
+    "message": "Show help content for {0}"
+  },
+  "skyux_help_inline_button_title_with_descriptor_el": {
+    "_description": "The title for the help button.",
+    "message": "Show help content for"
+  },
   "skyux_label_sr_attention": {
     "_description": "Screen reader text when the label contains info that needs attention",
     "message": "Attention:"

--- a/libs/components/indicators/src/lib/modules/help-inline/help-inline.component.html
+++ b/libs/components/indicators/src/lib/modules/help-inline/help-inline.component.html
@@ -2,7 +2,18 @@
   class="sky-help-inline"
   type="button"
   [attr.aria-label]="
-    ariaLabel || 'skyux_help_inline_button_title' | skyLibResources
+    ariaLabel ||
+    ((contentInfoObs | async)?.descriptor
+      ? (contentInfoObs | async)?.descriptor?.type === 'text'
+        ? ('skyux_help_inline_button_title_with_descriptor_text'
+          | skyLibResources : (contentInfoObs | async)?.descriptor?.value)
+        : undefined
+      : ('skyux_help_inline_button_title' | skyLibResources))
+  "
+  [attr.aria-labelledby]="
+    !ariaLabel && (contentInfoObs | async)?.descriptor?.type === 'elementId'
+      ? screenReaderLabel.id + ' ' + (contentInfoObs | async)?.descriptor?.value
+      : undefined
   "
   [attr.aria-controls]="ariaControls"
   [attr.aria-expanded]="ariaExpanded | skyHelpInlineAriaExpanded : ariaControls"
@@ -23,3 +34,12 @@
   >
   </sky-icon-stack>
 </button>
+
+<span
+  skyScreenReaderLabel
+  [createLabel]="!ariaLabel"
+  skyId
+  #screenReaderLabel="skyId"
+>
+  {{ 'skyux_help_inline_button_title_with_descriptor_el' | skyLibResources }}
+</span>

--- a/libs/components/indicators/src/lib/modules/help-inline/help-inline.component.spec.ts
+++ b/libs/components/indicators/src/lib/modules/help-inline/help-inline.component.spec.ts
@@ -2,6 +2,7 @@ import { DebugElement } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { BrowserModule, By } from '@angular/platform-browser';
 import { expect, expectAsync } from '@skyux-sdk/testing';
+import { SkyContentInfoProvider } from '@skyux/core';
 
 import { SkyHelpInlineModule } from '../help-inline/help-inline.module';
 
@@ -9,13 +10,22 @@ import { HelpInlineTestComponent } from './fixtures/help-inline.component.fixtur
 
 describe('Help inline component', () => {
   async function checkAriaPropertiesAndAccessibility(
-    ariaLabel: string,
+    ariaLabel: string | null,
+    ariaLabelledBy: string | null,
     ariaControls: string | null,
     ariaExpanded: string | null,
   ): Promise<void> {
     const helpInlineElement =
       fixture.nativeElement.querySelector('.sky-help-inline');
+    const ariaLabelledByAttribute =
+      helpInlineElement?.getAttribute('aria-labelledBy');
     expect(helpInlineElement?.getAttribute('aria-label')).toBe(ariaLabel);
+    if (ariaLabelledBy) {
+      expect(ariaLabelledByAttribute).toContain('sky-id-gen__');
+      expect(ariaLabelledByAttribute).toContain(ariaLabelledBy);
+    } else {
+      expect(ariaLabelledByAttribute).toBeNull();
+    }
     expect(helpInlineElement?.getAttribute('aria-controls')).toBe(ariaControls);
     expect(helpInlineElement?.getAttribute('aria-expanded')).toBe(ariaExpanded);
     await expectAsync(fixture.nativeElement).toBeAccessible();
@@ -24,16 +34,19 @@ describe('Help inline component', () => {
   let fixture: ComponentFixture<HelpInlineTestComponent>;
   let cmp: HelpInlineTestComponent;
   let debugElement: DebugElement;
+  let contentInfoProvider: SkyContentInfoProvider;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
       declarations: [HelpInlineTestComponent],
       imports: [BrowserModule, SkyHelpInlineModule],
+      providers: [SkyContentInfoProvider],
     });
 
     fixture = TestBed.createComponent(HelpInlineTestComponent);
     cmp = fixture.componentInstance as HelpInlineTestComponent;
     debugElement = fixture.debugElement;
+    contentInfoProvider = TestBed.inject(SkyContentInfoProvider);
 
     fixture.detectChanges();
   });
@@ -46,11 +59,70 @@ describe('Help inline component', () => {
     expect(cmp.showHelpText).toBe(true);
   });
 
-  it('should pass accessibility (ariaLabel: undefined, ariaControls: undefined, ariaExpanded: undefined)', async () => {
+  it('should pass accessibility (ariaLabel: undefined, ariaControls: undefined, ariaExpanded: undefined, contentInfoProvided: text)', async () => {
+    contentInfoProvider.patchInfo({
+      descriptor: { type: 'text', value: 'tile name' },
+    });
+
     fixture.detectChanges();
     await fixture.whenStable();
 
-    await checkAriaPropertiesAndAccessibility('Show help content', null, null);
+    await checkAriaPropertiesAndAccessibility(
+      'Show help content for tile name',
+      null,
+      null,
+      null,
+    );
+  });
+
+  it('should pass accessibility (ariaLabel: "Test label", ariaControls: undefined, ariaExpanded: undefined, contentInfoProvided: text)', async () => {
+    contentInfoProvider.patchInfo({
+      descriptor: { type: 'text', value: 'tile name' },
+    });
+
+    cmp.ariaLabel = 'Test label';
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    await checkAriaPropertiesAndAccessibility('Test label', null, null, null);
+  });
+
+  it('should pass accessibility (ariaLabel: undefined, ariaControls: undefined, ariaExpanded: undefined, contentInfoProvided: elementId)', async () => {
+    const elementId = 'element-id';
+    contentInfoProvider.patchInfo({
+      descriptor: { type: 'elementId', value: elementId },
+    });
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    await checkAriaPropertiesAndAccessibility(null, elementId, null, null);
+  });
+
+  it('should pass accessibility (ariaLabel: "Test label", ariaControls: undefined, ariaExpanded: undefined, contentInfoProvided: elementId)', async () => {
+    contentInfoProvider.patchInfo({
+      descriptor: { type: 'elementId', value: 'element-id' },
+    });
+
+    cmp.ariaLabel = 'Test label';
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    await checkAriaPropertiesAndAccessibility('Test label', null, null, null);
+  });
+
+  it('should pass accessibility (ariaLabel: undefined, ariaControls: undefined, ariaExpanded: undefined, contentInfoProvided: none)', async () => {
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    await checkAriaPropertiesAndAccessibility(
+      'Show help content',
+      null,
+      null,
+      null,
+    );
   });
 
   it('should pass accessibility (ariaLabel: undefined, ariaControls: "help-text", ariaExpanded: undefined)', async () => {
@@ -60,6 +132,7 @@ describe('Help inline component', () => {
 
     await checkAriaPropertiesAndAccessibility(
       'Show help content',
+      null,
       'help-text',
       'false',
     );
@@ -73,6 +146,7 @@ describe('Help inline component', () => {
 
     await checkAriaPropertiesAndAccessibility(
       'Show help content',
+      null,
       'help-text',
       'false',
     );
@@ -86,6 +160,7 @@ describe('Help inline component', () => {
 
     await checkAriaPropertiesAndAccessibility(
       'Show help content',
+      null,
       'help-text',
       'true',
     );
@@ -96,7 +171,7 @@ describe('Help inline component', () => {
     fixture.detectChanges();
     await fixture.whenStable();
 
-    await checkAriaPropertiesAndAccessibility('Test label', null, null);
+    await checkAriaPropertiesAndAccessibility('Test label', null, null, null);
   });
 
   it('should pass accessibility (ariaLabel: "Test label", ariaControls: "help-text", ariaExpanded: undefined)', async () => {
@@ -107,6 +182,7 @@ describe('Help inline component', () => {
 
     await checkAriaPropertiesAndAccessibility(
       'Test label',
+      null,
       'help-text',
       'false',
     );
@@ -121,6 +197,7 @@ describe('Help inline component', () => {
 
     await checkAriaPropertiesAndAccessibility(
       'Test label',
+      null,
       'help-text',
       'false',
     );
@@ -135,6 +212,7 @@ describe('Help inline component', () => {
 
     await checkAriaPropertiesAndAccessibility(
       'Test label',
+      null,
       'help-text',
       'true',
     );

--- a/libs/components/indicators/src/lib/modules/help-inline/help-inline.component.ts
+++ b/libs/components/indicators/src/lib/modules/help-inline/help-inline.component.ts
@@ -1,4 +1,7 @@
-import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { Component, EventEmitter, Input, Output, inject } from '@angular/core';
+import { SkyContentInfo, SkyContentInfoProvider } from '@skyux/core';
+
+import { Observable } from 'rxjs';
 
 @Component({
   selector: 'sky-help-inline',
@@ -37,6 +40,16 @@ export class SkyHelpInlineComponent {
    */
   @Output()
   public actionClick = new EventEmitter<void>();
+
+  readonly #contentInfoProvider = inject(SkyContentInfoProvider, {
+    optional: true,
+  });
+
+  protected contentInfoObs: Observable<SkyContentInfo> | undefined;
+
+  constructor() {
+    this.contentInfoObs = this.#contentInfoProvider?.getInfo();
+  }
 
   public onClick(): void {
     this.actionClick.emit();

--- a/libs/components/indicators/src/lib/modules/help-inline/help-inline.module.ts
+++ b/libs/components/indicators/src/lib/modules/help-inline/help-inline.module.ts
@@ -1,5 +1,6 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
+import { SkyIdModule, SkyScreenReaderLabelDirective } from '@skyux/core';
 import { SkyThemeModule } from '@skyux/theme';
 
 import { SkyIconModule } from '../icon/icon.module';
@@ -13,7 +14,9 @@ import { SkyHelpInlineComponent } from './help-inline.component';
   imports: [
     CommonModule,
     SkyIconModule,
+    SkyIdModule,
     SkyIndicatorsResourcesModule,
+    SkyScreenReaderLabelDirective,
     SkyThemeModule,
   ],
   exports: [SkyHelpInlineComponent],

--- a/libs/components/indicators/src/lib/modules/shared/sky-indicators-resources.module.ts
+++ b/libs/components/indicators/src/lib/modules/shared/sky-indicators-resources.module.ts
@@ -30,6 +30,12 @@ const RESOURCES: { [locale: string]: SkyLibResources } = {
     skyux_alert_sr_success: { message: 'Success:' },
     skyux_alert_sr_warning: { message: 'Warning:' },
     skyux_help_inline_button_title: { message: 'Show help content' },
+    skyux_help_inline_button_title_with_descriptor_text: {
+      message: 'Show help content for {0}',
+    },
+    skyux_help_inline_button_title_with_descriptor_el: {
+      message: 'Show help content for',
+    },
     skyux_label_sr_attention: { message: 'Attention:' },
     skyux_label_sr_caution: { message: 'Caution:' },
     skyux_label_sr_completed: { message: 'Completed:' },

--- a/libs/components/tiles/src/lib/modules/tiles/tile-dashboard/tile-dashboard.service.spec.ts
+++ b/libs/components/tiles/src/lib/modules/tiles/tile-dashboard/tile-dashboard.service.spec.ts
@@ -9,6 +9,7 @@ import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { SkyAppTestUtility, expect } from '@skyux-sdk/testing';
 import {
+  SkyContentInfoProvider,
   SkyMediaBreakpoints,
   SkyMediaQueryService,
   SkyUIConfigService,
@@ -28,6 +29,7 @@ import { BehaviorSubject } from 'rxjs';
 import { SkyTileDashboardConfig } from '../tile-dashboard-config/tile-dashboard-config';
 import { SkyTileDashboardComponent } from '../tile-dashboard/tile-dashboard.component';
 import { SkyTileDashboardService } from '../tile-dashboard/tile-dashboard.service';
+import { SKY_TILE_TITLE_ID } from '../tile/tile-title-id-token';
 import { SkyTileComponent } from '../tile/tile.component';
 import { SkyTilesModule } from '../tiles.module';
 
@@ -81,6 +83,8 @@ describe('Tile dashboard service', () => {
           provide: SkyThemeService,
           useValue: mockThemeSvc,
         },
+        SkyContentInfoProvider,
+        { provide: SKY_TILE_TITLE_ID, useValue: '1' },
       ],
     });
 
@@ -368,17 +372,19 @@ describe('Tile dashboard service', () => {
       .query(By.directive(SkyTileDashboardComponent))
       .injector.get(SkyTileDashboardService);
 
-    dashboardService.moveTileOnKeyDown(
-      new SkyTileComponent(
-        fixture.elementRef,
-        fixture.componentRef.changeDetectorRef,
-        {
-          configChange: new EventEmitter<SkyTileDashboardConfig>(),
-        } as SkyTileDashboardService,
-      ),
-      'left',
-      'Tile 1',
-    );
+    TestBed.runInInjectionContext(() => {
+      dashboardService.moveTileOnKeyDown(
+        new SkyTileComponent(
+          fixture.elementRef,
+          fixture.componentRef.changeDetectorRef,
+          {
+            configChange: new EventEmitter<SkyTileDashboardConfig>(),
+          } as SkyTileDashboardService,
+        ),
+        'left',
+        'Tile 1',
+      );
+    });
 
     // Make sure everything is still in the same spot
     const columnEls = fixture.nativeElement.querySelectorAll(

--- a/libs/components/tiles/src/lib/modules/tiles/tile/tile-title-id-token.ts
+++ b/libs/components/tiles/src/lib/modules/tiles/tile/tile-title-id-token.ts
@@ -1,0 +1,5 @@
+import { InjectionToken } from '@angular/core';
+
+export const SKY_TILE_TITLE_ID = new InjectionToken<string>(
+  'SKY_TILE_TITLE_ID',
+);

--- a/libs/components/tiles/src/lib/modules/tiles/tile/tile-title.component.html
+++ b/libs/components/tiles/src/lib/modules/tiles/tile/tile-title.component.html
@@ -1,5 +1,5 @@
 <h2 class="sky-tile-title sky-font-heading-2">
-  <span skyTrim><ng-content /></span
+  <span [id]="tileTitleId" skyTrim><ng-content /></span
   ><span class="sky-control-help-container"
     ><ng-content select=".sky-control-help"></ng-content
   ></span>

--- a/libs/components/tiles/src/lib/modules/tiles/tile/tile-title.component.ts
+++ b/libs/components/tiles/src/lib/modules/tiles/tile/tile-title.component.ts
@@ -1,5 +1,7 @@
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { SkyTrimModule } from '@skyux/core';
+
+import { SKY_TILE_TITLE_ID } from './tile-title-id-token';
 
 /**
  * Specifies content to display in the tile's title.
@@ -11,4 +13,6 @@ import { SkyTrimModule } from '@skyux/core';
   styleUrls: ['./tile-title.component.scss'],
   imports: [SkyTrimModule],
 })
-export class SkyTileTitleComponent {}
+export class SkyTileTitleComponent {
+  protected readonly tileTitleId = inject(SKY_TILE_TITLE_ID);
+}

--- a/libs/components/tiles/src/lib/modules/tiles/tile/tile.component.html
+++ b/libs/components/tiles/src/lib/modules/tiles/tile/tile.component.html
@@ -96,6 +96,7 @@
     role="region"
     skyId
     [attr.aria-label]="tileName"
+    [attr.aria-labelledBy]="!tileName && titleRef ? tileTitleId : undefined"
     [@skyAnimationSlide]="isCollapsed ? 'up' : 'down'"
     #tileContent="skyId"
   >

--- a/libs/components/tiles/src/lib/modules/tiles/tile/tile.component.spec.ts
+++ b/libs/components/tiles/src/lib/modules/tiles/tile/tile.component.spec.ts
@@ -6,6 +6,7 @@ import {
 } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { expect, expectAsync } from '@skyux-sdk/testing';
+import { SkyContentInfoProvider } from '@skyux/core';
 import {
   SkyTheme,
   SkyThemeMode,
@@ -21,6 +22,7 @@ import { SkyTilesModule } from '../tiles.module';
 
 import { MockSkyTileDashboardService } from './fixtures/mock-tile-dashboard.service';
 import { TileTestComponent } from './fixtures/tile.component.fixture';
+import { SKY_TILE_TITLE_ID } from './tile-title-id-token';
 import { SkyTileComponent } from './tile.component';
 
 describe('Tile component', () => {
@@ -46,6 +48,10 @@ describe('Tile component', () => {
     return fixture.nativeElement.querySelector('.sky-tile-settings');
   }
 
+  function getTileContent(fixture: ComponentFixture<any>): HTMLButtonElement {
+    return fixture.nativeElement.querySelector('.sky-tile-content');
+  }
+
   beforeEach(() => {
     mockThemeSvc = {
       settingsChange: new BehaviorSubject<SkyThemeSettingsChange>({
@@ -65,6 +71,7 @@ describe('Tile component', () => {
           provide: SkyThemeService,
           useValue: mockThemeSvc,
         },
+        SkyContentInfoProvider,
       ],
     });
   });
@@ -192,6 +199,48 @@ describe('Tile component', () => {
       jasmine.any(SkyTileComponent),
       true,
     );
+  });
+
+  it('should provide tileName to content info provider', () => {
+    const mockContentProvider = { patchInfo: jasmine.createSpy() };
+    const tileName = 'Tile name';
+    const fixture = TestBed.overrideComponent(SkyTileComponent, {
+      set: {
+        providers: [
+          { provide: SkyContentInfoProvider, useValue: mockContentProvider },
+          { provide: SKY_TILE_TITLE_ID, useValue: 'title-id' },
+        ],
+      },
+    }).createComponent(TileTestComponent);
+
+    fixture.componentInstance.tileName = tileName;
+
+    fixture.detectChanges();
+
+    expect(mockContentProvider.patchInfo).toHaveBeenCalledWith({
+      descriptor: { type: 'text', value: tileName },
+    });
+  });
+
+  it('should provide the tile tile ID to content info provider when no tileName is set', () => {
+    const mockContentProvider = { patchInfo: jasmine.createSpy() };
+    const tileTitleId = 'title-id';
+    const fixture = TestBed.overrideComponent(SkyTileComponent, {
+      set: {
+        providers: [
+          { provide: SkyContentInfoProvider, useValue: mockContentProvider },
+          { provide: SKY_TILE_TITLE_ID, useValue: tileTitleId },
+        ],
+      },
+    }).createComponent(TileTestComponent);
+
+    fixture.componentInstance.tileName = undefined;
+
+    fixture.detectChanges();
+
+    expect(mockContentProvider.patchInfo).toHaveBeenCalledWith({
+      descriptor: { type: 'elementId', value: tileTitleId },
+    });
   });
 
   describe('settings button', () => {
@@ -347,8 +396,17 @@ describe('Tile component', () => {
     });
   });
 
-  it('should create default aria labels when tileName is not defined', fakeAsync(() => {
-    const fixture = TestBed.createComponent(TileTestComponent);
+  it('should create default aria labels or set aria-labelledby to title id when tileName is not defined', fakeAsync(() => {
+    const tileTitleId = 'title-id';
+    const fixture = TestBed.overrideComponent(SkyTileComponent, {
+      set: {
+        providers: [
+          SkyContentInfoProvider,
+          { provide: SKY_TILE_TITLE_ID, useValue: tileTitleId },
+        ],
+      },
+    }).createComponent(TileTestComponent);
+
     fixture.componentInstance.tileName = undefined;
     fixture.detectChanges();
     tick();
@@ -356,20 +414,25 @@ describe('Tile component', () => {
     // Force tile to render move button.
     fixture.componentInstance.tileComponent.isInDashboardColumn = true;
     fixture.detectChanges();
+
     const helpButton = getHelpButton(fixture);
     const expandButton = getExpandButton(fixture);
     const moveButton = getMoveButton(fixture);
     const settingsButton = getSettingsButton(fixture);
+    const tileContent = getTileContent(fixture);
+
     expect(helpButton.getAttribute('aria-label')).toEqual('Help');
     expect(expandButton.getAttribute('aria-label')).toEqual(
       'Expand or collapse',
     );
     expect(moveButton.getAttribute('aria-label')).toEqual('Move');
     expect(settingsButton.getAttribute('aria-label')).toEqual('Settings');
+    expect(tileContent.getAttribute('aria-labelledBy')).toEqual(tileTitleId);
   }));
 
   it('should create accessible aria labels when tileName is defined', fakeAsync(() => {
     const fixture = TestBed.createComponent(TileTestComponent);
+
     fixture.componentInstance.tileName = 'Users';
     fixture.detectChanges();
     tick();
@@ -377,16 +440,20 @@ describe('Tile component', () => {
     // Force tile to render move button.
     fixture.componentInstance.tileComponent.isInDashboardColumn = true;
     fixture.detectChanges();
+
     const helpButton = getHelpButton(fixture);
     const expandButton = getExpandButton(fixture);
     const moveButton = getMoveButton(fixture);
     const settingsButton = getSettingsButton(fixture);
+    const tileContent = getTileContent(fixture);
+
     expect(helpButton.getAttribute('aria-label')).toEqual('Users help');
     expect(expandButton.getAttribute('aria-label')).toEqual(
       'Expand or collapse Users',
     );
     expect(moveButton.getAttribute('aria-label')).toEqual('Move Users');
     expect(settingsButton.getAttribute('aria-label')).toEqual('Users settings');
+    expect(tileContent.getAttribute('aria-label')).toEqual('Users');
   }));
 
   it('should pass accessibility', async () => {


### PR DESCRIPTION
This PR:
- creates a title id injection token so that the tile can set an ID on the consumer-provided `sky-tile-title` the same way we do with box
- sets the tile content region's `aria-labelledby` to the title ID if no `tileName` is provided
- provides the `tileName` or title ID if no `tileName` is set as content info via the `SkyContentInfoProvider`
- consumes the content info in `help-inline` to set a more specific aria string if content info is provided. The existing `ariaLabel` input still takes precedence.