### PR TITLE
fix(components/tabs): set appropriate `:focus-visible` styles for selected tab buttons

### DIFF
--- a/apps/e2e/tabs-storybook-e2e/src/e2e/tabs.component.cy.ts
+++ b/apps/e2e/tabs-storybook-e2e/src/e2e/tabs.component.cy.ts
@@ -24,6 +24,7 @@ describe(`tabs-storybook`, () => {
             `/iframe.html?globals=theme:${theme}&id=tabscomponent-tabs--tabs-dropdown`,
           ),
         );
+
         it('should render the component', () => {
           cy.get('app-tabs')
             .should('exist')
@@ -31,6 +32,11 @@ describe(`tabs-storybook`, () => {
             .get('sky-dropdown')
             .should('exist')
             .should('be.visible')
+            .as('tabs');
+
+          cy.get('@tabs').get('button.sky-dropdown-button').click();
+
+          cy.get('@tabs')
             .screenshot(`tabscomponent-tabs--tabs-dropdown-${theme}`)
             .percySnapshot(`tabscomponent-tabs--tabs-dropdown-${theme}`);
         });

--- a/libs/components/theme/src/lib/styles/_buttons.scss
+++ b/libs/components/theme/src/lib/styles/_buttons.scss
@@ -111,7 +111,7 @@ a.sky-btn {
 .sky-btn-tab {
   @include mixins.sky-btn-tab();
 
-  &.sky-btn-tab-selected:not(.sky-btn-tab-disabled):not(.sky-btn-tab-wizard) {
+  &.sky-btn-tab-selected:not(.sky-btn-tab-disabled) {
     @include mixins.sky-btn-tab-selected;
 
     .sky-btn-tab-close,
@@ -159,7 +159,7 @@ a.sky-btn {
     background-color: var(--sky-background-color-neutral-light);
   }
 
-  &.sky-btn-tab-selected {
+  &.sky-btn-tab-selected:not(.sky-btn-tab-disabled) {
     background-color: var(--sky-background-color-info);
     border-color: var(--sky-background-color-info);
     color: var(--sky-text-color-default);

--- a/libs/components/theme/src/lib/styles/_buttons.scss
+++ b/libs/components/theme/src/lib/styles/_buttons.scss
@@ -110,6 +110,15 @@ a.sky-btn {
 
 .sky-btn-tab {
   @include mixins.sky-btn-tab();
+
+  &.sky-btn-tab-selected:not(.sky-btn-tab-disabled) {
+    @include mixins.sky-btn-tab-selected;
+
+    .sky-btn-tab-close,
+    .sky-tab-header-count {
+      color: #fff;
+    }
+  }
 }
 
 .sky-btn-tab-close {
@@ -130,17 +139,6 @@ a.sky-btn {
   font-weight: 400;
   color: var(--sky-text-color-action-primary);
   margin-left: $sky-margin-half;
-}
-
-.sky-tab-dropdown-item-selected {
-  .sky-btn-tab-selected:not(.sky-btn-tab-disabled) {
-    @include mixins.sky-btn-tab-selected;
-
-    .sky-btn-tab-close,
-    .sky-tab-header-count {
-      color: #fff;
-    }
-  }
 }
 
 .sky-btn-tab-wizard {

--- a/libs/components/theme/src/lib/styles/_buttons.scss
+++ b/libs/components/theme/src/lib/styles/_buttons.scss
@@ -111,7 +111,7 @@ a.sky-btn {
 .sky-btn-tab {
   @include mixins.sky-btn-tab();
 
-  &.sky-btn-tab-selected:not(.sky-btn-tab-disabled) {
+  &.sky-btn-tab-selected:not(.sky-btn-tab-disabled):not(.sky-btn-tab-wizard) {
     @include mixins.sky-btn-tab-selected;
 
     .sky-btn-tab-close,

--- a/libs/components/theme/src/lib/styles/_buttons.scss
+++ b/libs/components/theme/src/lib/styles/_buttons.scss
@@ -132,12 +132,14 @@ a.sky-btn {
   margin-left: $sky-margin-half;
 }
 
-.sky-btn-tab-selected:not(.sky-btn-tab-disabled) {
-  @include mixins.sky-btn-tab-selected;
+.sky-tab-dropdown-item-selected {
+  .sky-btn-tab-selected:not(.sky-btn-tab-disabled) {
+    @include mixins.sky-btn-tab-selected;
 
-  .sky-btn-tab-close,
-  .sky-tab-header-count {
-    color: #fff;
+    .sky-btn-tab-close,
+    .sky-tab-header-count {
+      color: #fff;
+    }
   }
 }
 

--- a/libs/components/theme/src/lib/styles/_public-api/_compat/_mixins.scss
+++ b/libs/components/theme/src/lib/styles/_public-api/_compat/_mixins.scss
@@ -46,6 +46,7 @@
   background-color: var(--sky-background-color-primary-dark);
   color: var(--sky-text-color-on-dark);
 
+  &:focus-visible:not(.sky-btn-tab-disabled),
   &:hover:not(.sky-btn-tab-disabled) {
     background-color: var(--sky-background-color-primary-dark);
     color: var(--sky-text-color-on-dark);

--- a/libs/components/theme/src/lib/styles/_public-api/_compat/_mixins.scss
+++ b/libs/components/theme/src/lib/styles/_public-api/_compat/_mixins.scss
@@ -46,7 +46,8 @@
   background-color: var(--sky-background-color-primary-dark);
   color: var(--sky-text-color-on-dark);
 
-  &:hover:not(.sky-btn-tab-disabled) {
+  &:hover:not(.sky-btn-tab-disabled),
+  &:focus-visible:not(.sky-btn-tab-disabled) {
     background-color: var(--sky-background-color-primary-dark);
     color: var(--sky-text-color-on-dark);
   }

--- a/libs/components/theme/src/lib/styles/_public-api/_compat/_mixins.scss
+++ b/libs/components/theme/src/lib/styles/_public-api/_compat/_mixins.scss
@@ -46,8 +46,7 @@
   background-color: var(--sky-background-color-primary-dark);
   color: var(--sky-text-color-on-dark);
 
-  &:hover:not(.sky-btn-tab-disabled),
-  &:focus-visible:not(.sky-btn-tab-disabled) {
+  &:hover:not(.sky-btn-tab-disabled) {
     background-color: var(--sky-background-color-primary-dark);
     color: var(--sky-text-color-on-dark);
   }

--- a/libs/components/theme/src/lib/styles/_public-api/themes/modern/_compat/_mixins.scss
+++ b/libs/components/theme/src/lib/styles/_public-api/themes/modern/_compat/_mixins.scss
@@ -154,6 +154,7 @@
     background-color: transparent;
     box-shadow: vars.$sky-theme-modern-elevation-3-shadow-size
       vars.$sky-theme-modern-elevation-3-shadow-color;
+    color: var(--sky-text-color-default);
     outline: solid 2px var(--sky-background-color-primary-dark);
     outline-offset: -2px;
   }


### PR DESCRIPTION
[AB#2762941](https://dev.azure.com/blackbaud/Products/_workitems/edit/2762941)

Components that might be affected by this change (both Modern/Default themes):
- Tabs, tabs collapsed into a dropdown
- Wizard