### PR TITLE
feat(components/forms): add form errors to single file attachment (#2094)

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,6 @@
 {
   "singleQuote": true,
+  "printWidth": 80,
   "trailingComma": "all",
   "importOrder": ["^@(.*)$", "^\\w(.*)$", "^(../)(.*)$", "^(./)(.*)$"],
   "importOrderSeparation": true,

--- a/apps/e2e/forms-storybook/src/app/single-file-attachment/single-file-attachment.component.ts
+++ b/apps/e2e/forms-storybook/src/app/single-file-attachment/single-file-attachment.component.ts
@@ -51,6 +51,7 @@ export class SingleFileAttachmentComponent {
       imageAttachment: this.imageAttachment,
       fileAttachment: this.fileAttachment,
     });
+    this.attachment.markAsTouched();
   }
 
   public reactiveFileUpdated(result: SkyFileAttachmentChange): void {

--- a/apps/playground/src/app/components/forms/single-file-attachment/single-file-attachment.component.html
+++ b/apps/playground/src/app/components/forms/single-file-attachment/single-file-attachment.component.html
@@ -2,8 +2,9 @@
   <div style="margin-bottom: 50px">
     <sky-file-attachment
       formControlName="attachment"
-      labelText="label text"
+      labelText="Attach a file"
       [maxFileSize]="maxFileSize"
+      [acceptedTypes]="'image/jpeg'"
       [validateFn]="validateFile"
       (fileChange)="reactiveFileUpdated($event)"
       (fileClick)="fileClick($event)"

--- a/libs/components/forms/src/assets/locales/resources_en_US.json
+++ b/libs/components/forms/src/assets/locales/resources_en_US.json
@@ -143,6 +143,18 @@
     "_description": "Screen reader text when a link is removed",
     "message": "Link to {0} removed."
   },
+  "skyux_file_attachment_file_type_error_label_text": {
+    "_description": "The error message for file attachment incorrect file type error",
+    "message": "Please upload a file of type {0}."
+  },
+  "skyux_file_attachment_max_file_size_error_label_text": {
+    "_description": "The error message for file attachment max file size error",
+    "message": "Please upload a file under {0}KB."
+  },
+  "skyux_file_attachment_min_file_size_error_label_text": {
+    "_description": "The error message for file attachment min file size error",
+    "message": "Please upload a file over {0}KB."
+  },
   "skyux_file_attachment_label_no_file_chosen": {
     "_description": "Label for single file attachment when no file is chosen",
     "message": "No file chosen."

--- a/libs/components/forms/src/lib/modules/file-attachment/file-attachment.component.html
+++ b/libs/components/forms/src/lib/modules/file-attachment/file-attachment.component.html
@@ -51,7 +51,7 @@
         [attr.aria-label]="
           value
             ? ('skyux_file_attachment_button_label_replace_file_label'
-              | skyLibResources: fileName)
+              | skyLibResources : fileName)
             : ('skyux_file_attachment_button_label_choose_file_label'
               | skyLibResources)
         "
@@ -61,8 +61,8 @@
           (labelText
             ? labelElementId
             : hasLabelComponent
-              ? labelComponents?.get(0)?.labelContentId?.id
-              : undefined)
+            ? labelComponents?.get(0)?.labelContentId?.id
+            : undefined)
         "
         [disabled]="disabled"
         (click)="onDropClicked()"
@@ -107,7 +107,7 @@
       skyId
       type="button"
       [attr.aria-label]="
-        'skyux_file_attachment_file_item_remove' | skyLibResources: fileName
+        'skyux_file_attachment_file_item_remove' | skyLibResources : fileName
       "
       [attr.aria-labelledby]="
         deleteButton.id +

--- a/libs/components/forms/src/lib/modules/file-attachment/file-attachment.component.html
+++ b/libs/components/forms/src/lib/modules/file-attachment/file-attachment.component.html
@@ -51,7 +51,7 @@
         [attr.aria-label]="
           value
             ? ('skyux_file_attachment_button_label_replace_file_label'
-              | skyLibResources : fileName)
+              | skyLibResources: fileName)
             : ('skyux_file_attachment_button_label_choose_file_label'
               | skyLibResources)
         "
@@ -61,8 +61,8 @@
           (labelText
             ? labelElementId
             : hasLabelComponent
-            ? labelComponents?.get(0)?.labelContentId?.id
-            : undefined)
+              ? labelComponents?.get(0)?.labelContentId?.id
+              : undefined)
         "
         [disabled]="disabled"
         (click)="onDropClicked()"
@@ -107,7 +107,7 @@
       skyId
       type="button"
       [attr.aria-label]="
-        'skyux_file_attachment_file_item_remove' | skyLibResources : fileName
+        'skyux_file_attachment_file_item_remove' | skyLibResources: fileName
       "
       [attr.aria-labelledby]="
         deleteButton.id +
@@ -153,7 +153,7 @@
     [errorName]="'fileType'"
     [errorText]="
       'skyux_file_attachment_file_type_error_label_text'
-        | skyLibResources : fileErrorParam
+        | skyLibResources: fileErrorParam
     "
   />
   <sky-form-error
@@ -161,7 +161,7 @@
     [errorName]="'maxFileSize'"
     [errorText]="
       'skyux_file_attachment_max_file_size_error_label_text'
-        | skyLibResources : fileErrorParam
+        | skyLibResources: fileErrorParam
     "
   />
   <sky-form-error
@@ -169,7 +169,7 @@
     [errorName]="'minFileSize'"
     [errorText]="
       'skyux_file_attachment_min_file_size_error_label_text'
-        | skyLibResources : fileErrorParam
+        | skyLibResources: fileErrorParam
     "
   />
 </sky-form-errors>

--- a/libs/components/forms/src/lib/modules/file-attachment/file-attachment.component.html
+++ b/libs/components/forms/src/lib/modules/file-attachment/file-attachment.component.html
@@ -138,6 +138,42 @@
   />
 </div>
 
+<sky-form-errors
+  *ngIf="labelText && (ngControl?.control?.errors || fileErrorValidation)"
+  [id]="errorId"
+  [errors]="
+    ngControl?.errors !== null ? ngControl?.errors : fileErrorValidation
+  "
+  [labelText]="labelText"
+  [showErrors]="ngControl?.touched || ngControl?.dirty"
+>
+  <ng-content select="sky-form-error" />
+  <sky-form-error
+    *ngIf="fileErrorName === 'fileType'"
+    [errorName]="'fileType'"
+    [errorText]="
+      'skyux_file_attachment_file_type_error_label_text'
+        | skyLibResources : fileErrorParam
+    "
+  />
+  <sky-form-error
+    *ngIf="fileErrorName === 'maxFileSize'"
+    [errorName]="'maxFileSize'"
+    [errorText]="
+      'skyux_file_attachment_max_file_size_error_label_text'
+        | skyLibResources : fileErrorParam
+    "
+  />
+  <sky-form-error
+    *ngIf="fileErrorName === 'minFileSize'"
+    [errorName]="'minFileSize'"
+    [errorText]="
+      'skyux_file_attachment_min_file_size_error_label_text'
+        | skyLibResources : fileErrorParam
+    "
+  />
+</sky-form-errors>
+
 <ng-template #labelContent>
   <ng-content select="sky-file-attachment-label" />
 </ng-template>

--- a/libs/components/forms/src/lib/modules/file-attachment/file-attachment.component.ts
+++ b/libs/components/forms/src/lib/modules/file-attachment/file-attachment.component.ts
@@ -250,9 +250,7 @@ export class SkyFileAttachmentComponent
     this.#themeSvc = themeSvc;
 
     this.labelElementId = `sky-file-attachment-label-${this.#fileAttachmentId}`;
-    this.fileDropDescriptionElementId = `sky-file-attachment-drop-description-${
-      this.#fileAttachmentId
-    }`;
+    this.fileDropDescriptionElementId = `sky-file-attachment-drop-description-${this.#fileAttachmentId}`;
     if (this.ngControl) {
       this.ngControl.valueAccessor = this;
     }

--- a/libs/components/forms/src/lib/modules/file-attachment/file-attachment.component.ts
+++ b/libs/components/forms/src/lib/modules/file-attachment/file-attachment.component.ts
@@ -15,21 +15,24 @@ import {
   QueryList,
   Self,
   ViewChild,
+  booleanAttribute,
   inject,
 } from '@angular/core';
-import { NgControl } from '@angular/forms';
-import { SkyLiveAnnouncerService } from '@skyux/core';
+import { NgControl, ValidationErrors } from '@angular/forms';
+import { SkyIdService, SkyLiveAnnouncerService } from '@skyux/core';
 import { SkyLibResourcesService } from '@skyux/i18n';
 import { SkyThemeService } from '@skyux/theme';
 
 import { Subject } from 'rxjs';
 import { take, takeUntil } from 'rxjs/operators';
 
+import { SKY_FORM_ERRORS_ENABLED } from '../form-error/form-errors-enabled-token';
 import { SkyFormsUtility } from '../shared/forms-utility';
 
 import { SkyFileAttachmentLabelComponent } from './file-attachment-label.component';
 import { SkyFileAttachmentService } from './file-attachment.service';
 import { SkyFileItem } from './file-item';
+import { SkyFileItemErrorType } from './file-item-error-type';
 import { SkyFileItemService } from './file-item.service';
 import { SkyFileValidateFn } from './file-validate-function';
 import { SkyFileAttachmentChange } from './types/file-attachment-change';
@@ -47,7 +50,10 @@ const MIN_FILE_SIZE_DEFAULT = 0;
   selector: 'sky-file-attachment',
   templateUrl: './file-attachment.component.html',
   styleUrls: ['./file-attachment.component.scss'],
-  providers: [SkyFileAttachmentService],
+  providers: [
+    SkyFileAttachmentService,
+    { provide: SKY_FORM_ERRORS_ENABLED, useValue: true },
+  ],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class SkyFileAttachmentComponent
@@ -89,7 +95,7 @@ export class SkyFileAttachmentComponent
    * Whether to hide `labelText` from view.
    * @preview
    */
-  @Input()
+  @Input({ transform: booleanAttribute })
   public labelHidden = false;
 
   /**
@@ -217,11 +223,18 @@ export class SkyFileAttachmentComponent
   #changeDetector: ChangeDetectorRef;
   #fileAttachmentService: SkyFileAttachmentService;
   #fileItemService: SkyFileItemService;
-  #ngControl: NgControl | undefined;
   #themeSvc: SkyThemeService | undefined;
 
+  readonly #idSvc = inject(SkyIdService);
   readonly #liveAnnouncerSvc = inject(SkyLiveAnnouncerService);
   readonly #resourcesSvc = inject(SkyLibResourcesService);
+
+  protected ngControl: NgControl | undefined;
+  protected errorId = this.#idSvc.generateId();
+
+  protected fileErrorName: SkyFileItemErrorType | undefined;
+  protected fileErrorParam: string | undefined;
+  protected fileErrorValidation: ValidationErrors | null | undefined;
 
   constructor(
     changeDetector: ChangeDetectorRef,
@@ -233,13 +246,15 @@ export class SkyFileAttachmentComponent
     this.#changeDetector = changeDetector;
     this.#fileAttachmentService = fileAttachmentService;
     this.#fileItemService = fileItemService;
-    this.#ngControl = ngControl;
+    this.ngControl = ngControl;
     this.#themeSvc = themeSvc;
 
     this.labelElementId = `sky-file-attachment-label-${this.#fileAttachmentId}`;
-    this.fileDropDescriptionElementId = `sky-file-attachment-drop-description-${this.#fileAttachmentId}`;
-    if (this.#ngControl) {
-      this.#ngControl.valueAccessor = this;
+    this.fileDropDescriptionElementId = `sky-file-attachment-drop-description-${
+      this.#fileAttachmentId
+    }`;
+    if (this.ngControl) {
+      this.ngControl.valueAccessor = this;
     }
   }
 
@@ -261,9 +276,9 @@ export class SkyFileAttachmentComponent
     // Of note is the parent check which allows us to determine if the form is reactive.
     // Without this check there is a changed before checked error
     /* istanbul ignore else */
-    if (this.#ngControl) {
+    if (this.ngControl) {
       setTimeout(() => {
-        this.#ngControl!.control!.setValue(this.value, {
+        this.ngControl!.control!.setValue(this.value, {
           emitEvent: false,
         });
         this.#changeDetector.markForCheck();
@@ -271,7 +286,7 @@ export class SkyFileAttachmentComponent
 
       // Backwards compatibility support for anyone still using Validators.Required.
       this.required =
-        this.required || SkyFormsUtility.hasRequiredValidation(this.#ngControl);
+        this.required || SkyFormsUtility.hasRequiredValidation(this.ngControl);
     }
   }
 
@@ -446,6 +461,16 @@ export class SkyFileAttachmentComponent
   #emitFileChangeEvent(currentFile?: SkyFileItem): void {
     if (currentFile && !currentFile.errorType) {
       this.writeValue(currentFile);
+      this.fileErrorName = undefined;
+      this.fileErrorParam = undefined;
+      this.fileErrorValidation = undefined;
+    } else {
+      this.writeValue(undefined);
+      // Makes sure value accessor is marked as dirty even if current file is undefined
+      this.#onChange(undefined);
+      this.fileErrorValidation = { fileError: true };
+      this.fileErrorName = currentFile?.errorType;
+      this.fileErrorParam = currentFile?.errorParam;
     }
     this.fileChange.emit({
       file: currentFile,

--- a/libs/components/forms/src/lib/modules/file-attachment/file-attachments.module.ts
+++ b/libs/components/forms/src/lib/modules/file-attachment/file-attachments.module.ts
@@ -5,6 +5,8 @@ import { SkyIdModule, SkyTrimModule } from '@skyux/core';
 import { SkyIconModule } from '@skyux/indicators';
 import { SkyThemeModule } from '@skyux/theme';
 
+import { SkyFormErrorModule } from '../form-error/form-error.module';
+import { SkyFormErrorsModule } from '../form-error/form-errors.module';
 import { SkyFormsResourcesModule } from '../shared/sky-forms-resources.module';
 
 import { SkyFileAttachmentLabelComponent } from './file-attachment-label.component';
@@ -26,6 +28,8 @@ import { SkyFileSizePipe } from './file-size.pipe';
     CommonModule,
     FormsModule,
     SkyFormsResourcesModule,
+    SkyFormErrorModule,
+    SkyFormErrorsModule,
     SkyIconModule,
     SkyIdModule,
     SkyThemeModule,

--- a/libs/components/forms/src/lib/modules/file-attachment/fixtures/file-attachment.component.fixture.html
+++ b/libs/components/forms/src/lib/modules/file-attachment/fixtures/file-attachment.component.fixture.html
@@ -4,6 +4,7 @@
     [required]="required"
     [labelHidden]="labelHidden"
     [labelText]="labelText"
+    [maxFileSize]="maxFileSize"
   >
     <sky-file-attachment-label *ngIf="showLabel">
       {{ labelElementText }}

--- a/libs/components/forms/src/lib/modules/file-attachment/fixtures/file-attachment.component.fixture.ts
+++ b/libs/components/forms/src/lib/modules/file-attachment/fixtures/file-attachment.component.fixture.ts
@@ -26,6 +26,8 @@ export class FileAttachmentTestComponent {
 
   public showLabel = true;
 
+  public maxFileSize: number | undefined;
+
   @ViewChild(SkyFileAttachmentComponent)
   public fileAttachmentComponent!: SkyFileAttachmentComponent;
   public showInlineHelp = false;

--- a/libs/components/forms/src/lib/modules/shared/sky-forms-resources.module.ts
+++ b/libs/components/forms/src/lib/modules/shared/sky-forms-resources.module.ts
@@ -92,6 +92,15 @@ const RESOURCES: Record<string, SkyLibResources> = {
     skyux_file_attachment_file_upload_link_removed: {
       message: 'Link to {0} removed.',
     },
+    skyux_file_attachment_file_type_error_label_text: {
+      message: 'Please upload a file of type {0}.',
+    },
+    skyux_file_attachment_max_file_size_error_label_text: {
+      message: 'Please upload a file under {0}KB.',
+    },
+    skyux_file_attachment_min_file_size_error_label_text: {
+      message: 'Please upload a file over {0}KB.',
+    },
     skyux_file_attachment_label_no_file_chosen: { message: 'No file chosen.' },
     skyux_input_box_help_inline_aria_label: {
       message: 'Show help content for {0}',


### PR DESCRIPTION
:cherries: Cherry picked from #2094 [feat(components/forms): add form errors to single file attachment](https://github.com/blackbaud/skyux/pull/2094)