### PR TITLE
feat(components/datetime): add startAtDate to specify a date when the calendar initially opens

### DIFF
--- a/apps/playground/src/app/components/datetime/datepicker/datepicker.component.html
+++ b/apps/playground/src/app/components/datetime/datepicker/datepicker.component.html
@@ -35,6 +35,7 @@
       [disabled]="disabled"
       [maxDate]="maxDate"
       [minDate]="minDate"
+      [startAtDate]="startAtDate"
       [skyDatepickerNoValidate]="noValidate"
       [startingDay]="startingDay"
       [strict]="strict"
@@ -83,6 +84,24 @@
 </div>
 
 <div class="app-screenshot" style="max-width: 50%; height: 500px">
+  <p>Fuzzy datepicker template form</p>
+  <sky-datepicker>
+    <input
+      skyFuzzyDatepickerInput
+      [disabled]="disabled"
+      [maxDate]="fuzzyMaxDate"
+      [minDate]="fuzzyMinDate"
+      [startAtDate]="fuzzyStartAtDate"
+      [skyDatepickerNoValidate]="noValidate"
+      [startingDay]="startingDay"
+      [dateFormat]="dateFormat"
+      [(ngModel)]="selectedDate"
+      #date="ngModel"
+    />
+  </sky-datepicker>
+</div>
+
+<div class="app-screenshot" style="max-width: 50%; height: 500px">
   <p>Reactive form</p>
   <form novalidate [formGroup]="reactiveForm">
     <sky-datepicker>
@@ -92,6 +111,7 @@
         type="text"
         [maxDate]="maxDate"
         [minDate]="minDate"
+        [startAtDate]="startAtDate"
         [dateFormat]="dateFormat"
         [skyDatepickerNoValidate]="noValidate"
         [startingDay]="startingDay"
@@ -167,9 +187,16 @@
 <button
   class="sky-btn sky-btn-primary"
   type="button"
-  (click)="setMinMaxDates()"
+  (click)="setMinMaxStartAtDates()"
 >
-  Set min and max dates
+  Set min, max, and startAt dates
+</button>
+<button
+  class="sky-btn sky-btn-primary"
+  type="button"
+  (click)="setFuzzyMinMaxStartAtDates()"
+>
+  Set fuzzy min, max, and startAt dates
 </button>
 <button
   class="sky-btn sky-btn-primary"

--- a/apps/playground/src/app/components/datetime/datepicker/datepicker.component.ts
+++ b/apps/playground/src/app/components/datetime/datepicker/datepicker.component.ts
@@ -9,6 +9,7 @@ import {
 import {
   SkyDatepickerCalendarChange,
   SkyDatepickerCustomDate,
+  SkyFuzzyDate,
 } from '@skyux/datetime';
 
 import { of } from 'rxjs';
@@ -23,6 +24,10 @@ export class DatepickerComponent {
   public disabled = false;
   public minDate: Date | undefined;
   public maxDate: Date | undefined;
+  public startAtDate: Date | undefined;
+  public fuzzyMinDate: SkyFuzzyDate | undefined;
+  public fuzzyMaxDate: SkyFuzzyDate | undefined;
+  public fuzzyStartAtDate: SkyFuzzyDate | undefined;
   public noValidate = false;
   public reactiveForm: UntypedFormGroup;
   public showCustomDates = false;
@@ -54,9 +59,16 @@ export class DatepickerComponent {
     });
   }
 
-  public setMinMaxDates(): void {
+  public setMinMaxStartAtDates(): void {
     this.minDate = new Date('01/01/2018');
     this.maxDate = new Date('01/01/2020');
+    this.startAtDate = new Date('01/01/2018');
+  }
+
+  public setFuzzyMinMaxStartAtDates(): void {
+    this.fuzzyMinDate = { year: 2018, month: 1 };
+    this.fuzzyMaxDate = { year: 2020, month: 1 };
+    this.fuzzyStartAtDate = { year: 2018 };
   }
 
   public setStartingDay(): void {

--- a/libs/components/datetime/src/lib/modules/datepicker/datepicker-calendar-inner.component.ts
+++ b/libs/components/datetime/src/lib/modules/datepicker/datepicker-calendar-inner.component.ts
@@ -55,6 +55,9 @@ export class SkyDatepickerCalendarInnerComponent
   public maxDate: Date | undefined;
 
   @Input()
+  public startAtDate: Date | undefined;
+
+  @Input()
   public set selectedDate(value: Date | undefined) {
     if (value && this.dateFormatter.dateIsValid(value)) {
       this.#_selectedDate = value;
@@ -155,7 +158,7 @@ export class SkyDatepickerCalendarInnerComponent
     if (this.selectedDate) {
       this.activeDate = new Date(this.selectedDate);
     } else {
-      this.activeDate = new Date();
+      this.activeDate = this.startAtDate ?? new Date();
     }
 
     this.#resourcesSvc

--- a/libs/components/datetime/src/lib/modules/datepicker/datepicker-calendar.component.html
+++ b/libs/components/datetime/src/lib/modules/datepicker/datepicker-calendar.component.html
@@ -3,6 +3,7 @@
     [customDates]="customDates"
     [maxDate]="maxDate"
     [minDate]="minDate"
+    [startAtDate]="startAtDate"
     [selectedDate]="selectedDate"
     [startingDay]="startingDay"
     (calendarModeChange)="onCalendarModeChange($event)"

--- a/libs/components/datetime/src/lib/modules/datepicker/datepicker-calendar.component.spec.ts
+++ b/libs/components/datetime/src/lib/modules/datepicker/datepicker-calendar.component.spec.ts
@@ -368,7 +368,7 @@ describe('datepicker calendar', () => {
     verifyDatepicker(element, dayPickerLabel, selectedLabel, dayLabel, '');
   }
 
-  it('should open current month in daypicker when no selected date is provided', () => {
+  it('should open current month in daypicker when no selected date and no startAtDate is provided', () => {
     fixture.detectChanges();
 
     verifyTodayDayPicker(nativeElement);
@@ -793,6 +793,26 @@ describe('datepicker calendar', () => {
         verifyDatepicker(nativeElement, 'May 2017', '01', '01', '');
         expect(component.selectedDate).toEqual(new Date('5/1/2017'));
       });
+    });
+  });
+
+  describe('startAtDate', () => {
+    it('should select correct date when provided', () => {
+      component.startAtDate = new Date('3/10/1995');
+      fixture.detectChanges();
+
+      component.datepicker.writeValue(undefined);
+      fixture.detectChanges();
+
+      verifyDatepicker(nativeElement, 'March 1995', '10', '10', '');
+    });
+
+    it('should display selectedDate instead of startAtDate if selectedDate is provided', () => {
+      component.startAtDate = new Date('3/10/1995');
+      component.selectedDate = new Date('12/21/1991');
+      fixture.detectChanges();
+
+      verifyDatepicker(nativeElement, 'December 1991', '21', '21', '');
     });
   });
 });

--- a/libs/components/datetime/src/lib/modules/datepicker/datepicker-calendar.component.ts
+++ b/libs/components/datetime/src/lib/modules/datepicker/datepicker-calendar.component.ts
@@ -33,6 +33,9 @@ export class SkyDatepickerCalendarComponent {
   @Input()
   public maxDate: Date | undefined;
 
+  @Input()
+  public startAtDate: Date | undefined;
+
   /** currently selected date */
   @Input()
   public selectedDate: Date | undefined;
@@ -110,8 +113,8 @@ export class SkyDatepickerCalendarComponent {
       this.selectedDate = value;
       this.datepicker?.select(value, false);
     } else {
-      this.selectedDate = new Date();
-      this.datepicker?.select(new Date(), false);
+      this.selectedDate = this.startAtDate ?? new Date();
+      this.datepicker?.select(this.startAtDate ?? new Date(), false);
     }
   }
 }

--- a/libs/components/datetime/src/lib/modules/datepicker/datepicker-config.service.ts
+++ b/libs/components/datetime/src/lib/modules/datepicker/datepicker-config.service.ts
@@ -21,6 +21,12 @@ export class SkyDatepickerConfigService {
   public minDate: Date | undefined;
 
   /**
+   * The date to open the calendar to initially.
+   * @default the current date
+   */
+  public startAtDate: Date | undefined;
+
+  /**
    * The starting day of the week in the calendar,
    * where `0` sets the starting day to Sunday.
    * @default 0

--- a/libs/components/datetime/src/lib/modules/datepicker/datepicker-input-fuzzy.directive.ts
+++ b/libs/components/datetime/src/lib/modules/datepicker/datepicker-input-fuzzy.directive.ts
@@ -159,6 +159,23 @@ export class SkyFuzzyDatepickerInputDirective
   }
 
   /**
+   * The fuzzy date to open the calendar to initially.
+   * This property accepts a `SkyFuzzyDate` value that includes numeric month, day, and year values.
+   * For example: `{ month: 1, day: 1, year: 2007 }`.
+   * @default The current date
+   */
+  @Input()
+  public set startAtDate(value: SkyFuzzyDate | undefined) {
+    this.#_startAtDate = value;
+    this.#datepickerComponent.startAtDate = this.#getStartAtDate();
+  }
+
+  // TODO: Refactor to not have getter logic
+  public get startAtDate(): SkyFuzzyDate | undefined {
+    return this.#_startAtDate;
+  }
+
+  /**
    * Whether to disable date validation on the fuzzy datepicker input.
    * @default false
    */
@@ -225,6 +242,8 @@ export class SkyFuzzyDatepickerInputDirective
   #_maxDate: SkyFuzzyDate | undefined;
 
   #_minDate: SkyFuzzyDate | undefined;
+
+  #_startAtDate: SkyFuzzyDate | undefined;
 
   #_startingDay: number | undefined;
 
@@ -506,6 +525,18 @@ export class SkyFuzzyDatepickerInputDirective
       }
     }
     return this.#configService.minDate;
+  }
+
+  #getStartAtDate(): Date | undefined {
+    if (this.startAtDate) {
+      const startAtDate = this.#fuzzyDateService.getMomentFromFuzzyDate(
+        this.startAtDate,
+      );
+      if (startAtDate.isValid()) {
+        return startAtDate.toDate();
+      }
+    }
+    return this.#configService.startAtDate;
   }
 
   /* istanbul ignore next */

--- a/libs/components/datetime/src/lib/modules/datepicker/datepicker-input.directive.ts
+++ b/libs/components/datetime/src/lib/modules/datepicker/datepicker-input.directive.ts
@@ -133,6 +133,21 @@ export class SkyDatepickerInputDirective
   }
 
   /**
+   * The date to open the calendar to initially. Place this attribute on the `input` element to override the default in `SkyDatepickerConfigService`.
+   * @default The current date
+   */
+  @Input()
+  public set startAtDate(value: Date | undefined) {
+    this.#_startAtDate = value;
+    this.#datepickerComponent.startAtDate = this.startAtDate;
+  }
+
+  // TODO: Refactor to not have getter logic
+  public get startAtDate(): Date | undefined {
+    return this.#_startAtDate || this.#configService.startAtDate;
+  }
+
+  /**
    * Creates the datepicker input and calendar. Place this directive on an `input` element,
    * and wrap the input in a `sky-datepicker` component. The value that users select is driven
    * through the `ngModel` attribute specified on the `input` element.
@@ -213,6 +228,7 @@ export class SkyDatepickerInputDirective
   #_disabled = false;
   #_maxDate: Date | undefined;
   #_minDate: Date | undefined;
+  #_startAtDate: Date | undefined;
   #_startingDay: number | undefined;
   #_strict = false;
   #_value: any;

--- a/libs/components/datetime/src/lib/modules/datepicker/datepicker.component.html
+++ b/libs/components/datetime/src/lib/modules/datepicker/datepicker.component.html
@@ -56,6 +56,7 @@
       [isDaypickerWaiting]="isDaypickerWaiting"
       [maxDate]="maxDate"
       [minDate]="minDate"
+      [startAtDate]="startAtDate"
       [startingDay]="startingDay"
       (calendarDateRangeChange)="onCalendarDateRangeChange($event)"
       (calendarModeChange)="onCalendarModeChange()"

--- a/libs/components/datetime/src/lib/modules/datepicker/datepicker.component.spec.ts
+++ b/libs/components/datetime/src/lib/modules/datepicker/datepicker.component.spec.ts
@@ -969,6 +969,20 @@ describe('datepicker', () => {
       }));
     });
 
+    describe('startAtDate', () => {
+      it('should be passed to calendar', fakeAsync(() => {
+        fixture.detectChanges();
+        setInputProperty(undefined, component, fixture);
+        component.startAtDate = new Date('3/10/1995');
+        detectChanges(fixture);
+
+        clickTrigger(fixture);
+
+        expect(getSelectedCalendarItem()).toHaveText('10');
+        expect(getCalendarTitle(fixture)).toHaveText('March 1995');
+      }));
+    });
+
     describe('custom dates', () => {
       const initialDate = '11/5/1955';
       beforeEach(fakeAsync(() => {
@@ -1714,6 +1728,20 @@ describe('datepicker', () => {
 
         const firstDayCol = getCalendarColumn(0, fixture);
         expect(firstDayCol).toHaveText('Fr');
+      }));
+    });
+
+    describe('startAtDate', () => {
+      it('should be passed to calendar', fakeAsync(() => {
+        fixture.detectChanges();
+        setFormControlProperty(undefined, component, fixture);
+        component.startAtDate = new Date('3/10/1995');
+        detectChanges(fixture);
+
+        clickTrigger(fixture);
+
+        expect(getSelectedCalendarItem()).toHaveText('10');
+        expect(getCalendarTitle(fixture)).toHaveText('March 1995');
       }));
     });
 

--- a/libs/components/datetime/src/lib/modules/datepicker/datepicker.component.ts
+++ b/libs/components/datetime/src/lib/modules/datepicker/datepicker.component.ts
@@ -124,6 +124,8 @@ export class SkyDatepickerComponent implements OnDestroy, OnInit {
 
   public minDate: Date | undefined;
 
+  public startAtDate: Date | undefined;
+
   public startingDay: number | undefined;
 
   public triggerButtonId: string;

--- a/libs/components/datetime/src/lib/modules/datepicker/fixtures/datepicker-calendar.component.fixture.html
+++ b/libs/components/datetime/src/lib/modules/datepicker/fixtures/datepicker-calendar.component.fixture.html
@@ -4,6 +4,7 @@
     [customDates]="customDates"
     [minDate]="minDate"
     [maxDate]="maxDate"
+    [startAtDate]="startAtDate"
     [startingDay]="startingDay"
     [selectedDate]="selectedDate"
     (selectedDateChange)="selectedDate = $event"

--- a/libs/components/datetime/src/lib/modules/datepicker/fixtures/datepicker-calendar.component.fixture.ts
+++ b/libs/components/datetime/src/lib/modules/datepicker/fixtures/datepicker-calendar.component.fixture.ts
@@ -14,6 +14,8 @@ export class DatepickerCalendarTestComponent {
 
   public maxDate: Date | undefined;
 
+  public startAtDate: Date | undefined;
+
   public selectedDate: any;
 
   public startingDay: number | undefined;

--- a/libs/components/datetime/src/lib/modules/datepicker/fixtures/datepicker-reactive.component.fixture.html
+++ b/libs/components/datetime/src/lib/modules/datepicker/fixtures/datepicker-reactive.component.fixture.html
@@ -7,6 +7,7 @@
       [skyDatepickerNoValidate]="noValidate"
       [minDate]="minDate"
       [maxDate]="maxDate"
+      [startAtDate]="startAtDate"
       [startingDay]="startingDay"
       [strict]="strict"
       formControlName="date"

--- a/libs/components/datetime/src/lib/modules/datepicker/fixtures/datepicker-reactive.component.fixture.ts
+++ b/libs/components/datetime/src/lib/modules/datepicker/fixtures/datepicker-reactive.component.fixture.ts
@@ -29,6 +29,8 @@ export class DatepickerReactiveTestComponent implements OnInit {
 
   public minDate: Date | undefined;
 
+  public startAtDate: Date | undefined;
+
   public noValidate = false;
 
   public startingDay = 0;

--- a/libs/components/datetime/src/lib/modules/datepicker/fixtures/datepicker.component.fixture.html
+++ b/libs/components/datetime/src/lib/modules/datepicker/fixtures/datepicker.component.fixture.html
@@ -10,6 +10,7 @@
     [disabled]="isDisabled"
     [maxDate]="maxDate"
     [minDate]="minDate"
+    [startAtDate]="startAtDate"
     [skyDatepickerInput]="picker"
     [skyDatepickerNoValidate]="noValidate"
     [startingDay]="startingDay"

--- a/libs/components/datetime/src/lib/modules/datepicker/fixtures/datepicker.component.fixture.ts
+++ b/libs/components/datetime/src/lib/modules/datepicker/fixtures/datepicker.component.fixture.ts
@@ -20,6 +20,8 @@ export class DatepickerTestComponent {
 
   public minDate: Date | undefined;
 
+  public startAtDate: Date | undefined;
+
   public noValidate = false;
 
   public showCustomDates = false;

--- a/libs/components/datetime/src/lib/modules/datepicker/fixtures/fuzzy-datepicker-reactive.component.fixture.html
+++ b/libs/components/datetime/src/lib/modules/datepicker/fixtures/fuzzy-datepicker-reactive.component.fixture.html
@@ -7,6 +7,7 @@
       [dateFormat]="dateFormat"
       [maxDate]="maxDate"
       [minDate]="minDate"
+      [startAtDate]="startAtDate"
       [skyDatepickerNoValidate]="noValidate"
       [startingDay]="startingDay"
       [yearRequired]="yearRequired"

--- a/libs/components/datetime/src/lib/modules/datepicker/fixtures/fuzzy-datepicker-reactive.component.fixture.ts
+++ b/libs/components/datetime/src/lib/modules/datepicker/fixtures/fuzzy-datepicker-reactive.component.fixture.ts
@@ -28,6 +28,8 @@ export class FuzzyDatepickerReactiveTestComponent implements OnInit {
 
   public minDate: any;
 
+  public startAtDate: any;
+
   public noValidate = false;
 
   public startingDay = 0;

--- a/libs/components/datetime/src/lib/modules/datepicker/fixtures/fuzzy-datepicker.component.fixture.html
+++ b/libs/components/datetime/src/lib/modules/datepicker/fixtures/fuzzy-datepicker.component.fixture.html
@@ -8,6 +8,7 @@
     [disabled]="isDisabled"
     [maxDate]="maxDate"
     [minDate]="minDate"
+    [startAtDate]="startAtDate"
     [skyDatepickerNoValidate]="noValidate"
     [startingDay]="startingDay"
     [yearRequired]="yearRequired"

--- a/libs/components/datetime/src/lib/modules/datepicker/fixtures/fuzzy-datepicker.component.fixture.ts
+++ b/libs/components/datetime/src/lib/modules/datepicker/fixtures/fuzzy-datepicker.component.fixture.ts
@@ -19,6 +19,8 @@ export class FuzzyDatepickerTestComponent {
 
   public minDate: any;
 
+  public startAtDate: any;
+
   public noValidate = false;
 
   public selectedDate: any;

--- a/libs/components/datetime/src/lib/modules/datepicker/fuzzy-datepicker.component.spec.ts
+++ b/libs/components/datetime/src/lib/modules/datepicker/fuzzy-datepicker.component.spec.ts
@@ -1071,6 +1071,21 @@ describe('fuzzy datepicker input', () => {
       }));
     });
 
+    describe('startAtDate', () => {
+      it('should be passed to calendar', fakeAsync(() => {
+        setInputProperty(undefined, component, fixture);
+        component.startAtDate = { year: 1995 };
+        detectChanges(fixture);
+
+        clickDatepickerButton(fixture);
+
+        expect(getSelectedCalendarItem()).toHaveText('01');
+        expect(getCalendarTitle()).toHaveText('January 1995');
+
+        flush();
+      }));
+    });
+
     describe('detectInputValueChange', () => {
       it('updates selectedDate without a change event', fakeAsync(() => {
         const inputEl = getInputElement(fixture);
@@ -1783,6 +1798,22 @@ describe('fuzzy datepicker input', () => {
 
         flush();
       }));
+
+      describe('startAtDate', () => {
+        it('should be passed to calendar', fakeAsync(() => {
+          fixture.detectChanges();
+          setFormControlProperty(undefined, component, fixture);
+          component.startAtDate = { year: 1995 };
+          detectChanges(fixture);
+
+          clickDatepickerButton(fixture);
+
+          expect(getSelectedCalendarItem()).toHaveText('01');
+          expect(getCalendarTitle()).toHaveText('January 1995');
+
+          flush();
+        }));
+      });
     });
 
     describe('disabled state', () => {


### PR DESCRIPTION
Original contribution: https://github.com/blackbaud/skyux/pull/2198

