### PR TITLE
chore(components/icon): icon stack overrides visual tests (#2496)

### DIFF
--- a/apps/e2e/indicators-storybook/src/app/icon/icon.component.html
+++ b/apps/e2e/indicators-storybook/src/app/icon/icon.component.html
@@ -115,4 +115,16 @@
     [topIcon]="{ icon: 'eye', iconType: 'skyux' }"
   />
 </div>
+<div class="sky-padding-even-md icon-stack-alert-overrides">
+  <sky-icon-stack
+    size="1x"
+    [baseIcon]="{ icon: 'circle-solid', iconType: 'skyux' }"
+    [topIcon]="{ icon: 'check', iconType: 'skyux' }"
+  />
+  <sky-icon-stack
+    size="1x"
+    [baseIcon]="{ icon: 'triangle-solid', iconType: 'skyux' }"
+    [topIcon]="{ icon: 'exclamation', iconType: 'skyux' }"
+  />
+</div>
 <span id="ready" *ngIf="ready | async"></span>

--- a/libs/components/icon/src/lib/icon/icon-stack.component.scss
+++ b/libs/components/icon/src/lib/icon/icon-stack.component.scss
@@ -23,6 +23,7 @@
 }
 
 // Temporary overrides until the proportions of stackable SKY UX icons have been corrected.
+// TODO: correct the proportions of stackable SKY UX icons
 .fa-stack-1x {
   &.sky-i-check:before {
     position: relative;


### PR DESCRIPTION
:cherries: Cherry picked from #2496 [chore(components/icon): icon stack overrides visual tests](https://github.com/blackbaud/skyux/pull/2496)