### PR TITLE
feat(components/forms): file attachment automatically creates download link for file uploads

### DIFF
--- a/libs/components/forms/src/lib/modules/file-attachment/file-attachment/file-attachment.component.html
+++ b/libs/components/forms/src/lib/modules/file-attachment/file-attachment/file-attachment.component.html
@@ -97,7 +97,7 @@
     />
     <span
       *ngIf="value || currentThemeName === 'default'"
-      class="sky-file-attachment-name"
+      class="sky-file-attachment-file-link"
     >
       <a
         *ngIf="value; else noFileRef"

--- a/libs/components/forms/src/lib/modules/file-attachment/file-attachment/file-attachment.component.html
+++ b/libs/components/forms/src/lib/modules/file-attachment/file-attachment/file-attachment.component.html
@@ -101,6 +101,8 @@
     >
       <a
         *ngIf="value; else noFileRef"
+        [href]="isData ? value.url : undefined"
+        [download]="isData ? value.file.name : undefined"
         [attr.title]="fileName"
         (click)="emitClick()"
       >

--- a/libs/components/forms/src/lib/modules/file-attachment/file-attachment/file-attachment.component.scss
+++ b/libs/components/forms/src/lib/modules/file-attachment/file-attachment/file-attachment.component.scss
@@ -38,7 +38,7 @@
   }
 }
 
-.sky-file-attachment-name {
+.sky-file-attachment-file-link {
   padding: 0 5px;
 
   a {
@@ -105,7 +105,7 @@
       display: flex;
       align-items: flex-start;
 
-      .sky-file-attachment-name {
+      .sky-file-attachment-file-link {
         margin: $sky-theme-modern-space-sm $sky-theme-modern-space-sm 0 0;
         padding: 0;
       }

--- a/libs/components/forms/src/lib/modules/file-attachment/file-attachment/file-attachment.component.spec.ts
+++ b/libs/components/forms/src/lib/modules/file-attachment/file-attachment/file-attachment.component.spec.ts
@@ -101,11 +101,13 @@ describe('File attachment', () => {
   }
 
   function getFileNameLinkEl(): HTMLElement | null {
-    return el.querySelector('.sky-file-attachment-name a');
+    return el.querySelector('.sky-file-attachment-file-link a');
   }
 
   function getFileNameText(): string | undefined {
-    return el.querySelector('.sky-file-attachment-name')?.textContent?.trim();
+    return el
+      .querySelector('.sky-file-attachment-file-link')
+      ?.textContent?.trim();
   }
 
   function getDeleteEl(): HTMLElement | null {
@@ -689,7 +691,9 @@ describe('File attachment', () => {
     expect(getFileNameText()).toBe('abcdefghijklmnopqrstuvwxyz...');
 
     expect(
-      el.querySelector('.sky-file-attachment-name > a')?.getAttribute('title'),
+      el
+        .querySelector('.sky-file-attachment-file-link > a')
+        ?.getAttribute('title'),
     ).toBe(
       'abcdefghijklmnopqrstuvwxyz12345.png',
       'Expected the anchor title to display the full file name.',

--- a/libs/components/forms/src/lib/modules/file-attachment/file-attachment/file-attachment.component.ts
+++ b/libs/components/forms/src/lib/modules/file-attachment/file-attachment/file-attachment.component.ts
@@ -214,9 +214,7 @@ export class SkyFileAttachmentComponent
   public fileChange = new EventEmitter<SkyFileAttachmentChange>();
 
   /**
-   * Fires when users select the file name link. Make sure to bind the event.
-   * If you do not, the file name link will be a dead link.
-   * @deprecated The download link attributes for the attached file are now set automatically and this output binding is no longer needed.
+   * Fires when users select the file name link.
    */
   @Output()
   public fileClick = new EventEmitter<SkyFileAttachmentClick>();

--- a/libs/components/forms/src/lib/modules/file-attachment/file-attachment/file-attachment.component.ts
+++ b/libs/components/forms/src/lib/modules/file-attachment/file-attachment/file-attachment.component.ts
@@ -278,7 +278,8 @@ export class SkyFileAttachmentComponent
     | undefined;
 
   public isImage = false;
-  public isData = false;
+
+  protected isData = false;
 
   protected get isRequired(): boolean {
     return (

--- a/libs/components/forms/src/lib/modules/file-attachment/file-attachment/file-attachment.component.ts
+++ b/libs/components/forms/src/lib/modules/file-attachment/file-attachment/file-attachment.component.ts
@@ -216,6 +216,7 @@ export class SkyFileAttachmentComponent
   /**
    * Fires when users select the file name link. Make sure to bind the event.
    * If you do not, the file name link will be a dead link.
+   * @deprecated The download link attributes for the attached file are now set automatically and this output binding is no longer needed.
    */
   @Output()
   public fileClick = new EventEmitter<SkyFileAttachmentClick>();
@@ -244,8 +245,10 @@ export class SkyFileAttachmentComponent
 
     if (isNewValue) {
       if (value) {
+        this.isData = value.url?.startsWith('data:');
         this.isImage = this.#fileItemService.isImage(value);
       } else {
+        this.isData = false;
         this.isImage = false;
       }
       this.#setFileName(value);
@@ -277,6 +280,7 @@ export class SkyFileAttachmentComponent
     | undefined;
 
   public isImage = false;
+  public isData = false;
 
   protected get isRequired(): boolean {
     return (


### PR DESCRIPTION
BREAKING CHANGE

The file attachment component file links will now automatically initiate a download when clicked. The `linkClick` output handler is no longer needed, and will cause duplicate downloads when used.

[AB#2915129](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/2915129)