### PR TITLE
fix(components/icon): provide HTTP with interceptors (#2474)

### DIFF
--- a/libs/components/icon/src/lib/icon/icon.module.ts
+++ b/libs/components/icon/src/lib/icon/icon.module.ts
@@ -1,5 +1,9 @@
 import { CommonModule } from '@angular/common';
-import { provideHttpClient, withFetch } from '@angular/common/http';
+import {
+  provideHttpClient,
+  withFetch,
+  withInterceptorsFromDi,
+} from '@angular/common/http';
 import { NgModule } from '@angular/core';
 
 import { SkyIconClassListPipe } from './icon-class-list.pipe';
@@ -12,6 +16,9 @@ import { SkyIconComponent } from './icon.component';
   declarations: [SkyIconClassListPipe, SkyIconComponent, SkyIconStackComponent],
   imports: [CommonModule, SkyIconSvgComponent],
   exports: [SkyIconComponent, SkyIconStackComponent],
-  providers: [provideHttpClient(withFetch()), SkyIconSvgResolverService],
+  providers: [
+    provideHttpClient(withFetch(), withInterceptorsFromDi()),
+    SkyIconSvgResolverService,
+  ],
 })
 export class SkyIconModule {}


### PR DESCRIPTION
:cherries: Cherry picked from #2474 [fix(components/icon): provide HTTP with interceptors](https://github.com/blackbaud/skyux/pull/2474)

[AB#2996990](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/2996990) 