### PR TITLE
feat(components/forms): improve file attachments error messaging for incorrect file types (#2553)

### DIFF
--- a/libs/components/forms/src/assets/locales/resources_en_US.json
+++ b/libs/components/forms/src/assets/locales/resources_en_US.json
@@ -177,11 +177,11 @@
   },
   "skyux_file_attachment_file_type_error_label_text": {
     "_description": "The error message for file attachment incorrect file type error",
-    "message": "Upload a file of type {0}."
+    "message": "Upload one of these file types: {0}."
   },
   "skyux_file_attachment_file_type_error_label_text_with_name": {
     "_description": "The error message for file attachment incorrect file type error",
-    "message": "{0}: Upload a file of type {1}."
+    "message": "{0}: Upload one of these file types: {1}."
   },
   "skyux_file_attachment_max_file_size_error_label_text": {
     "_description": "The error message for file attachment max file size error",

--- a/libs/components/forms/src/lib/modules/file-attachment/file-attachment.component.html
+++ b/libs/components/forms/src/lib/modules/file-attachment/file-attachment.component.html
@@ -178,7 +178,8 @@
     *ngIf="fileErrorName === 'fileType'"
     [errorName]="'fileType'"
     [errorText]="
-      'skyux_file_attachment_file_type_error_label_text'
+      acceptedTypesErrorMessage ??
+        'skyux_file_attachment_file_type_error_label_text'
         | skyLibResources: fileErrorParam
     "
   />

--- a/libs/components/forms/src/lib/modules/file-attachment/file-attachment.component.spec.ts
+++ b/libs/components/forms/src/lib/modules/file-attachment/file-attachment.component.spec.ts
@@ -1243,9 +1243,7 @@ describe('File attachment', () => {
     expect(fileChangeActual?.file?.file.name).toBe('woo.txt');
     expect(fileChangeActual?.file?.file.size).toBe(2000);
     expect(fileChangeActual?.file?.errorType).toBe('fileType');
-    expect(fileChangeActual?.file?.errorParam).toBe(
-      fileAttachmentInstance.acceptedTypes,
-    );
+    expect(fileChangeActual?.file?.errorParam).toBe('PNG, TIFF');
   });
 
   it('should reject a file with no type when accepted types are defined', () => {
@@ -1271,9 +1269,7 @@ describe('File attachment', () => {
     expect(fileChangeActual?.file?.file.name).toBe('foo.txt');
     expect(fileChangeActual?.file?.file.size).toBe(1000);
     expect(fileChangeActual?.file?.errorType).toBe('fileType');
-    expect(fileChangeActual?.file?.errorParam).toBe(
-      fileAttachmentInstance.acceptedTypes,
-    );
+    expect(fileChangeActual?.file?.errorParam).toBe('PNG, TIFF');
   });
 
   it('should allow the user to specify accepted type with wildcards', () => {

--- a/libs/components/forms/src/lib/modules/file-attachment/file-attachment.component.ts
+++ b/libs/components/forms/src/lib/modules/file-attachment/file-attachment.component.ts
@@ -74,6 +74,13 @@ export class SkyFileAttachmentComponent
   public acceptedTypes: string | undefined;
 
   /**
+   * A custom error message to display when a file doesn't match the accepted types.
+   * This replaces a default error message that lists all accepted types.
+   */
+  @Input()
+  public acceptedTypesErrorMessage: string | undefined;
+
+  /**
    * Whether to disable the input on template-driven forms. Don't use this input on reactive forms because they may overwrite the input or leave the control out of sync.
    * To set the disabled state on reactive forms, use the `FormControl` instead.
    */

--- a/libs/components/forms/src/lib/modules/file-attachment/file-attachment.service.ts
+++ b/libs/components/forms/src/lib/modules/file-attachment/file-attachment.service.ts
@@ -32,7 +32,7 @@ export class SkyFileAttachmentService {
         fileResults.push(fileItem);
       } else if (this.fileTypeRejected(fileItem.file.type, acceptedTypes)) {
         fileItem.errorType = 'fileType';
-        fileItem.errorParam = acceptedTypes;
+        fileItem.errorParam = this.#getAcceptedTypesList(acceptedTypes);
         fileResults.push(fileItem);
       } else if (validateFn) {
         const errorParam = validateFn(fileItem);
@@ -98,6 +98,17 @@ export class SkyFileAttachmentService {
     }
 
     return false;
+  }
+
+  #getAcceptedTypesList(rawTypes: string | undefined): string | undefined {
+    return rawTypes
+      ?.toUpperCase()
+      .split(',')
+      .map((type) => {
+        const subType = this.#getMimeSubtype(type);
+        return subType.startsWith('X-') ? subType.substr(2) : subType;
+      })
+      .join(', ');
   }
 
   #getMimeSubtype(type: string): string {

--- a/libs/components/forms/src/lib/modules/file-attachment/file-drop.component.html
+++ b/libs/components/forms/src/lib/modules/file-attachment/file-drop.component.html
@@ -189,7 +189,8 @@
       *ngIf="rejectedFile.errorType === 'maxFileSize'"
       errorName="maxFileSize"
       [errorText]="
-        'skyux_file_attachment_max_file_size_error_label_text_with_name'
+        acceptedTypesErrorMessage ??
+          'skyux_file_attachment_max_file_size_error_label_text_with_name'
           | skyLibResources
             : rejectedFile.file.name
             : (rejectedFile.errorParam | skyFileSize)

--- a/libs/components/forms/src/lib/modules/file-attachment/file-drop.component.spec.ts
+++ b/libs/components/forms/src/lib/modules/file-attachment/file-drop.component.spec.ts
@@ -474,7 +474,7 @@ describe('File drop component', () => {
 
     expect(typeError).toBeVisible();
     expect(typeError.textContent).toContain(
-      'Upload a file of type image/png, image/jpeg.',
+      'Upload one of these file types: PNG, JPEG.',
     );
   });
 
@@ -859,7 +859,7 @@ describe('File drop component', () => {
       (filesChanged: SkyFileDropChange) => (filesChangedActual = filesChanged),
     );
 
-    componentInstance.acceptedTypes = 'image/png,image/tiff';
+    componentInstance.acceptedTypes = 'image/png,audio/x-midi';
 
     fixture.detectChanges();
 
@@ -869,9 +869,7 @@ describe('File drop component', () => {
     expect(filesChangedActual?.rejectedFiles[0].file.name).toBe('woo.txt');
     expect(filesChangedActual?.rejectedFiles[0].file.size).toBe(2000);
     expect(filesChangedActual?.rejectedFiles[0].errorType).toBe('fileType');
-    expect(filesChangedActual?.rejectedFiles[0].errorParam).toBe(
-      componentInstance.acceptedTypes,
-    );
+    expect(filesChangedActual?.rejectedFiles[0].errorParam).toBe('PNG, MIDI');
 
     expect(filesChangedActual?.files.length).toBe(1);
     expect(filesChangedActual?.files[0].url).toBe('url');
@@ -911,16 +909,12 @@ describe('File drop component', () => {
     expect(filesChangedActual?.rejectedFiles[1].file.name).toBe('woo.txt');
     expect(filesChangedActual?.rejectedFiles[1].file.size).toBe(2000);
     expect(filesChangedActual?.rejectedFiles[1].errorType).toBe('fileType');
-    expect(filesChangedActual?.rejectedFiles[1].errorParam).toBe(
-      componentInstance.acceptedTypes,
-    );
+    expect(filesChangedActual?.rejectedFiles[1].errorParam).toBe('PNG, TIFF');
 
     expect(filesChangedActual?.rejectedFiles[0].file.name).toBe('foo.txt');
     expect(filesChangedActual?.rejectedFiles[0].file.size).toBe(1000);
     expect(filesChangedActual?.rejectedFiles[0].errorType).toBe('fileType');
-    expect(filesChangedActual?.rejectedFiles[0].errorParam).toBe(
-      componentInstance.acceptedTypes,
-    );
+    expect(filesChangedActual?.rejectedFiles[0].errorParam).toBe('PNG, TIFF');
 
     expect(liveAnnouncerSpy.calls.count()).toBe(0);
   });

--- a/libs/components/forms/src/lib/modules/file-attachment/file-drop.component.ts
+++ b/libs/components/forms/src/lib/modules/file-attachment/file-drop.component.ts
@@ -135,6 +135,13 @@ export class SkyFileDropComponent implements OnInit, OnDestroy {
   public acceptedTypes: string | undefined;
 
   /**
+   * A custom error message to display when a file doesn't match the accepted types.
+   * This replaces a default error message that lists all accepted types.
+   */
+  @Input()
+  public acceptedTypesErrorMessage: string | undefined;
+
+  /**
    * Whether to disable the option to browse for files to attach.
    */
   @Input()

--- a/libs/components/forms/src/lib/modules/shared/sky-forms-resources.module.ts
+++ b/libs/components/forms/src/lib/modules/shared/sky-forms-resources.module.ts
@@ -113,10 +113,10 @@ const RESOURCES: Record<string, SkyLibResources> = {
       message: 'Link to {0} removed.',
     },
     skyux_file_attachment_file_type_error_label_text: {
-      message: 'Upload a file of type {0}.',
+      message: 'Upload one of these file types: {0}.',
     },
     skyux_file_attachment_file_type_error_label_text_with_name: {
-      message: '{0}: Upload a file of type {1}.',
+      message: '{0}: Upload one of these file types: {1}.',
     },
     skyux_file_attachment_max_file_size_error_label_text: {
       message: 'Upload a file under {0}.',


### PR DESCRIPTION
:cherries: Cherry picked from #2553 [feat(components/forms): improve file attachments error messaging for incorrect file types](https://github.com/blackbaud/skyux/pull/2553)

[AB#2955042](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/2955042) 