### PR TITLE
feat(components/lists): repeater back to top button uses new `arrow-up` icon

### DIFF
--- a/libs/components/lists/src/lib/modules/repeater/repeater-item.component.html
+++ b/libs/components/lists/src/lib/modules/repeater/repeater-item.component.html
@@ -119,7 +119,7 @@
         "
         (click)="moveToTop($event)"
       >
-        <sky-icon icon="arrow-circle-up" />
+        <sky-icon icon="arrow-up" />
         {{ 'skyux_repeater_item_reorder_top' | skyLibResources }}
       </button>
       <div *ngIf="isCollapsible" class="sky-repeater-item-chevron">


### PR DESCRIPTION
[AB#2707073](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/2707073)