### PR TITLE
fix(components/forms): improve default value handling for heading styles on form group components (#2420)

### DIFF
--- a/apps/playground/src/app/components/forms/radio/radio.component.html
+++ b/apps/playground/src/app/components/forms/radio/radio.component.html
@@ -29,6 +29,13 @@
 >
   Mark all fields as touched
 </button>
+<button
+  type="button"
+  class="sky-btn sky-btn-primary sky-test-label"
+  (click)="toggleHeadingStyle()"
+>
+  Toggle heading style: {{ headingStyle ?? 'undefined' }}
+</button>
 
 <h1>Radio buttons (reactive)</h1>
 
@@ -41,8 +48,7 @@
       headingText="What is your favorite season? (reactive)"
       [required]="required"
       [stacked]="true"
-      headingLevel="3"
-      headingStyle="3"
+      [headingStyle]="headingStyle"
     >
       <ul class="sky-list-unstyled">
         <li *ngFor="let value of seasons">

--- a/apps/playground/src/app/components/forms/radio/radio.component.ts
+++ b/apps/playground/src/app/components/forms/radio/radio.component.ts
@@ -36,6 +36,8 @@ export class RadioComponent {
 
   public selectedValue = '3';
 
+  public headingStyle: number | undefined;
+
   constructor(formBuilder: UntypedFormBuilder) {
     this.favoriteSeason = new UntypedFormControl(
       {
@@ -76,5 +78,14 @@ export class RadioComponent {
 
     model.control.markAsTouched();
     model.control.updateValueAndValidity();
+  }
+
+  public toggleHeadingStyle(): void {
+    const newStyle = (this.headingStyle ?? 2) + 1;
+    if (newStyle > 5) {
+      this.headingStyle = undefined;
+    } else {
+      this.headingStyle = newStyle;
+    }
   }
 }

--- a/libs/components/forms/src/lib/modules/checkbox/checkbox-group.component.spec.ts
+++ b/libs/components/forms/src/lib/modules/checkbox/checkbox-group.component.spec.ts
@@ -88,7 +88,12 @@ describe('Checkbox group component', function () {
         4,
         5,
       ];
-      const headingStyles: SkyCheckboxGroupHeadingStyle[] = [3, 4, 5];
+      const headingStyles: (SkyCheckboxGroupHeadingStyle | undefined)[] = [
+        undefined,
+        3,
+        4,
+        5,
+      ];
       headingLevels.forEach((headingLevel) => {
         headingStyles.forEach((headingStyle) => {
           componentInstance.headingLevel = headingLevel;
@@ -96,8 +101,8 @@ describe('Checkbox group component', function () {
           fixture.detectChanges();
 
           const selector = headingLevel
-            ? `h${headingLevel}.sky-font-heading-${headingStyle}`
-            : `span.sky-font-heading-${headingStyle}`;
+            ? `h${headingLevel}.sky-font-heading-${headingStyle ?? 4}`
+            : `span.sky-font-heading-${headingStyle ?? 4}`;
           const heading = fixture.nativeElement.querySelector(selector);
 
           expect(heading).toExist();

--- a/libs/components/forms/src/lib/modules/checkbox/checkbox-group.component.ts
+++ b/libs/components/forms/src/lib/modules/checkbox/checkbox-group.component.ts
@@ -24,6 +24,10 @@ import { SkyFormsResourcesModule } from '../shared/sky-forms-resources.module';
 import { SkyCheckboxGroupHeadingLevel } from './checkbox-group-heading-level';
 import { SkyCheckboxGroupHeadingStyle } from './checkbox-group-heading-style';
 
+function numberAttribute4(value: unknown): number {
+  return numberAttribute(value, 4);
+}
+
 /**
  * Organizes checkboxes into a group.
  */
@@ -93,8 +97,10 @@ export class SkyCheckboxGroupComponent implements Validator {
    * The heading [font style](https://developer.blackbaud.com/skyux/design/styles/typography#headings).
    * @default 4
    */
-  @Input({ transform: numberAttribute })
-  public headingStyle: SkyCheckboxGroupHeadingStyle = 4;
+  @Input({ transform: numberAttribute4 })
+  public set headingStyle(value: SkyCheckboxGroupHeadingStyle) {
+    this.headingClass = `sky-font-heading-${value}`;
+  }
 
   /**
    * [Persistent inline help text](https://developer.blackbaud.com/skyux/design/guidelines/user-assistance#inline-help) that provides
@@ -137,12 +143,9 @@ export class SkyCheckboxGroupComponent implements Validator {
   @HostBinding('class.sky-margin-stacked-xl')
   public stackedXL = false;
 
-  public get headingClass(): string {
-    return `sky-font-heading-${this.headingStyle}`;
-  }
-
   readonly #idSvc = inject(SkyIdService);
   protected errorId = this.#idSvc.generateId();
+  protected headingClass = 'sky-font-heading-4';
   protected formErrorsDataId = 'checkbox-group-form-errors';
   protected formGroup: FormGroup | null | undefined;
 

--- a/libs/components/forms/src/lib/modules/checkbox/fixtures/standard-checkbox-group.component.ts
+++ b/libs/components/forms/src/lib/modules/checkbox/fixtures/standard-checkbox-group.component.ts
@@ -32,7 +32,7 @@ export class SkyStandardCheckboxGroupComponent {
   public hintText: string | undefined;
   public headingHidden = false;
   public headingLevel: SkyCheckboxGroupHeadingLevel | undefined = 3;
-  public headingStyle: SkyCheckboxGroupHeadingStyle = 3;
+  public headingStyle: SkyCheckboxGroupHeadingStyle | undefined = 3;
   public required: boolean | undefined = false;
   public stacked: boolean | undefined = true;
 

--- a/libs/components/forms/src/lib/modules/field-group/field-group.component.spec.ts
+++ b/libs/components/forms/src/lib/modules/field-group/field-group.component.spec.ts
@@ -5,6 +5,8 @@ import {
   SkyHelpTestingModule,
 } from '@skyux/core/testing';
 
+import { SkyFieldGroupHeadingLevel } from './field-group-heading-level';
+import { SkyFieldGroupHeadingStyle } from './field-group-heading-style';
 import { FieldGroupComponent } from './fixtures/field-group.component.fixture';
 
 describe('Field group component', function () {
@@ -65,14 +67,24 @@ describe('Field group component', function () {
   });
 
   it('should render the correct heading level and styles', () => {
-    [3, 4].forEach((headingLevel) => {
-      [3, 4].forEach((headingStyle) => {
+    const headingLevels: (SkyFieldGroupHeadingLevel | undefined)[] = [
+      undefined,
+      3,
+      4,
+    ];
+    const headingStyles: (SkyFieldGroupHeadingStyle | undefined)[] = [
+      undefined,
+      3,
+      4,
+    ];
+    headingLevels.forEach((headingLevel) => {
+      headingStyles.forEach((headingStyle) => {
         componentInstance.headingLevel = headingLevel;
         componentInstance.headingStyle = headingStyle;
         fixture.detectChanges();
 
         const heading = fixture.nativeElement.querySelector(
-          `h${headingLevel}.sky-font-heading-${headingStyle}`,
+          `h${headingLevel ?? 3}.sky-font-heading-${headingStyle ?? 3}`,
         );
 
         expect(heading).toExist();

--- a/libs/components/forms/src/lib/modules/field-group/field-group.component.ts
+++ b/libs/components/forms/src/lib/modules/field-group/field-group.component.ts
@@ -15,6 +15,10 @@ import { SkyFormFieldLabelTextRequiredService } from '../shared/form-field-label
 import { SkyFieldGroupHeadingLevel } from './field-group-heading-level';
 import { SkyFieldGroupHeadingStyle } from './field-group-heading-style';
 
+function numberAttribute3(value: unknown): number {
+  return numberAttribute(value, 3);
+}
+
 /**
  * Organizes form fields into a group.
  */
@@ -58,14 +62,14 @@ export class SkyFieldGroupComponent {
    * The semantic heading level in the document structure.
    * @default 3
    */
-  @Input({ transform: numberAttribute })
+  @Input({ transform: numberAttribute3 })
   public headingLevel: SkyFieldGroupHeadingLevel = 3;
 
   /**
    * The heading [font style](https://developer.blackbaud.com/skyux/design/styles/typography#headings).
    * @default 3
    */
-  @Input({ transform: numberAttribute })
+  @Input({ transform: numberAttribute3 })
   public set headingStyle(value: SkyFieldGroupHeadingStyle) {
     this.headingClass = `sky-font-heading-${value}`;
   }

--- a/libs/components/forms/src/lib/modules/field-group/fixtures/field-group.component.fixture.ts
+++ b/libs/components/forms/src/lib/modules/field-group/fixtures/field-group.component.fixture.ts
@@ -8,6 +8,8 @@ import {
 } from '@angular/forms';
 
 import { SkyInputBoxModule } from '../../input-box/input-box.module';
+import { SkyFieldGroupHeadingLevel } from '../field-group-heading-level';
+import { SkyFieldGroupHeadingStyle } from '../field-group-heading-style';
 import { SkyFieldGroupModule } from '../field-group.module';
 
 @Component({
@@ -27,8 +29,8 @@ export class FieldGroupComponent {
   public headingText = 'Heading text';
   public hintText: string | undefined;
   public headingHidden = false;
-  public headingStyle = 3;
-  public headingLevel = 3;
+  public headingStyle: SkyFieldGroupHeadingStyle | undefined = 3;
+  public headingLevel: SkyFieldGroupHeadingLevel | undefined = 3;
   public helpKey: string | undefined;
   public helpPopoverContent: string | undefined;
   public helpPopoverTitle: string | undefined;

--- a/libs/components/forms/src/lib/modules/radio/fixtures/radio-group-reactive.component.fixture.ts
+++ b/libs/components/forms/src/lib/modules/radio/fixtures/radio-group-reactive.component.fixture.ts
@@ -55,7 +55,7 @@ export class SkyRadioGroupReactiveFixtureComponent implements OnInit {
 
   public headingLevel: SkyRadioGroupHeadingLevel | undefined = 3;
 
-  public headingStyle: SkyRadioGroupHeadingStyle = 3;
+  public headingStyle: SkyRadioGroupHeadingStyle | undefined = 3;
 
   @ViewChild(SkyRadioGroupComponent)
   public radioGroupComponent: SkyRadioGroupComponent | undefined;

--- a/libs/components/forms/src/lib/modules/radio/radio-group.component.spec.ts
+++ b/libs/components/forms/src/lib/modules/radio/radio-group.component.spec.ts
@@ -646,7 +646,12 @@ describe('Radio group component (reactive)', function () {
       4,
       5,
     ];
-    const headingStyles: SkyRadioGroupHeadingStyle[] = [3, 4, 5];
+    const headingStyles: (SkyRadioGroupHeadingStyle | undefined)[] = [
+      undefined,
+      3,
+      4,
+      5,
+    ];
     headingLevels.forEach((headingLevel) => {
       headingStyles.forEach((headingStyle) => {
         componentInstance.headingText = 'Label text';
@@ -655,8 +660,8 @@ describe('Radio group component (reactive)', function () {
         fixture.detectChanges();
 
         const selector = headingLevel
-          ? `h${headingLevel}.sky-font-heading-${headingStyle}`
-          : `span.sky-font-heading-${headingStyle}`;
+          ? `h${headingLevel}.sky-font-heading-${headingStyle ?? 4}`
+          : `span.sky-font-heading-${headingStyle ?? 4}`;
         const heading = fixture.nativeElement.querySelector(selector);
 
         expect(heading).toExist();

--- a/libs/components/forms/src/lib/modules/radio/radio-group.component.ts
+++ b/libs/components/forms/src/lib/modules/radio/radio-group.component.ts
@@ -33,6 +33,10 @@ import { SkyRadioGroupHeadingStyle } from './types/radio-group-heading-style';
 
 let nextUniqueId = 0;
 
+function numberAttribute4(value: unknown): number {
+  return numberAttribute(value, 4);
+}
+
 /**
  * Organizes radio buttons into a group. It is required for radio
  * buttons on Angular reactive forms, and we recommend using it with all radio buttons.
@@ -132,8 +136,10 @@ export class SkyRadioGroupComponent
    * The heading [font style](https://developer.blackbaud.com/skyux/design/styles/typography#headings).
    * @default 4
    */
-  @Input({ transform: numberAttribute })
-  public headingStyle: SkyRadioGroupHeadingStyle = 4;
+  @Input({ transform: numberAttribute4 })
+  public set headingStyle(value: SkyRadioGroupHeadingStyle) {
+    this.headingClass = `sky-font-heading-${value}`;
+  }
 
   /**
    * The name for the collection of radio buttons that the component groups together.
@@ -257,10 +263,6 @@ export class SkyRadioGroupComponent
   @Input()
   public helpKey: string | undefined;
 
-  public get headingClass(): string {
-    return `sky-font-heading-${this.headingStyle}`;
-  }
-
   /**
    * Our radio components are usually implemented using an unordered list. This is an
    * accessibility violation because the unordered list has an implicit role which
@@ -281,6 +283,8 @@ export class SkyRadioGroupComponent
 
   @HostBinding('class.sky-margin-stacked-xl')
   public stackedXL = false;
+
+  protected headingClass = 'sky-font-heading-4';
 
   #controlValue: any;
 


### PR DESCRIPTION
:cherries: Cherry picked from #2420 [fix(components/forms): improve default value handling for heading styles on form group components](https://github.com/blackbaud/skyux/pull/2420)