### PR TITLE
chore(components/indicators): split expansion indicator styles (#2453)

### DIFF
--- a/libs/components/indicators/src/lib/modules/expansion-indicator/expansion-indicator.component.ts
+++ b/libs/components/indicators/src/lib/modules/expansion-indicator/expansion-indicator.component.ts
@@ -6,7 +6,10 @@ import { Component, Input } from '@angular/core';
  */
 @Component({
   selector: 'sky-expansion-indicator',
-  styleUrls: ['./expansion-indicator.component.scss'],
+  styleUrls: [
+    './expansion-indicator.default.component.scss',
+    './expansion-indicator.modern.component.scss',
+  ],
   templateUrl: './expansion-indicator.component.html',
 })
 export class SkyExpansionIndicatorComponent {

--- a/libs/components/indicators/src/lib/modules/expansion-indicator/expansion-indicator.default.component.scss
+++ b/libs/components/indicators/src/lib/modules/expansion-indicator/expansion-indicator.default.component.scss
@@ -1,7 +1,7 @@
 @use 'libs/components/theme/src/lib/styles/mixins' as mixins;
 @use 'libs/components/theme/src/lib/styles/variables' as *;
 
-.sky-expansion-indicator {
+@include mixins.sky-component('default', '.sky-expansion-indicator') {
   display: inline-block;
   border: none;
   background-color: transparent;
@@ -14,7 +14,7 @@
   vertical-align: top;
 }
 
-.sky-expansion-indicator-part {
+@include mixins.sky-component('default', '.sky-expansion-indicator-part') {
   border-color: $sky-text-color-icon-borderless;
   border-style: solid;
   border-width: 3px 0 0 0;
@@ -29,7 +29,7 @@
   width: 10px;
 }
 
-.sky-expansion-indicator-up {
+@include mixins.sky-component('default', '.sky-expansion-indicator-up') {
   .sky-expansion-indicator-left {
     left: 7px;
     transform: rotate(-45deg);
@@ -41,7 +41,7 @@
   }
 }
 
-.sky-expansion-indicator-down {
+@include mixins.sky-component('default', '.sky-expansion-indicator-down') {
   .sky-expansion-indicator-left {
     left: 2px;
     transform: rotate(45deg);
@@ -50,44 +50,5 @@
   .sky-expansion-indicator-right {
     left: 12px;
     transform: rotate(-45deg);
-  }
-}
-
-@include mixins.sky-theme-modern {
-  .sky-expansion-indicator {
-    height: 26px;
-    width: 26px;
-  }
-
-  .sky-expansion-indicator-part {
-    background: $sky-theme-modern-font-deemphasized-color;
-    border: none;
-    height: 2px;
-    width: 11px;
-    top: 13px;
-  }
-
-  .sky-expansion-indicator-glyph-container {
-    transform: scale(0.68);
-    display: inline-block;
-    position: absolute;
-    top: 3.5px;
-    left: 4px;
-  }
-
-  .sky-expansion-indicator-left {
-    border-radius: 1px 0 0 1px;
-  }
-
-  .sky-expansion-indicator-right {
-    border-radius: 0 1px 1px 0;
-  }
-
-  .sky-expansion-indicator-left {
-    left: 4px;
-  }
-
-  .sky-expansion-indicator-right {
-    left: 10.5px;
   }
 }

--- a/libs/components/indicators/src/lib/modules/expansion-indicator/expansion-indicator.modern.component.scss
+++ b/libs/components/indicators/src/lib/modules/expansion-indicator/expansion-indicator.modern.component.scss
@@ -1,0 +1,70 @@
+@use 'libs/components/theme/src/lib/styles/mixins' as mixins;
+@use 'libs/components/theme/src/lib/styles/variables' as *;
+
+@include mixins.sky-component('modern', '.sky-expansion-indicator') {
+  display: inline-block;
+  border: none;
+  background-color: transparent;
+  flex-shrink: 0;
+  height: 26px;
+  margin: 0;
+  overflow: hidden;
+  position: relative;
+  vertical-align: top;
+  width: 26px;
+}
+
+@include mixins.sky-component('modern', '.sky-expansion-indicator-part') {
+  background: $sky-theme-modern-font-deemphasized-color;
+  border: none;
+  display: inline-block;
+  height: 2px;
+  position: absolute;
+  top: 13px;
+  transition:
+    transform $sky-transition-time-medium,
+    left $sky-transition-time-medium;
+  vertical-align: top;
+  width: 11px;
+}
+
+@include mixins.sky-component(
+  'modern',
+  '.sky-expansion-indicator-glyph-container'
+) {
+  left: 4px;
+  display: inline-block;
+  position: absolute;
+  top: 3.5px;
+  transform: scale(0.68);
+}
+
+@include mixins.sky-component('modern', '.sky-expansion-indicator-left') {
+  border-radius: 1px 0 0 1px;
+  left: 4px;
+}
+
+@include mixins.sky-component('modern', '.sky-expansion-indicator-right') {
+  border-radius: 0 1px 1px 0;
+  left: 10.5px;
+}
+
+@include mixins.sky-component('modern', '.sky-expansion-indicator-up') {
+  .sky-expansion-indicator-left {
+    transform: rotate(-45deg);
+  }
+
+  .sky-expansion-indicator-right {
+    transform: rotate(45deg);
+  }
+}
+
+@include mixins.sky-component('modern', '.sky-expansion-indicator-down') {
+  .sky-expansion-indicator-left {
+    transform: rotate(45deg);
+  }
+
+  .sky-expansion-indicator-right {
+    transform: rotate(-45deg);
+  }
+}


### PR DESCRIPTION
:cherries: Cherry picked from #2453 [chore(components/indicators): split expansion indicator styles](https://github.com/blackbaud/skyux/pull/2453)

[AB#2767140](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/2767140) 