### PR TITLE
fix(components/text-editor): paste menu button works on browsers supporting the Clipboard API

### DIFF
--- a/libs/components/text-editor/src/assets/locales/resources_en_US.json
+++ b/libs/components/text-editor/src/assets/locales/resources_en_US.json
@@ -91,6 +91,10 @@
     "_description": "Text for the 'Insert merge field' dropdown button in the menubar",
     "message": "Insert merge field"
   },
+  "skyux_text_editor_paste_incompatibility_error": {
+    "_description": "Text for alert when attempting to paste via the menu bar in Firefox",
+    "message": "Direct clipboard access is not supported by this browser. Use the Ctrl+X/C/V keyboard shortcuts instead."
+  },
   "skyux_text_editor_url_modal_header_label": {
     "_description": "Text for the 'Create link' header of the url modal",
     "message": "Create link"

--- a/libs/components/text-editor/src/lib/modules/shared/sky-text-editor-resources.module.ts
+++ b/libs/components/text-editor/src/lib/modules/shared/sky-text-editor-resources.module.ts
@@ -64,6 +64,10 @@ const RESOURCES: { [locale: string]: SkyLibResources } = {
     skyux_text_editor_menubar_dropdown_button_insert_label: {
       message: 'Insert merge field',
     },
+    skyux_text_editor_paste_incompatibility_error: {
+      message:
+        'Direct clipboard access is not supported by this browser. Use the Ctrl+X/C/V keyboard shortcuts instead.',
+    },
     skyux_text_editor_url_modal_header_label: { message: 'Create link' },
     skyux_text_editor_url_modal_url_label: {
       message: 'Enter a URL to link to:',

--- a/libs/components/text-editor/src/lib/modules/text-editor/services/text-editor-adapter.service.ts
+++ b/libs/components/text-editor/src/lib/modules/text-editor/services/text-editor-adapter.service.ts
@@ -1,7 +1,8 @@
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { SkyAppWindowRef } from '@skyux/core';
+import { SkyLibResourcesService } from '@skyux/i18n';
 
-import { Subject } from 'rxjs';
+import { Subject, take } from 'rxjs';
 
 import { STYLE_STATE_DEFAULTS } from '../defaults/style-state-defaults';
 import { EditorCommand } from '../types/editor-command';
@@ -18,6 +19,7 @@ import { SkyTextEditorService } from './text-editor.service';
  */
 @Injectable()
 export class SkyTextEditorAdapterService {
+  readonly #resourceSvc = inject(SkyLibResourcesService);
   #selectionService: SkyTextEditorSelectionService;
   #textEditorService: SkyTextEditorService;
   #windowRef: SkyAppWindowRef;
@@ -95,16 +97,36 @@ export class SkyTextEditorAdapterService {
     if (this.#textEditorService.editor) {
       const documentEl = this.#getIframeDocumentEl();
 
-      /* istanbul ignore else */
-      if (this.editorSelected()) {
-        documentEl.execCommand(
-          editorCommand.command,
-          false,
-          editorCommand.value,
-        );
+      if (editorCommand.command === 'paste') {
+        // Firefox does not support the clipboard API's `readText` as of 3/24. We are ok with just firing an alert when the paste button is used in Firefox.
+        if (!navigator.clipboard.readText) {
+          this.#resourceSvc
+            .getString('skyux_text_editor_paste_incompatibility_error')
+            .pipe(take(1))
+            .subscribe((errorString) => alert(errorString));
+        } else {
+          navigator.clipboard.readText().then((clipText) => {
+            /* istanbul ignore else */
+            if (this.editorSelected()) {
+              documentEl.execCommand('insertHTML', false, clipText);
 
-        this.focusEditor();
-        this.#textEditorService.editor.commandChangeObservable.next();
+              this.focusEditor();
+              this.#textEditorService.editor.commandChangeObservable.next();
+            }
+          });
+        }
+      } else {
+        /* istanbul ignore else */
+        if (this.editorSelected()) {
+          documentEl.execCommand(
+            editorCommand.command,
+            false,
+            editorCommand.value,
+          );
+
+          this.focusEditor();
+          this.#textEditorService.editor.commandChangeObservable.next();
+        }
       }
     }
   }

--- a/libs/components/text-editor/src/lib/modules/text-editor/text-editor.component.html
+++ b/libs/components/text-editor/src/lib/modules/text-editor/text-editor.component.html
@@ -47,6 +47,7 @@
     }"
     (load)="onIframeLoad()"
     #iframe
+    allow="clipboard-read *; clipboard-write *"
   >
   </iframe>
 </div>

--- a/libs/components/text-editor/src/lib/modules/text-editor/text-editor.component.spec.ts
+++ b/libs/components/text-editor/src/lib/modules/text-editor/text-editor.component.spec.ts
@@ -1576,13 +1576,36 @@ describe('Text editor', () => {
       }));
 
       it('should execute paste', fakeAsync(() => {
+        spyOn(navigator.clipboard, 'readText').and.returnValue(
+          Promise.resolve('test content'),
+        );
         fixture.detectChanges();
-        const expectedCommand = 'paste';
+        const expectedCommand = 'insertHTML';
         const optionNumber = 4;
         dropdownButtonExecCommandTest(
           '.sky-text-editor-menu-edit',
           optionNumber,
           expectedCommand,
+          'test content',
+        );
+      }));
+
+      it('should fire a browser alert if pasting is not supported (Firefox)', fakeAsync(() => {
+        spyOnProperty(navigator, 'clipboard').and.returnValue({} as Clipboard);
+        spyOn(window, 'alert').and.stub();
+        fixture.detectChanges();
+        const optionNumber = 4;
+        openDropdown('.sky-text-editor-menu-edit');
+
+        const optionButtons = document.querySelectorAll(
+          '.sky-dropdown-item button',
+        );
+        SkyAppTestUtility.fireDomEvent(optionButtons[optionNumber], 'click');
+        fixture.detectChanges();
+        tick();
+        fixture.detectChanges();
+        expect(window.alert).toHaveBeenCalledWith(
+          'Direct clipboard access is not supported by this browser. Use the Ctrl+X/C/V keyboard shortcuts instead.',
         );
       }));
 


### PR DESCRIPTION
[AB#2460000](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/2460000)