### PR TITLE
fix(components/phone-field): required phone field controls are not "touched" on initialization (#2443)

### DIFF
--- a/apps/e2e/phone-field-storybook/src/app/phone-field/phone-field.component.ts
+++ b/apps/e2e/phone-field-storybook/src/app/phone-field/phone-field.component.ts
@@ -30,6 +30,7 @@ export class PhoneFieldComponent implements AfterViewInit {
       phoneControlError: this.phoneControlError,
     });
     this.phoneControlError.setValue('bbb');
+    this.phoneControlError.markAsTouched();
 
     this.phoneControlInput = new UntypedFormControl();
     this.phoneFormInput = new UntypedFormGroup({

--- a/libs/components/phone-field/src/lib/modules/phone-field/phone-field-adapter.service.ts
+++ b/libs/components/phone-field/src/lib/modules/phone-field/phone-field-adapter.service.ts
@@ -26,6 +26,17 @@ export class SkyPhoneFieldAdapterService implements OnDestroy {
     this.#renderer.addClass(elementRef.nativeElement, className);
   }
 
+  public getInputValue(elementRef: ElementRef): string | undefined {
+    const el = elementRef.nativeElement as HTMLElement | null;
+
+    if (el && 'value' in el) {
+      return (el as HTMLInputElement).value;
+    }
+
+    /* istanbul ignore next: safety check */
+    return undefined;
+  }
+
   public setElementDisabledState(
     elementRef: ElementRef,
     disabled: boolean,

--- a/libs/components/phone-field/src/lib/modules/phone-field/phone-field-input.directive.ts
+++ b/libs/components/phone-field/src/lib/modules/phone-field/phone-field-input.directive.ts
@@ -1,15 +1,12 @@
-import { coerceBooleanProperty } from '@angular/cdk/coercion';
 import {
-  AfterViewInit,
-  ChangeDetectorRef,
   Directive,
   ElementRef,
   HostListener,
   Input,
   OnDestroy,
   OnInit,
-  Optional,
-  forwardRef,
+  booleanAttribute,
+  inject,
 } from '@angular/core';
 import {
   AbstractControl,
@@ -21,23 +18,10 @@ import {
 } from '@angular/forms';
 
 import { PhoneNumberFormat, PhoneNumberUtil } from 'google-libphonenumber';
-import { BehaviorSubject, Subject } from 'rxjs';
-import { debounceTime, takeUntil } from 'rxjs/operators';
+import { Subject, takeUntil } from 'rxjs';
 
 import { SkyPhoneFieldAdapterService } from './phone-field-adapter.service';
 import { SkyPhoneFieldComponent } from './phone-field.component';
-
-const SKY_PHONE_FIELD_VALUE_ACCESSOR = {
-  provide: NG_VALUE_ACCESSOR,
-  useExisting: forwardRef(() => SkyPhoneFieldInputDirective),
-  multi: true,
-};
-
-const SKY_PHONE_FIELD_VALIDATOR = {
-  provide: NG_VALIDATORS,
-  useExisting: forwardRef(() => SkyPhoneFieldInputDirective),
-  multi: true,
-};
 
 /**
  * Creates a button, search input, and text input for entering and validating
@@ -54,24 +38,35 @@ const SKY_PHONE_FIELD_VALIDATOR = {
  */
 @Directive({
   selector: '[skyPhoneFieldInput]',
-  providers: [SKY_PHONE_FIELD_VALUE_ACCESSOR, SKY_PHONE_FIELD_VALIDATOR],
+  providers: [
+    {
+      provide: NG_VALIDATORS,
+      useExisting: SkyPhoneFieldInputDirective,
+      multi: true,
+    },
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: SkyPhoneFieldInputDirective,
+      multi: true,
+    },
+  ],
 })
 export class SkyPhoneFieldInputDirective
-  implements OnInit, OnDestroy, AfterViewInit, ControlValueAccessor, Validator
+  implements OnInit, OnDestroy, ControlValueAccessor, Validator
 {
   /**
    * Whether to disable the phone field on template-driven forms. Don't use this input on reactive forms because they may overwrite the input or leave the control out of sync.
    * To set the disabled state on reactive forms, use the `FormControl` instead.
    * @default false
    */
-  @Input()
-  public set disabled(value: boolean | undefined) {
-    const coercedValue = coerceBooleanProperty(value);
+  @Input({ transform: booleanAttribute })
+  public set disabled(value: boolean) {
     if (this.#phoneFieldComponent) {
-      this.#phoneFieldComponent.countrySelectDisabled = coercedValue;
-      this.#adapterService?.setElementDisabledState(this.#elRef, coercedValue);
+      this.#phoneFieldComponent.countrySelectDisabled = value;
+      this.#adapterSvc?.setElementDisabledState(this.#elRef, value);
     }
-    this.#_disabled = coercedValue;
+
+    this.#_disabled = value;
   }
 
   public get disabled(): boolean {
@@ -85,57 +80,28 @@ export class SkyPhoneFieldInputDirective
    * set this property to `true`.
    * @default false
    */
-  @Input()
-  public skyPhoneFieldNoValidate: boolean | undefined = false;
+  @Input({ transform: booleanAttribute })
+  public skyPhoneFieldNoValidate = false;
 
-  set #modelValue(value: string | undefined) {
-    const valueOrDefault = value ?? '';
-    this.#_modelValue = valueOrDefault;
-    this.#adapterService?.setElementValue(this.#elRef, valueOrDefault);
-
-    if (valueOrDefault) {
-      const formattedValue = this.#formatNumber(valueOrDefault.toString());
-
-      this.#onChange(formattedValue);
-    } else {
-      this.#onChange(valueOrDefault);
-    }
-    this.#validatorChange();
-  }
-
-  get #modelValue(): string {
-    return this.#_modelValue;
-  }
-
+  #_disabled = false;
+  #_value = '';
   #control: AbstractControl | undefined;
-
-  #textChanges: BehaviorSubject<string> | undefined;
-
   #ngUnsubscribe = new Subject<void>();
-
+  #notifyChange: ((value: string) => void) | undefined;
+  #notifyTouched: (() => void) | undefined;
   #phoneUtils = PhoneNumberUtil.getInstance();
 
-  #_disabled!: boolean;
+  readonly #adapterSvc = inject(SkyPhoneFieldAdapterService, {
+    host: true,
+    optional: true,
+    skipSelf: true,
+  });
 
-  #_modelValue = '';
-
-  #changeDetector: ChangeDetectorRef;
-  #elRef: ElementRef;
-
-  #adapterService: SkyPhoneFieldAdapterService | undefined;
-  #phoneFieldComponent: SkyPhoneFieldComponent | undefined;
-
-  constructor(
-    changeDetector: ChangeDetectorRef,
-    elRef: ElementRef,
-    @Optional() adapterService?: SkyPhoneFieldAdapterService,
-    @Optional() phoneFieldComponent?: SkyPhoneFieldComponent,
-  ) {
-    this.#changeDetector = changeDetector;
-    this.#elRef = elRef;
-    this.#adapterService = adapterService;
-    this.#phoneFieldComponent = phoneFieldComponent;
-  }
+  readonly #elRef = inject(ElementRef);
+  readonly #phoneFieldComponent = inject(SkyPhoneFieldComponent, {
+    host: true,
+    optional: true,
+  });
 
   public ngOnInit(): void {
     if (!this.#phoneFieldComponent) {
@@ -145,24 +111,17 @@ export class SkyPhoneFieldInputDirective
       );
     }
 
-    this.#adapterService?.setElementType(this.#elRef);
-    this.#adapterService?.addElementClass(this.#elRef, 'sky-form-control');
-  }
+    this.#adapterSvc?.setElementType(this.#elRef);
+    this.#adapterSvc?.addElementClass(this.#elRef, 'sky-form-control');
 
-  public ngAfterViewInit(): void {
     this.#phoneFieldComponent?.selectedCountryChange
       .pipe(takeUntil(this.#ngUnsubscribe))
       .subscribe(() => {
-        this.#modelValue = this.#elRef.nativeElement.value;
+        const value = this.#adapterSvc?.getInputValue(this.#elRef);
+        this.#setValue(value);
+        this.#notifyChange?.(this.#getValue());
+        this.#notifyTouched?.();
       });
-
-    // This is needed to address a bug in Angular 4, where the value is not changed on the view.
-    // See: https://github.com/angular/angular/issues/13792
-    /* istanbul ignore else */
-    if (this.#control && this.#modelValue) {
-      this.#control.setValue(this.#modelValue, { emitEvent: false });
-      this.#changeDetector.detectChanges();
-    }
   }
 
   public ngOnDestroy(): void {
@@ -170,198 +129,168 @@ export class SkyPhoneFieldInputDirective
     this.#ngUnsubscribe.complete();
   }
 
-  /**
-   * Writes the new value for reactive forms on change events on the input element
-   * @param event The change event that was received
-   */
-  @HostListener('change', ['$event'])
-  public onInputChange(event: any): void {
-    if (!this.#textChanges) {
-      this.#setupTextChangeSubscription(event.target.value);
-    } else {
-      this.#textChanges.next(event.target.value);
-    }
-  }
-
-  /**
-   * Marks reactive form controls as touched on input blur events
-   */
-  @HostListener('blur')
-  public onInputBlur(): void {
-    this.#onTouched();
-  }
-
-  @HostListener('input', ['$event'])
-  public onInputTyping(event: any): void {
-    if (!this.#textChanges) {
-      this.#setupTextChangeSubscription(event.target.value);
-    } else {
-      this.#textChanges.next(event.target.value);
-    }
-  }
-
-  /**
-   * Writes the new value for reactive forms
-   * @param value The new value for the input
-   */
-  public writeValue(value: string): void {
-    this.#phoneFieldComponent?.setCountryByDialCode(value);
-
-    this.#modelValue = value;
-  }
-
-  public registerOnChange(fn: (value: string | undefined) => void): void {
-    this.#onChange = fn;
+  public registerOnChange(fn: (value: string) => void): void {
+    this.#notifyChange = fn;
   }
 
   public registerOnTouched(fn: () => void): void {
-    this.#onTouched = fn;
+    this.#notifyTouched = fn;
   }
 
-  public registerOnValidatorChange(fn: () => void): void {
-    this.#validatorChange = fn;
-  }
-
-  /**
-   * Sets the disabled state on the input
-   * @param isDisabled the new value of the input's disabled state
-   */
   public setDisabledState(isDisabled: boolean): void {
     this.disabled = isDisabled;
   }
 
-  /**
-   * Validate's the form control's current value
-   * @param control the form control for the input
-   */
   public validate(control: AbstractControl): ValidationErrors | null {
-    if (!this.#control) {
-      this.#control = control;
-    }
-
-    if (this.skyPhoneFieldNoValidate) {
-      return null;
-    }
+    this.#control ??= control;
 
     const value = control.value;
 
-    if (!value) {
+    if (!value || this.skyPhoneFieldNoValidate) {
       return null;
     }
 
-    if (
-      this.#phoneFieldComponent?.selectedCountry &&
-      !this.#validateNumber(value)
-    ) {
-      if (!this.#textChanges) {
-        // Mark the invalid control as touched so that the input's invalid CSS styles appear.
-        // (This is only required when the invalid value is set by the FormControl constructor.)
-        // We don't do this if the input is the active element so that we don't show validation
-        // errors unless it is invalid on initialization or the input has been blurred.
-        control.markAsTouched();
-      }
-
+    if (!this.#isValidPhoneNumber(value)) {
       return {
         skyPhoneField: {
           invalid: value,
         },
       };
     }
+
     return null;
   }
 
-  #setupTextChangeSubscription(text: string): void {
-    this.#textChanges = new BehaviorSubject(text);
+  public writeValue(value: unknown): void {
+    const rawValue = typeof value === 'string' ? value : '';
 
-    this.#textChanges
-      .pipe(debounceTime(500), takeUntil(this.#ngUnsubscribe))
-      .subscribe((newValue) => {
-        this.writeValue(newValue);
-        this.#changeDetector.markForCheck();
-      });
+    this.#phoneFieldComponent?.setCountryByDialCode(rawValue);
+    this.#adapterSvc?.setElementValue(this.#elRef, rawValue);
+
+    this.#setValue(rawValue);
+    const newValue = this.#getValue();
+
+    if (rawValue !== newValue) {
+      // If the value is set before the control is initialized, wait for the
+      // first cycle to complete before triggering a value change event.
+      // (This occurs when the control is initialized with an unformatted value
+      // but is formatted into a new value immediately in the `writeValue`
+      // method.)
+      if (!this.#control) {
+        setTimeout(() => {
+          this.#notifyChange?.(newValue);
+        });
+      } else {
+        this.#notifyChange?.(newValue);
+      }
+    }
   }
 
-  #validateNumber(phoneNumber: string): boolean {
+  @HostListener('blur')
+  protected onBlur(): void {
+    this.#notifyTouched?.();
+  }
+
+  @HostListener('change')
+  protected onChange(): void {
+    const value = this.#adapterSvc?.getInputValue(this.#elRef);
+    this.#setValue(value);
+    this.#notifyChange?.(this.#getValue());
+  }
+
+  @HostListener('input')
+  protected onInput(): void {
+    const value = this.#adapterSvc?.getInputValue(this.#elRef);
+    this.#phoneFieldComponent?.setCountryByDialCode(value);
+  }
+
+  #formatPhoneNumber(value: string | undefined): string | undefined {
+    if (!value) {
+      return;
+    }
+
+    const defaultCountry = this.#getDefaultCountry();
+    const regionCode = this.#getRegionCode();
+    const returnFormat = this.#phoneFieldComponent?.returnFormat;
+
     try {
-      const numberObj = this.#phoneUtils.parseAndKeepRawInput(
-        phoneNumber,
-        this.#phoneFieldComponent?.selectedCountry?.iso2,
+      const phoneNumber = this.#phoneUtils.parseAndKeepRawInput(
+        value,
+        regionCode ?? defaultCountry,
       );
 
-      if (
-        this.#phoneFieldComponent &&
-        !this.#phoneFieldComponent.allowExtensions &&
-        numberObj.getExtension()
-      ) {
+      if (this.#phoneUtils.isPossibleNumber(phoneNumber)) {
+        switch (returnFormat) {
+          case 'international':
+            return this.#phoneUtils.format(
+              phoneNumber,
+              PhoneNumberFormat.INTERNATIONAL,
+            );
+
+          case 'national':
+            return this.#phoneUtils.format(
+              phoneNumber,
+              PhoneNumberFormat.NATIONAL,
+            );
+
+          case 'default':
+          default:
+            return regionCode && regionCode !== defaultCountry
+              ? this.#phoneUtils.format(
+                  phoneNumber,
+                  PhoneNumberFormat.INTERNATIONAL,
+                )
+              : this.#phoneUtils.format(
+                  phoneNumber,
+                  PhoneNumberFormat.NATIONAL,
+                );
+        }
+      }
+    } catch (err) {
+      /* */
+    }
+
+    return;
+  }
+
+  #getDefaultCountry(): string | undefined {
+    return this.#phoneFieldComponent?.defaultCountry;
+  }
+
+  #getRegionCode(): string | undefined {
+    return this.#phoneFieldComponent?.selectedCountry?.iso2;
+  }
+
+  #getValue(): string {
+    return this.#_value;
+  }
+
+  #isValidPhoneNumber(value: string): boolean {
+    const defaultCountry = this.#getDefaultCountry();
+    const regionCode = this.#getRegionCode() ?? defaultCountry;
+    const allowExtensions = !!this.#phoneFieldComponent?.allowExtensions;
+
+    try {
+      const phoneNumber = this.#phoneUtils.parseAndKeepRawInput(
+        value,
+        regionCode,
+      );
+
+      if (!allowExtensions && phoneNumber.getExtension()) {
         return false;
       }
 
-      return this.#phoneUtils.isValidNumberForRegion(
-        numberObj,
-        this.#phoneFieldComponent?.selectedCountry?.iso2,
-      );
+      return this.#phoneUtils.isValidNumberForRegion(phoneNumber, regionCode);
     } catch (e) {
       return false;
     }
   }
 
-  /**
-   * Format's the given phone number based on the currently selected country.
-   * @param phoneNumber The number to format
-   */
-  #formatNumber(phoneNumber: string): string {
-    try {
-      const numberObj = this.#phoneUtils.parseAndKeepRawInput(
-        phoneNumber,
-        this.#phoneFieldComponent?.selectedCountry?.iso2,
-      );
-      if (this.#phoneUtils.isPossibleNumber(numberObj)) {
-        switch (this.#phoneFieldComponent?.returnFormat) {
-          case 'international':
-            return this.#phoneUtils.format(
-              numberObj,
-              PhoneNumberFormat.INTERNATIONAL,
-            );
-          case 'national':
-            return this.#phoneUtils.format(
-              numberObj,
-              PhoneNumberFormat.NATIONAL,
-            );
-          case 'default':
-          default:
-            if (
-              this.#phoneFieldComponent?.selectedCountry?.iso2 !==
-              this.#phoneFieldComponent?.defaultCountry
-            ) {
-              return this.#phoneUtils.format(
-                numberObj,
-                PhoneNumberFormat.INTERNATIONAL,
-              );
-            } else {
-              return this.#phoneUtils.format(
-                numberObj,
-                PhoneNumberFormat.NATIONAL,
-              );
-            }
-        }
-      } else {
-        return phoneNumber;
-      }
-    } catch (e) {
-      /* sanity check */
-      /* istanbul ignore next */
-      return phoneNumber;
+  #setValue(value: string | undefined): void {
+    /* istanbul ignore else */
+    if (value !== undefined) {
+      const formatted = this.#formatPhoneNumber(value);
+      this.#_value = formatted ?? value;
     }
   }
-
-  // eslint-disable-next-line @typescript-eslint/no-empty-function , @typescript-eslint/no-unused-vars
-  #onChange = (_: string | undefined) => {};
-
-  // istanbul ignore next
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
-  #onTouched = () => {};
-
-  // istanbul ignore next
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
-  #validatorChange = () => {};
 }

--- a/libs/components/phone-field/src/lib/modules/phone-field/phone-field.component.html
+++ b/libs/components/phone-field/src/lib/modules/phone-field/phone-field.component.html
@@ -91,7 +91,7 @@
         [ngClass]="{
           'sky-btn-default':
             (themeSvc?.settingsChange | async)?.currentSettings?.theme?.name ===
-            'modern'
+            'modern',
         }"
         (click)="toggleCountrySearch(false)"
       >

--- a/libs/components/phone-field/src/lib/modules/phone-field/phone-field.component.html
+++ b/libs/components/phone-field/src/lib/modules/phone-field/phone-field.component.html
@@ -1,10 +1,10 @@
-<ng-container *ngIf="!inputBoxHostSvc">
+@if (!inputBoxHostSvc) {
   <div class="sky-input-group sky-phone-field" [@blockAnimationOnLoad]>
-    <ng-container *ngTemplateOutlet="countryBtnTemplateRef"></ng-container>
-    <ng-container *ngTemplateOutlet="inputTemplateRef"></ng-container>
-    <ng-container *ngTemplateOutlet="buttonsInsetTemplateRef"></ng-container>
+    <ng-container *ngTemplateOutlet="countryBtnTemplateRef" />
+    <ng-container *ngTemplateOutlet="inputTemplateRef" />
+    <ng-container *ngTemplateOutlet="buttonsInsetTemplateRef" />
   </div>
-</ng-container>
+}
 
 <ng-template #countryBtnTemplateRef>
   <div
@@ -40,59 +40,68 @@
 </ng-template>
 
 <ng-template #inputTemplateRef>
-  <span
-    *ngIf="phoneInputShown"
-    class="sky-phone-field-container"
-    [@phoneInputAnimation]="phoneInputShown ? 'open' : 'closed'"
-    (@phoneInputAnimation.done)="phoneInputAnimationEnd($event)"
-  >
-    <ng-content />
-  </span>
-  <span
-    *ngIf="countrySearchShown"
-    class="sky-phone-field-container"
-    [@countrySearchAnimation]="
-      'open' +
-      ((themeSvc?.settingsChange | async)?.currentSettings?.theme?.name ===
-      'modern'
-        ? '-modern'
-        : '')
-    "
-    (@countrySearchAnimation.done)="countrySearchAnimationEnd($event)"
-  >
-    <div class="sky-phone-field-country-search" [formGroup]="countrySearchForm">
-      <sky-country-field
-        formControlName="countrySearch"
-        [defaultCountry]="defaultCountry"
-        [hideSelectedCountryFlag]="true"
-        [includePhoneInfo]="true"
-        [supportedCountryISOs]="supportedCountryISOs"
-        (selectedCountryChange)="onCountrySelected($event)"
-      />
-    </div>
-  </span>
+  @if (phoneInputShown) {
+    <span
+      class="sky-phone-field-container"
+      [@phoneInputAnimation]="phoneInputShown ? 'open' : 'closed'"
+      (@phoneInputAnimation.done)="phoneInputAnimationEnd($event)"
+    >
+      <ng-content />
+    </span>
+  } @else if (countrySearchShown) {
+    <span
+      class="sky-phone-field-container"
+      [@countrySearchAnimation]="
+        'open' +
+        ((themeSvc?.settingsChange | async)?.currentSettings?.theme?.name ===
+        'modern'
+          ? '-modern'
+          : '')
+      "
+      (@countrySearchAnimation.done)="countrySearchAnimationEnd($event)"
+    >
+      <div
+        class="sky-phone-field-country-search"
+        [formGroup]="countrySearchForm"
+      >
+        <sky-country-field
+          formControlName="countrySearch"
+          [defaultCountry]="defaultCountry"
+          [hideSelectedCountryFlag]="true"
+          [includePhoneInfo]="true"
+          [supportedCountryISOs]="supportedCountryISOs"
+          (selectedCountryChange)="onCountrySelected($event)"
+        />
+      </div>
+    </span>
+  }
 </ng-template>
 
 <ng-template #buttonsInsetTemplateRef>
-  <div
-    *ngIf="countrySearchShown"
-    class="sky-input-group-btn sky-input-box-btn-inset sky-search-item-dismiss"
-  >
-    <button
-      class="sky-btn sky-phone-field-search-btn-dismiss"
-      type="button"
-      [attr.title]="
-        'skyux_phone_field_country_search_dismiss' | skyLibResources
-      "
-      [ngClass]="{
-        'sky-btn-default':
-          (themeSvc?.settingsChange | async)?.currentSettings?.theme?.name ===
-          'modern'
-      }"
-      (click)="toggleCountrySearch(false)"
+  @if (countrySearchShown) {
+    <div
+      class="sky-input-group-btn sky-input-box-btn-inset sky-search-item-dismiss"
     >
-      <sky-icon *skyThemeIf="'default'" icon="chevron-circle-left" size="lg" />
-      <sky-icon *skyThemeIf="'modern'" icon="double-chevron-left" size="2x" />
-    </button>
-  </div>
+      <button
+        class="sky-btn sky-phone-field-search-btn-dismiss"
+        type="button"
+        [attr.title]="
+          'skyux_phone_field_country_search_dismiss' | skyLibResources
+        "
+        [ngClass]="{
+          'sky-btn-default':
+            (themeSvc?.settingsChange | async)?.currentSettings?.theme?.name ===
+            'modern'
+        }"
+        (click)="toggleCountrySearch(false)"
+      >
+        <sky-icon
+          *skyThemeIf="'default'"
+          icon="chevron-circle-left"
+          size="lg"
+        />
+        <sky-icon *skyThemeIf="'modern'" icon="double-chevron-left" size="2x" />
+      </button>
+    </div>
+  }
 </ng-template>

--- a/libs/components/phone-field/src/lib/modules/phone-field/phone-field.component.spec.ts
+++ b/libs/components/phone-field/src/lib/modules/phone-field/phone-field.component.spec.ts
@@ -210,8 +210,8 @@ describe('Phone Field Component', () => {
   }
 
   function validateInputAndModel(
-    modelValue: string,
-    formattedValue: string,
+    inputValue: string,
+    modelValue: string | undefined,
     isValid: boolean,
     isTouched: boolean,
     model: NgModel | UntypedFormControl | undefined,
@@ -222,9 +222,9 @@ describe('Phone Field Component', () => {
     >,
   ): void {
     fixture.detectChanges();
-    expect(fixture.nativeElement.querySelector('input').value).toBe(modelValue);
+    expect(fixture.nativeElement.querySelector('input').value).toBe(inputValue);
 
-    expect(model?.value).toBe(formattedValue);
+    expect(model?.value).toBe(modelValue);
 
     expect(model?.valid).toBe(isValid);
 
@@ -233,7 +233,7 @@ describe('Phone Field Component', () => {
     } else {
       expect(model?.errors).toEqual({
         skyPhoneField: {
-          invalid: formattedValue,
+          invalid: modelValue,
         },
       });
     }
@@ -539,7 +539,7 @@ describe('Phone Field Component', () => {
         await fixture.whenStable();
         fixture.detectChanges();
 
-        validateInputAndModel('1234', '1234', false, true, ngModel, fixture);
+        validateInputAndModel('1234', '1234', false, false, ngModel, fixture);
 
         blurInput(fixture.nativeElement, fixture, true);
 
@@ -558,7 +558,7 @@ describe('Phone Field Component', () => {
           '667-555-530',
           '667-555-530',
           false,
-          true,
+          false,
           ngModel,
           fixture,
         );
@@ -615,7 +615,7 @@ describe('Phone Field Component', () => {
 
         fixture.detectChanges();
         await fixture.whenStable();
-        validateInputAndModel('1234', '1234', false, true, ngModel, fixture);
+        validateInputAndModel('1234', '1234', false, false, ngModel, fixture);
       });
 
       it('should validate properly when input changed to empty string', async () => {
@@ -702,7 +702,7 @@ describe('Phone Field Component', () => {
           '667-555-5309ext3',
           '(667) 555-5309 ext. 3',
           false,
-          true,
+          false,
           ngModel,
           fixture,
         );
@@ -867,7 +867,7 @@ describe('Phone Field Component', () => {
           '+3556675555309',
           '+3556675555309',
           false,
-          true,
+          false,
           ngModel,
           fixture,
         );
@@ -1238,7 +1238,7 @@ describe('Phone Field Component', () => {
           '+12045555555',
           '+1 204-555-5555',
           true,
-          true,
+          false,
           ngModel,
           fixture,
         );
@@ -1297,7 +1297,7 @@ describe('Phone Field Component', () => {
         fixture.detectChanges();
         tick();
 
-        validateInputAndModel('', '', true, false, ngModel, fixture);
+        validateInputAndModel('', undefined, true, false, ngModel, fixture);
 
         setCountry('Albania', fixture);
 
@@ -1308,7 +1308,7 @@ describe('Phone Field Component', () => {
           '024569874',
           '+355 24 569 874',
           true,
-          false,
+          true,
           ngModel,
           fixture,
         );
@@ -1606,7 +1606,7 @@ describe('Phone Field Component', () => {
           '1234',
           '1234',
           false,
-          true,
+          false,
           component.phoneControl,
           fixture,
         );
@@ -1632,7 +1632,7 @@ describe('Phone Field Component', () => {
           '667-555-530',
           '667-555-530',
           false,
-          true,
+          false,
           component.phoneControl,
           fixture,
         );
@@ -1686,7 +1686,7 @@ describe('Phone Field Component', () => {
           '1234',
           '1234',
           false,
-          true,
+          false,
           component.phoneControl,
           fixture,
         );
@@ -1778,7 +1778,7 @@ describe('Phone Field Component', () => {
           '667-555-5309ext3',
           '(667) 555-5309 ext. 3',
           false,
-          true,
+          false,
           component.phoneControl,
           fixture,
         );
@@ -1793,7 +1793,7 @@ describe('Phone Field Component', () => {
           '8675558309',
           '(867) 555-8309',
           false,
-          true,
+          false,
           component.phoneControl,
           fixture,
         );
@@ -1974,7 +1974,7 @@ describe('Phone Field Component', () => {
           '+3556675555309',
           '+3556675555309',
           false,
-          true,
+          false,
           component.phoneControl,
           fixture,
         );
@@ -2178,7 +2178,7 @@ describe('Phone Field Component', () => {
           '024569874',
           '+355 24 569 874',
           true,
-          false,
+          true,
           component.phoneControl,
           fixture,
         );


### PR DESCRIPTION
:cherries: Cherry picked from #2443 [fix(components/phone-field): required phone field controls are not "touched" on initialization](https://github.com/blackbaud/skyux/pull/2443)

[AB#2976646](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/2976646) 