### PR TITLE
feat(components/ag-grid): allow template ref cell renderers to be used for row actions in editable grids

### DIFF
--- a/apps/code-examples/src/app/code-examples/ag-grid/data-entry-grid/basic/edit-modal.component.ts
+++ b/apps/code-examples/src/app/code-examples/ag-grid/data-entry-grid/basic/edit-modal.component.ts
@@ -19,7 +19,6 @@ import { SkyModalInstance, SkyModalModule } from '@skyux/modals';
 
 import { AgGridModule } from 'ag-grid-angular';
 import {
-  CellEditingStartedEvent,
   ColDef,
   GridApi,
   GridOptions,
@@ -212,16 +211,6 @@ export class EditModalComponent implements OnInit {
 
   public onGridReady(gridReadyEvent: GridReadyEvent): void {
     this.#gridApi = gridReadyEvent.api;
-    this.#gridApi.addEventListener(
-      'cellEditingStarted',
-      (params: CellEditingStartedEvent) => {
-        if (params.colDef?.type === SkyCellType.Template) {
-          if (params.rowIndex !== null) {
-            this.#gridApi?.setFocusedCell(params.rowIndex, params.column);
-          }
-        }
-      },
-    );
 
     this.#changeDetectorRef.markForCheck();
   }

--- a/apps/playground/src/app/components/ag-grid/edit-complex-cells/edit-complex-cells.component.ts
+++ b/apps/playground/src/app/components/ag-grid/edit-complex-cells/edit-complex-cells.component.ts
@@ -339,12 +339,6 @@ export class EditComplexCellsComponent implements OnInit {
       }
     });
 
-    this.gridApi.addEventListener('cellEditingStarted', (params) => {
-      if (params.colDef?.type === SkyCellType.Template) {
-        this.gridApi.setFocusedCell(params.rowIndex, params.column);
-      }
-    });
-
     this.sizeGrid();
   }
 

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/ag-grid-wrapper.component.spec.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/ag-grid-wrapper.component.spec.ts
@@ -34,6 +34,7 @@ import {
 } from './fixtures/ag-grid.component.fixture';
 import { SkyAgGridFixtureModule } from './fixtures/ag-grid.module.fixture';
 import { SecondInlineHelpComponent } from './fixtures/inline-help.component';
+import { SkyCellType } from './types/cell-type';
 
 describe('SkyAgGridWrapperComponent', () => {
   let gridFixture: ComponentFixture<SkyAgGridFixtureComponent>;
@@ -271,6 +272,18 @@ describe('SkyAgGridWrapperComponent', () => {
     expect(
       gridWrapperNativeElement.querySelector('.sky-ag-grid'),
     ).not.toHaveCssClass('sky-ag-grid-cell-editing-test');
+  });
+
+  it('should set focus to template cells when editing', () => {
+    const spy = (agGrid.api.setFocusedCell as jasmine.Spy).and.stub();
+    agGrid.cellEditingStarted.next({
+      colDef: { type: SkyCellType.Template },
+      rowIndex: 0,
+      column: {} as AgColumn,
+    } as unknown as CellEditingStartedEvent);
+    gridWrapperFixture.detectChanges();
+
+    expect(spy).toHaveBeenCalled();
   });
 
   describe('onGridKeydown', () => {

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/ag-grid-wrapper.component.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/ag-grid-wrapper.component.ts
@@ -48,6 +48,7 @@ import {
 import { agGridTheme } from '../../styles/ag-grid-theme';
 
 import { SkyAgGridAdapterService } from './ag-grid-adapter.service';
+import { SkyCellType } from './types/cell-type';
 
 let idIndex = 0;
 
@@ -191,6 +192,12 @@ export class SkyAgGridWrapperComponent
               ...this.#wrapperClasses.getValue(),
               ...addClasses,
             ]);
+            if (
+              types.includes(SkyCellType.Template) &&
+              params.rowIndex !== null
+            ) {
+              this.agGrid?.api.setFocusedCell(params.rowIndex, params.column);
+            }
           }
         });
       this.agGrid.cellEditingStopped


### PR DESCRIPTION
[AB#2860042](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/2860042)