### PR TITLE
fix(components/colorpicker): match label text to easy mode label styling (#2591)

### DIFF
--- a/apps/playground/src/app/components/colorpicker/colorpicker/colorpicker.component.html
+++ b/apps/playground/src/app/components/colorpicker/colorpicker/colorpicker.component.html
@@ -1,14 +1,14 @@
 <form novalidate [formGroup]="reactiveForm" (ngSubmit)="submit()">
-  <div class="sky-form-group">
+  <div class="sky-form-group sky-padding-even-md">
     <sky-colorpicker
+      #colorPicker
       helpKey="help-key.html"
       hintText="Hint text content."
-      labelText="What is your favorite color?"
+      labelText="Favorite color"
       pickerButtonIcon="calendar"
       pickerButtonIconType="skyux"
       stacked="true"
       (selectedColorChanged)="onSelectedColorChanged($event)"
-      #colorPicker
     >
       <input
         formControlName="favoriteColor"
@@ -17,14 +17,14 @@
         [skyColorpickerInput]="colorPicker"
       />
 
-      <sky-form-error
-        *ngIf="favoriteColor.errors?.['opaque']"
-        errorName="opaque"
-        errorText="Color must have at least 80% opacity."
-      />
+      @if ("favoriteColor.errors?.['opaque']") {
+        <sky-form-error
+          errorName="opaque"
+          errorText="Color must have at least 80% opacity."
+        />
+      }
     </sky-colorpicker>
   </div>
-
   <table>
     <tr>
       <th>Touched</th>

--- a/libs/components/colorpicker/src/lib/modules/colorpicker/colorpicker.component.html
+++ b/libs/components/colorpicker/src/lib/modules/colorpicker/colorpicker.component.html
@@ -30,6 +30,7 @@
   </div>
 
   <button
+    #triggerButtonRef
     aria-haspopup="dialog"
     class="sky-colorpicker-button"
     type="button"
@@ -61,7 +62,6 @@
     }"
     [style.background-color]="backgroundColorForDisplay"
     (click)="onTriggerButtonClick()"
-    #triggerButtonRef
   >
     <sky-icon
       *ngIf="pickerButtonIcon"
@@ -85,6 +85,7 @@
 
   <ng-template #colorpickerTemplateRef>
     <div
+      #colorpickerRef
       class="sky-colorpicker-container"
       role="dialog"
       [attr.aria-labelledby]="triggerButtonId"
@@ -96,7 +97,6 @@
       }"
       [cdkTrapFocus]="true"
       [cdkTrapFocusAutoCapture]="false"
-      #colorpickerRef
     >
       <div class="sky-colorpicker">
         <div
@@ -125,11 +125,11 @@
           </div>
           <div class="right">
             <div
+              #hueSlider
               class="hue"
               [skyColorpickerSlider]
               [xAxis]="1"
               (newColorContrast)="hue = $event"
-              #hueSlider
             >
               <div
                 class="cursor sky-rounded-circle"
@@ -137,13 +137,13 @@
               ></div>
             </div>
             <div
+              #alphaSlider
               *ngIf="this.allowTransparency"
               class="alpha"
               [skyColorpickerSlider]
               [style.background-color]="alphaSliderColor"
               [xAxis]="1"
               (newColorContrast)="alphaAxis = $event"
-              #alphaSlider
             >
               <div
                 class="cursor sky-rounded-circle"

--- a/libs/components/colorpicker/src/lib/modules/colorpicker/colorpicker.component.scss
+++ b/libs/components/colorpicker/src/lib/modules/colorpicker/colorpicker.component.scss
@@ -349,6 +349,12 @@ sky-colorpicker.sky-margin-stacked-lg {
 }
 
 .sky-theme-modern {
+  .sky-color-picker-label-wrapper {
+    .sky-control-label {
+      color: $sky-theme-modern-font-data-label-color;
+    }
+  }
+
   .sky-colorpicker-disabled {
     opacity: 1;
   }


### PR DESCRIPTION
:cherries: Cherry picked from #2591 [fix(components/colorpicker): match label text to easy mode label styling](https://github.com/blackbaud/skyux/pull/2591)

[AB#3005644](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3005644) 