### PR TITLE
fix(components/modals): keep absolutely positioned background elements visible (#2219)

### DIFF
--- a/apps/e2e/modals-storybook-e2e/src/e2e/modal.component.cy.ts
+++ b/apps/e2e/modals-storybook-e2e/src/e2e/modal.component.cy.ts
@@ -16,6 +16,7 @@ describe('modals-storybook', () => {
         'full-page',
         'help-inline',
         'error',
+        'positioned-background',
       ]) {
         it(`should render the ${modalType} modal on desktop`, () => {
           cy.get('app-modal').should('exist').should('be.visible');

--- a/apps/e2e/modals-storybook/src/app/modal/modal.component.html
+++ b/apps/e2e/modals-storybook/src/app/modal/modal.component.html
@@ -46,3 +46,13 @@
 >
   Open error modal
 </button>
+<button
+  [ngClass]="buttonsHidden ? 'modal-screenshot-buttons-hidden' : ''"
+  class="sky-btn sky-btn-default open-positioned-background-modal-btn"
+  type="button"
+  (click)="onOpenModalWithPositionedElClick()"
+>
+  Open modal with absolutely-positioned background
+</button>
+
+<div *ngIf="showPositionedEl" class="modal-screenshot-positioned"></div>

--- a/apps/e2e/modals-storybook/src/app/modal/modal.component.scss
+++ b/apps/e2e/modals-storybook/src/app/modal/modal.component.scss
@@ -5,3 +5,12 @@
 .modal-screenshot-buttons-hidden {
   visibility: hidden;
 }
+
+.modal-screenshot-positioned {
+  background-color: #f00;
+  width: 100px;
+  height: 100px;
+  position: absolute;
+  top: 0;
+  left: 0;
+}

--- a/apps/e2e/modals-storybook/src/app/modal/modal.component.ts
+++ b/apps/e2e/modals-storybook/src/app/modal/modal.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, Renderer2, inject } from '@angular/core';
 import {
   SkyModalConfigurationInterface,
   SkyModalInstance,
@@ -14,6 +14,9 @@ import { ModalBasicComponent } from './modals/modal-basic.component';
 })
 export class ModalComponent {
   public buttonsHidden = false;
+  public showPositionedEl = false;
+
+  #renderer = inject(Renderer2);
 
   constructor(private modal: SkyModalService) {}
 
@@ -61,6 +64,15 @@ export class ModalComponent {
     ];
   }
 
+  protected onOpenModalWithPositionedElClick(): void {
+    // This test verifies that absolutely-positioned elements don't disappear
+    // when a modal is displayed. Before the fix that accompanies this test,
+    // absolutely-positioned elements would be positioned relative to the margins
+    // and size of the body element and would be pushed off the screen.
+    this.#showPositionedEl();
+    this.openModal(ModalBasicComponent, { size: 'medium' });
+  }
+
   private openModal(
     modalInstance: any,
     options?: SkyModalConfigurationInterface,
@@ -71,8 +83,19 @@ export class ModalComponent {
 
     instance.closed.subscribe(() => {
       this.showButtons();
+      this.#hidePositionedEl();
     });
 
     return instance;
+  }
+
+  #showPositionedEl(): void {
+    this.showPositionedEl = true;
+    this.#renderer.addClass(document.body, 'modal-body-margin-test');
+  }
+
+  #hidePositionedEl(): void {
+    this.showPositionedEl = false;
+    this.#renderer.removeClass(document.body, 'modal-body-margin-test');
   }
 }

--- a/apps/e2e/modals-storybook/src/styles.scss
+++ b/apps/e2e/modals-storybook/src/styles.scss
@@ -1,1 +1,3 @@
-/* You can add global styles to this file, and also import other style files */
+.modal-body-margin-test {
+  margin-left: 2000px;
+}

--- a/libs/components/theme/src/lib/styles/_modals.scss
+++ b/libs/components/theme/src/lib/styles/_modals.scss
@@ -1,5 +1,4 @@
 .sky-modal-body-open {
   height: 100%;
   overflow: hidden;
-  position: relative;
 }


### PR DESCRIPTION
:cherries: Cherry picked from #2219 [fix(components/modals): keep absolutely positioned background elements visible](https://github.com/blackbaud/skyux/pull/2219)

[AB#2559252](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/2559252) 