### PR TITLE
fix(components/datetime): ignore extraneous properties when setting calculator value

### DIFF
--- a/libs/components/datetime/src/lib/modules/date-range-picker/date-range-picker.component.spec.ts
+++ b/libs/components/datetime/src/lib/modules/date-range-picker/date-range-picker.component.spec.ts
@@ -714,6 +714,15 @@ describe('Date range picker', function () {
     );
   }));
 
+  it('should ignore extraneous properties when setting the value', () => {
+    component.dateRange?.setValue({
+      foo: 'bar',
+      calculatorId: SkyDateRangeCalculatorId.LastWeek,
+    });
+
+    expect(() => fixture.detectChanges()).not.toThrow();
+  });
+
   describe('accessibility', () => {
     function verifyFormFieldsRequired(expectation: boolean): void {
       const inputBoxes =

--- a/libs/components/datetime/src/lib/modules/date-range-picker/date-range-picker.component.ts
+++ b/libs/components/datetime/src/lib/modules/date-range-picker/date-range-picker.component.ts
@@ -604,7 +604,7 @@ export class SkyDateRangePickerComponent
       }
 
       if (options?.emitEvent) {
-        this.formGroup.setValue(valueOrDefault);
+        this.formGroup.patchValue(valueOrDefault);
       }
     }
   }


### PR DESCRIPTION
[AB#2991138](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/2991138)