### PR TITLE
fix(components/lists): repeater focus styles show on focus-visible in modern theme (#2554)

### DIFF
--- a/libs/components/lists/src/lib/modules/repeater/repeater-item.component.scss
+++ b/libs/components/lists/src/lib/modules/repeater/repeater-item.component.scss
@@ -184,13 +184,13 @@ sky-repeater-item {
         border-left-color: $sky-theme-modern-background-color-primary-dark;
       }
 
-      &:focus,
-      &:active:focus {
+      &:focus-visible,
+      &:focus-visible:active {
         outline: solid 2px $sky-theme-modern-background-color-primary-dark;
         outline-offset: -2px;
       }
 
-      &:focus:not(:active) {
+      &:focus-visible:not(:active) {
         box-shadow: $sky-theme-modern-elevation-3-shadow-size
           $sky-theme-modern-elevation-3-shadow-color;
       }


### PR DESCRIPTION
:cherries: Cherry picked from #2554 [fix(components/lists): repeater focus styles show on focus-visible in modern theme](https://github.com/blackbaud/skyux/pull/2554)

[AB#2768290](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/2768290) 