### PR TITLE
fix(components/tabs): suppress indistinct values from sectioned form `indexChange` event (#2147)

### DIFF
--- a/libs/components/tabs/src/lib/modules/sectioned-form/sectioned-form.component.spec.ts
+++ b/libs/components/tabs/src/lib/modules/sectioned-form/sectioned-form.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
 import { expect, expectAsync } from '@skyux-sdk/testing';
 import { SkyMediaBreakpoints, SkyMediaQueryService } from '@skyux/core';
 import { MockSkyMediaQueryService } from '@skyux/core/testing';
@@ -259,6 +260,22 @@ describe('Sectioned form component', () => {
 
     const activeIndexEl = el.querySelector('#activeIndexDiv');
     expect(activeIndexEl.textContent.trim()).toBe('active index = 0');
+  });
+
+  it('should only fire indexChanged event once when value changes', () => {
+    const fixture = createTestComponent();
+
+    fixture.detectChanges();
+
+    const indexChangedSpy = spyOn(fixture.componentInstance, 'updateIndex');
+
+    fixture.debugElement
+      .queryAll(By.css('.sky-vertical-tab'))
+      .at(0)
+      ?.nativeElement.click();
+
+    expect(indexChangedSpy).toHaveBeenCalledWith(0);
+    expect(indexChangedSpy.calls.count()).toEqual(1);
   });
 
   it('should have a visible animation state on load in mobile', () => {

--- a/libs/components/tabs/src/lib/modules/sectioned-form/sectioned-form.component.ts
+++ b/libs/components/tabs/src/lib/modules/sectioned-form/sectioned-form.component.ts
@@ -15,7 +15,7 @@ import {
 import { SkyLogService } from '@skyux/core';
 
 import { Subject, Subscription } from 'rxjs';
-import { takeUntil } from 'rxjs/operators';
+import { distinctUntilChanged, takeUntil } from 'rxjs/operators';
 
 import { SkyTabIdService } from '../shared/tab-id.service';
 
@@ -125,7 +125,7 @@ export class SkySectionedFormComponent
     this.tabService.maintainTabContent = this.maintainSectionContent;
 
     this.tabService.indexChanged
-      .pipe(takeUntil(this.#ngUnsubscribe))
+      .pipe(distinctUntilChanged(), takeUntil(this.#ngUnsubscribe))
       .subscribe((index) => {
         this.indexChanged.emit(index);
         this.#changeRef.markForCheck();


### PR DESCRIPTION
:cherries: Cherry picked from #2147 [fix(components/tabs): suppress indistinct values from sectioned form `indexChange` event](https://github.com/blackbaud/skyux/pull/2147)