### PR TITLE
fix(components/datetime): resources strings for default calculators are not resolved in the service

### DIFF
--- a/libs/components/datetime/src/lib/modules/date-range-picker/date-range.service.spec.ts
+++ b/libs/components/datetime/src/lib/modules/date-range-picker/date-range.service.spec.ts
@@ -1,54 +1,56 @@
 import { TestBed } from '@angular/core/testing';
 
-import { SkyDatetimeResourcesModule } from '../shared/sky-datetime-resources.module';
-
 import { SkyDateRangeService } from './date-range.service';
 import { SkyDateRangeCalculator } from './types/date-range-calculator';
 import { SkyDateRangeCalculatorId } from './types/date-range-calculator-id';
 import { SkyDateRangeCalculatorType } from './types/date-range-calculator-type';
 
-describe('Date range service', function () {
+describe('Date range service', () => {
   let service: SkyDateRangeService;
 
-  beforeEach(function () {
-    TestBed.configureTestingModule({
-      imports: [SkyDatetimeResourcesModule],
-    });
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
 
     service = TestBed.inject(SkyDateRangeService);
   });
 
-  it('should return a calculator by ID', function () {
+  it('should return a calculator by ID', () => {
     service.getCalculatorById(SkyDateRangeCalculatorId.After).then((result) => {
       expect(result instanceof SkyDateRangeCalculator).toEqual(true);
       expect(result.calculatorId).toEqual(SkyDateRangeCalculatorId.After);
       expect(result.type).toEqual(SkyDateRangeCalculatorType.After);
-      expect(result.shortDescription).toEqual('After');
+      expect(result._shortDescriptionResourceKey).toEqual(
+        'skyux_date_range_picker_format_label_after',
+      );
       expect(typeof result.getValue).toEqual('function');
       expect(typeof result.validate).toEqual('function');
     });
   });
 
-  it('should return calculators given an array of IDs', function () {
+  it('should return calculators given an array of IDs', () => {
     service.getCalculators([SkyDateRangeCalculatorId.After]).then((result) => {
       expect(result[0] instanceof SkyDateRangeCalculator).toEqual(true);
       expect(result[0].calculatorId).toEqual(SkyDateRangeCalculatorId.After);
       expect(result[0].type).toEqual(SkyDateRangeCalculatorType.After);
-      expect(result[0].shortDescription).toEqual('After');
+      expect(result[0]._shortDescriptionResourceKey).toEqual(
+        'skyux_date_range_picker_format_label_after',
+      );
       expect(typeof result[0].getValue).toEqual('function');
       expect(typeof result[0].validate).toEqual('function');
     });
   });
 
-  it('should handle calculator not found', function () {
-    service.getCalculatorById(5000 as any).catch((error) => {
-      expect(error.message).toEqual(
-        'A calculator with the ID 5000 was not found.',
-      );
-    });
+  it('should handle calculator not found', () => {
+    service
+      .getCalculatorById(5000 as SkyDateRangeCalculatorId)
+      .catch((error) => {
+        expect(error.message).toEqual(
+          'A calculator with the ID 5000 was not found.',
+        );
+      });
   });
 
-  it('should create custom calculators', function () {
+  it('should create custom calculators', () => {
     const expectedValue = new Date('1/1/2001');
     const calculator = service.createCalculator({
       shortDescription: 'My calculator',
@@ -58,8 +60,7 @@ describe('Date range service', function () {
       },
     });
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    expect(calculator.calculatorId).toEqual(1000 as any);
+    expect(calculator.calculatorId).toEqual(1000 as SkyDateRangeCalculatorId);
     expect(calculator.shortDescription).toEqual('My calculator');
     expect(calculator.type).toEqual(SkyDateRangeCalculatorType.Relative);
     expect(typeof calculator.getValue).toEqual('function');
@@ -72,10 +73,7 @@ describe('Date range service', function () {
     });
   });
 
-  it('should increment the IDs if multiple calculators are created', function () {
-    // Reset the auto-incremented ID.
-    SkyDateRangeService['lastId'] = 1000;
-
+  it('should increment the IDs if multiple calculators are created', () => {
     const calculator1 = service.createCalculator({
       shortDescription: 'My calculator 1',
       type: SkyDateRangeCalculatorType.Relative,
@@ -88,10 +86,8 @@ describe('Date range service', function () {
       getValue: () => ({}),
     });
 
-    /* eslint-disable @typescript-eslint/no-explicit-any */
-    expect(calculator1.calculatorId).toEqual(1000 as any);
-    expect(calculator2.calculatorId).toEqual(1001 as any);
-    /* eslint-enable @typescript-eslint/no-explicit-any */
+    expect(calculator1.calculatorId).toEqual(1001 as SkyDateRangeCalculatorId);
+    expect(calculator2.calculatorId).toEqual(1002 as SkyDateRangeCalculatorId);
   });
 
   describe('synchronous methods', () => {


### PR DESCRIPTION
[AB#2930286](https://dev.azure.com/blackbaud/Products/_workitems/edit/2930286)

BREAKING CHANGE

Resources strings for the default calculators' `shortDescription` property are resolved in the date range picker's template, but any consumers expecting the `shortDescription` values to be resolved in the `SkyDateRangeService` will need to change assertions in their unit tests.