### PR TITLE
fix: `sky-form-errors` is no longer created and destroyed when form errors are present (#2596)

### DIFF
--- a/libs/components/colorpicker/src/lib/modules/colorpicker/colorpicker.component.html
+++ b/libs/components/colorpicker/src/lib/modules/colorpicker/colorpicker.component.html
@@ -355,7 +355,6 @@
 </div>
 
 <sky-form-errors
-  *ngIf="labelText && ngControl?.errors"
   [id]="errorId"
   [errors]="ngControl?.errors"
   [labelText]="labelText"

--- a/libs/components/datetime/src/lib/modules/date-range-picker/date-range-picker.component.html
+++ b/libs/components/datetime/src/lib/modules/date-range-picker/date-range-picker.component.html
@@ -39,10 +39,7 @@
         </option>
       </select>
     </sky-input-box>
-    <sky-form-errors
-      *ngIf="labelText && hostControl?.errors?.['skyDateRange']"
-      [labelText]="labelText"
-    >
+    <sky-form-errors [labelText]="labelText">
       <sky-form-error
         *ngIf="
           hostControl?.errors?.['skyDateRange']?.errors.endDateBeforeStartDate

--- a/libs/components/datetime/src/lib/modules/date-range-picker/date-range-picker.component.spec.ts
+++ b/libs/components/datetime/src/lib/modules/date-range-picker/date-range-picker.component.spec.ts
@@ -702,7 +702,9 @@ describe('Date range picker', function () {
     });
     detectChanges();
 
-    expect(fixture.nativeElement.querySelector('sky-form-error')).toBeNull();
+    expect(
+      fixture.nativeElement.querySelector('sky-form-error')?.textContent.trim(),
+    ).toBe(undefined);
 
     component.labelText = 'Date range picker';
     detectChanges();

--- a/libs/components/forms/src/assets/locales/resources_en_US.json
+++ b/libs/components/forms/src/assets/locales/resources_en_US.json
@@ -210,13 +210,5 @@
   "skyux_input_box_help_inline_aria_label": {
     "_description": "The accessible label for an input box help inline button",
     "message": "Show help content for {0}"
-  },
-  "skyux_checkbox_required_label_text": {
-    "_description": "The label text portion of the required validation message for checkboxes",
-    "message": "This selection"
-  },
-  "skyux_radio_group_required_label_text": {
-    "_description": "The label text portion of the required validation message for radio groups",
-    "message": "This selection"
   }
 }

--- a/libs/components/forms/src/lib/modules/checkbox/checkbox-group.component.html
+++ b/libs/components/forms/src/lib/modules/checkbox/checkbox-group.component.html
@@ -61,7 +61,6 @@
   </span>
 </fieldset>
 <sky-form-errors
-  *ngIf="headingText && formGroup?.errors"
   [id]="errorId"
   [attr.data-sky-id]="formErrorsDataId"
   [errors]="formGroup?.errors"

--- a/libs/components/forms/src/lib/modules/checkbox/checkbox.component.html
+++ b/libs/components/forms/src/lib/modules/checkbox/checkbox.component.html
@@ -91,11 +91,10 @@
   </div>
 </span>
 <sky-form-errors
-  class="sky-checkbox-form-margin"
-  *ngIf="labelText && control?.errors"
+  [class.sky-checkbox-form-margin]="labelText && control?.errors"
   [id]="errorId"
   [errors]="control?.errors"
-  [labelText]="'skyux_checkbox_required_label_text' | skyLibResources"
+  [labelText]="labelText"
   [showErrors]="control?.touched || control?.dirty"
 >
   <ng-content select="sky-form-error" />

--- a/libs/components/forms/src/lib/modules/checkbox/checkbox.default.component.scss
+++ b/libs/components/forms/src/lib/modules/checkbox/checkbox.default.component.scss
@@ -18,6 +18,7 @@
 }
 
 @include mixins.sky-component('default', '.sky-checkbox-form-margin') {
+  display: block;
   margin-left: calc(var(--sky-switch-size) + var(--sky-switch-margin));
 }
 

--- a/libs/components/forms/src/lib/modules/checkbox/checkbox.modern.component.scss
+++ b/libs/components/forms/src/lib/modules/checkbox/checkbox.modern.component.scss
@@ -34,6 +34,7 @@
 }
 
 @include mixins.sky-component('modern', '.sky-checkbox-form-margin') {
+  display: block;
   margin-left: calc(var(--sky-switch-size) + var(--sky-switch-margin));
 }
 

--- a/libs/components/forms/src/lib/modules/file-attachment/file-attachment/file-attachment.component.html
+++ b/libs/components/forms/src/lib/modules/file-attachment/file-attachment/file-attachment.component.html
@@ -166,11 +166,8 @@
 </div>
 
 <sky-form-errors
-  *ngIf="labelText && (ngControl?.control?.errors || fileErrorValidation)"
   [id]="errorId"
-  [errors]="
-    ngControl?.errors !== null ? ngControl?.errors : fileErrorValidation
-  "
+  [errors]="ngControl?.errors ?? fileErrorValidation"
   [labelText]="labelText"
   [showErrors]="ngControl?.touched || ngControl?.dirty"
 >

--- a/libs/components/forms/src/lib/modules/file-attachment/file-drop/file-drop.component.html
+++ b/libs/components/forms/src/lib/modules/file-attachment/file-drop/file-drop.component.html
@@ -170,8 +170,7 @@
   </div>
 </fieldset>
 <sky-form-errors
-  *ngIf="labelText && rejectedFiles.length"
-  class="sky-file-drop-errors"
+  [class.sky-file-drop-errors]="labelText && rejectedFiles.length"
   [id]="errorId"
   [labelText]="labelText"
   [showErrors]="rejectedFiles.length"

--- a/libs/components/forms/src/lib/modules/form-error/form-errors.component.html
+++ b/libs/components/forms/src/lib/modules/form-error/form-errors.component.html
@@ -1,4 +1,4 @@
-<ng-container *ngIf="labelText && showErrors">
+<div *ngIf="labelText && showErrors">
   <ng-container *ngIf="errors">
     <sky-form-error
       *ngIf="errors['required']"
@@ -101,4 +101,4 @@
     />
   </ng-container>
   <ng-content />
-</ng-container>
+</div>

--- a/libs/components/forms/src/lib/modules/form-error/form-errors.component.scss
+++ b/libs/components/forms/src/lib/modules/form-error/form-errors.component.scss
@@ -1,4 +1,3 @@
-:host,
 sky-status-indicator {
   display: block;
   line-height: normal;

--- a/libs/components/forms/src/lib/modules/radio/radio-group.component.html
+++ b/libs/components/forms/src/lib/modules/radio/radio-group.component.html
@@ -56,10 +56,9 @@
   <ng-content />
 </fieldset>
 <sky-form-errors
-  *ngIf="headingText && ngControl?.errors"
   [id]="errorId"
   [errors]="ngControl?.errors"
-  [labelText]="'skyux_radio_group_required_label_text' | skyLibResources"
+  [labelText]="headingText"
   [showErrors]="ngControl?.touched || ngControl?.dirty"
 >
   <ng-content select="sky-form-error" />

--- a/libs/components/forms/src/lib/modules/shared/sky-forms-resources.module.ts
+++ b/libs/components/forms/src/lib/modules/shared/sky-forms-resources.module.ts
@@ -135,8 +135,6 @@ const RESOURCES: Record<string, SkyLibResources> = {
     skyux_input_box_help_inline_aria_label: {
       message: 'Show help content for {0}',
     },
-    skyux_checkbox_required_label_text: { message: 'This selection' },
-    skyux_radio_group_required_label_text: { message: 'This selection' },
   },
 };
 

--- a/libs/components/forms/testing/src/checkbox/checkbox-group-harness.ts
+++ b/libs/components/forms/testing/src/checkbox/checkbox-group-harness.ts
@@ -180,14 +180,16 @@ export class SkyCheckboxGroupHarness extends SkyComponentHarness {
   }
 
   async #getFormErrors(): Promise<SkyFormErrorsHarness> {
-    const harness = await this.locatorForOptional(
+    const errorsHarness = await this.locatorFor(
       SkyFormErrorsHarness.with({
         dataSkyId: 'checkbox-group-form-errors',
       }),
     )();
 
-    if (harness) {
-      return harness;
+    const errors = await errorsHarness.getFormErrors();
+
+    if (errors.length) {
+      return errorsHarness;
     }
 
     throw Error('No form errors found.');

--- a/libs/components/forms/testing/src/checkbox/checkbox-harness.ts
+++ b/libs/components/forms/testing/src/checkbox/checkbox-harness.ts
@@ -211,10 +211,12 @@ export class SkyCheckboxHarness extends SkyComponentHarness {
   }
 
   async #getFormErrors(): Promise<SkyFormErrorsHarness> {
-    const harness = await this.locatorForOptional(SkyFormErrorsHarness)();
+    const errorsHarness = await this.locatorFor(SkyFormErrorsHarness)();
 
-    if (harness) {
-      return harness;
+    const errors = await errorsHarness.getFormErrors();
+
+    if (errors.length) {
+      return errorsHarness;
     }
 
     throw Error('No form errors found.');

--- a/libs/components/text-editor/src/lib/modules/text-editor/text-editor.component.html
+++ b/libs/components/text-editor/src/lib/modules/text-editor/text-editor.component.html
@@ -92,7 +92,7 @@
   {{ hintText }}
 </div>
 <sky-form-errors
-  *ngIf="labelText && ngControl?.errors"
+  class="sky-text-editor-errors"
   [id]="errorId"
   [errors]="ngControl.errors"
   [labelText]="labelText"

--- a/libs/components/text-editor/src/lib/modules/text-editor/text-editor.component.spec.ts
+++ b/libs/components/text-editor/src/lib/modules/text-editor/text-editor.component.spec.ts
@@ -2087,7 +2087,9 @@ describe('Text editor', () => {
       validateIframeDocumentAttribute('aria-invalid', 'true');
       validateIframeDocumentAttribute(
         'aria-errormessage',
-        fixture.nativeElement.querySelector('sky-form-errors').id,
+        fixture.nativeElement.querySelector(
+          'sky-form-errors.sky-text-editor-errors',
+        ).id,
       );
     }));
 


### PR DESCRIPTION
:cherries: Cherry picked from #2596 [fix: `sky-form-errors` is no longer created and destroyed when form errors are present](https://github.com/blackbaud/skyux/pull/2596)

[AB#3013061](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3013061) 