### PR TITLE
fix(sdk/testing): allow fieldsets with radiogroup role during accessibility testing (#2192)

### DIFF
--- a/libs/sdk/testing/src/lib/a11y/a11y-analyzer.spec.ts
+++ b/libs/sdk/testing/src/lib/a11y/a11y-analyzer.spec.ts
@@ -66,6 +66,116 @@ describe('A11y analyzer', () => {
     });
   }));
 
+  it('should filter error for radiogroup on a fieldset (pre-4.0.0 compat)', waitForAsync(() => {
+    function mockRun(
+      context: axe.ElementContext,
+      options: axe.RunOptions,
+      callback: axe.RunCallback,
+    ): void {
+      callback(new Error(), {
+        violations: [
+          {
+            id: 'aria-allowed-role',
+            tags: ['wcag2a', 'wcag412'],
+            nodes: [
+              {
+                target: ['fieldset'],
+                html: '<fieldset role="radiogroup" class="sky-radio-group">',
+                any: [],
+                all: [],
+                none: [],
+                impact: 'minor',
+                failureSummary: 'some failure summary',
+              } as axe.NodeResult,
+            ],
+          },
+        ],
+      } as axe.AxeResults);
+    }
+
+    spyOn(SkyA11yAnalyzer['analyzer'], 'run').and.callFake(mockRun as any);
+
+    SkyA11yAnalyzer.run('element').then(() => {
+      expect(true).toBe(true);
+    });
+  }));
+
+  it('should not filter error for radiogroup on an invalid element', waitForAsync(() => {
+    function mockRun(
+      context: axe.ElementContext,
+      options: axe.RunOptions,
+      callback: axe.RunCallback,
+    ): void {
+      callback(new Error(), {
+        violations: [
+          {
+            id: 'aria-allowed-role',
+            tags: ['wcag2a', 'wcag412'],
+            nodes: [
+              {
+                target: ['p'],
+                html: '<p role="radiogroup">',
+                any: [],
+                all: [],
+                none: [],
+                impact: 'minor',
+                failureSummary: 'some failure summary',
+              } as axe.NodeResult,
+            ],
+          },
+        ],
+      } as axe.AxeResults);
+    }
+
+    spyOn(SkyA11yAnalyzer['analyzer'], 'run').and.callFake(mockRun as any);
+
+    SkyA11yAnalyzer.run('element')
+      .then(() => {
+        fail('Other: Expected error to be thrown');
+      })
+      .catch((result) => {
+        expect(result).toMatch(/<p role="radiogroup">/);
+      });
+  }));
+
+  it('should not filter error for an invalid role on a fieldset element', waitForAsync(() => {
+    function mockRun(
+      context: axe.ElementContext,
+      options: axe.RunOptions,
+      callback: axe.RunCallback,
+    ): void {
+      callback(new Error(), {
+        violations: [
+          {
+            id: 'aria-allowed-role',
+            tags: ['wcag2a', 'wcag412'],
+            nodes: [
+              {
+                target: ['p'],
+                html: '<fieldset role="alert">',
+                any: [],
+                all: [],
+                none: [],
+                impact: 'minor',
+                failureSummary: 'some failure summary',
+              } as axe.NodeResult,
+            ],
+          },
+        ],
+      } as axe.AxeResults);
+    }
+
+    spyOn(SkyA11yAnalyzer['analyzer'], 'run').and.callFake(mockRun as any);
+
+    SkyA11yAnalyzer.run('element')
+      .then(() => {
+        fail('Other: Expected error to be thrown');
+      })
+      .catch((result) => {
+        expect(result).toMatch(/<fieldset role="alert">/);
+      });
+  }));
+
   it('should return detailed results', waitForAsync(() => {
     function mockRun(
       context: axe.ElementContext,

--- a/libs/sdk/testing/src/lib/a11y/a11y-analyzer.ts
+++ b/libs/sdk/testing/src/lib/a11y/a11y-analyzer.ts
@@ -70,6 +70,11 @@ function filterViolationNodeResults(
     ].includes(result.id)
   ) {
     return (node: axe.NodeResult) => !node.html.includes('class="ag-');
+  } else if (result.id === 'aria-allowed-role') {
+    const fieldsetRadiogroupRegex = new RegExp(
+      /<fieldset[^>]+role="radiogroup"/,
+    );
+    return (node: axe.NodeResult) => !fieldsetRadiogroupRegex.test(node.html);
   } else {
     return () => true;
   }


### PR DESCRIPTION
:cherries: Cherry picked from #2192 [fix(sdk/testing): allow fieldsets with radiogroup role during accessibility testing](https://github.com/blackbaud/skyux/pull/2192)

[AB#2874905](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/2874905) 