### PR TITLE
chore(components/indicators): split key info and illustration styles (#2466)

### DIFF
--- a/libs/components/indicators/src/lib/modules/illustration/illustration.component.scss
+++ b/libs/components/indicators/src/lib/modules/illustration/illustration.component.scss
@@ -1,4 +1,0 @@
-:host,
-.sky-illustration-img {
-  display: block;
-}

--- a/libs/components/indicators/src/lib/modules/illustration/illustration.component.ts
+++ b/libs/components/indicators/src/lib/modules/illustration/illustration.component.ts
@@ -7,6 +7,7 @@ import {
   input,
 } from '@angular/core';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
+import { SkyThemeComponentClassDirective } from '@skyux/theme';
 
 import { catchError, from, of, switchMap } from 'rxjs';
 
@@ -28,7 +29,11 @@ const pixelSizes: Record<SkyIllustrationSize, number> = {
   standalone: true,
   imports: [CommonModule, NgOptimizedImage],
   templateUrl: './illustration.component.html',
-  styleUrls: ['./illustration.component.scss'],
+  styleUrls: [
+    './illustration.default.component.scss',
+    './illustration.modern.component.scss',
+  ],
+  hostDirectives: [SkyThemeComponentClassDirective],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class SkyIllustrationComponent {

--- a/libs/components/indicators/src/lib/modules/illustration/illustration.default.component.scss
+++ b/libs/components/indicators/src/lib/modules/illustration/illustration.default.component.scss
@@ -1,0 +1,9 @@
+@use 'libs/components/theme/src/lib/styles/mixins' as mixins;
+
+@include mixins.sky-component-host('default') {
+  display: block;
+}
+
+@include mixins.sky-component('default', '.sky-illustration-img') {
+  display: block;
+}

--- a/libs/components/indicators/src/lib/modules/illustration/illustration.modern.component.scss
+++ b/libs/components/indicators/src/lib/modules/illustration/illustration.modern.component.scss
@@ -1,0 +1,9 @@
+@use 'libs/components/theme/src/lib/styles/mixins' as mixins;
+
+@include mixins.sky-component-host('modern') {
+  display: block;
+}
+
+@include mixins.sky-component('modern', '.sky-illustration-img') {
+  display: block;
+}

--- a/libs/components/indicators/src/lib/modules/key-info/key-info.component.ts
+++ b/libs/components/indicators/src/lib/modules/key-info/key-info.component.ts
@@ -5,7 +5,10 @@ import { SkyKeyInfoLayoutType } from './key-info-layout-type';
 @Component({
   selector: 'sky-key-info',
   templateUrl: './key-info.component.html',
-  styleUrls: ['./key-info.component.scss'],
+  styleUrls: [
+    './key-info.default.component.scss',
+    './key-info.modern.component.scss',
+  ],
 })
 export class SkyKeyInfoComponent {
   /**

--- a/libs/components/indicators/src/lib/modules/key-info/key-info.default.component.scss
+++ b/libs/components/indicators/src/lib/modules/key-info/key-info.default.component.scss
@@ -1,0 +1,16 @@
+@use 'libs/components/theme/src/lib/styles/mixins' as mixins;
+
+@include mixins.sky-component('default', '.sky-key-info') {
+  display: inline-block;
+
+  &.sky-key-info-horizontal {
+    .sky-key-info-value,
+    .sky-key-info-label {
+      display: inline-block;
+    }
+
+    .sky-key-info-label {
+      padding: 0 0 0 var(--sky-margin-inline-xs);
+    }
+  }
+}

--- a/libs/components/indicators/src/lib/modules/key-info/key-info.modern.component.scss
+++ b/libs/components/indicators/src/lib/modules/key-info/key-info.modern.component.scss
@@ -1,4 +1,6 @@
-.sky-key-info {
+@use 'libs/components/theme/src/lib/styles/mixins' as mixins;
+
+@include mixins.sky-component('modern', '.sky-key-info') {
   display: inline-block;
 
   &.sky-key-info-horizontal {


### PR DESCRIPTION
:cherries: Cherry picked from #2466 [chore(components/indicators): split key info and illustration styles](https://github.com/blackbaud/skyux/pull/2466)

[AB#2767153](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/2767153) 