### PR TITLE
feat!: remove compat variables for previous compat stylesheets

### DIFF
--- a/libs/components/forms/src/lib/modules/selection-box/selection-box-grid.component.scss
+++ b/libs/components/forms/src/lib/modules/selection-box/selection-box-grid.component.scss
@@ -9,7 +9,7 @@
   display: flex;
   flex-flow: row wrap;
   padding: 0 7.5px;
-  margin: 0 auto var(--sky-compat-selection-box-grid-margin-bottom, -15px) auto;
+  margin: 0 auto -15px auto;
 
   &.sky-selection-box-grid-align-center {
     justify-content: center;

--- a/libs/components/layout/src/lib/modules/action-button/action-button-container.default.component.scss
+++ b/libs/components/layout/src/lib/modules/action-button/action-button-container.default.component.scss
@@ -30,10 +30,7 @@
   .sky-action-button-flex {
     display: block;
     padding: 0;
-    margin: calc(
-        var(--sky-compat-action-button-flex-margin, $sky-margin-double) * -1
-      )
-      0;
+    margin: -$sky-margin-double 0;
 
     sky-action-button {
       margin: $sky-margin-double 0;
@@ -50,9 +47,8 @@
   .sky-action-button-flex {
     display: flex;
     flex-flow: row wrap;
-    padding: var(--sky-compat-action-button-flex-sm-padding, 0) 0;
-    margin: calc(var(--sky-compat-action-button-flex-margin, $sky-margin) * -1)
-      0;
+    padding: 0;
+    margin: -$sky-margin 0;
 
     &.sky-action-button-flex-align-center {
       justify-content: center;

--- a/libs/components/layout/src/lib/modules/action-button/action-button-container.default.component.scss
+++ b/libs/components/layout/src/lib/modules/action-button/action-button-container.default.component.scss
@@ -30,7 +30,7 @@
   .sky-action-button-flex {
     display: block;
     padding: 0;
-    margin: -$sky-margin-double 0;
+    margin: (-$sky-margin-double) 0;
 
     sky-action-button {
       margin: $sky-margin-double 0;
@@ -48,7 +48,7 @@
     display: flex;
     flex-flow: row wrap;
     padding: 0;
-    margin: -$sky-margin 0;
+    margin: (-$sky-margin) 0;
 
     &.sky-action-button-flex-align-center {
       justify-content: center;

--- a/libs/components/layout/src/lib/modules/description-list/description-list.component.scss
+++ b/libs/components/layout/src/lib/modules/description-list/description-list.component.scss
@@ -38,8 +38,7 @@
   &.sky-description-list-horizontal-mode {
     display: flex;
     flex-wrap: wrap;
-    margin: 0 0 var(--sky-compat-description-list-margin-bottom, -$sky-space-lg)
-      0;
+    margin: 0 0 -$sky-space-lg 0;
 
     .sky-description-list-content {
       margin: 0 0 $sky-space-lg 0;

--- a/libs/components/layout/src/lib/modules/description-list/description-list.component.scss
+++ b/libs/components/layout/src/lib/modules/description-list/description-list.component.scss
@@ -38,7 +38,7 @@
   &.sky-description-list-horizontal-mode {
     display: flex;
     flex-wrap: wrap;
-    margin: 0 0 -$sky-space-lg 0;
+    margin: 0 0 (-$sky-space-lg) 0;
 
     .sky-description-list-content {
       margin: 0 0 $sky-space-lg 0;

--- a/libs/components/layout/src/lib/modules/text-expand-repeater/text-expand-repeater.component.scss
+++ b/libs/components/layout/src/lib/modules/text-expand-repeater/text-expand-repeater.component.scss
@@ -6,7 +6,7 @@
   overflow-y: hidden;
   height: auto;
   margin-bottom: 0;
-  margin-top: var(--sky-compat-text-expand-repeater-margin-top, 0);
+  margin-top: 0;
 }
 .sky-text-expand-repeater-see-more {
   white-space: nowrap;

--- a/libs/components/modals/src/lib/modules/modal/modal-footer.component.scss
+++ b/libs/components/modals/src/lib/modules/modal/modal-footer.component.scss
@@ -37,10 +37,7 @@
     }
 
     .sky-btn + .sky-btn-link {
-      margin-left: var(
-        --sky-compat-modal-footer-adjacent-btn-btn-link-margin,
-        $sky-margin
-      );
+      margin-left: $sky-margin;
     }
   }
 }

--- a/libs/components/pages/src/lib/modules/action-hub/action-hub.component.scss
+++ b/libs/components/pages/src/lib/modules/action-hub/action-hub.component.scss
@@ -1,7 +1,6 @@
 @use 'libs/components/theme/src/lib/styles/mixins' as mixins;
 
 :host {
-  --sky-compat-page-header-margin-top-and-bottom: 0;
   display: block;
   margin: var(--sky-padding-even-xl);
 }

--- a/libs/components/pages/src/lib/modules/page-header/page-header.component.scss
+++ b/libs/components/pages/src/lib/modules/page-header/page-header.component.scss
@@ -7,10 +7,7 @@
 }
 
 .sky-page-header {
-  margin: var(
-    --sky-layout-host-header-spacing,
-    var(--sky-compat-page-header-margin-top-and-bottom, 0) 0
-  );
+  margin: var(--sky-layout-host-header-spacing, 0);
 
   &-info {
     display: flex;

--- a/libs/components/tabs/src/lib/modules/sectioned-form/sectioned-form.component.scss
+++ b/libs/components/tabs/src/lib/modules/sectioned-form/sectioned-form.component.scss
@@ -53,13 +53,6 @@
   }
 }
 
-:host-context(sky-modal-content) {
-  :host .sky-sectioned-form,
-  form :host .sky-sectioned-form {
-    margin: var(--sky-compat-sectioned-form-modal-margin);
-  }
-}
-
 :host-context(sky-modal-content) > {
   :host .sky-sectioned-form,
   form :host .sky-sectioned-form {
@@ -76,13 +69,6 @@
 }
 
 @include mixins.sky-theme-modern {
-  :host-context(sky-modal-content) {
-    :host .sky-sectioned-form,
-    form :host .sky-sectioned-form {
-      margin: var(--sky-compat-sectioned-form-theme-modern-modal-margin);
-    }
-  }
-
   :host-context(sky-modal-content) > {
     :host .sky-sectioned-form,
     form :host .sky-sectioned-form {

--- a/libs/components/tabs/src/lib/modules/tabs/tabset.component.scss
+++ b/libs/components/tabs/src/lib/modules/tabs/tabset.component.scss
@@ -40,10 +40,10 @@ sky-tabset {
 
 .sky-modal-content {
   .sky-tabset-style-tabs {
-    --sky-tabset-margin: 0 (-$sky-space-lg) $sky-space-xl;
+    --sky-tabset-margin: #{0 (-$sky-space-lg) $sky-space-xl};
   }
   .sky-tabset-style-wizard {
-    --sky-tabset-margin: 0 0 $sky-space-xl;
+    --sky-tabset-margin: #{0 0 $sky-space-xl};
   }
 }
 

--- a/libs/components/tabs/src/lib/modules/tabs/tabset.component.scss
+++ b/libs/components/tabs/src/lib/modules/tabs/tabset.component.scss
@@ -40,16 +40,10 @@ sky-tabset {
 
 .sky-modal-content {
   .sky-tabset-style-tabs {
-    --sky-tabset-margin: var(
-      --sky-compat-tabset-tabs-modal-margin,
-      #{0 (-$sky-space-lg) $sky-space-xl}
-    );
+    --sky-tabset-margin: 0 (-$sky-space-lg) $sky-space-xl;
   }
   .sky-tabset-style-wizard {
-    --sky-tabset-margin: var(
-      --sky-compat-tabset-wizard-modal-margin,
-      #{0 0 $sky-space-xl}
-    );
+    --sky-tabset-margin: 0 0 $sky-space-xl;
   }
 }
 

--- a/libs/components/tabs/src/lib/modules/vertical-tabset/vertical-tabset.component.scss
+++ b/libs/components/tabs/src/lib/modules/vertical-tabset/vertical-tabset.component.scss
@@ -46,10 +46,6 @@
   overflow-y: auto;
 }
 
-:host-context(sky-modal-content) > .sky-vertical-tabset {
-  margin: var(--sky-compat-vertical-tabs-modal-margin);
-}
-
 :host-context(sky-modal-content) > :host .sky-vertical-tabset {
   margin: -15px;
 }

--- a/libs/components/theme/src/lib/styles/_forms.scss
+++ b/libs/components/theme/src/lib/styles/_forms.scss
@@ -29,7 +29,7 @@
 }
 
 .sky-form-group {
-  margin-bottom: var(--sky-compat-sky-form-group-margin-bottom, 0px);
+  margin-bottom: 0px;
 }
 
 input.ng-invalid.ng-touched,

--- a/libs/components/theme/src/lib/styles/themes/modern/_theme.scss
+++ b/libs/components/theme/src/lib/styles/themes/modern/_theme.scss
@@ -43,36 +43,18 @@
 
   h4,
   .sky-font-heading-4 {
-    color: var(
-      --sky-compat-theme-modern-heading-4-font-color,
-      var(--sky-text-color-default)
-    );
+    color: var(--sky-text-color-default);
     font-size: $sky-theme-modern-font-heading-4-size;
-    font-weight: var(
-      --sky-compat-theme-modern-heading-4-font-weight,
-      var(--sky-theme-modern-font-heading-4-weight)
-    );
-    text-transform: var(
-      --sky-compat-theme-modern-heading-4-text-transform,
-      none
-    );
+    font-weight: var(--sky-theme-modern-font-heading-4-weight);
+    text-transform: none;
   }
 
   h5,
   .sky-font-heading-5 {
-    color: var(
-      --sky-compat-theme-modern-heading-5-font-color,
-      var(--sky-text-color-default)
-    );
+    color: var(--sky-text-color-default);
     font-size: $sky-theme-modern-font-heading-5-size;
-    font-weight: var(
-      --sky-compat-theme-modern-heading-5-font-weight,
-      var(--sky-theme-modern-font-heading-5-weight)
-    );
-    text-transform: var(
-      --sky-compat-theme-modern-heading-5-text-transform,
-      none
-    );
+    font-weight: var(--sky-theme-modern-font-heading-5-weight);
+    text-transform: none;
   }
 
   p {


### PR DESCRIPTION
[AB#3023827](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3023827)

BREAKING CHANGE: Custom properties used by compatibility stylesheets for previous SKY UX major versions have been removed. Consumers should adopt the updated styles within their applications.