### PR TITLE
fix(components/modals): `SkyModalTestingController.closeTopModal` passes `reason` and `result` to the modal instance (#2565)

### DIFF
--- a/libs/components/modals/testing/src/modal/controller/modal-testing.controller.spec.ts
+++ b/libs/components/modals/testing/src/modal/controller/modal-testing.controller.spec.ts
@@ -82,6 +82,10 @@ class TestComponent implements OnDestroy {
     this.#instances.forEach((i) => i.close());
   }
 
+  public getInstanceAt(index: number): SkyModalInstance | undefined {
+    return this.#instances.at(index);
+  }
+
   public openModal(): void {
     const instance = this.#modalSvc.open(ModalTestComponent, {
       providers: [
@@ -141,6 +145,24 @@ describe('modal-testing.controller', () => {
     modalController.expectOpen(ModalTestComponent);
     modalController.closeTopModal();
     modalController.expectNone();
+  });
+
+  it('should close a modal with args', () => {
+    const { fixture, modalController } = setupTest();
+
+    fixture.componentInstance.openModal();
+    fixture.detectChanges();
+
+    const closeSpy = spyOn(
+      fixture.componentInstance.getInstanceAt(0)!,
+      'close',
+    ).and.callThrough();
+
+    modalController.closeTopModal({ reason: 'save', data: { foo: 'bar' } });
+
+    fixture.detectChanges();
+
+    expect(closeSpy).toHaveBeenCalledWith({ foo: 'bar' }, 'save');
   });
 
   it('should throw if topmost modal does not match criteria', () => {

--- a/libs/components/modals/testing/src/modal/controller/modal-testing.service.ts
+++ b/libs/components/modals/testing/src/modal/controller/modal-testing.service.ts
@@ -40,7 +40,7 @@ export class SkyModalTestingService
       );
     }
 
-    modal.instance.close(args);
+    modal.instance.close(args?.data, args?.reason);
   }
 
   public expectCount(value: number): void {


### PR DESCRIPTION
:cherries: Cherry picked from #2565 [fix(components/modals): `SkyModalTestingController.closeTopModal` passes `reason` and `result` to the modal instance](https://github.com/blackbaud/skyux/pull/2565)

[AB#2995302](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/2995302) 