### PR TITLE
fix(components/forms): update checkbox and checkbox group harness to return false instead of throw when no form errors are present

### DIFF
--- a/libs/components/forms/testing/src/checkbox/checkbox-group-harness.spec.ts
+++ b/libs/components/forms/testing/src/checkbox/checkbox-group-harness.spec.ts
@@ -240,9 +240,9 @@ describe('Checkbox group harness', () => {
 
     await checkboxHarness.check();
 
-    await expectAsync(
-      checkboxGroupHarness.hasError('test'),
-    ).toBeRejectedWithError('No form errors found.');
+    await expectAsync(checkboxGroupHarness.hasError('test')).toBeResolvedTo(
+      false,
+    );
   });
 
   it('should throw an error if no help inline is found', async () => {

--- a/libs/components/forms/testing/src/checkbox/checkbox-group-harness.ts
+++ b/libs/components/forms/testing/src/checkbox/checkbox-group-harness.ts
@@ -180,19 +180,11 @@ export class SkyCheckboxGroupHarness extends SkyComponentHarness {
   }
 
   async #getFormErrors(): Promise<SkyFormErrorsHarness> {
-    const errorsHarness = await this.locatorFor(
+    return await this.locatorFor(
       SkyFormErrorsHarness.with({
         dataSkyId: 'checkbox-group-form-errors',
       }),
     )();
-
-    const errors = await errorsHarness.getFormErrors();
-
-    if (errors.length) {
-      return errorsHarness;
-    }
-
-    throw Error('No form errors found.');
   }
 
   async #getHelpInline(): Promise<SkyHelpInlineHarness> {

--- a/libs/components/forms/testing/src/checkbox/checkbox-harness.spec.ts
+++ b/libs/components/forms/testing/src/checkbox/checkbox-harness.spec.ts
@@ -1,5 +1,6 @@
+import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
-import { TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { SkyHelpService } from '@skyux/core';
 import { SkyHelpTestingModule } from '@skyux/core/testing';
 
@@ -9,7 +10,11 @@ import { CheckboxHarnessTestModule } from './fixtures/checkbox-harness-test.modu
 
 async function setupTest(
   options: { dataSkyId?: string; hideEmailLabel?: boolean } = {},
-) {
+): Promise<{
+  checkboxHarness: SkyCheckboxHarness;
+  fixture: ComponentFixture<CheckboxHarnessTestComponent>;
+  loader: HarnessLoader;
+}> {
   await TestBed.configureTestingModule({
     imports: [CheckboxHarnessTestModule, SkyHelpTestingModule],
   }).compileComponents();
@@ -227,9 +232,7 @@ describe('Checkbox harness', () => {
       dataSkyId: 'my-email-checkbox',
     });
 
-    await expectAsync(checkboxHarness.hasRequiredError()).toBeRejectedWithError(
-      'No form errors found.',
-    );
+    await expectAsync(checkboxHarness.hasRequiredError()).toBeResolvedTo(false);
   });
 
   it('should throw an error if no help inline is found', async () => {

--- a/libs/components/forms/testing/src/checkbox/checkbox-harness.ts
+++ b/libs/components/forms/testing/src/checkbox/checkbox-harness.ts
@@ -211,15 +211,7 @@ export class SkyCheckboxHarness extends SkyComponentHarness {
   }
 
   async #getFormErrors(): Promise<SkyFormErrorsHarness> {
-    const errorsHarness = await this.locatorFor(SkyFormErrorsHarness)();
-
-    const errors = await errorsHarness.getFormErrors();
-
-    if (errors.length) {
-      return errorsHarness;
-    }
-
-    throw Error('No form errors found.');
+    return await this.locatorFor(SkyFormErrorsHarness)();
   }
 
   async #getHelpInline(): Promise<SkyHelpInlineHarness> {


### PR DESCRIPTION
[AB#3032270](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3032270)

BREAKING CHANGE

Previously the `hasRequiredError()` and other error reporting methods on checkbox and checkbox group harnesses would return false if the specified error was not present alongside other errors, but throw an exception if no errors were present at all. Now these methods simply return false if the specified error is not present regardless of the overall error state.