### PR TITLE
fix(components/router): fix `SkyHrefHarness` to find elements when `skyHref` is bound to a template variable (#2580)

### DIFF
--- a/libs/components/router/testing/src/href/fixtures/href-harness-test.component.html
+++ b/libs/components/router/testing/src/href/fixtures/href-harness-test.component.html
@@ -6,4 +6,7 @@
     >Link 1</a
   >
   <a data-sky-id="my-href-2" skyHref="https://example.com/test2">Link 2</a>
+  <a data-sky-id="my-href-3" skyHref="https://example.com/{{ baseHref }}"
+    >Link 3</a
+  >
 </p>

--- a/libs/components/router/testing/src/href/fixtures/href-harness-test.component.ts
+++ b/libs/components/router/testing/src/href/fixtures/href-harness-test.component.ts
@@ -4,4 +4,6 @@ import { Component } from '@angular/core';
   selector: 'sky-href-harness-test',
   templateUrl: './href-harness-test.component.html',
 })
-export class HrefHarnessTestComponent {}
+export class HrefHarnessTestComponent {
+  protected baseHref = 'my-base-href';
+}

--- a/libs/components/router/testing/src/href/href-harness.spec.ts
+++ b/libs/components/router/testing/src/href/href-harness.spec.ts
@@ -80,4 +80,15 @@ describe('SkyHrefHarness', () => {
     await expectAsync(hrefHarness.getText()).toBeResolvedTo('');
     await expectAsync(hrefHarness.isVisible()).toBeResolvedTo(false);
   });
+
+  it('should find elements when skyHref is bound to a variable', async () => {
+    const { hrefHarness } = await setupTest({
+      dataSkyId: 'my-href-3',
+      userHasAccess: true,
+    });
+
+    await expectAsync(hrefHarness.getHref()).toBeResolvedTo(
+      'https://example.com/my-base-href',
+    );
+  });
 });

--- a/libs/components/router/testing/src/href/href-harness.ts
+++ b/libs/components/router/testing/src/href/href-harness.ts
@@ -7,7 +7,7 @@ import { SkyHrefHarnessFilters } from './href-harness-filters';
  * Allows interaction with a SkyHref directive during testing.
  */
 export class SkyHrefHarness extends SkyComponentHarness {
-  public static hostSelector = '[skyHref]';
+  public static hostSelector = '.sky-href';
 
   /**
    * Gets a `HarnessPredicate` that can be used to search for a


### PR DESCRIPTION
:cherries: Cherry picked from #2580 [fix(components/router): fix `SkyHrefHarness` to find elements when `skyHref` is bound to a template variable](https://github.com/blackbaud/skyux/pull/2580)