### PR TITLE
feat(components/popovers): remove `dismissOnBlur` input from popover and dropdown

### DIFF
--- a/apps/code-examples/src/app/code-examples/popovers/popover/basic/demo.component.html
+++ b/apps/code-examples/src/app/code-examples/popovers/popover/basic/demo.component.html
@@ -18,10 +18,6 @@
   Open popover on hover
 </button>
 
-<sky-popover
-  [dismissOnBlur]="dismissOnBlur"
-  [popoverTitle]="popoverTitle"
-  #myPopover
->
+<sky-popover [popoverTitle]="popoverTitle" #myPopover>
   {{ popoverBody }}
 </sky-popover>

--- a/apps/code-examples/src/app/code-examples/popovers/popover/basic/demo.component.spec.ts
+++ b/apps/code-examples/src/app/code-examples/popovers/popover/basic/demo.component.spec.ts
@@ -11,7 +11,6 @@ describe('Basic popover', () => {
     titleText?: string;
     alignment?: SkyPopoverAlignment;
     placement?: SkyPopoverPlacement;
-    dismissOnBlur?: boolean;
   }): Promise<{
     popoverHarness: SkyPopoverHarness;
     fixture: ComponentFixture<DemoComponent>;
@@ -23,7 +22,6 @@ describe('Basic popover', () => {
       fixture.componentInstance.popoverAlignment = options.alignment;
       fixture.componentInstance.popoverPlacement = options.placement;
       fixture.componentInstance.popoverTitle = options.titleText;
-      fixture.componentInstance.dismissOnBlur = options.dismissOnBlur;
     }
 
     fixture.detectChanges();

--- a/apps/code-examples/src/app/code-examples/popovers/popover/basic/demo.component.ts
+++ b/apps/code-examples/src/app/code-examples/popovers/popover/basic/demo.component.ts
@@ -12,7 +12,6 @@ import {
   imports: [SkyPopoverModule],
 })
 export class DemoComponent {
-  public dismissOnBlur: boolean | undefined;
   public popoverAlignment: SkyPopoverAlignment | undefined;
   public popoverBody = 'This is a popover.';
   public popoverPlacement: SkyPopoverPlacement | undefined;

--- a/apps/playground/src/app/components/core/affix/affix.component.html
+++ b/apps/playground/src/app/components/core/affix/affix.component.html
@@ -85,11 +85,7 @@
     H: Open popover on hover
   </button>
 
-  <sky-popover
-    [dismissOnBlur]="dismissOnBlur"
-    [popoverTitle]="popoverTitle"
-    #myPopover
-  >
+  <sky-popover [popoverTitle]="popoverTitle" #myPopover>
     {{ popoverBody }}
   </sky-popover>
 </div>

--- a/apps/playground/src/app/components/core/affix/affix.component.ts
+++ b/apps/playground/src/app/components/core/affix/affix.component.ts
@@ -7,7 +7,6 @@ import { SkyPopoverAlignment, SkyPopoverPlacement } from '@skyux/popovers';
   styleUrl: './affix.component.css',
 })
 export class AffixComponent {
-  public dismissOnBlur: boolean | undefined;
   public popoverAlignment: SkyPopoverAlignment | undefined;
   public popoverBody = 'This is a popover.';
   public popoverPlacement: SkyPopoverPlacement | undefined;

--- a/libs/components/popovers/src/lib/modules/dropdown/dropdown-menu.component.ts
+++ b/libs/components/popovers/src/lib/modules/dropdown/dropdown-menu.component.ts
@@ -346,9 +346,8 @@ export class SkyDropdownMenuComponent implements AfterContentInit, OnDestroy {
             break;
 
           case 'tab':
-            if (this.#dropdownComponent?.dismissOnBlur) {
-              this.#sendMessage(SkyDropdownMessageType.Close);
-            }
+            this.#sendMessage(SkyDropdownMessageType.Close);
+
             this.#sendMessage(SkyDropdownMessageType.FocusTriggerButton);
             break;
         }

--- a/libs/components/popovers/src/lib/modules/dropdown/dropdown.component.spec.ts
+++ b/libs/components/popovers/src/lib/modules/dropdown/dropdown.component.spec.ts
@@ -157,7 +157,6 @@ describe('Dropdown component', function () {
     expect(dropdownRef?.buttonStyle).toEqual('default');
     expect(dropdownRef?.buttonType).toEqual('select');
     expect(dropdownRef?.disabled).toBeUndefined();
-    expect(dropdownRef?.dismissOnBlur).toEqual(true);
     expect(dropdownRef?.horizontalAlignment).toEqual('left');
     expect(dropdownRef?.label).toBeUndefined();
     expect(dropdownRef?.title).toBeUndefined();
@@ -459,27 +458,6 @@ describe('Dropdown component', function () {
       container = getMenuContainerElement();
 
       expect(container).toBeNull();
-    }));
-
-    it('should allow preventing menu close on window click', fakeAsync(() => {
-      fixture.componentInstance.dismissOnBlur = false;
-      detectChangesFakeAsync();
-
-      const button = getButtonElement();
-      button?.click();
-      detectChangesFakeAsync();
-
-      let container = getMenuContainerElement();
-
-      expect(isElementVisible(container)).toEqual(true);
-
-      SkyAppTestUtility.fireDomEvent(window.document.body, 'click');
-      detectChangesFakeAsync();
-
-      container = getMenuContainerElement();
-
-      // Menu should still be open.
-      expect(isElementVisible(container)).toEqual(true);
     }));
 
     it('should focus on first menu item when clicked', fakeAsync(() => {
@@ -893,74 +871,6 @@ describe('Dropdown component', function () {
 
       // Tab key should progress to next item after the trigger button.
       expect(container).toBeNull();
-    }));
-
-    it('should not close the menu if dismissOnBlur is false (trigger has focus)', fakeAsync(() => {
-      fixture.componentInstance.dismissOnBlur = false;
-      detectChangesFakeAsync();
-
-      const button = getButtonElement();
-
-      SkyAppTestUtility.fireDomEvent(button, 'keydown', {
-        keyboardEventInit: {
-          key: 'enter',
-        },
-      });
-
-      detectChangesFakeAsync();
-
-      let container = getMenuContainerElement();
-
-      expect(isElementVisible(container)).toEqual(true);
-
-      // Run 'tab' on trigger button.
-      SkyAppTestUtility.fireDomEvent(button, 'keydown', {
-        keyboardEventInit: {
-          key: 'tab',
-        },
-      });
-      button?.blur();
-
-      detectChangesFakeAsync();
-
-      container = getMenuContainerElement();
-
-      expect(isElementVisible(container)).toEqual(true);
-    }));
-
-    it('should not close the menu if dismissOnBlur is false (menu has focus)', fakeAsync(() => {
-      fixture.componentInstance.dismissOnBlur = false;
-      detectChangesFakeAsync();
-
-      const button = getButtonElement();
-
-      SkyAppTestUtility.fireDomEvent(button, 'keydown', {
-        keyboardEventInit: {
-          key: 'enter',
-        },
-      });
-
-      detectChangesFakeAsync();
-
-      let container = getMenuContainerElement();
-
-      expect(isElementVisible(container)).toEqual(true);
-
-      const firstButton = getMenuItems()?.item(0)?.querySelector('button');
-
-      // Run 'tab' on first item.
-      SkyAppTestUtility.fireDomEvent(firstButton, 'keydown', {
-        keyboardEventInit: {
-          key: 'tab',
-        },
-      });
-      firstButton?.blur();
-
-      detectChangesFakeAsync();
-
-      container = getMenuContainerElement();
-
-      expect(isElementVisible(container)).toEqual(true);
     }));
 
     it('should close the menu when tab key is pressed within the menu', fakeAsync(() => {

--- a/libs/components/popovers/src/lib/modules/dropdown/dropdown.component.ts
+++ b/libs/components/popovers/src/lib/modules/dropdown/dropdown.component.ts
@@ -89,19 +89,6 @@ export class SkyDropdownComponent implements OnInit, OnDestroy {
   public disabled: boolean | undefined = false;
 
   /**
-   * Whether to close the dropdown when users click away from the menu.
-   * @default true
-   */
-  @Input()
-  public set dismissOnBlur(value: boolean | undefined) {
-    this.#_dismissOnBlur = value ?? true;
-  }
-
-  public get dismissOnBlur(): boolean {
-    return this.#_dismissOnBlur;
-  }
-
-  /**
    * The ARIA label for the dropdown. This sets the dropdown's `aria-label` attribute to provide a text equivalent for screen readers
    * [to support accessibility](https://developer.blackbaud.com/skyux/learn/accessibility). If multiple dropdowns with no label or the same label appear on the same page,
    * they must have unique ARIA labels that provide context, such as "Context menu for Robert Hernandez" or "Edit Robert Hernandez."
@@ -227,7 +214,6 @@ export class SkyDropdownComponent implements OnInit, OnDestroy {
 
   #_buttonStyle = DEFAULT_BUTTON_STYLE;
   #_buttonType = DEFAULT_BUTTON_TYPE;
-  #_dismissOnBlur = true;
   #_horizontalAlignment = DEFAULT_HORIZONTAL_ALIGNMENT;
   #_isOpen = false;
   #_trigger = DEFAULT_TRIGGER_TYPE;
@@ -297,7 +283,7 @@ export class SkyDropdownComponent implements OnInit, OnDestroy {
               break;
 
             case 'tab':
-              if (this.isOpen && this.dismissOnBlur) {
+              if (this.isOpen) {
                 this.#sendMessage(SkyDropdownMessageType.Close);
               }
               break;
@@ -378,9 +364,7 @@ export class SkyDropdownComponent implements OnInit, OnDestroy {
       overlay.backdropClick
         .pipe(takeUntil(this.#ngUnsubscribe))
         .subscribe(() => {
-          if (this.dismissOnBlur) {
-            this.#sendMessage(SkyDropdownMessageType.Close);
-          }
+          this.#sendMessage(SkyDropdownMessageType.Close);
         });
 
       this.#overlay = overlay;

--- a/libs/components/popovers/src/lib/modules/dropdown/fixtures/dropdown.component.fixture.html
+++ b/libs/components/popovers/src/lib/modules/dropdown/fixtures/dropdown.component.fixture.html
@@ -3,7 +3,6 @@
     [buttonStyle]="buttonStyle"
     [buttonType]="buttonType"
     [disabled]="disabled"
-    [dismissOnBlur]="dismissOnBlur"
     [horizontalAlignment]="horizontalAlignment"
     [label]="label"
     [messageStream]="messageStream"

--- a/libs/components/popovers/src/lib/modules/dropdown/fixtures/dropdown.component.fixture.ts
+++ b/libs/components/popovers/src/lib/modules/dropdown/fixtures/dropdown.component.fixture.ts
@@ -30,8 +30,6 @@ export class DropdownFixtureComponent {
 
   public disabled: boolean | undefined;
 
-  public dismissOnBlur: boolean | undefined;
-
   public horizontalAlignment: SkyDropdownHorizontalAlignment | undefined;
 
   public itemAriaRole: string | undefined;

--- a/libs/components/popovers/src/lib/modules/popover/fixtures/popover.component.fixture.html
+++ b/libs/components/popovers/src/lib/modules/popover/fixtures/popover.component.fixture.html
@@ -23,7 +23,6 @@
 
   <sky-popover
     [alignment]="popoverAlignment"
-    [dismissOnBlur]="dismissOnBlur"
     [placement]="popoverPlacement"
     [popoverTitle]="popoverTitle"
     [popoverType]="popoverType"

--- a/libs/components/popovers/src/lib/modules/popover/fixtures/popover.component.fixture.ts
+++ b/libs/components/popovers/src/lib/modules/popover/fixtures/popover.component.fixture.ts
@@ -26,8 +26,6 @@ export class PopoverFixtureComponent implements OnInit, AfterViewInit {
 
   public alignment: SkyPopoverAlignment | undefined;
 
-  public dismissOnBlur: boolean | undefined;
-
   public messageStream: Subject<SkyPopoverMessage> | undefined =
     new Subject<SkyPopoverMessage>();
 

--- a/libs/components/popovers/src/lib/modules/popover/popover-content.component.ts
+++ b/libs/components/popovers/src/lib/modules/popover/popover-content.component.ts
@@ -68,8 +68,6 @@ export class SkyPopoverContentComponent implements OnInit, OnDestroy {
 
   public arrowTop: number | undefined;
 
-  public dismissOnBlur = true;
-
   public enableAnimations = true;
 
   public horizontalAlignment: SkyPopoverAlignment = 'center';
@@ -205,7 +203,6 @@ export class SkyPopoverContentComponent implements OnInit, OnDestroy {
   public open(
     caller: ElementRef,
     config: {
-      dismissOnBlur: boolean;
       enableAnimations: boolean;
       horizontalAlignment: SkyPopoverAlignment;
       id: string;
@@ -216,7 +213,6 @@ export class SkyPopoverContentComponent implements OnInit, OnDestroy {
     },
   ): void {
     this.#caller = caller;
-    this.dismissOnBlur = config.dismissOnBlur;
     this.enableAnimations = config.enableAnimations;
     this.horizontalAlignment = config.horizontalAlignment;
     this.popoverId = config.id;
@@ -377,10 +373,6 @@ export class SkyPopoverContentComponent implements OnInit, OnDestroy {
           // to handle the tab key ourselves. Otherwise, focus would be moved to the browser's
           // search bar.
           case 'tab':
-            if (!this.dismissOnBlur) {
-              return;
-            }
-
             /*istanbul ignore else*/
             if (this.#isFocusLeavingElement(event)) {
               this.close();

--- a/libs/components/popovers/src/lib/modules/popover/popover.component.ts
+++ b/libs/components/popovers/src/lib/modules/popover/popover.component.ts
@@ -50,20 +50,6 @@ export class SkyPopoverComponent implements OnDestroy {
   }
 
   /**
-   * Whether to close the popover when it loses focus.
-   * To require users to click a trigger button to close the popover, set this input to false.
-   * @default true
-   */
-  @Input()
-  public set dismissOnBlur(value: boolean | undefined) {
-    this.#_dismissOnBlur = value ?? true;
-  }
-
-  public get dismissOnBlur(): boolean {
-    return this.#_dismissOnBlur;
-  }
-
-  /**
    * The placement of the popover in relation to the trigger element.
    * The `skyPopoverPlacement` property on the popover directive takes precedence over this property when specified.
    * @default "above"
@@ -141,8 +127,6 @@ export class SkyPopoverComponent implements OnDestroy {
 
   #_alignment: SkyPopoverAlignment = 'center';
 
-  #_dismissOnBlur = true;
-
   #_placement: SkyPopoverPlacement = 'above';
 
   #_popoverType: SkyPopoverType = 'info';
@@ -194,7 +178,6 @@ export class SkyPopoverComponent implements OnDestroy {
     this.isActive = true;
 
     this.#contentRef.open(caller, {
-      dismissOnBlur: this.dismissOnBlur,
       enableAnimations: this.enableAnimations,
       horizontalAlignment: this.alignment,
       id: this.popoverId,
@@ -254,9 +237,7 @@ export class SkyPopoverComponent implements OnDestroy {
       overlay.backdropClick
         .pipe(takeUntil(this.#ngUnsubscribe))
         .subscribe(() => {
-          if (this.dismissOnBlur) {
-            this.close();
-          }
+          this.close();
         });
 
       const contentRef = overlay.attachComponent(SkyPopoverContentComponent, [

--- a/libs/components/popovers/src/lib/modules/popover/popover.directive.spec.ts
+++ b/libs/components/popovers/src/lib/modules/popover/popover.directive.spec.ts
@@ -117,7 +117,6 @@ describe('Popover directive', () => {
 
     const popoverRef = fixture.componentInstance.popoverRef;
     expect(popoverRef?.alignment).toEqual('center');
-    expect(popoverRef?.dismissOnBlur).toEqual(true);
     expect(popoverRef?.placement).toEqual('above');
     expect(popoverRef?.popoverTitle).toBeUndefined();
   }));
@@ -508,27 +507,6 @@ describe('Popover directive', () => {
       expect(popover).toBeNull();
     }));
 
-    it('should allow preventing popover close on window click', fakeAsync(() => {
-      fixture.componentInstance.dismissOnBlur = false;
-      detectChangesFakeAsync();
-
-      const button = getCallerElement();
-      button?.click();
-      detectChangesFakeAsync();
-
-      let popover = getPopoverElement();
-
-      expect(isElementVisible(popover)).toEqual(true);
-
-      SkyAppTestUtility.fireDomEvent(window.document.body, 'click');
-      detectChangesFakeAsync();
-
-      popover = getPopoverElement();
-
-      // Menu should still be open.
-      expect(isElementVisible(popover)).toEqual(true);
-    }));
-
     it('should handle undefined popover', fakeAsync(() => {
       detectChangesFakeAsync();
 
@@ -711,87 +689,6 @@ describe('Popover directive', () => {
       popover = getPopoverElement();
 
       expect(popover).toBeNull();
-    }));
-
-    it('should not close popover if dismissOnBlur is false (trigger has focus)', fakeAsync(() => {
-      fixture.componentInstance.dismissOnBlur = false;
-      detectChangesFakeAsync();
-
-      const button = getCallerElement();
-      button?.click();
-      detectChangesFakeAsync();
-
-      let popover = getPopoverElement();
-
-      expect(isElementVisible(popover)).toEqual(true);
-
-      SkyAppTestUtility.fireDomEvent(button, 'keydown', {
-        keyboardEventInit: {
-          key: 'tab',
-        },
-      });
-      detectChangesFakeAsync();
-
-      popover = getPopoverElement();
-
-      expect(isElementVisible(popover)).toEqual(true);
-    }));
-
-    it('should not close popover if dismissOnBlur is false (popover has focus)', fakeAsync(() => {
-      fixture.componentInstance.dismissOnBlur = false;
-      detectChangesFakeAsync();
-
-      const button = getCallerElement();
-      button?.click();
-      detectChangesFakeAsync();
-
-      let container = getPopoverElement();
-
-      expect(isElementVisible(container)).toEqual(true);
-
-      const popover: HTMLElement | undefined | null =
-        container?.querySelector('.sky-popover');
-      popover?.focus();
-
-      SkyAppTestUtility.fireDomEvent(popover, 'keydown', {
-        keyboardEventInit: {
-          key: 'tab',
-        },
-      });
-      detectChangesFakeAsync();
-
-      container = getPopoverElement();
-
-      expect(isElementVisible(container)).toEqual(true);
-    }));
-
-    it('should not close popover with interactable content if dismissOnBlur is false', fakeAsync(() => {
-      fixture.componentInstance.dismissOnBlur = false;
-      fixture.componentInstance.showFocusableChildren = true;
-      detectChangesFakeAsync();
-
-      const button = getCallerElement();
-
-      // Open and bring focus to the popover.
-      button?.click();
-      detectChangesFakeAsync();
-
-      const focusableItems = getFocusableItems();
-
-      // Focus the last item and press 'tab' to have focus leave the popover.
-      (focusableItems?.item(1) as HTMLElement | undefined)?.focus();
-      detectChangesFakeAsync();
-
-      SkyAppTestUtility.fireDomEvent(focusableItems?.item(1), 'keydown', {
-        keyboardEventInit: {
-          key: 'tab',
-        },
-      });
-
-      detectChangesFakeAsync();
-      const popover = getPopoverElement();
-
-      expect(popover).not.toBeNull();
     }));
   });
 

--- a/libs/components/popovers/src/lib/modules/popover/popover.directive.ts
+++ b/libs/components/popovers/src/lib/modules/popover/popover.directive.ts
@@ -168,7 +168,7 @@ export class SkyPopoverDirective implements OnInit, OnDestroy {
               this.#sendMessage(SkyPopoverMessageType.Focus);
               event.stopPropagation();
               event.preventDefault();
-            } else if (this.skyPopover.dismissOnBlur) {
+            } else {
               this.#sendMessage(SkyPopoverMessageType.Close);
             }
             break;

--- a/libs/components/popovers/testing/src/dropdown/harness/dropdown-harness.spec.ts
+++ b/libs/components/popovers/testing/src/dropdown/harness/dropdown-harness.spec.ts
@@ -11,7 +11,6 @@ import { SkyDropdownHarness } from './dropdown-harness';
   selector: 'sky-dropdown-test',
   template: `
     <sky-dropdown
-      [dismissOnBlur]="dismissOnBlur"
       [buttonStyle]="buttonStyle"
       [buttonType]="buttonType"
       [disabled]="disabledFlag"
@@ -27,7 +26,6 @@ import { SkyDropdownHarness } from './dropdown-harness';
   `,
 })
 class TestDropdownComponent {
-  public dismissOnBlur: boolean | undefined;
   public buttonStyle: string | undefined;
   public buttonType: string | undefined;
   public disabledFlag: boolean | undefined;
@@ -207,28 +205,15 @@ describe('Dropdown test harness', () => {
     await expectAsync(dropdownHarness.isOpen()).toBeResolvedTo(false);
   });
 
-  it('should close the dropdown menu if clicking out when dismissOnBlur is set to true', async () => {
+  it('should close the dropdown menu if clicking out', async () => {
     const { dropdownHarness, fixture } = await setupTest();
 
-    fixture.componentInstance.dismissOnBlur = true;
     fixture.detectChanges();
     await dropdownHarness.clickDropdownButton();
     fixture.detectChanges();
     await (await dropdownHarness.getDropdownMenu()).clickOut();
 
     await expectAsync(dropdownHarness.isOpen()).toBeResolvedTo(false);
-  });
-
-  it('should not close the dropdown menu if clicking out when dismissOnBlur is set to false', async () => {
-    const { dropdownHarness, fixture } = await setupTest();
-
-    fixture.componentInstance.dismissOnBlur = false;
-    fixture.detectChanges();
-    await dropdownHarness.clickDropdownButton();
-    fixture.detectChanges();
-    await (await dropdownHarness.getDropdownMenu()).clickOut();
-
-    await expectAsync(dropdownHarness.isOpen()).toBeResolvedTo(true);
   });
 
   it('should get the dropdown menu harness', async () => {

--- a/libs/components/popovers/testing/src/dropdown/harness/dropdown-menu-harness.ts
+++ b/libs/components/popovers/testing/src/dropdown/harness/dropdown-menu-harness.ts
@@ -28,7 +28,7 @@ export class SkyDropdownMenuHarness extends SkyComponentHarness {
   }
 
   /**
-   * Clicks out of the dropdown menu. If `dismissOnBlur` property is set to false, then the dropdown menu does not close.
+   * Clicks out of the dropdown menu.
    */
   public async clickOut(): Promise<void> {
     (await (await this.#getOverlay())?.host())?.click();

--- a/libs/components/popovers/testing/src/popover/harness/fixtures/popover-harness-test.component.html
+++ b/libs/components/popovers/testing/src/popover/harness/fixtures/popover-harness-test.component.html
@@ -9,11 +9,7 @@
 >
   Open popover on click
 </button>
-<sky-popover
-  [dismissOnBlur]="dismissOnBlur"
-  [popoverTitle]="popoverTitle"
-  #myPopover
->
+<sky-popover [popoverTitle]="popoverTitle" #myPopover>
   <span class="popover-body">
     {{ popoverBody }}
   </span>
@@ -29,10 +25,6 @@
 >
   Another popover trigger
 </button>
-<sky-popover
-  [dismissOnBlur]="dismissOnBlur"
-  popoverTitle="Another popover"
-  #myOtherPopover
->
+<sky-popover popoverTitle="Another popover" #myOtherPopover>
   <span class="popover-body">I have different content</span>
 </sky-popover>

--- a/libs/components/popovers/testing/src/popover/harness/fixtures/popover-harness-test.component.ts
+++ b/libs/components/popovers/testing/src/popover/harness/fixtures/popover-harness-test.component.ts
@@ -13,7 +13,6 @@ import {
   imports: [CommonModule, SkyPopoverModule],
 })
 export class PopoverHarnessTestComponent {
-  public dismissOnBlur: boolean | undefined;
   public popoverAlignment: SkyPopoverAlignment | undefined;
   public popoverBody = 'popover body';
   public popoverPlacement: SkyPopoverPlacement | undefined;

--- a/libs/components/popovers/testing/src/popover/harness/popover-content-harness.ts
+++ b/libs/components/popovers/testing/src/popover/harness/popover-content-harness.ts
@@ -81,7 +81,7 @@ export class SkyPopoverContentHarness extends SkyQueryableComponentHarness {
   }
 
   /**
-   * Clicks out of the popover. If `dismissOnBlur` property is set to false, then the popover does not close.
+   * Clicks out of the popover.
    */
   public async clickOut(): Promise<void> {
     (await (await this.#getOverlay())?.host())?.click();

--- a/libs/components/popovers/testing/src/popover/harness/popover-harness.spec.ts
+++ b/libs/components/popovers/testing/src/popover/harness/popover-harness.spec.ts
@@ -13,7 +13,6 @@ async function setupTest(options?: {
   titleText?: string;
   alignment?: SkyPopoverAlignment;
   placement?: SkyPopoverPlacement;
-  dismissOnBlur?: boolean;
 }): Promise<{
   popoverHarness: SkyPopoverHarness;
   fixture: ComponentFixture<PopoverHarnessTestComponent>;
@@ -25,7 +24,6 @@ async function setupTest(options?: {
     fixture.componentInstance.popoverAlignment = options.alignment;
     fixture.componentInstance.popoverPlacement = options.placement;
     fixture.componentInstance.popoverTitle = options.titleText;
-    fixture.componentInstance.dismissOnBlur = options.dismissOnBlur;
   }
 
   fixture.detectChanges();
@@ -130,11 +128,9 @@ describe('Popover harness', () => {
     ).toBeResolvedTo(null);
   });
 
-  it('should close the popover if clicking out when dismissOnBlur is set to true', async () => {
+  it('should close the popover if clicking out', async () => {
     const { popoverHarness, fixture } = await setupTest();
 
-    fixture.componentInstance.dismissOnBlur = true;
-
     fixture.detectChanges();
     await fixture.whenStable();
 
@@ -142,27 +138,6 @@ describe('Popover harness', () => {
     await expectAsync(popoverHarness.isOpen()).toBeResolvedTo(true);
 
     await (await popoverHarness.getPopoverContent()).clickOut();
-    await expectAsync(popoverHarness.isOpen()).toBeResolvedTo(false);
-  });
-
-  it('should not close the popover if clicking out when dismissOnBlur is set to false', async () => {
-    const { popoverHarness, fixture } = await setupTest({
-      dismissOnBlur: false,
-    });
-
-    fixture.detectChanges();
-    await fixture.whenStable();
-
-    // click on the trigger to open it
-    await popoverHarness.clickPopoverButton();
-    await expectAsync(popoverHarness.isOpen()).toBeResolvedTo(true);
-
-    // clicking away from the trigger does not close it
-    await (await popoverHarness.getPopoverContent()).clickOut();
-    await expectAsync(popoverHarness.isOpen()).toBeResolvedTo(true);
-
-    // clicking on the trigger again will force close it
-    await popoverHarness.clickPopoverButton();
     await expectAsync(popoverHarness.isOpen()).toBeResolvedTo(false);
   });
 
@@ -186,7 +161,7 @@ describe('Popover harness', () => {
     const fixture = TestBed.createComponent(PopoverHarnessTestComponent);
     const loader = TestbedHarnessEnvironment.loader(fixture);
 
-    fixture.componentInstance.dismissOnBlur = false;
+    // fixture.componentInstance.dismissOnBlur = false;
 
     const popoverHarness1 = await loader.getHarness(SkyPopoverHarness);
 
@@ -197,16 +172,28 @@ describe('Popover harness', () => {
     );
 
     await popoverHarness1.clickPopoverButton();
-    await popoverHarness2.clickPopoverButton();
 
     const contentHarness1 = await popoverHarness1.getPopoverContent();
-    const contentHarness2 = await popoverHarness2.getPopoverContent();
+    await expectAsync(
+      popoverHarness2.getPopoverContent(),
+    ).toBeRejectedWithError(
+      'Unable to retrieve the popover content because the popover is not open.',
+    );
 
     await expectAsync(contentHarness1.getTitleText()).toBeResolvedTo(
       'popover title',
     );
     await expectAsync(contentHarness1.getBodyText()).toBeResolvedTo(
       'popover body',
+    );
+
+    await popoverHarness2.clickPopoverButton();
+
+    const contentHarness2 = await popoverHarness2.getPopoverContent();
+    await expectAsync(
+      popoverHarness1.getPopoverContent(),
+    ).toBeRejectedWithError(
+      'Unable to retrieve the popover content because the popover is not open.',
     );
 
     await expectAsync(contentHarness2.getTitleText()).toBeResolvedTo(

--- a/libs/components/popovers/testing/src/popover/harness/popover-harness.spec.ts
+++ b/libs/components/popovers/testing/src/popover/harness/popover-harness.spec.ts
@@ -161,8 +161,6 @@ describe('Popover harness', () => {
     const fixture = TestBed.createComponent(PopoverHarnessTestComponent);
     const loader = TestbedHarnessEnvironment.loader(fixture);
 
-    // fixture.componentInstance.dismissOnBlur = false;
-
     const popoverHarness1 = await loader.getHarness(SkyPopoverHarness);
 
     const popoverHarness2 = await loader.getHarness(

--- a/libs/components/popovers/testing/src/popover/popover-fixture.spec.ts
+++ b/libs/components/popovers/testing/src/popover/popover-fixture.spec.ts
@@ -20,17 +20,12 @@ import { SkyPopoverTestingModule } from './popover-testing.module';
       Open popover on click
     </button>
 
-    <sky-popover
-      [dismissOnBlur]="dismissOnBlur"
-      [popoverTitle]="popoverTitle"
-      #myPopover
-    >
+    <sky-popover [popoverTitle]="popoverTitle" #myPopover>
       {{ popoverBody }}
     </sky-popover>
   `,
 })
 class PopoverTestComponent {
-  public dismissOnBlur: boolean | undefined;
   public popoverAlignment: string | undefined;
   public popoverBody = 'popover body';
   public popoverPlacement: string | undefined;
@@ -113,21 +108,5 @@ describe('Popover fixture', () => {
 
     // expect the popover to be dismissed
     expect(popoverFixture.popoverIsVisible).toEqual(false);
-  });
-
-  it('should honor dismissOnBlur flag', async () => {
-    // override the dismissOnBlur default
-    testComponent.dismissOnBlur = false;
-    fixture.detectChanges();
-
-    // open the popover
-    await openPopover();
-
-    // blur
-    await popoverFixture.blur();
-    fixture.detectChanges();
-
-    // expect the popover to remain open
-    expect(popoverFixture.popoverIsVisible).toEqual(true);
   });
 });


### PR DESCRIPTION
[AB#2909107](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/2909107)

BREAKING CHANGE

The `dismissOnBlur` inputs on Popover and Dropdown components have been removed.

