### PR TITLE
fix(components/tiles): do not expand/collapse content when help inline clicked (#2468)

### DIFF
--- a/libs/components/tiles/src/lib/modules/tiles/tile/tile.component.html
+++ b/libs/components/tiles/src/lib/modules/tiles/tile/tile.component.html
@@ -1,10 +1,10 @@
 <section
   class="sky-tile"
   [ngClass]="{
-    'sky-tile-collapsed': isCollapsed
+    'sky-tile-collapsed': isCollapsed,
   }"
   [skyThemeClass]="{
-    'sky-box sky-elevation-1-bordered sky-padding-even-xl': 'modern'
+    'sky-box sky-elevation-1-bordered sky-padding-even-xl': 'modern',
   }"
 >
   <header class="sky-tile-header">
@@ -37,7 +37,7 @@
                 : ('skyux_tile_help_default' | skyLibResources)
             "
             [skyThemeClass]="{
-              'sky-btn-icon-borderless': 'modern'
+              'sky-btn-icon-borderless': 'modern',
             }"
             (click)="helpButtonClicked()"
           >
@@ -54,7 +54,7 @@
           [direction]="isCollapsed ? 'down' : 'up'"
           [skyThemeClass]="{
             'sky-tile-tools-control': 'default',
-            'sky-margin-inline-default': 'modern'
+            'sky-margin-inline-default': 'modern',
           }"
           (directionChange)="chevronDirectionChange($event)"
         >
@@ -70,7 +70,7 @@
           "
           [skyThemeClass]="{
             'sky-tile-tools-control': 'default',
-            'sky-btn-icon-borderless sky-margin-inline-default': 'modern'
+            'sky-btn-icon-borderless sky-margin-inline-default': 'modern',
           }"
           (click)="settingsButtonClicked()"
         >
@@ -88,7 +88,7 @@
           [attr.aria-describedby]="ariaDescribedBy"
           [skyThemeClass]="{
             'sky-tile-tools-control': 'default',
-            'sky-btn-icon-borderless': 'modern'
+            'sky-btn-icon-borderless': 'modern',
           }"
           (click)="$event.stopPropagation()"
           (keydown)="moveTile($event)"

--- a/libs/components/tiles/src/lib/modules/tiles/tile/tile.component.html
+++ b/libs/components/tiles/src/lib/modules/tiles/tile/tile.component.html
@@ -8,7 +8,7 @@
   }"
 >
   <header class="sky-tile-header">
-    <div class="sky-tile-header-content" (click)="titleClick()">
+    <div class="sky-tile-header-content" (click)="titleClick($event)">
       <div class="sky-tile-header-title" #titleContainer>
         <ng-content select="sky-tile-title" />
         @if (tileName && (helpKey || helpPopoverContent)) {

--- a/libs/components/tiles/src/lib/modules/tiles/tile/tile.component.spec.ts
+++ b/libs/components/tiles/src/lib/modules/tiles/tile/tile.component.spec.ts
@@ -286,7 +286,7 @@ describe('Tile component', () => {
     });
   });
 
-  describe('help button', () => {
+  describe('help button (legacy)', () => {
     it('should be absent if a callback is not provided', () => {
       const html = `
         <sky-tile tileName="test" [isCollapsed]="tileIsCollapsed">
@@ -488,5 +488,22 @@ describe('Tile component', () => {
     fixture.detectChanges();
 
     expect(getHelpInlineButton(fixture)).toBeNull();
+  });
+
+  it('should not expand/collapse the content when the help inline button is clicked', () => {
+    const fixture = TestBed.createComponent(TileTestComponent);
+    const el = fixture.nativeElement;
+
+    fixture.componentInstance.tileName = 'Tile 1';
+    fixture.componentInstance.helpPopoverContent = 'Example popover content.';
+    fixture.detectChanges();
+
+    const contentAttrs = el.querySelector('.sky-tile-content').attributes;
+
+    expect(contentAttrs['hidden']).toBeUndefined();
+
+    getHelpInlineButton(fixture)?.click();
+
+    expect(contentAttrs['hidden']).toBeUndefined();
   });
 });

--- a/libs/components/tiles/src/lib/modules/tiles/tile/tile.component.ts
+++ b/libs/components/tiles/src/lib/modules/tiles/tile/tile.component.ts
@@ -242,8 +242,13 @@ export class SkyTileComponent implements OnChanges, OnDestroy {
     return this.helpClick.observers.length > 0 && this.showHelp;
   }
 
-  public titleClick(): void {
-    this.isCollapsed = !this.isCollapsed;
+  public titleClick(evt: MouseEvent): void {
+    const targetEl = evt.target as HTMLElement | null;
+
+    // Don't expand/collapse if the help inline button is clicked.
+    if (targetEl?.closest('sky-help-inline') === null) {
+      this.isCollapsed = !this.isCollapsed;
+    }
   }
 
   public chevronDirectionChange(direction: string): void {


### PR DESCRIPTION
:cherries: Cherry picked from #2468 [fix(components/tiles): do not expand/collapse content when help inline clicked](https://github.com/blackbaud/skyux/pull/2468)