### PR TITLE
fix(components/forms): restore spacing between file attachment action buttons in mobile size

### DIFF
--- a/libs/components/forms/src/lib/modules/file-attachment/file-drop.component.scss
+++ b/libs/components/forms/src/lib/modules/file-attachment/file-drop.component.scss
@@ -155,7 +155,13 @@ button.sky-file-drop {
 }
 
 .sky-file-drop-errors {
-  margin-bottom: var(--sky-margin-stacked-lg);
+  margin-bottom: $sky-margin;
+}
+
+@media (max-width: $sky-screen-sm-min) {
+  .sky-file-drop-col:not(:last-of-type) {
+    margin-bottom: $sky-margin;
+  }
 }
 
 @include mixins.sky-theme-modern {


### PR DESCRIPTION
[AB#2895743](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/2895743)