### PR TITLE
feat(components/indicators): add `@skyux/help-inline` support to status indicator

### DIFF
--- a/libs/components/help-inline/src/lib/modules/help-inline/help-inline.component.html
+++ b/libs/components/help-inline/src/lib/modules/help-inline/help-inline.component.html
@@ -6,8 +6,11 @@
       ? ('skyux_help_inline_aria_label' | skyLibResources: labelText)
       : ariaLabel
         ? ariaLabel
-        : ('skyux_help_inline_button_title' | skyLibResources)
+        : ariaLabelledby
+          ? undefined
+          : ('skyux_help_inline_button_title' | skyLibResources)
   "
+  [attr.aria-labelledby]="labelText || ariaLabel ? undefined : ariaLabelledby"
   [attr.aria-controls]="
     ariaControls | skyHelpInlineAriaControls: popoverId : helpKey
   "

--- a/libs/components/help-inline/src/lib/modules/help-inline/help-inline.component.ts
+++ b/libs/components/help-inline/src/lib/modules/help-inline/help-inline.component.ts
@@ -75,6 +75,13 @@ export class SkyHelpInlineComponent {
   public ariaLabel: string | undefined;
 
   /**
+   * The ID of an element whose text describes the help inline button. This sets the button's `aria-labelledby` to provide a text equivalent for screen readers.
+   * Will be overridden if label text or aria-label is set.
+   */
+  @Input()
+  public ariaLabelledby: string | undefined;
+
+  /**
    * The label of the component help inline is attached to.
    */
   @Input()

--- a/libs/components/indicators/package.json
+++ b/libs/components/indicators/package.json
@@ -23,6 +23,7 @@
     "@angular/platform-browser": "^17.3.4",
     "@skyux-sdk/testing": "0.0.0-PLACEHOLDER",
     "@skyux/core": "0.0.0-PLACEHOLDER",
+    "@skyux/help-inline": "0.0.0-PLACEHOLDER",
     "@skyux/i18n": "0.0.0-PLACEHOLDER",
     "@skyux/icon": "0.0.0-PLACEHOLDER",
     "@skyux/theme": "0.0.0-PLACEHOLDER"

--- a/libs/components/indicators/src/lib/modules/status-indicator/status-indicator.component.html
+++ b/libs/components/indicators/src/lib/modules/status-indicator/status-indicator.component.html
@@ -1,3 +1,6 @@
+<ng-template #helpContent
+  ><ng-content select=".sky-control-help"
+/></ng-template>
 <div *ngIf="descriptionType" class="sky-status-indicator">
   <div
     aria-hidden="true"
@@ -16,9 +19,15 @@
     <span *ngIf="descriptionComputed" class="sky-screen-reader-only">
       {{ descriptionComputed }}
     </span>
-    <span class="sky-status-indicator-message" skyTrim><ng-content /></span
+    <span skyId #message="skyId" class="sky-status-indicator-message" skyTrim
+      ><ng-content /></span
     ><span class="sky-control-help-container"
-      ><ng-content select=".sky-control-help"></ng-content
-    ></span>
+      ><sky-help-inline
+        *ngIf="helpPopoverContent || helpKey; else helpContent"
+        [ariaLabelledby]="message.id"
+        [helpKey]="helpKey"
+        [popoverTitle]="helpPopoverTitle"
+        [popoverContent]="helpPopoverContent"
+    /></span>
   </div>
 </div>

--- a/libs/components/indicators/src/lib/modules/status-indicator/status-indicator.component.ts
+++ b/libs/components/indicators/src/lib/modules/status-indicator/status-indicator.component.ts
@@ -4,6 +4,7 @@ import {
   Component,
   Input,
   OnInit,
+  TemplateRef,
   inject,
 } from '@angular/core';
 import { SkyLibResourcesService } from '@skyux/i18n';
@@ -67,6 +68,31 @@ export class SkyStatusIndicatorComponent implements OnInit {
   public get customDescription(): string | undefined {
     return this.#_customDescription;
   }
+
+  /**
+   * The content of the help popover. When specified, a [help inline](https://developer.blackbaud.com/skyux/components/help-inline)
+   * button is added to the status indicator. The help inline button displays a [popover](https://developer.blackbaud.com/skyux/components/popover)
+   * when clicked using the specified content and optional title.
+   * @preview
+   */
+  @Input()
+  public helpPopoverContent: string | TemplateRef<unknown> | undefined;
+
+  /**
+   * The title of the help popover. This property only applies when `helpPopoverContent` is
+   * also specified.
+   * @preview
+   */
+  @Input()
+  public helpPopoverTitle: string | undefined;
+
+  /**
+   * A help key that identifies the global help content to display. When specified, a [help inline](https://developer.blackbaud.com/skyux/components/help-inline) button is
+   * placed beside the status indicator label. Clicking the button invokes global help as configured by the application.
+   * @preview
+   */
+  @Input()
+  public helpKey: string | undefined;
 
   public descriptionComputed: string | undefined;
 

--- a/libs/components/indicators/src/lib/modules/status-indicator/status-indicator.module.ts
+++ b/libs/components/indicators/src/lib/modules/status-indicator/status-indicator.module.ts
@@ -1,6 +1,7 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
-import { SkyTrimModule } from '@skyux/core';
+import { SkyIdModule, SkyTrimModule } from '@skyux/core';
+import { SkyHelpInlineModule } from '@skyux/help-inline';
 import { SkyIconModule } from '@skyux/icon';
 
 import { SkyIndicatorsResourcesModule } from '../shared/sky-indicators-resources.module';
@@ -11,7 +12,9 @@ import { SkyStatusIndicatorComponent } from './status-indicator.component';
   declarations: [SkyStatusIndicatorComponent],
   imports: [
     CommonModule,
+    SkyHelpInlineModule,
     SkyIconModule,
+    SkyIdModule,
     SkyIndicatorsResourcesModule,
     SkyTrimModule,
   ],

--- a/libs/components/packages/src/schematics/migrations/migration-collection.json
+++ b/libs/components/packages/src/schematics/migrations/migration-collection.json
@@ -54,6 +54,11 @@
       "version": "10.7.0",
       "factory": "./update-10/add-forms-help-inline-peer-dependency/add-forms-help-inline-peer-dependency.schematic",
       "description": "Add @skyux/help-inline peer dependency for @skyux/forms."
+    },
+    "add-indicators-help-inline-peer-dependency": {
+      "version": "10.27.0",
+      "factory": "./update-10/add-indicators-help-inline-peer-dependency/add-indicators-help-inline-peer-dependency.schematic",
+      "description": "Add @skyux/help-inline peer dependency for @skyux/indicators."
     }
   }
 }

--- a/libs/components/packages/src/schematics/migrations/update-10/add-indicators-help-inline-peer-dependency/add-indicators-help-inline-peer-dependency.schematic.spec.ts
+++ b/libs/components/packages/src/schematics/migrations/update-10/add-indicators-help-inline-peer-dependency/add-indicators-help-inline-peer-dependency.schematic.spec.ts
@@ -1,0 +1,78 @@
+import { SchematicTestRunner } from '@angular-devkit/schematics/testing';
+
+import { join } from 'path';
+
+import { createTestApp } from '../../../testing/scaffold';
+
+describe('Migrations > add indicators/help-inline peer dependency', () => {
+  const runner = new SchematicTestRunner(
+    'migrations',
+    join(__dirname, '../../migration-collection.json'),
+  );
+
+  async function setupTest() {
+    const tree = await createTestApp(runner, {
+      projectName: 'my-app',
+    });
+
+    return {
+      runSchematic: () =>
+        runner.runSchematic(
+          'add-indicators-help-inline-peer-dependency',
+          {},
+          tree,
+        ),
+      tree,
+    };
+  }
+
+  it('should add @skyux/help-inline if @skyux/indicators is installed in dependencies', async () => {
+    const { runSchematic, tree } = await setupTest();
+
+    tree.overwrite(
+      '/package.json',
+      '{"dependencies": {"@skyux/indicators": "10.26.0"}}',
+    );
+
+    await runSchematic();
+
+    expect(tree.readJson('/package.json')).toEqual({
+      dependencies: {
+        '@skyux/help-inline': '10.26.0',
+        '@skyux/indicators': '10.26.0',
+      },
+    });
+  });
+
+  it('should add @skyux/help-inline if @skyux/indicators is installed in devDependencies', async () => {
+    const { runSchematic, tree } = await setupTest();
+
+    tree.overwrite(
+      '/package.json',
+      '{"devDependencies": {"@skyux/indicators": "10.26.0"}}',
+    );
+
+    await runSchematic();
+
+    expect(tree.readJson('/package.json')).toEqual({
+      dependencies: {
+        '@skyux/help-inline': '10.26.0',
+      },
+      devDependencies: {
+        '@skyux/indicators': '10.26.0',
+      },
+    });
+  });
+
+  it('should not add @skyux/help-inline if @skyux/indicators is not installed', async () => {
+    const { runSchematic, tree } = await setupTest();
+
+    tree.overwrite('/package.json', '{"dependencies": {}}');
+
+    await runSchematic();
+
+    expect(tree.readJson('/package.json')).toEqual({
+      dependencies: {},
+    });
+  });
+});

--- a/libs/components/packages/src/schematics/migrations/update-10/add-indicators-help-inline-peer-dependency/add-indicators-help-inline-peer-dependency.schematic.ts
+++ b/libs/components/packages/src/schematics/migrations/update-10/add-indicators-help-inline-peer-dependency/add-indicators-help-inline-peer-dependency.schematic.ts
@@ -1,0 +1,14 @@
+import { Rule } from '@angular-devkit/schematics';
+import { NodeDependencyType } from '@schematics/angular/utility/dependencies';
+
+import { ensurePeersInstalled } from '../../../rules/ensure-peers-installed';
+
+export default function (): Rule {
+  return ensurePeersInstalled('@skyux/indicators', [
+    {
+      matchVersion: true,
+      name: '@skyux/help-inline',
+      type: NodeDependencyType.Default,
+    },
+  ]);
+}


### PR DESCRIPTION
Verifying that creating `@skyux/icon` fixes the dependency issue