### PR TITLE
fix(components/indicators): hide illustration while loading (#2526)

### DIFF
--- a/libs/components/indicators/src/lib/modules/illustration/illustration.component.html
+++ b/libs/components/indicators/src/lib/modules/illustration/illustration.component.html
@@ -4,6 +4,9 @@
   loading="lazy"
   [attr.data-sky-illustration-name]="name()"
   [height]="pixelSize()"
+  [ngClass]="{
+    'sky-illustration-img-loaded': !!url()
+  }"
   [src]="url()"
   [width]="pixelSize()"
 />

--- a/libs/components/indicators/src/lib/modules/illustration/illustration.component.html
+++ b/libs/components/indicators/src/lib/modules/illustration/illustration.component.html
@@ -5,7 +5,7 @@
   [attr.data-sky-illustration-name]="name()"
   [height]="pixelSize()"
   [ngClass]="{
-    'sky-illustration-img-loaded': !!url()
+    'sky-illustration-img-loaded': !!url(),
   }"
   [src]="url()"
   [width]="pixelSize()"

--- a/libs/components/indicators/src/lib/modules/illustration/illustration.default.component.scss
+++ b/libs/components/indicators/src/lib/modules/illustration/illustration.default.component.scss
@@ -6,4 +6,8 @@
 
 @include mixins.sky-component('default', '.sky-illustration-img') {
   display: block;
+
+  &[src=''] {
+    visibility: hidden;
+  }
 }

--- a/libs/components/indicators/src/lib/modules/illustration/illustration.modern.component.scss
+++ b/libs/components/indicators/src/lib/modules/illustration/illustration.modern.component.scss
@@ -6,4 +6,8 @@
 
 @include mixins.sky-component('modern', '.sky-illustration-img') {
   display: block;
+
+  &[src=''] {
+    visibility: hidden;
+  }
 }


### PR DESCRIPTION
:cherries: Cherry picked from #2526 [fix(components/indicators): hide illustration while loading](https://github.com/blackbaud/skyux/pull/2526)