### PR TITLE
fix(components/forms): radio group uses a fieldset for accessibility grouping (#2142)

### DIFF
--- a/apps/playground/src/app/components/forms/radio/radio.component.html
+++ b/apps/playground/src/app/components/forms/radio/radio.component.html
@@ -38,7 +38,7 @@
       ariaLabelledBy="favorite-id"
       formControlName="favoriteSeason"
       [required]="required"
-      labelText="What is your favorite season?"
+      labelText="What is your favorite season? (reactive)"
     >
       <ul class="sky-list-unstyled">
         <li *ngFor="let value of seasons">
@@ -93,7 +93,8 @@
     [disabled]="disabled"
     [required]="required"
     [(ngModel)]="radioValue"
-    labelText="What is your favorite season?"
+    labelText="What is your favorite season? (template)"
+    [labelHidden]="true"
     #foo="ngModel"
   >
     <ul class="sky-list-unstyled">

--- a/libs/components/forms/src/lib/modules/radio/radio-group.component.html
+++ b/libs/components/forms/src/lib/modules/radio/radio-group.component.html
@@ -1,10 +1,7 @@
-<label *ngIf="labelText && !labelHidden" class="sky-control-label">
-  {{ labelText }}
-</label>
-<div
+<fieldset
   class="sky-radio-group"
   role="radiogroup"
-  [attr.aria-label]="labelText || ariaLabel"
+  [attr.aria-label]="labelText ? undefined : ariaLabel"
   [attr.aria-labelledby]="labelText ? undefined : ariaLabelledBy"
   [attr.aria-owns]="ariaOwns"
   [attr.aria-required]="required ? true : null"
@@ -14,8 +11,15 @@
     labelText && ngControl?.errors ? errorId : undefined
   "
 >
+  <legend
+    *ngIf="labelText"
+    class="sky-control-label"
+    [ngClass]="{ 'sky-screen-reader-only': labelHidden }"
+  >
+    {{ labelText }}
+  </legend>
   <ng-content />
-</div>
+</fieldset>
 <sky-form-errors
   *ngIf="labelText && ngControl?.errors"
   [id]="errorId"

--- a/libs/components/forms/src/lib/modules/radio/radio-group.component.spec.ts
+++ b/libs/components/forms/src/lib/modules/radio/radio-group.component.spec.ts
@@ -606,7 +606,7 @@ describe('Radio group component (reactive)', function () {
     expect(labelEl.textContent.trim()).toBe(labelText);
   });
 
-  it('should not display `labelText` if `labelHidden` is true', () => {
+  it('should not display `labelText` if `labelHidden` is true', async () => {
     const labelText = 'Label Text';
     componentInstance.labelText = labelText;
     componentInstance.labelHidden = true;
@@ -615,7 +615,8 @@ describe('Radio group component (reactive)', function () {
 
     const labelEl = fixture.nativeElement.querySelector('.sky-control-label');
 
-    expect(labelEl).toBeNull();
+    expect(labelEl).not.toBeNull();
+    expect(labelEl).toHaveCssClass('sky-screen-reader-only');
   });
 
   it('should use `labelText` as an accessible label over `ariaLabel` and `ariaLabelledBy`', () => {
@@ -625,10 +626,12 @@ describe('Radio group component (reactive)', function () {
 
     fixture.detectChanges();
 
+    const labelEl = fixture.nativeElement.querySelector('.sky-control-label');
     const radioGroup = fixture.nativeElement.querySelector('.sky-radio-group');
 
+    expect(labelEl).not.toBeNull();
     expect(radioGroup.getAttribute('aria-labelledBy')).toBeNull();
-    expect(radioGroup.getAttribute('aria-label')).toEqual(labelText);
+    expect(radioGroup.getAttribute('aria-label')).toBeNull();
   });
 
   it('should log a deprecation warning when ariaLabel and ariaLabelledBy are set', () => {


### PR DESCRIPTION
:cherries: Cherry picked from #2142 [fix(components/forms): radio group uses a fieldset for accessibility grouping](https://github.com/blackbaud/skyux/pull/2142)

[AB#2837546](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/2837546) 