### PR TITLE
fix(components/ag-grid): row delete confirmation should still show when first column is hidden

### DIFF
--- a/libs/components/ag-grid/src/lib/modules/ag-grid/ag-grid-row-delete.directive.spec.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/ag-grid-row-delete.directive.spec.ts
@@ -9,7 +9,10 @@ import { SkyAgGridFixtureModule } from './fixtures/ag-grid.module.fixture';
 describe('SkyAgGridRowDeleteDirective', () => {
   let fixture: ComponentFixture<SkyAgGridRowDeleteFixtureComponent>;
 
-  function setupTest(options?: { stackingContextZIndex?: number }) {
+  function setupTest(options?: {
+    stackingContextZIndex?: number;
+    hideFirstColumn?: boolean;
+  }): void {
     TestBed.configureTestingModule({
       imports: [SkyAgGridFixtureModule],
       providers: [
@@ -36,6 +39,8 @@ describe('SkyAgGridRowDeleteDirective', () => {
     });
 
     fixture = TestBed.createComponent(SkyAgGridRowDeleteFixtureComponent);
+    fixture.componentInstance.hideFirstColumn =
+      options?.hideFirstColumn ?? false;
     fixture.detectChanges();
   }
 
@@ -487,6 +492,39 @@ describe('SkyAgGridRowDeleteDirective', () => {
 
   it('should place the row delete overlay on top of the row correctly', async () => {
     setupTest();
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    fixture.componentInstance.rowDeleteIds = ['0', '1'];
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const row1Rect = fixture.nativeElement
+      .querySelector('[row-id="0"] div')
+      .getBoundingClientRect();
+    const row2Rect = fixture.nativeElement
+      .querySelector('[row-id="1"] div')
+      .getBoundingClientRect();
+    const inlineDelete1 = document.querySelector(
+      '#row-delete-ref-0',
+    ) as HTMLElement;
+    const inlineDelete2 = document.querySelector(
+      '#row-delete-ref-1',
+    ) as HTMLElement;
+    expect(fixture.componentInstance.rowDeleteIds).toEqual(['0', '1']);
+    expect(inlineDelete1.offsetLeft).toEqual(Math.round(row1Rect.left));
+    expect(inlineDelete1.offsetTop).toEqual(Math.round(row1Rect.top));
+    expect(inlineDelete2.offsetLeft).toEqual(Math.round(row2Rect.left));
+    expect(inlineDelete2.offsetTop).toEqual(Math.round(row2Rect.top));
+  });
+
+  it('should place the row delete overlay on top of the row correctly', async () => {
+    setupTest({
+      hideFirstColumn: true,
+    });
     fixture.detectChanges();
     await fixture.whenStable();
     fixture.detectChanges();

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/ag-grid-row-delete.directive.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/ag-grid-row-delete.directive.ts
@@ -176,7 +176,7 @@ export class SkyAgGridRowDeleteDirective
   readonly #affixService = inject(SkyAffixService);
   readonly #changeDetector = inject(ChangeDetectorRef);
   readonly #dynamicComponentSvc = inject(SkyDynamicComponentService);
-  readonly #elementRef = inject(ElementRef);
+  readonly #elementRef = inject(ElementRef<HTMLElement>);
   readonly #environmentInjector = inject(EnvironmentInjector);
   readonly #overlayService = inject(SkyOverlayService);
   readonly #scrollableHostService = inject(SkyScrollableHostService);
@@ -274,26 +274,10 @@ export class SkyAgGridRowDeleteDirective
   }
 
   #affixToRow(affixer: SkyAffixer, id: string): void {
-    let rowElement: HTMLElement = this.#elementRef.nativeElement.querySelector(`
-      [row-id="${id}"] div[aria-colindex="1"],
-      .ag-row.sky-ag-grid-row-${id} div[aria-colindex="1"]
+    const rowElement = this.#elementRef.nativeElement.querySelector(`
+      [row-id="${id}"] div[aria-colindex],
+      .ag-row.sky-ag-grid-row-${id} div[aria-colindex]
     `);
-
-    // This covers cases where AG Grid places the column index on an inner element (such as with the `enableCellTextSelection` option)
-    // This appears to have been fixed by AG Grid in version 24 and so it is not testable after that version.
-    /* istanbul ignore if */
-    if (!rowElement) {
-      const columns = this.#elementRef.nativeElement.querySelectorAll(
-        '[row-id="' + id + '"] > div',
-      );
-
-      for (const column of Array.from<HTMLElement>(columns)) {
-        if (column.querySelector('[aria-colindex="1"]')) {
-          rowElement = column;
-          break;
-        }
-      }
-    }
 
     affixer.affixTo(rowElement, {
       autoFitContext: SkyAffixAutoFitContext.Viewport,

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/fixtures/ag-grid-row-delete.component.fixture.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/fixtures/ag-grid-row-delete.component.fixture.ts
@@ -6,7 +6,7 @@ import {
   GridOptions,
   GridReadyEvent,
 } from 'ag-grid-community';
-import { fromEventPattern } from 'rxjs';
+import { firstValueFrom, fromEventPattern } from 'rxjs';
 import { first, map } from 'rxjs/operators';
 
 import { SkyAgGridService } from '../ag-grid.service';
@@ -26,8 +26,9 @@ import {
 })
 export class SkyAgGridRowDeleteFixtureComponent implements OnInit {
   public allColumnWidth = 0;
+  public hideFirstColumn = false;
 
-  public columnDefs = [
+  public columnDefs = () => [
     {
       field: 'selected',
       headerName: '',
@@ -35,6 +36,7 @@ export class SkyAgGridRowDeleteFixtureComponent implements OnInit {
       sortable: false,
       type: SkyCellType.RowSelector,
       width: this.allColumnWidth,
+      hide: this.hideFirstColumn,
     },
     {
       field: 'name',
@@ -74,10 +76,7 @@ export class SkyAgGridRowDeleteFixtureComponent implements OnInit {
   public gridApi: GridApi | undefined;
   public gridData = SKY_AG_GRID_DATA;
 
-  public gridOptions: GridOptions = {
-    columnDefs: this.columnDefs,
-    onGridReady: (gridReadyEvent) => this.onGridReady(gridReadyEvent),
-  };
+  public gridOptions: GridOptions | undefined;
 
   public rowDeleteIds: string[] | undefined;
 
@@ -89,7 +88,10 @@ export class SkyAgGridRowDeleteFixtureComponent implements OnInit {
 
   public ngOnInit(): void {
     this.gridOptions = this.#gridService.getEditableGridOptions({
-      gridOptions: this.gridOptions,
+      gridOptions: {
+        columnDefs: this.columnDefs(),
+        onGridReady: (gridReadyEvent) => this.onGridReady(gridReadyEvent),
+      },
     });
   }
 
@@ -116,17 +118,20 @@ export class SkyAgGridRowDeleteFixtureComponent implements OnInit {
   }
 
   public filterName(): Promise<void> {
-    const filterChangedPromise = fromEventPattern(
-      (handler) =>
-        this.gridApi?.addEventListener(Events.EVENT_FILTER_CHANGED, handler),
-      (handler) =>
-        this.gridApi?.removeEventListener(Events.EVENT_FILTER_CHANGED, handler),
-    )
-      .pipe(
+    const filterChangedPromise = firstValueFrom(
+      fromEventPattern(
+        (handler) =>
+          this.gridApi?.addEventListener(Events.EVENT_FILTER_CHANGED, handler),
+        (handler) =>
+          this.gridApi?.removeEventListener(
+            Events.EVENT_FILTER_CHANGED,
+            handler,
+          ),
+      ).pipe(
         first(),
         map(() => undefined),
-      )
-      .toPromise();
+      ),
+    );
     this.gridApi?.setFilterModel({
       name: {
         filterType: 'text',
@@ -138,17 +143,20 @@ export class SkyAgGridRowDeleteFixtureComponent implements OnInit {
   }
 
   public clearFilter(): Promise<void> {
-    const filterChangedPromise = fromEventPattern(
-      (handler) =>
-        this.gridApi?.addEventListener(Events.EVENT_FILTER_CHANGED, handler),
-      (handler) =>
-        this.gridApi?.removeEventListener(Events.EVENT_FILTER_CHANGED, handler),
-    )
-      .pipe(
+    const filterChangedPromise = firstValueFrom(
+      fromEventPattern(
+        (handler) =>
+          this.gridApi?.addEventListener(Events.EVENT_FILTER_CHANGED, handler),
+        (handler) =>
+          this.gridApi?.removeEventListener(
+            Events.EVENT_FILTER_CHANGED,
+            handler,
+          ),
+      ).pipe(
         first(),
         map(() => undefined),
-      )
-      .toPromise();
+      ),
+    );
     this.gridApi?.destroyFilter('name');
     return filterChangedPromise;
   }
@@ -167,17 +175,17 @@ export class SkyAgGridRowDeleteFixtureComponent implements OnInit {
   }
 
   public sortName(): Promise<void> {
-    const sortChangedPromise = fromEventPattern(
-      (handler) =>
-        this.gridApi?.addEventListener(Events.EVENT_SORT_CHANGED, handler),
-      (handler) =>
-        this.gridApi?.removeEventListener(Events.EVENT_SORT_CHANGED, handler),
-    )
-      .pipe(
+    const sortChangedPromise = firstValueFrom(
+      fromEventPattern(
+        (handler) =>
+          this.gridApi?.addEventListener(Events.EVENT_SORT_CHANGED, handler),
+        (handler) =>
+          this.gridApi?.removeEventListener(Events.EVENT_SORT_CHANGED, handler),
+      ).pipe(
         first(),
         map(() => undefined),
-      )
-      .toPromise();
+      ),
+    );
     this.gridApi?.applyColumnState({
       state: [
         {


### PR DESCRIPTION
[AB#2947153](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/2947153)