### PR TITLE
fix(components/lookup): search emits a change event when set back to previous text after the value is cleared via the input binding

### DIFF
--- a/apps/code-examples/src/app/code-examples/lookup/search/basic/demo.component.html
+++ b/apps/code-examples/src/app/code-examples/lookup/search/basic/demo.component.html
@@ -3,9 +3,9 @@
     <button
       class="sky-btn sky-btn-default sky-demo-search-bar-item"
       type="button"
-      (click)="searchApplied('')"
+      (click)="searchApplied('Robert')"
     >
-      Clear
+      Predefined search text
     </button>
   </sky-toolbar-item>
   <sky-toolbar-item>

--- a/apps/code-examples/src/app/code-examples/lookup/search/basic/demo.component.html
+++ b/apps/code-examples/src/app/code-examples/lookup/search/basic/demo.component.html
@@ -3,9 +3,9 @@
     <button
       class="sky-btn sky-btn-default sky-demo-search-bar-item"
       type="button"
-      (click)="searchApplied('Robert')"
+      (click)="searchApplied('')"
     >
-      Predefined search text
+      Clear
     </button>
   </sky-toolbar-item>
   <sky-toolbar-item>

--- a/libs/components/lookup/src/lib/modules/search/search.component.spec.ts
+++ b/libs/components/lookup/src/lib/modules/search/search.component.spec.ts
@@ -312,6 +312,46 @@ describe('Search component', () => {
       expect(component.lastSearchTextChanged).toBe('');
     }));
 
+    it('should emit the apply event when search text is cleared via the `searchText` binding to an empty string', fakeAsync(() => {
+      setNgModel('applied text');
+      fixture.detectChanges();
+      tick();
+
+      expect(component.lastSearchTextChanged).toBe('applied text');
+
+      component.searchText = '';
+      fixture.detectChanges();
+      tick(10);
+
+      expect(component.lastSearchTextChanged).toBe('');
+
+      setNgModel('applied text');
+      fixture.detectChanges();
+      tick(10);
+
+      expect(component.lastSearchTextChanged).toBe('applied text');
+    }));
+
+    it('should emit the apply event when search text is cleared via the `searchText` binding to undefined', async () => {
+      component.searchText = 'applied text';
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      expect(component.lastSearchTextChanged).toBe('applied text');
+
+      component.searchText = undefined;
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      expect(component.lastSearchTextChanged).toBe('');
+
+      component.searchText = 'applied text';
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      expect(component.lastSearchTextChanged).toBe('applied text');
+    });
+
     it('should emit the change event when text is given, then cleared, and then reset to the same value', fakeAsync(() => {
       setNgModel('applied text');
       fixture.detectChanges();

--- a/libs/components/lookup/src/lib/modules/search/search.component.ts
+++ b/libs/components/lookup/src/lib/modules/search/search.component.ts
@@ -245,6 +245,7 @@ export class SkySearchComponent implements OnDestroy, OnInit, OnChanges {
     }
 
     if (this.#searchBindingChanged(changes)) {
+      this.#searchUpdated.next(this.searchText ?? '');
       this.clearButtonShown = !!(this.searchText && this.searchText !== '');
       if (this.#shouldOpenInput()) {
         this.inputAnimate = INPUT_SHOWN_STATE;


### PR DESCRIPTION
[AB#2930902](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/2930902)