### PR TITLE
fix(components/ag-grid): lookup renderer should use `descriptorProperty`

### DIFF
--- a/apps/playground/src/app/components/ag-grid/edit-complex-cells/edit-complex-cells.component.ts
+++ b/apps/playground/src/app/components/ag-grid/edit-complex-cells/edit-complex-cells.component.ts
@@ -219,7 +219,7 @@ export class EditComplexCellsComponent implements OnInit {
         },
         cellRendererParams: {
           skyComponentProperties: {
-            descriptorProperty: 'name',
+            descriptorProperty: 'interestingFact',
           },
         },
       },

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/ag-grid.service.spec.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/ag-grid.service.spec.ts
@@ -483,6 +483,21 @@ describe('SkyAgGridService', () => {
         }),
       ).toBe('expected');
     });
+
+    it('should use descriptorProperty', () => {
+      expect(
+        lookupValueFormatter({
+          colDef: {
+            cellEditorParams: {
+              skyComponentProperties: {
+                descriptorProperty: 'other',
+              },
+            },
+          },
+          value: [{ name: 'not-expected', other: 'expected' }],
+        } as ValueFormatterParams),
+      ).toBe('expected');
+    });
   });
 
   describe('suppressKeyboardEvent', () => {

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/ag-grid.service.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/ag-grid.service.ts
@@ -375,7 +375,11 @@ export class SkyAgGridService implements OnDestroy {
           cellEditor: SkyAgGridCellEditorLookupComponent,
           cellRenderer: SkyAgGridCellRendererLookupComponent,
           valueFormatter: (params) => {
-            const lookupProperties = applySkyLookupPropertiesDefaults(params);
+            const lookupProperties = applySkyLookupPropertiesDefaults(
+              params.colDef?.cellRendererParams?.skyComponentProperties ??
+                params.colDef?.cellEditorParams?.skyComponentProperties ??
+                {},
+            );
             return (params.value || [])
               .map((value: Record<string, unknown>) => {
                 return value[lookupProperties.descriptorProperty as string];


### PR DESCRIPTION
[AB#2937430](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/2937430)