### PR TITLE
fix(components/phone-field): phone field hint text uses an example number instead of an example format

### DIFF
--- a/libs/components/phone-field/src/assets/locales/resources_en_US.json
+++ b/libs/components/phone-field/src/assets/locales/resources_en_US.json
@@ -21,6 +21,6 @@
   },
   "skyux_phone_field_format_hint_text": {
     "_description": "Hint text for the phone number format currently set on the phone field.",
-    "message": "Use the format {0}."
+    "message": "Example: {0}."
   }
 }

--- a/libs/components/phone-field/src/lib/modules/phone-field/phone-field.component.spec.ts
+++ b/libs/components/phone-field/src/lib/modules/phone-field/phone-field.component.spec.ts
@@ -2245,7 +2245,7 @@ describe('Phone Field Component', () => {
         .querySelector('.sky-input-box-hint-text')
         .textContent.trim();
 
-      expect(hintText).toEqual('Use the format (###) ###-####.');
+      expect(hintText).toEqual('Example: (201) 555-0123.');
     }));
 
     it('should show hint text for the the consumer provided date format', fakeAsync(() => {
@@ -2258,7 +2258,7 @@ describe('Phone Field Component', () => {
         .querySelector('.sky-input-box-hint-text')
         .textContent.trim();
 
-      expect(hintText).toEqual('Use the format #### ### ####.');
+      expect(hintText).toEqual('Example: 0121 234 5678.');
     }));
 
     it('should allow consumer to provide hint text along with the format hint text', fakeAsync(() => {
@@ -2271,7 +2271,7 @@ describe('Phone Field Component', () => {
         .textContent.trim();
 
       expect(hintText).toEqual(
-        'Enter a phone number. Use the format (###) ###-####.',
+        'Enter a phone number. Example: (201) 555-0123.',
       );
     }));
 

--- a/libs/components/phone-field/src/lib/modules/phone-field/phone-field.component.ts
+++ b/libs/components/phone-field/src/lib/modules/phone-field/phone-field.component.ts
@@ -500,7 +500,7 @@ export class SkyPhoneFieldComponent implements OnDestroy, OnInit {
       this.inputBoxHostSvc?.setHintText(
         this.#appFormat.formatText(
           this.#phoneNumberFormatHintTextTemplateString,
-          this.#_selectedCountry?.exampleNumber?.replace(/\d/g, '#'),
+          this.#_selectedCountry?.exampleNumber,
         ),
       );
     }

--- a/libs/components/phone-field/src/lib/modules/shared/sky-phone-field-resources.module.ts
+++ b/libs/components/phone-field/src/lib/modules/shared/sky-phone-field-resources.module.ts
@@ -32,7 +32,7 @@ const RESOURCES: Record<string, SkyLibResources> = {
     skyux_phone_field_country_selected_label: {
       message: '{0} is currently selected.',
     },
-    skyux_phone_field_format_hint_text: { message: 'Use the format {0}.' },
+    skyux_phone_field_format_hint_text: { message: 'Example: {0}.' },
   },
 };
 


### PR DESCRIPTION
[AB#2925206](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/2925206)