### PR TITLE
fix(components/datetime): update date-range-picker status when calculator changes

### DIFF
--- a/libs/components/datetime/src/lib/modules/date-range-picker/date-range-picker.component.spec.ts
+++ b/libs/components/datetime/src/lib/modules/date-range-picker/date-range-picker.component.spec.ts
@@ -461,6 +461,25 @@ describe('Date range picker', function () {
     });
   }));
 
+  it('should update validation errors from selected calculator', fakeAsync(function () {
+    detectChanges();
+    selectCalculator(SkyDateRangeCalculatorId.Before);
+    detectChanges();
+    enterStartDate('bogus value');
+    detectChanges();
+
+    const control = component.dateRange;
+
+    expect(control?.errors).toEqual({
+      skyDate: { invalid: true },
+    });
+
+    selectCalculator(SkyDateRangeCalculatorId.Today);
+    detectChanges();
+
+    expect(control?.errors).toBeFalsy();
+  }));
+
   it('should catch validation errors from date picker', fakeAsync(function () {
     detectChanges();
 

--- a/libs/components/datetime/src/lib/modules/date-range-picker/date-range-picker.component.ts
+++ b/libs/components/datetime/src/lib/modules/date-range-picker/date-range-picker.component.ts
@@ -525,7 +525,7 @@ export class SkyDateRangePickerComponent
   #addEventListeners(): void {
     // Watch for selected calculator change.
     this.#calculatorIdControl?.valueChanges
-      .pipe(takeUntil(this.#ngUnsubscribe))
+      .pipe(distinctUntilChanged(), takeUntil(this.#ngUnsubscribe))
       .subscribe((value) => {
         if (value !== this.#valueOrDefault?.calculatorId) {
           const id = parseInt(value, 10);
@@ -542,6 +542,7 @@ export class SkyDateRangePickerComponent
             this.#showRelevantFormFields();
           }
         }
+        this.#control?.updateValueAndValidity({ emitEvent: false });
       });
 
     // Watch for start date value changes.


### PR DESCRIPTION
[AB#2559597](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/2559597)

See the fix by [running the code example](https://blackbaud.github.io/skyux-pr-preview/2153/code-examples/#/datetime/date-range-picker/basic)

1. Set the calculator to a date.
2. Enter some bogus date value like `aaa`.
3. Set the calulator to `Today` and the error message is dismissed.