### PR TITLE
fix(components/router): unlinked skyHref instances do not style as links when in an alert (#2125)

### DIFF
--- a/apps/e2e/indicators-storybook/src/app/alert/alert.component.html
+++ b/apps/e2e/indicators-storybook/src/app/alert/alert.component.html
@@ -1,7 +1,15 @@
 <ng-container *ngFor="let variant of variations">
   <ng-container *ngFor="let close of closeable">
     <sky-alert [alertType]="variant" [closeable]="close">
-      {{ variant | titlecase }} alert
+      {{ variant | titlecase }} alert with a <a href="#">link</a> and a
+      <a skyHref="https://example.com" data-sky-id="my-href-1">skyHref link</a>
+      and a
+      <a
+        skyHref="deny://example.com"
+        skyHrefElse="unlink"
+        data-sky-id="my-href-unlinked"
+        >skyHref unlinked link</a
+      >
     </sky-alert>
   </ng-container>
 </ng-container>

--- a/apps/playground/src/app/components/components.module.ts
+++ b/apps/playground/src/app/components/components.module.ts
@@ -113,6 +113,11 @@ export const componentRoutes: Routes = [
       import('./split-view/split-view.module').then((m) => m.SplitViewModule),
   },
   {
+    path: 'router',
+    loadChildren: () =>
+      import('./router/router.module').then((m) => m.RouterModule),
+  },
+  {
     path: 'tabs',
     loadChildren: () => import('./tabs/tabs.module').then((m) => m.TabsModule),
   },

--- a/apps/playground/src/app/components/router/router-routing.module.ts
+++ b/apps/playground/src/app/components/router/router-routing.module.ts
@@ -1,0 +1,23 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+
+const routes: Routes = [
+  {
+    path: 'skyHref',
+    loadComponent: () =>
+      import('./skyHref/skyHref.component').then((m) => m.SkyHrefComponent),
+    data: {
+      name: 'SkyHref',
+      icon: 'link',
+      library: 'router',
+    },
+  },
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule],
+})
+export class RouterRoutingModule {
+  public static routes = routes;
+}

--- a/apps/playground/src/app/components/router/router.module.ts
+++ b/apps/playground/src/app/components/router/router.module.ts
@@ -1,0 +1,10 @@
+import { NgModule } from '@angular/core';
+
+import { RouterRoutingModule } from './router-routing.module';
+
+@NgModule({
+  imports: [RouterRoutingModule],
+})
+export class RouterModule {
+  public static routes = RouterRoutingModule.routes;
+}

--- a/apps/playground/src/app/components/router/skyHref/skyHref.component.html
+++ b/apps/playground/src/app/components/router/skyHref/skyHref.component.html
@@ -1,0 +1,62 @@
+<p>
+  <span>Link where the user has access:</span>
+  <a skyHref="https://example.com" data-sky-id="my-href-1">Example.com</a>
+</p>
+<p>
+  <span>Link where the user has access, translated:</span>
+  <a skyHref="allow://example.com" data-sky-id="my-href-allow"
+    >Example.com with “allow” protocol</a
+  >
+</p>
+<p>
+  <span>Link where the user does not have access, hidden by default:</span>
+  <a skyHref="deny://example.com" data-sky-id="my-href-hidden"
+    >Example.com with “deny” protocol</a
+  >
+</p>
+<p>
+  <span>Link where the user does not have access, shown as plain text:</span>
+  <a
+    skyHref="deny://example.com"
+    skyHrefElse="unlink"
+    data-sky-id="my-href-unlinked"
+    >Example.com with “deny” protocol</a
+  >
+</p>
+
+<sky-alert class="sky-margin-stacked-xl"
+  ><p>
+    <span>Link where the user has access:</span>
+    <a skyHref="https://example.com" data-sky-id="my-href-1">Example.com</a>
+  </p></sky-alert
+>
+
+<sky-alert class="sky-margin-stacked-xl"
+  ><p>
+    <span>Link where the user has access, translated:</span>
+    <a skyHref="allow://example.com" data-sky-id="my-href-allow"
+      >Example.com with “allow” protocol</a
+    >
+  </p></sky-alert
+>
+
+<sky-alert class="sky-margin-stacked-xl"
+  ><p>
+    <span>Link where the user does not have access, hidden by default:</span>
+    <a skyHref="deny://example.com" data-sky-id="my-href-hidden"
+      >Example.com with “deny” protocol</a
+    >
+  </p></sky-alert
+>
+
+<sky-alert class="sky-margin-stacked-xl"
+  ><p>
+    <span>Link where the user does not have access, shown as plain text:</span>
+    <a
+      skyHref="deny://example.com"
+      skyHrefElse="unlink"
+      data-sky-id="my-href-unlinked"
+      >Example.com with “deny” protocol</a
+    >
+  </p></sky-alert
+>

--- a/apps/playground/src/app/components/router/skyHref/skyHref.component.scss
+++ b/apps/playground/src/app/components/router/skyHref/skyHref.component.scss
@@ -1,0 +1,16 @@
+:host {
+  display: block;
+}
+
+span {
+  display: inline-block;
+  margin-right: var(--sky-margin-inline-xs);
+}
+
+a[skyhref]::after {
+  display: block;
+  content: 'skyhref=“' attr(skyhref) '” ➜ href=“' attr(href) '”';
+  font-size: 10px;
+  color: var(--sky-text-color-deemphasized);
+  text-decoration: none;
+}

--- a/apps/playground/src/app/components/router/skyHref/skyHref.component.ts
+++ b/apps/playground/src/app/components/router/skyHref/skyHref.component.ts
@@ -1,6 +1,4 @@
-import { CommonModule } from '@angular/common';
-import { NgModule } from '@angular/core';
-import { RouterModule, Routes } from '@angular/router';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { SkyAlertModule } from '@skyux/indicators';
 import {
   SkyHref,
@@ -9,18 +7,13 @@ import {
   SkyHrefResolverService,
 } from '@skyux/router';
 
-import { AlertComponent } from './alert.component';
-
-const routes: Routes = [{ path: '', component: AlertComponent }];
-@NgModule({
-  declarations: [AlertComponent],
-  exports: [AlertComponent],
-  imports: [
-    CommonModule,
-    RouterModule.forChild(routes),
-    SkyAlertModule,
-    SkyHrefModule,
-  ],
+@Component({
+  standalone: true,
+  selector: 'app-sky-href',
+  templateUrl: './skyHref.component.html',
+  styleUrls: ['./skyHref.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [SkyAlertModule, SkyHrefModule],
   providers: [
     {
       provide: SkyHrefResolverService,
@@ -34,4 +27,4 @@ const routes: Routes = [{ path: '', component: AlertComponent }];
     },
   ],
 })
-export class AlertModule {}
+export class SkyHrefComponent {}

--- a/libs/components/theme/src/lib/styles/_theme.scss
+++ b/libs/components/theme/src/lib/styles/_theme.scss
@@ -79,8 +79,8 @@ a {
     &,
     &:hover,
     &:active {
-      color: inherit;
-      text-decoration: none;
+      color: inherit !important;
+      text-decoration: none !important;
     }
   }
 }


### PR DESCRIPTION
:cherries: Cherry picked from #2125 [fix(components/router): unlinked skyHref instances do not style as links when in an alert](https://github.com/blackbaud/skyux/pull/2125)

[AB#2797836](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/2797836) 