### PR TITLE
fix(components/datetime): adjust date range picker component vertical spacing in responsive containers

### DIFF
--- a/libs/components/datetime/src/lib/modules/date-range-picker/date-range-picker.component.scss
+++ b/libs/components/datetime/src/lib/modules/date-range-picker/date-range-picker.component.scss
@@ -9,14 +9,6 @@
   display: flex;
 }
 
-@media (max-width: $sky-screen-sm-min) {
-  .sky-date-range-picker-form-group {
-    &:not(.sky-date-range-picker-last-input) {
-      margin-bottom: var(--sky-margin-stacked-lg);
-    }
-  }
-}
-
 @include mixins.sky-host-responsive-container-xs-min() {
   .sky-date-range-picker {
     flex-direction: column;
@@ -31,6 +23,10 @@
 
     &:not(:last-of-type) {
       padding-right: initial;
+    }
+
+    &:not(.sky-date-range-picker-last-input) {
+      margin-bottom: var(--sky-margin-stacked-lg);
     }
   }
 }

--- a/libs/components/datetime/src/lib/modules/date-range-picker/date-range-picker.component.scss
+++ b/libs/components/datetime/src/lib/modules/date-range-picker/date-range-picker.component.scss
@@ -46,6 +46,10 @@
     &:not(:last-of-type) {
       padding-right: $sky-padding-half;
     }
+
+    &:not(.sky-date-range-picker-last-input) {
+      margin-bottom: 0;
+    }
   }
 }
 


### PR DESCRIPTION
[AB#2921900](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/2921900)