### PR TITLE
feat(components/forms): update `sky-file-attachment` component to use `ControlValueAccessor`; deprecate `validateFn` attribute in favor of custom form control validators; deprecate `fileChange` event in favor of form control `valueChanges` observable

### DIFF
--- a/apps/code-examples/src/app/code-examples/forms/file-attachment/basic/demo.component.html
+++ b/apps/code-examples/src/app/code-examples/forms/file-attachment/basic/demo.component.html
@@ -1,16 +1,15 @@
-<form class="sky-padding-even-lg" [formGroup]="formGroup">
+<form [formGroup]="formGroup">
   <sky-file-attachment
     acceptedTypes="application/pdf,image/jpeg,image/png,image/gif"
     formControlName="attachment"
     helpPopoverTitle="Requirements"
     hintText="Attach a .pdf, .gif, .png, or .jpeg file."
     labelText="Birth certificate"
-    [helpPopoverContent]="inlineHelpPopover"
+    [helpPopoverContent]="helpInlinePopoverRef"
     [maxFileSize]="maxFileSize"
-    (fileChange)="onFileChange($event)"
     (fileClick)="onFileClick($event)"
   >
-    @if (attachmentControl.errors?.['invalidStartingLetter']) {
+    @if (attachment.errors?.['invalidStartingLetter']) {
       <sky-form-error
         errorName="invalidStartingLetter"
         errorText="You may not upload a file that begins with the letter 'a'."
@@ -19,7 +18,7 @@
   </sky-file-attachment>
 </form>
 
-<ng-template #inlineHelpPopover>
+<ng-template #helpInlinePopoverRef>
   Make sure the birth certificate includes:
   <ul>
     <li>Full name of child</li>

--- a/apps/code-examples/src/app/code-examples/forms/file-attachment/basic/demo.component.html
+++ b/apps/code-examples/src/app/code-examples/forms/file-attachment/basic/demo.component.html
@@ -1,4 +1,4 @@
-<form [formGroup]="formGroup" class="sky-padding-even-lg">
+<form class="sky-padding-even-lg" [formGroup]="formGroup">
   <sky-file-attachment
     acceptedTypes="application/pdf,image/jpeg,image/png,image/gif"
     formControlName="attachment"
@@ -7,11 +7,10 @@
     labelText="Birth certificate"
     [helpPopoverContent]="inlineHelpPopover"
     [maxFileSize]="maxFileSize"
-    [validateFn]="validateFile"
     (fileChange)="onFileChange($event)"
     (fileClick)="onFileClick($event)"
   >
-    @if (customValidationError === 'invalidStartingLetter') {
+    @if (attachmentControl.errors?.['invalidStartingLetter']) {
       <sky-form-error
         errorName="invalidStartingLetter"
         errorText="You may not upload a file that begins with the letter 'a'."

--- a/apps/code-examples/src/app/code-examples/forms/file-attachment/basic/demo.component.ts
+++ b/apps/code-examples/src/app/code-examples/forms/file-attachment/basic/demo.component.ts
@@ -11,7 +11,6 @@ import {
   Validators,
 } from '@angular/forms';
 import {
-  SkyFileAttachmentChange,
   SkyFileAttachmentClick,
   SkyFileAttachmentModule,
   SkyFileItem,
@@ -42,7 +41,7 @@ function customValidator(
   ],
 })
 export class DemoComponent {
-  protected attachmentControl: FormControl<SkyFileItem | null | undefined>;
+  protected attachment: FormControl<SkyFileItem | null | undefined>;
 
   protected formGroup: FormGroup<{
     attachment: FormControl<SkyFileItem | null | undefined>;
@@ -51,16 +50,14 @@ export class DemoComponent {
   protected maxFileSize = 4000000;
 
   constructor() {
-    this.attachmentControl = new FormControl(undefined, {
+    this.attachment = new FormControl(undefined, {
       validators: [Validators.required, customValidator],
     });
 
     this.formGroup = inject(FormBuilder).group({
-      attachment: this.attachmentControl,
+      attachment: this.attachment,
     });
   }
-
-  protected onFileChange(result: SkyFileAttachmentChange): void {}
 
   protected onFileClick($event: SkyFileAttachmentClick): void {
     // Ensure we are only attempting to navigate to locally updated data for download.

--- a/apps/code-examples/src/app/code-examples/forms/file-attachment/basic/demo.component.ts
+++ b/apps/code-examples/src/app/code-examples/forms/file-attachment/basic/demo.component.ts
@@ -7,6 +7,7 @@ import {
   FormGroup,
   FormsModule,
   ReactiveFormsModule,
+  ValidationErrors,
   Validators,
 } from '@angular/forms';
 import {
@@ -15,6 +16,19 @@ import {
   SkyFileAttachmentModule,
   SkyFileItem,
 } from '@skyux/forms';
+
+/**
+ * Demonstrates how to create a custom validator function for your form control.
+ */
+function customValidator(
+  control: AbstractControl<SkyFileItem | null | undefined>,
+): ValidationErrors | null {
+  const fileItem = control.value;
+
+  return fileItem?.file?.name.startsWith('a')
+    ? { invalidStartingLetter: true }
+    : null;
+}
 
 @Component({
   standalone: true,
@@ -28,37 +42,25 @@ import {
   ],
 })
 export class DemoComponent {
-  protected attachment: FormControl;
-  protected customValidationError: string | undefined;
-  protected formGroup: FormGroup;
+  protected attachmentControl: FormControl<SkyFileItem | null | undefined>;
+
+  protected formGroup: FormGroup<{
+    attachment: FormControl<SkyFileItem | null | undefined>;
+  }>;
+
   protected maxFileSize = 4000000;
 
-  get #reactiveFile(): AbstractControl | null {
-    return this.formGroup.get('attachment');
-  }
-
   constructor() {
-    this.attachment = new FormControl(undefined, Validators.required);
+    this.attachmentControl = new FormControl(undefined, {
+      validators: [Validators.required, customValidator],
+    });
+
     this.formGroup = inject(FormBuilder).group({
-      attachment: this.attachment,
+      attachment: this.attachmentControl,
     });
   }
 
-  protected onFileChange(result: SkyFileAttachmentChange): void {
-    const file = result.file;
-
-    if (file?.errorType) {
-      this.#reactiveFile?.setValue(undefined);
-    } else {
-      this.#reactiveFile?.setValue(file);
-    }
-
-    if (file && file.errorType === 'validate') {
-      this.customValidationError = file.errorParam;
-    } else {
-      this.customValidationError = undefined;
-    }
-  }
+  protected onFileChange(result: SkyFileAttachmentChange): void {}
 
   protected onFileClick($event: SkyFileAttachmentClick): void {
     // Ensure we are only attempting to navigate to locally updated data for download.
@@ -68,9 +70,5 @@ export class DemoComponent {
       link.href = $event.file.url;
       link.click();
     }
-  }
-
-  protected validateFile(file: SkyFileItem): string {
-    return file.file.name.startsWith('a') ? 'invalidStartingLetter' : '';
   }
 }

--- a/libs/components/forms/src/lib/modules/file-attachment/file-attachment/file-attachment-join-ids.pipe.ts
+++ b/libs/components/forms/src/lib/modules/file-attachment/file-attachment/file-attachment-join-ids.pipe.ts
@@ -1,7 +1,7 @@
 import { Pipe, PipeTransform } from '@angular/core';
 
 /**
- * Joins an array of IDs with a "space" character
+ * Joins an array of IDs with a single space.
  * @internal
  */
 @Pipe({

--- a/libs/components/forms/src/lib/modules/file-attachment/file-attachment/file-attachment-join-ids.pipe.ts
+++ b/libs/components/forms/src/lib/modules/file-attachment/file-attachment/file-attachment-join-ids.pipe.ts
@@ -1,0 +1,16 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+/**
+ * Joins an array of IDs with a "space" character
+ * @internal
+ */
+@Pipe({
+  name: 'skyFileAttachmentJoinIds',
+  standalone: true,
+})
+export class SkyFileAttachmentJoinIdsPipe implements PipeTransform {
+  public transform(...ids: (string | null | undefined)[]): string | null {
+    // Remove undefined values and join with a " ".
+    return ids && ids.filter((id) => id).join(' ');
+  }
+}

--- a/libs/components/forms/src/lib/modules/file-attachment/file-attachment/file-attachment.component.html
+++ b/libs/components/forms/src/lib/modules/file-attachment/file-attachment/file-attachment.component.html
@@ -133,7 +133,7 @@
       [attr.aria-labelledby]="
         deleteButtonRef.id
           | skyFileAttachmentJoinIds
-            : hasLabelComponent && labelComponents?.get(0)?.labelContentId?.id
+            : labelComponents?.get(0)?.labelContentId?.id
       "
       [disabled]="disabled"
       [skyThemeClass]="{

--- a/libs/components/forms/src/lib/modules/file-attachment/file-attachment/file-attachment.component.html
+++ b/libs/components/forms/src/lib/modules/file-attachment/file-attachment/file-attachment.component.html
@@ -1,7 +1,8 @@
 <div class="sky-file-attachment-wrapper">
   <div
+    #labelRef="skyId"
     class="sky-file-attachment-label-wrapper"
-    [attr.id]="labelElementId"
+    skyId
     [ngClass]="{
       'sky-control-label-required':
         !labelText && isRequired && hasLabelComponent
@@ -24,8 +25,8 @@
       />
     </ng-container>
     <span
-      class="sky-screen-reader-only"
       *ngIf="isRequired && (hasLabelComponent || labelText)"
+      class="sky-screen-reader-only"
       >{{ 'skyux_file_attachment_required' | skyLibResources }}</span
     >
   </div>
@@ -41,14 +42,16 @@
     (drop)="fileDrop($event)"
   >
     <div
+      #fileDropDescriptionRef="skyId"
       aria-hidden="true"
       class="sky-screen-reader-only"
       role="tooltip"
-      [attr.id]="fileDropDescriptionElementId"
+      skyId
     >
       {{ 'skyux_file_attachment_file_upload_drag_or_click' | skyLibResources }}
     </div>
     <input
+      #fileInputRef
       hidden
       tabindex="-1"
       type="file"
@@ -56,16 +59,17 @@
       [disabled]="disabled"
       [required]="isRequired"
       (change)="fileChangeEvent($event)"
-      #fileInput
     />
     <ng-container *ngIf="showFileAttachmentButton">
       <button
         *ngIf="showFileAttachmentButton"
+        #attachButtonRef="skyId"
         class="sky-file-attachment-btn sky-btn sky-btn-default"
         type="button"
         skyId
         [attr.aria-describedby]="
-          (hintText ? hintTextEl.id + ' ' : '') + fileDropDescriptionElementId
+          hintText && hintTextEl.id
+            | skyFileAttachmentJoinIds: fileDropDescriptionRef.id
         "
         [attr.aria-label]="
           value
@@ -75,17 +79,14 @@
               | skyLibResources)
         "
         [attr.aria-labelledby]="
-          attachButton.id +
-          ' ' +
-          (labelText
-            ? labelElementId
-            : hasLabelComponent
-              ? labelComponents?.get(0)?.labelContentId?.id
-              : undefined)
+          attachButtonRef.id
+            | skyFileAttachmentJoinIds
+              : (labelText
+                  ? labelRef.id
+                  : labelComponents?.get(0)?.labelContentId?.id)
         "
         [disabled]="disabled"
         (click)="onDropClicked()"
-        #attachButton="skyId"
       >
         <sky-icon icon="folder-open-o" />
         {{
@@ -108,20 +109,21 @@
       class="sky-file-attachment-name"
     >
       <a
-        *ngIf="value; else noFile"
+        *ngIf="value; else noFileRef"
         [attr.title]="fileName"
         (click)="emitClick()"
       >
         {{ truncatedFileName }}
       </a>
     </span>
-    <ng-template #noFile>
+    <ng-template #noFileRef>
       <span class="sky-file-attachment-none sky-deemphasized">
         {{ 'skyux_file_attachment_label_no_file_chosen' | skyLibResources }}
       </span>
     </ng-template>
     <button
       *ngIf="value"
+      #deleteButtonRef="skyId"
       class="sky-btn sky-btn-borderless sky-file-attachment-delete"
       skyId
       type="button"
@@ -129,18 +131,15 @@
         'skyux_file_attachment_file_item_remove' | skyLibResources: fileName
       "
       [attr.aria-labelledby]="
-        deleteButton.id +
-        ' ' +
-        (hasLabelComponent
-          ? labelComponents?.get(0)?.labelContentId?.id
-          : undefined)
+        deleteButtonRef.id
+          | skyFileAttachmentJoinIds
+            : hasLabelComponent && labelComponents?.get(0)?.labelContentId?.id
       "
       [disabled]="disabled"
       [skyThemeClass]="{
         'sky-btn-icon-borderless': 'modern'
       }"
       (click)="deleteFileAttachment()"
-      #deleteButton="skyId"
     >
       <sky-icon icon="trash-o" size="md" />
     </button>

--- a/libs/components/forms/src/lib/modules/file-attachment/file-attachment/file-attachment.component.html
+++ b/libs/components/forms/src/lib/modules/file-attachment/file-attachment/file-attachment.component.html
@@ -191,7 +191,12 @@
   <ng-content select="sky-file-attachment-label" />
 </ng-template>
 
-<span #attachButtonLabelRef="skyId" skyId>
+<span
+  #attachButtonLabelRef="skyId"
+  aria-hidden="true"
+  class="sky-screen-reader-only"
+  skyId
+>
   {{
     value
       ? ('skyux_file_attachment_button_label_replace_file_label'
@@ -201,6 +206,11 @@
   }}
 </span>
 
-<span #deleteButtonLabelRef="skyId" skyId>
+<span
+  #deleteButtonLabelRef="skyId"
+  aria-hidden="true"
+  class="sky-screen-reader-only"
+  skyId
+>
   {{ 'skyux_file_attachment_file_item_remove' | skyLibResources: fileName }}
 </span>

--- a/libs/components/forms/src/lib/modules/file-attachment/file-attachment/file-attachment.component.html
+++ b/libs/components/forms/src/lib/modules/file-attachment/file-attachment/file-attachment.component.html
@@ -25,8 +25,8 @@
       />
     </ng-container>
     <span
-      *ngIf="isRequired && (hasLabelComponent || labelText)"
       class="sky-screen-reader-only"
+      *ngIf="isRequired && (hasLabelComponent || labelText)"
       >{{ 'skyux_file_attachment_required' | skyLibResources }}</span
     >
   </div>
@@ -63,23 +63,14 @@
     <ng-container *ngIf="showFileAttachmentButton">
       <button
         *ngIf="showFileAttachmentButton"
-        #attachButtonRef="skyId"
         class="sky-file-attachment-btn sky-btn sky-btn-default"
         type="button"
-        skyId
         [attr.aria-describedby]="
           hintText && hintTextEl.id
             | skyFileAttachmentJoinIds: fileDropDescriptionRef.id
         "
-        [attr.aria-label]="
-          value
-            ? ('skyux_file_attachment_button_label_replace_file_label'
-              | skyLibResources: fileName)
-            : ('skyux_file_attachment_button_label_choose_file_label'
-              | skyLibResources)
-        "
         [attr.aria-labelledby]="
-          attachButtonRef.id
+          attachButtonLabelRef.id
             | skyFileAttachmentJoinIds
               : (labelText
                   ? labelRef.id
@@ -123,15 +114,10 @@
     </ng-template>
     <button
       *ngIf="value"
-      #deleteButtonRef="skyId"
       class="sky-btn sky-btn-borderless sky-file-attachment-delete"
-      skyId
       type="button"
-      [attr.aria-label]="
-        'skyux_file_attachment_file_item_remove' | skyLibResources: fileName
-      "
       [attr.aria-labelledby]="
-        deleteButtonRef.id
+        deleteButtonLabelRef.id
           | skyFileAttachmentJoinIds
             : labelComponents?.get(0)?.labelContentId?.id
       "
@@ -204,3 +190,17 @@
 <ng-template #labelContent>
   <ng-content select="sky-file-attachment-label" />
 </ng-template>
+
+<span #attachButtonLabelRef="skyId" skyId>
+  {{
+    value
+      ? ('skyux_file_attachment_button_label_replace_file_label'
+        | skyLibResources: fileName)
+      : ('skyux_file_attachment_button_label_choose_file_label'
+        | skyLibResources)
+  }}
+</span>
+
+<span #deleteButtonLabelRef="skyId" skyId>
+  {{ 'skyux_file_attachment_file_item_remove' | skyLibResources: fileName }}
+</span>

--- a/libs/components/forms/src/lib/modules/file-attachment/file-attachment/file-attachment.component.spec.ts
+++ b/libs/components/forms/src/lib/modules/file-attachment/file-attachment/file-attachment.component.spec.ts
@@ -73,9 +73,10 @@ describe('File attachment', () => {
       ],
     });
 
-    spyOn(TestBed.inject(SkyIdService), 'generateId').and.returnValue(
-      'MOCK_ID',
-    );
+    let idIndex = 0;
+    spyOn(TestBed.inject(SkyIdService), 'generateId').and.callFake(() => {
+      return `MOCK_ID_${idIndex++}`;
+    });
 
     liveAnnouncerSpy = spyOn(
       TestBed.inject(SkyLiveAnnouncerService),
@@ -1449,10 +1450,10 @@ describe('File attachment', () => {
     const btn = getButtonEl(fixture.nativeElement);
     const deleteBtn = getDeleteButtonEl(fixture.nativeElement);
 
-    expect(btn?.getAttribute('aria-describedby')).toEqual('MOCK_ID');
-    expect(btn?.getAttribute('aria-labelledby')).toEqual('MOCK_ID MOCK_ID');
+    expect(btn?.getAttribute('aria-describedby')).toEqual('MOCK_ID_3');
+    expect(btn?.getAttribute('aria-labelledby')).toEqual('MOCK_ID_5 MOCK_ID_7');
     expect(deleteBtn?.getAttribute('aria-labelledby')).toEqual(
-      'MOCK_ID MOCK_ID',
+      'MOCK_ID_6 MOCK_ID_7',
     );
 
     await expectAsync(fixture.nativeElement).toBeAccessible();
@@ -1462,9 +1463,9 @@ describe('File attachment', () => {
     componentInstance.showLabel = false;
     fixture.detectChanges();
 
-    expect(btn?.getAttribute('aria-describedby')).toEqual('MOCK_ID');
-    expect(btn?.getAttribute('aria-labelledby')).toEqual('MOCK_ID MOCK_ID');
-    expect(deleteBtn?.getAttribute('aria-labelledby')).toEqual('MOCK_ID');
+    expect(btn?.getAttribute('aria-describedby')).toEqual('MOCK_ID_3');
+    expect(btn?.getAttribute('aria-labelledby')).toEqual('MOCK_ID_5 MOCK_ID_2');
+    expect(deleteBtn?.getAttribute('aria-labelledby')).toEqual('MOCK_ID_6');
 
     await expectAsync(fixture.nativeElement).toBeAccessible();
 
@@ -1473,9 +1474,9 @@ describe('File attachment', () => {
     componentInstance.showLabel = false;
     fixture.detectChanges();
 
-    expect(btn?.getAttribute('aria-describedby')).toEqual('MOCK_ID');
-    expect(btn?.getAttribute('aria-labelledby')).toEqual('MOCK_ID');
-    expect(deleteBtn?.getAttribute('aria-labelledby')).toEqual('MOCK_ID');
+    expect(btn?.getAttribute('aria-describedby')).toEqual('MOCK_ID_3');
+    expect(btn?.getAttribute('aria-labelledby')).toEqual('MOCK_ID_5');
+    expect(deleteBtn?.getAttribute('aria-labelledby')).toEqual('MOCK_ID_6');
 
     await expectAsync(fixture.nativeElement).toBeAccessible();
   });

--- a/libs/components/forms/src/lib/modules/file-attachment/file-attachment/file-attachment.component.ts
+++ b/libs/components/forms/src/lib/modules/file-attachment/file-attachment/file-attachment.component.ts
@@ -53,10 +53,9 @@ import { SkyFileValidateFn } from '../shared/file-validate-function';
 
 import { SkyFileAttachmentChange } from './file-attachment-change';
 import { SkyFileAttachmentClick } from './file-attachment-click';
+import { SkyFileAttachmentJoinIdsPipe } from './file-attachment-join-ids.pipe';
 import { SkyFileAttachmentLabelComponent } from './file-attachment-label.component';
 import { SkyFileAttachmentService } from './file-attachment.service';
-
-let uniqueId = 0;
 
 const MAX_FILE_SIZE_DEFAULT = 500000;
 const MIN_FILE_SIZE_DEFAULT = 0;
@@ -74,6 +73,7 @@ const MIN_FILE_SIZE_DEFAULT = 0;
   ],
   imports: [
     CommonModule,
+    SkyFileAttachmentJoinIdsPipe,
     SkyFileSizePipe,
     SkyFormErrorComponent,
     SkyFormErrorsComponent,
@@ -224,10 +224,6 @@ export class SkyFileAttachmentComponent
 
   public hasLabelComponent = false;
 
-  public fileDropDescriptionElementId: string;
-
-  public labelElementId: string;
-
   public rejectedOver = false;
 
   /**
@@ -272,7 +268,7 @@ export class SkyFileAttachmentComponent
 
   public truncatedFileName = '';
 
-  @ViewChild('fileInput')
+  @ViewChild('fileInputRef')
   public inputEl: ElementRef | undefined;
 
   @ContentChildren(SkyFileAttachmentLabelComponent)
@@ -290,8 +286,6 @@ export class SkyFileAttachmentComponent
   }
 
   #enterEventTarget: EventTarget | undefined | null;
-
-  #fileAttachmentId = uniqueId++;
 
   #ngUnsubscribe = new Subject<void>();
 
@@ -330,8 +324,6 @@ export class SkyFileAttachmentComponent
     this.ngControl = ngControl;
     this.#themeSvc = themeSvc;
 
-    this.labelElementId = `sky-file-attachment-label-${this.#fileAttachmentId}`;
-    this.fileDropDescriptionElementId = `sky-file-attachment-drop-description-${this.#fileAttachmentId}`;
     if (this.ngControl) {
       this.ngControl.valueAccessor = this;
     }
@@ -653,5 +645,4 @@ export class SkyFileAttachmentComponent
 /**
  * TODO:
  * - pipe for aria-describedby, aria-label, aria-labelledby
- * - use number attribute transform
  */

--- a/libs/components/forms/src/lib/modules/file-attachment/file-attachment/file-attachment.component.ts
+++ b/libs/components/forms/src/lib/modules/file-attachment/file-attachment/file-attachment.component.ts
@@ -641,8 +641,3 @@ export class SkyFileAttachmentComponent
     return;
   };
 }
-
-/**
- * TODO:
- * - pipe for aria-describedby, aria-label, aria-labelledby
- */

--- a/libs/components/forms/src/lib/modules/file-attachment/file-attachment/file-attachment.component.ts
+++ b/libs/components/forms/src/lib/modules/file-attachment/file-attachment/file-attachment.component.ts
@@ -21,7 +21,12 @@ import {
   booleanAttribute,
   inject,
 } from '@angular/core';
-import { NgControl, ValidationErrors, Validators } from '@angular/forms';
+import {
+  ControlValueAccessor,
+  NgControl,
+  ValidationErrors,
+  Validators,
+} from '@angular/forms';
 import {
   SkyIdModule,
   SkyIdService,
@@ -88,7 +93,12 @@ const MIN_FILE_SIZE_DEFAULT = 0;
   templateUrl: './file-attachment.component.html',
 })
 export class SkyFileAttachmentComponent
-  implements AfterViewInit, AfterContentInit, OnInit, OnDestroy
+  implements
+    AfterViewInit,
+    AfterContentInit,
+    ControlValueAccessor,
+    OnInit,
+    OnDestroy
 {
   /**
    * The comma-delimited string literal of MIME types that users can attach.
@@ -191,12 +201,14 @@ export class SkyFileAttachmentComponent
   /**
    * The custom validation function. This validation runs alongside the internal
    * file validation. This function takes a `SkyFileItem` object as a parameter.
+   * @deprecated Add a custom Angular `Validator` function to the `FormControl` instead.
    */
   @Input()
   public validateFn: SkyFileValidateFn | undefined;
 
   /**
    * Fires when users add or remove files.
+   * @deprecated Subscribe to the form control's `valueChanges` event instead.
    */
   @Output()
   public fileChange = new EventEmitter<SkyFileAttachmentChange>();
@@ -637,3 +649,9 @@ export class SkyFileAttachmentComponent
     return;
   };
 }
+
+/**
+ * TODO:
+ * - pipe for aria-describedby, aria-label, aria-labelledby
+ * - use number attribute transform
+ */


### PR DESCRIPTION
[AB#2916698](https://dev.azure.com/blackbaud/Products/_workitems/edit/2916698)