### PR TITLE
fix(components/packages): abort path replacement when symbols are found without respective import path

### DIFF
--- a/libs/components/packages/src/schematics/utility/move-class-to-library.spec.ts
+++ b/libs/components/packages/src/schematics/utility/move-class-to-library.spec.ts
@@ -175,4 +175,29 @@ import { BrowserModule } from '@angular/platform-browser';
 `,
     );
   });
+
+  it('should abort if symbols are found, but "previousLibrary" path is not', async () => {
+    const content = `
+import { SkyIconModule } from 'foo';
+import { SkyIconStackItem } from 'bar';
+`;
+
+    tree.create(path, content);
+
+    moveClassToLibrary(
+      tree,
+      path,
+      ts.createSourceFile(path, content, ts.ScriptTarget.Latest, true),
+      content,
+      {
+        classNames: ['SkyIconModule'],
+        previousLibrary: '@skyux/indicators',
+        newLibrary: '@skyux/icon',
+      },
+    );
+
+    const updatedContent = tree.readText(path);
+
+    expect(updatedContent).toEqual(content);
+  });
 });

--- a/libs/components/packages/src/schematics/utility/move-class-to-library.ts
+++ b/libs/components/packages/src/schematics/utility/move-class-to-library.ts
@@ -27,7 +27,12 @@ export function moveClassToLibrary(
       node.moduleSpecifier.text === options.previousLibrary,
   );
 
+  if (moduleImports.length === 0) {
+    return;
+  }
+
   const replacedImports: { [key: string]: ts.ImportSpecifier } = {};
+
   options.classNames.forEach((importName) => {
     const namedImportSpecifier = findNodes(
       sourceFile,
@@ -80,6 +85,7 @@ export function moveClassToLibrary(
       }
     }
   });
+
   if (Object.keys(replacedImports).length > 0) {
     recorder.insertLeft(
       moduleImports[0].getStart(sourceFile),


### PR DESCRIPTION
I was seeing `✖ Migration failed: Cannot read properties of undefined (reading 'getStart')` for a few SPA migrations. When reading a file with `import { SkyIconModule } from '@skyux/icon'`, a symbol is found to be migrated (`SkyIconModule`) but the import paths array is empty. An error is thrown when we go to access the first item in the import array:

See: https://github.com/blackbaud/skyux/blob/main/libs/components/packages/src/schematics/utility/move-class-to-library.ts#L85