### PR TITLE
fix(components/pages): use CSP_NONCE when creating style elements (#2599)

### DIFF
--- a/libs/components/pages/src/lib/modules/page/page-theme-adapter.service.ts
+++ b/libs/components/pages/src/lib/modules/page/page-theme-adapter.service.ts
@@ -1,5 +1,5 @@
 import { DOCUMENT } from '@angular/common';
-import { Inject, Injectable } from '@angular/core';
+import { CSP_NONCE, Inject, Injectable, inject } from '@angular/core';
 
 /**
  * @internal
@@ -9,6 +9,7 @@ export class SkyPageThemeAdapterService {
   #styleEl: HTMLStyleElement | undefined;
 
   #document: Document;
+  #nonce = inject(CSP_NONCE, { optional: true });
 
   constructor(@Inject(DOCUMENT) document: Document) {
     this.#document = document;
@@ -22,6 +23,11 @@ export class SkyPageThemeAdapterService {
   public addTheme(): void {
     if (!this.#styleEl) {
       this.#styleEl = this.#document.createElement('style');
+
+      if (this.#nonce) {
+        this.#styleEl.nonce = this.#nonce;
+      }
+
       this.#styleEl.appendChild(
         this.#document.createTextNode(
           'body:not(.sky-theme-modern) { background-color: #fff; }',


### PR DESCRIPTION
:cherries: Cherry picked from #2599 [fix(components/pages): use CSP_NONCE when creating style elements](https://github.com/blackbaud/skyux/pull/2599)

[AB#3027388](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3027388) 