### PR TITLE
fix(sdk/testing): `expectAsync` type includes async matchers from Jasmine

### DIFF
--- a/libs/sdk/testing/src/lib/matchers/matchers.spec.ts
+++ b/libs/sdk/testing/src/lib/matchers/matchers.spec.ts
@@ -59,6 +59,11 @@ describe('Jasmine matchers', () => {
     document.body.innerHTML = '';
   });
 
+  it('should allow use of main jasmine matchers', waitForAsync(() => {
+    expect(2).toBe(2);
+    expectAsync(Promise.resolve(2)).toBeResolved();
+  }));
+
   describe('toBeVisible', () => {
     let child: HTMLDivElement;
     let parent: HTMLDivElement;

--- a/libs/sdk/testing/src/lib/matchers/matchers.ts
+++ b/libs/sdk/testing/src/lib/matchers/matchers.ts
@@ -576,11 +576,11 @@ windowRef.beforeEach(() => {
 /**
  * Interface for "asynchronous" custom Sky matchers which cannot be paired with a `.not` operator.
  */
-export interface SkyAsyncMatchers<T> {
+export interface SkyAsyncMatchers<T, U> extends jasmine.AsyncMatchers<T, U> {
   /**
    * Invert the matcher following this `expect`
    */
-  not: SkyAsyncMatchers<T>;
+  not: SkyAsyncMatchers<T, U>;
 
   /**
    * `expect` an element to be accessible based on Web Content Accessibility
@@ -769,6 +769,6 @@ export function expect<T>(actual: T): SkyMatchers<T> {
  * Create an async expectation for a spec.
  * @param actual Actual computed value to test expectations against.
  */
-export function expectAsync<T>(actual: T): SkyAsyncMatchers<T> {
+export function expectAsync<T, U>(actual: T): SkyAsyncMatchers<T, U> {
   return windowRef.expectAsync(actual);
 }


### PR DESCRIPTION
[AB#2999225](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/2999225)