### PR TITLE
fix(components/icon): variant input is respected for SVG-based icons (#2688)

### DIFF
--- a/libs/components/icon/src/lib/icon/fixtures/icon.component.fixture.html
+++ b/libs/components/icon/src/lib/icon/fixtures/icon.component.fixture.html
@@ -1,6 +1,7 @@
 <sky-icon
   [fixedWidth]="fixedWidth"
   [icon]="icon"
+  [iconName]="iconName"
   [iconType]="iconType"
   [size]="size"
   [variant]="variant"

--- a/libs/components/icon/src/lib/icon/fixtures/icon.component.fixture.ts
+++ b/libs/components/icon/src/lib/icon/fixtures/icon.component.fixture.ts
@@ -8,6 +8,7 @@ import { SkyIconVariantType } from '../types/icon-variant-type';
 })
 export class IconTestComponent {
   public icon = 'circle';
+  public iconName: string | undefined;
   public iconType: 'fa' | 'skyux' | undefined;
   public size: string | undefined = '3x';
   public fixedWidth: boolean | undefined = false;

--- a/libs/components/icon/src/lib/icon/icon-svg.component.spec.ts
+++ b/libs/components/icon/src/lib/icon/icon-svg.component.spec.ts
@@ -4,6 +4,7 @@ import {
   fakeAsync,
   tick,
 } from '@angular/core/testing';
+import { expectAsync } from '@skyux-sdk/testing';
 
 import { SkyIconSvgResolverService } from './icon-svg-resolver.service';
 import { SkyIconSvgComponent } from './icon-svg.component';
@@ -77,6 +78,15 @@ describe('Icon SVG component', () => {
     validateIconId('#test-16-solid');
   }));
 
+  it('should display the resolved icon by ID, size, and variant', fakeAsync(() => {
+    fixture.componentRef.setInput('iconName', 'test');
+    fixture.componentRef.setInput('iconSize', '2x');
+    fixture.componentRef.setInput('iconVariant', 'solid');
+    detectUrlChanges();
+
+    validateIconId('#test-32-solid');
+  }));
+
   it("should use the host element's text color as its fill color", fakeAsync(() => {
     fixture.nativeElement.style.color = '#0f0';
 
@@ -94,4 +104,63 @@ describe('Icon SVG component', () => {
 
     validateIconId('');
   }));
+
+  describe('a11y', () => {
+    async function detectUrlChanges(): Promise<void> {
+      fixture.detectChanges();
+
+      // Resolve icon ID Observable and apply changes.
+      await fixture.whenStable();
+      fixture.detectChanges();
+    }
+
+    it('should be accessible (icon: "test", size: undefined, variant: undefined)', async () => {
+      fixture.componentRef.setInput('iconName', 'test');
+      await detectUrlChanges();
+
+      await expectAsync(fixture.nativeElement).toBeAccessible();
+    });
+
+    it('should be accessible (icon: "test", size: 2x, variant: undefined)', async () => {
+      fixture.componentRef.setInput('iconName', 'test');
+      fixture.componentRef.setInput('iconSize', '2x');
+      await detectUrlChanges();
+
+      await expectAsync(fixture.nativeElement).toBeAccessible();
+    });
+
+    it('should be accessible (icon: "test", size: undefined, variant: "solid")', async () => {
+      fixture.componentRef.setInput('iconName', 'test');
+      fixture.componentRef.setInput('iconVariant', 'solid');
+      await detectUrlChanges();
+
+      await expectAsync(fixture.nativeElement).toBeAccessible();
+    });
+
+    it('should be accessible (icon: "test", size: undefined, variant: "line")', async () => {
+      fixture.componentRef.setInput('iconName', 'test');
+      fixture.componentRef.setInput('iconVariant', 'line');
+      await detectUrlChanges();
+
+      await expectAsync(fixture.nativeElement).toBeAccessible();
+    });
+
+    it('should be accessible (icon: "test", size: 2x, variant: "solid")', async () => {
+      fixture.componentRef.setInput('iconName', 'test');
+      fixture.componentRef.setInput('iconSize', '2x');
+      fixture.componentRef.setInput('iconVariant', 'solid');
+      await detectUrlChanges();
+
+      await expectAsync(fixture.nativeElement).toBeAccessible();
+    });
+
+    it('should be accessible (icon: "test", size: 2x, variant: "line")', async () => {
+      fixture.componentRef.setInput('iconName', 'test');
+      fixture.componentRef.setInput('iconSize', '2x');
+      fixture.componentRef.setInput('iconVariant', 'line');
+      await detectUrlChanges();
+
+      await expectAsync(fixture.nativeElement).toBeAccessible();
+    });
+  });
 });

--- a/libs/components/icon/src/lib/icon/icon.component.html
+++ b/libs/components/icon/src/lib/icon/icon.component.html
@@ -1,5 +1,9 @@
 @if (iconName) {
-  <sky-icon-svg [iconName]="iconName" [iconSize]="size" />
+  <sky-icon-svg
+    [iconName]="iconName"
+    [iconSize]="size"
+    [iconVariant]="variant"
+  />
 } @else {
   <i
     *ngIf="icon"

--- a/libs/components/icon/src/lib/icon/icon.component.spec.ts
+++ b/libs/components/icon/src/lib/icon/icon.component.spec.ts
@@ -1,320 +1,452 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import {
+  ComponentFixture,
+  TestBed,
+  fakeAsync,
+  tick,
+} from '@angular/core/testing';
 import { expect, expectAsync } from '@skyux-sdk/testing';
 
 import { SkyIconFixturesModule } from './fixtures/icon-fixtures.module';
 import { IconTestComponent } from './fixtures/icon.component.fixture';
 import { SkyIconResolverService } from './icon-resolver.service';
+import { SkyIconSvgResolverService } from './icon-svg-resolver.service';
 import { SkyIconType } from './types/icon-type';
 import { SkyIconVariantType } from './types/icon-variant-type';
 
 describe('Icon component', () => {
-  function setupIcon(
-    icon: string,
-    iconType?: SkyIconType,
-    size?: string,
-    fixedWidth?: boolean,
-    variant?: SkyIconVariantType,
-  ): void {
-    cmp.icon = icon;
-    cmp.iconType = iconType;
-    cmp.size = size;
-    cmp.fixedWidth = fixedWidth;
-    cmp.variant = variant;
-
-    fixture.detectChanges();
-  }
-
   let fixture: ComponentFixture<IconTestComponent>;
   let cmp: IconTestComponent;
   let element: HTMLElement;
-  let mockResolver: jasmine.SpyObj<SkyIconResolverService>;
 
-  beforeEach(() => {
-    mockResolver = jasmine.createSpyObj('mockResolver', ['resolveIcon']);
+  describe('icon', () => {
+    let mockResolver: jasmine.SpyObj<SkyIconResolverService>;
+    function setupIcon(
+      icon: string,
+      iconType?: SkyIconType,
+      size?: string,
+      fixedWidth?: boolean,
+      variant?: SkyIconVariantType,
+    ): void {
+      cmp.icon = icon;
+      cmp.iconType = iconType;
+      cmp.size = size;
+      cmp.fixedWidth = fixedWidth;
+      cmp.variant = variant;
 
-    mockResolver.resolveIcon.and.callFake((icon, variant) => {
-      let iconType = 'fa';
+      fixture.detectChanges();
+    }
 
-      if (icon === 'variant-test') {
-        icon = 'variant-test-' + variant;
-        iconType = 'skyux';
-      }
+    beforeEach(() => {
+      mockResolver = jasmine.createSpyObj('mockResolver', ['resolveIcon']);
 
-      return {
-        icon,
-        iconType,
-      };
+      mockResolver.resolveIcon.and.callFake((icon, variant) => {
+        let iconType = 'fa';
+
+        if (icon === 'variant-test') {
+          icon = 'variant-test-' + variant;
+          iconType = 'skyux';
+        }
+
+        return {
+          icon,
+          iconType,
+        };
+      });
+
+      TestBed.configureTestingModule({
+        imports: [SkyIconFixturesModule],
+        providers: [
+          {
+            provide: SkyIconResolverService,
+            useValue: mockResolver,
+          },
+        ],
+      });
+
+      fixture = TestBed.createComponent(IconTestComponent);
+      cmp = fixture.componentInstance as IconTestComponent;
+      element = fixture.nativeElement as HTMLElement;
     });
 
-    TestBed.configureTestingModule({
-      imports: [SkyIconFixturesModule],
-      providers: [
-        {
-          provide: SkyIconResolverService,
-          useValue: mockResolver,
-        },
-      ],
+    it('should display an icon based on the given icon', async () => {
+      fixture.detectChanges();
+      expect(element.querySelector('.sky-icon')).toHaveCssClass('fa-circle');
+      expect(element.querySelector('.sky-icon')).toHaveCssClass('fa-3x');
+      expect(element.querySelector('.sky-icon')).not.toHaveCssClass('fa-fw');
+      expect(
+        element.querySelector('.sky-icon')?.getAttribute('aria-hidden'),
+      ).toBe('true');
+      expect(element.querySelector('.sky-icon')?.classList.length).toBe(4);
     });
 
-    fixture = TestBed.createComponent(IconTestComponent);
-    cmp = fixture.componentInstance as IconTestComponent;
-    element = fixture.nativeElement as HTMLElement;
+    it('should display a different icon with a different size and a fixedWidth', () => {
+      setupIcon('broom', undefined, '5x', true);
+
+      expect(cmp.icon).toBe('broom');
+      expect(element.querySelector('.sky-icon')).toHaveCssClass('fa-broom');
+      expect(element.querySelector('.sky-icon')).toHaveCssClass('fa-5x');
+      expect(element.querySelector('.sky-icon')).toHaveCssClass('fa-fw');
+      expect(element.querySelector('.sky-icon')?.classList.length).toBe(5);
+      expect(
+        element.querySelector('.sky-icon')?.getAttribute('aria-hidden'),
+      ).toBe('true');
+    });
+
+    it('should show an icon without optional inputs', () => {
+      setupIcon('spinner', undefined, undefined, undefined, undefined);
+
+      expect(element.querySelector('.sky-icon')).toHaveCssClass('fa-spinner');
+      expect(element.querySelector('.sky-icon')?.classList.length).toBe(3);
+    });
+
+    it('should display the specified variant', () => {
+      setupIcon('variant-test', 'skyux', undefined, undefined, 'solid');
+
+      expect(element.querySelector('.sky-icon')).toHaveCssClass(
+        'sky-i-variant-test-solid',
+      );
+    });
+
+    describe('a11y', () => {
+      it('should be accessible (icon: "close", iconType: undefined, size: undefined, fixedWidth: undefined/false, variant: undefined)', async () => {
+        setupIcon('close', undefined, undefined, undefined, undefined);
+
+        await expectAsync(fixture.nativeElement).toBeAccessible();
+      });
+
+      it('should be accessible (icon: "close", iconType: "fa", size: undefined, fixedWidth: undefined/false, variant: undefined)', async () => {
+        setupIcon('spinner', 'fa', undefined, undefined, undefined);
+
+        await expectAsync(fixture.nativeElement).toBeAccessible();
+      });
+
+      it('should be accessible (icon: "close", iconType: "skyux", size: undefined, fixedWidth: undefined/false, variant: undefined)', async () => {
+        setupIcon('close', 'skyux', undefined, undefined, undefined);
+
+        await expectAsync(fixture.nativeElement).toBeAccessible();
+      });
+
+      it('should be accessible (icon: "close", iconType: undefined, size: "3x", fixedWidth: undefined/false, variant: undefined)', async () => {
+        setupIcon('close', undefined, '3x', undefined, undefined);
+
+        await expectAsync(fixture.nativeElement).toBeAccessible();
+      });
+
+      it('should be accessible (icon: "close", iconType: "fa", size: "3x", fixedWidth: undefined/false, variant: undefined)', async () => {
+        setupIcon('close', 'fa', '3x', undefined, undefined);
+
+        await expectAsync(fixture.nativeElement).toBeAccessible();
+      });
+
+      it('should be accessible (icon: "close", iconType: "skyux", size: "3x", fixedWidth: undefined/false, variant: undefined)', async () => {
+        setupIcon('close', 'skyux', '3x', undefined, undefined);
+
+        await expectAsync(fixture.nativeElement).toBeAccessible();
+      });
+
+      it('should be accessible (icon: "close", iconType: undefined, size: undefined, fixedWidth: true, variant: undefined)', async () => {
+        setupIcon('close', undefined, undefined, true, undefined);
+
+        await expectAsync(fixture.nativeElement).toBeAccessible();
+      });
+
+      it('should be accessible (icon: "close", iconType: "fa", size: undefined, fixedWidth: true, variant: undefined)', async () => {
+        setupIcon('close', 'fa', undefined, true, undefined);
+
+        await expectAsync(fixture.nativeElement).toBeAccessible();
+      });
+
+      it('should be accessible (icon: "close", iconType: "skyux", size: undefined, fixedWidth: true, variant: undefined)', async () => {
+        setupIcon('close', 'skyux', undefined, true, undefined);
+
+        await expectAsync(fixture.nativeElement).toBeAccessible();
+      });
+
+      it('should be accessible (icon: "close", iconType: undefined, size: "3x", fixedWidth: true, variant: undefined)', async () => {
+        setupIcon('close', undefined, '3x', true, undefined);
+
+        await expectAsync(fixture.nativeElement).toBeAccessible();
+      });
+
+      it('should be accessible (icon: "close", iconType: "fa", size: "3x", fixedWidth: true, variant: undefined)', async () => {
+        setupIcon('close', 'fa', '3x', true, undefined);
+
+        await expectAsync(fixture.nativeElement).toBeAccessible();
+      });
+
+      it('should be accessible (icon: "close", iconType: "skyux", size: "3x", fixedWidth: true, variant: undefined)', async () => {
+        setupIcon('close', 'skyux', '3x', true, undefined);
+
+        await expectAsync(fixture.nativeElement).toBeAccessible();
+      });
+
+      it('should be accessible (icon: "info-circle", iconType: undefined, size: undefined, fixedWidth: undefined/false, variant: "solid")', async () => {
+        setupIcon('info-circle', undefined, undefined, undefined, 'solid');
+
+        await expectAsync(fixture.nativeElement).toBeAccessible();
+      });
+
+      it('should be accessible (icon: "info-circle", iconType: "fa", size: undefined, fixedWidth: undefined/false, variant: "solid")', async () => {
+        setupIcon('info-circle', 'fa', undefined, undefined, 'solid');
+
+        await expectAsync(fixture.nativeElement).toBeAccessible();
+      });
+
+      it('should be accessible (icon: "notification", iconType: "skyux", size: undefined, fixedWidth: undefined/false, variant: "solid")', async () => {
+        setupIcon('notification', 'skyux', undefined, undefined, 'solid');
+
+        await expectAsync(fixture.nativeElement).toBeAccessible();
+      });
+
+      it('should be accessible (icon: "info-circle", iconType: undefined, size: "3x", fixedWidth: undefined/false, variant: "solid")', async () => {
+        setupIcon('info-circle', undefined, '3x', undefined, 'solid');
+
+        await expectAsync(fixture.nativeElement).toBeAccessible();
+      });
+
+      it('should be accessible (icon: "info-circle", iconType: "fa", size: "3x", fixedWidth: undefined/false, variant: "solid")', async () => {
+        setupIcon('info-circle', 'fa', '3x', undefined, 'solid');
+
+        await expectAsync(fixture.nativeElement).toBeAccessible();
+      });
+
+      it('should be accessible (icon: "notification", iconType: "skyux", size: "3x", fixedWidth: undefined/false, variant: "solid")', async () => {
+        setupIcon('notification', 'skyux', '3x', undefined, 'solid');
+
+        await expectAsync(fixture.nativeElement).toBeAccessible();
+      });
+
+      it('should be accessible (icon: "info-circle", iconType: undefined, size: undefined, fixedWidth: true, variant: "solid")', async () => {
+        setupIcon('info-circle', undefined, undefined, true, 'solid');
+
+        await expectAsync(fixture.nativeElement).toBeAccessible();
+      });
+
+      it('should be accessible (icon: "info-circle", iconType: "fa", size: undefined, fixedWidth: true, variant: "solid")', async () => {
+        setupIcon('info-circle', 'fa', undefined, true, 'solid');
+
+        await expectAsync(fixture.nativeElement).toBeAccessible();
+      });
+
+      it('should be accessible (icon: "close", iconType: "skyux", size: undefined, fixedWidth: true, variant: "solid")', async () => {
+        setupIcon('notification', 'skyux', undefined, true, 'solid');
+
+        await expectAsync(fixture.nativeElement).toBeAccessible();
+      });
+
+      it('should be accessible (icon: "info-circle", iconType: undefined, size: "3x", fixedWidth: true, variant: "solid")', async () => {
+        setupIcon('info-circle', undefined, '3x', true, 'solid');
+
+        await expectAsync(fixture.nativeElement).toBeAccessible();
+      });
+
+      it('should be accessible (icon: "info-circle", iconType: "fa", size: "3x", fixedWidth: true, variant: "solid")', async () => {
+        setupIcon('info-circle', 'fa', '3x', true, 'solid');
+
+        await expectAsync(fixture.nativeElement).toBeAccessible();
+      });
+
+      it('should be accessible (icon: "notification", iconType: "skyux", size: "3x", fixedWidth: true, variant: "solid")', async () => {
+        setupIcon('notification', 'skyux', '3x', true, 'solid');
+
+        await expectAsync(fixture.nativeElement).toBeAccessible();
+      });
+
+      it('should be accessible (icon: "info-circle", iconType: undefined, size: undefined, fixedWidth: undefined/false, variant: "line")', async () => {
+        setupIcon('info-circle', undefined, undefined, undefined, 'line');
+
+        await expectAsync(fixture.nativeElement).toBeAccessible();
+      });
+
+      it('should be accessible (icon: "info-circle", iconType: "fa", size: undefined, fixedWidth: undefined/false, variant: "line")', async () => {
+        setupIcon('info-circle', 'fa', undefined, undefined, 'line');
+
+        await expectAsync(fixture.nativeElement).toBeAccessible();
+      });
+
+      it('should be accessible (icon: "notification", iconType: "skyux", size: undefined, fixedWidth: undefined/false, variant: "line")', async () => {
+        setupIcon('notification', 'skyux', undefined, undefined, 'line');
+
+        await expectAsync(fixture.nativeElement).toBeAccessible();
+      });
+
+      it('should be accessible (icon: "info-circle", iconType: undefined, size: "3x", fixedWidth: undefined/false, variant: "line")', async () => {
+        setupIcon('info-circle', undefined, '3x', undefined, 'line');
+
+        await expectAsync(fixture.nativeElement).toBeAccessible();
+      });
+
+      it('should be accessible (icon: "info-circle", iconType: "fa", size: "3x", fixedWidth: undefined/false, variant: "line")', async () => {
+        setupIcon('info-circle', 'fa', '3x', undefined, 'line');
+
+        await expectAsync(fixture.nativeElement).toBeAccessible();
+      });
+
+      it('should be accessible (icon: "notification", iconType: "skyux", size: "3x", fixedWidth: undefined/false, variant: "line")', async () => {
+        setupIcon('notification', 'skyux', '3x', undefined, 'line');
+
+        await expectAsync(fixture.nativeElement).toBeAccessible();
+      });
+
+      it('should be accessible (icon: "info-circle", iconType: undefined, size: undefined, fixedWidth: true, variant: "line")', async () => {
+        setupIcon('info-circle', undefined, undefined, true, 'line');
+
+        await expectAsync(fixture.nativeElement).toBeAccessible();
+      });
+
+      it('should be accessible (icon: "info-circle", iconType: "fa", size: undefined, fixedWidth: true, variant: "line")', async () => {
+        setupIcon('info-circle', 'fa', undefined, true, 'line');
+
+        await expectAsync(fixture.nativeElement).toBeAccessible();
+      });
+
+      it('should be accessible (icon: "close", iconType: "skyux", size: undefined, fixedWidth: true, variant: "line")', async () => {
+        setupIcon('notification', 'skyux', undefined, true, 'line');
+
+        await expectAsync(fixture.nativeElement).toBeAccessible();
+      });
+
+      it('should be accessible (icon: "info-circle", iconType: undefined, size: "3x", fixedWidth: true, variant: "line")', async () => {
+        setupIcon('info-circle', undefined, '3x', true, 'line');
+
+        await expectAsync(fixture.nativeElement).toBeAccessible();
+      });
+
+      it('should be accessible (icon: "info-circle", iconType: "fa", size: "3x", fixedWidth: true, variant: "line")', async () => {
+        setupIcon('info-circle', 'fa', '3x', true, 'line');
+
+        await expectAsync(fixture.nativeElement).toBeAccessible();
+      });
+
+      it('should be accessible (icon: "notification", iconType: "skyux", size: "3x", fixedWidth: true, variant: "line")', async () => {
+        setupIcon('notification', 'skyux', '3x', true, 'line');
+
+        await expectAsync(fixture.nativeElement).toBeAccessible();
+      });
+    });
   });
 
-  it('should display an icon based on the given icon', async () => {
-    fixture.detectChanges();
-    expect(element.querySelector('.sky-icon')).toHaveCssClass('fa-circle');
-    expect(element.querySelector('.sky-icon')).toHaveCssClass('fa-3x');
-    expect(element.querySelector('.sky-icon')).not.toHaveCssClass('fa-fw');
-    expect(
-      element.querySelector('.sky-icon')?.getAttribute('aria-hidden'),
-    ).toBe('true');
-    expect(element.querySelector('.sky-icon')?.classList.length).toBe(4);
-  });
+  describe('iconName', () => {
+    let resolverSvc: jasmine.SpyObj<SkyIconSvgResolverService>;
 
-  it('should display a different icon with a different size and a fixedWidth', () => {
-    setupIcon('broom', undefined, '5x', true);
+    function detectUrlChanges(): void {
+      fixture.detectChanges();
 
-    expect(cmp.icon).toBe('broom');
-    expect(element.querySelector('.sky-icon')).toHaveCssClass('fa-broom');
-    expect(element.querySelector('.sky-icon')).toHaveCssClass('fa-5x');
-    expect(element.querySelector('.sky-icon')).toHaveCssClass('fa-fw');
-    expect(element.querySelector('.sky-icon')?.classList.length).toBe(5);
-    expect(
-      element.querySelector('.sky-icon')?.getAttribute('aria-hidden'),
-    ).toBe('true');
-  });
+      // Resolve icon ID Observable and apply changes.
+      tick();
+      fixture.detectChanges();
+    }
 
-  it('should show an icon without optional inputs', () => {
-    setupIcon('spinner', undefined, undefined, undefined, undefined);
+    function getSvgEl(): SVGElement {
+      return fixture.nativeElement.querySelector('.sky-icon-svg-img');
+    }
 
-    expect(element.querySelector('.sky-icon')).toHaveCssClass('fa-spinner');
-    expect(element.querySelector('.sky-icon')?.classList.length).toBe(3);
-  });
+    function setupIcon(
+      iconName: string,
+      size?: string,
+      variant?: SkyIconVariantType,
+    ): void {
+      cmp.iconName = iconName;
+      cmp.size = size;
+      cmp.variant = variant;
 
-  it('should display the specified variant', () => {
-    setupIcon('variant-test', 'skyux', undefined, undefined, 'solid');
+      fixture.detectChanges();
+    }
 
-    expect(element.querySelector('.sky-icon')).toHaveCssClass(
-      'sky-i-variant-test-solid',
-    );
-  });
+    function validateIconId(expectedId: string): void {
+      const useEl = getSvgEl().querySelector<SVGUseElement>('use');
 
-  describe('a11y', () => {
-    it('should be accessible (icon: "close", iconType: undefined, size: undefined, fixedWidth: undefined/false, variant: undefined)', async () => {
-      setupIcon('close', undefined, undefined, undefined, undefined);
+      expect(useEl?.href.baseVal).toBe(expectedId);
+    }
 
-      await expectAsync(fixture.nativeElement).toBeAccessible();
+    beforeEach(() => {
+      resolverSvc = jasmine.createSpyObj<SkyIconSvgResolverService>(
+        'SkyIconSvgResolverService',
+        ['resolveHref'],
+      );
+
+      resolverSvc.resolveHref.and.callFake((src, size, variant) => {
+        return Promise.resolve(`#${src}-${size}-${variant ?? 'line'}`);
+      });
+
+      TestBed.configureTestingModule({
+        imports: [SkyIconFixturesModule],
+        providers: [
+          {
+            provide: SkyIconSvgResolverService,
+            useValue: resolverSvc,
+          },
+        ],
+      });
+
+      fixture = TestBed.createComponent(IconTestComponent);
+      cmp = fixture.componentInstance;
     });
 
-    it('should be accessible (icon: "close", iconType: "fa", size: undefined, fixedWidth: undefined/false, variant: undefined)', async () => {
-      setupIcon('spinner', 'fa', undefined, undefined, undefined);
+    it('should display the resolved icon by ID', fakeAsync(() => {
+      setupIcon('test', undefined, undefined);
+      detectUrlChanges();
 
-      await expectAsync(fixture.nativeElement).toBeAccessible();
-    });
+      validateIconId('#test-16-line');
+    }));
 
-    it('should be accessible (icon: "close", iconType: "skyux", size: undefined, fixedWidth: undefined/false, variant: undefined)', async () => {
-      setupIcon('close', 'skyux', undefined, undefined, undefined);
+    it('should display the resolved icon by ID and size', fakeAsync(() => {
+      setupIcon('test', '2x', undefined);
+      detectUrlChanges();
 
-      await expectAsync(fixture.nativeElement).toBeAccessible();
-    });
+      validateIconId('#test-32-line');
+    }));
 
-    it('should be accessible (icon: "close", iconType: undefined, size: "3x", fixedWidth: undefined/false, variant: undefined)', async () => {
-      setupIcon('close', undefined, '3x', undefined, undefined);
+    it('should display the resolved icon by ID and variant', fakeAsync(() => {
+      setupIcon('test', undefined, 'solid');
+      detectUrlChanges();
 
-      await expectAsync(fixture.nativeElement).toBeAccessible();
-    });
+      validateIconId('#test-16-solid');
+    }));
 
-    it('should be accessible (icon: "close", iconType: "fa", size: "3x", fixedWidth: undefined/false, variant: undefined)', async () => {
-      setupIcon('close', 'fa', '3x', undefined, undefined);
+    it('should display the resolved icon by ID, size, and variant', fakeAsync(() => {
+      setupIcon('test', '2x', 'solid');
+      detectUrlChanges();
 
-      await expectAsync(fixture.nativeElement).toBeAccessible();
-    });
+      validateIconId('#test-32-solid');
+    }));
 
-    it('should be accessible (icon: "close", iconType: "skyux", size: "3x", fixedWidth: undefined/false, variant: undefined)', async () => {
-      setupIcon('close', 'skyux', '3x', undefined, undefined);
+    describe('a11y', () => {
+      it('should be accessible (icon: "test", size: undefined, variant: undefined)', async () => {
+        setupIcon('test', undefined, undefined);
 
-      await expectAsync(fixture.nativeElement).toBeAccessible();
-    });
+        await expectAsync(fixture.nativeElement).toBeAccessible();
+      });
 
-    it('should be accessible (icon: "close", iconType: undefined, size: undefined, fixedWidth: true, variant: undefined)', async () => {
-      setupIcon('close', undefined, undefined, true, undefined);
+      it('should be accessible (icon: "test", size: 2x, variant: undefined)', async () => {
+        setupIcon('test', '2x', undefined);
 
-      await expectAsync(fixture.nativeElement).toBeAccessible();
-    });
+        await expectAsync(fixture.nativeElement).toBeAccessible();
+      });
 
-    it('should be accessible (icon: "close", iconType: "fa", size: undefined, fixedWidth: true, variant: undefined)', async () => {
-      setupIcon('close', 'fa', undefined, true, undefined);
+      it('should be accessible (icon: "test", size: undefined, variant: "solid")', async () => {
+        setupIcon('test', undefined, 'solid');
 
-      await expectAsync(fixture.nativeElement).toBeAccessible();
-    });
+        await expectAsync(fixture.nativeElement).toBeAccessible();
+      });
 
-    it('should be accessible (icon: "close", iconType: "skyux", size: undefined, fixedWidth: true, variant: undefined)', async () => {
-      setupIcon('close', 'skyux', undefined, true, undefined);
+      it('should be accessible (icon: "test", size: undefined, variant: "line")', async () => {
+        setupIcon('test', undefined, 'line');
 
-      await expectAsync(fixture.nativeElement).toBeAccessible();
-    });
+        await expectAsync(fixture.nativeElement).toBeAccessible();
+      });
 
-    it('should be accessible (icon: "close", iconType: undefined, size: "3x", fixedWidth: true, variant: undefined)', async () => {
-      setupIcon('close', undefined, '3x', true, undefined);
+      it('should be accessible (icon: "test", size: 2x, variant: "solid")', async () => {
+        setupIcon('test', '2x', 'solid');
 
-      await expectAsync(fixture.nativeElement).toBeAccessible();
-    });
+        await expectAsync(fixture.nativeElement).toBeAccessible();
+      });
 
-    it('should be accessible (icon: "close", iconType: "fa", size: "3x", fixedWidth: true, variant: undefined)', async () => {
-      setupIcon('close', 'fa', '3x', true, undefined);
+      it('should be accessible (icon: "test", size: 2x, variant: "line")', async () => {
+        setupIcon('test', '2x', 'line');
 
-      await expectAsync(fixture.nativeElement).toBeAccessible();
-    });
-
-    it('should be accessible (icon: "close", iconType: "skyux", size: "3x", fixedWidth: true, variant: undefined)', async () => {
-      setupIcon('close', 'skyux', '3x', true, undefined);
-
-      await expectAsync(fixture.nativeElement).toBeAccessible();
-    });
-
-    it('should be accessible (icon: "info-circle", iconType: undefined, size: undefined, fixedWidth: undefined/false, variant: "solid")', async () => {
-      setupIcon('info-circle', undefined, undefined, undefined, 'solid');
-
-      await expectAsync(fixture.nativeElement).toBeAccessible();
-    });
-
-    it('should be accessible (icon: "info-circle", iconType: "fa", size: undefined, fixedWidth: undefined/false, variant: "solid")', async () => {
-      setupIcon('info-circle', 'fa', undefined, undefined, 'solid');
-
-      await expectAsync(fixture.nativeElement).toBeAccessible();
-    });
-
-    it('should be accessible (icon: "notification", iconType: "skyux", size: undefined, fixedWidth: undefined/false, variant: "solid")', async () => {
-      setupIcon('notification', 'skyux', undefined, undefined, 'solid');
-
-      await expectAsync(fixture.nativeElement).toBeAccessible();
-    });
-
-    it('should be accessible (icon: "info-circle", iconType: undefined, size: "3x", fixedWidth: undefined/false, variant: "solid")', async () => {
-      setupIcon('info-circle', undefined, '3x', undefined, 'solid');
-
-      await expectAsync(fixture.nativeElement).toBeAccessible();
-    });
-
-    it('should be accessible (icon: "info-circle", iconType: "fa", size: "3x", fixedWidth: undefined/false, variant: "solid")', async () => {
-      setupIcon('info-circle', 'fa', '3x', undefined, 'solid');
-
-      await expectAsync(fixture.nativeElement).toBeAccessible();
-    });
-
-    it('should be accessible (icon: "notification", iconType: "skyux", size: "3x", fixedWidth: undefined/false, variant: "solid")', async () => {
-      setupIcon('notification', 'skyux', '3x', undefined, 'solid');
-
-      await expectAsync(fixture.nativeElement).toBeAccessible();
-    });
-
-    it('should be accessible (icon: "info-circle", iconType: undefined, size: undefined, fixedWidth: true, variant: "solid")', async () => {
-      setupIcon('info-circle', undefined, undefined, true, 'solid');
-
-      await expectAsync(fixture.nativeElement).toBeAccessible();
-    });
-
-    it('should be accessible (icon: "info-circle", iconType: "fa", size: undefined, fixedWidth: true, variant: "solid")', async () => {
-      setupIcon('info-circle', 'fa', undefined, true, 'solid');
-
-      await expectAsync(fixture.nativeElement).toBeAccessible();
-    });
-
-    it('should be accessible (icon: "close", iconType: "skyux", size: undefined, fixedWidth: true, variant: "solid")', async () => {
-      setupIcon('notification', 'skyux', undefined, true, 'solid');
-
-      await expectAsync(fixture.nativeElement).toBeAccessible();
-    });
-
-    it('should be accessible (icon: "info-circle", iconType: undefined, size: "3x", fixedWidth: true, variant: "solid")', async () => {
-      setupIcon('info-circle', undefined, '3x', true, 'solid');
-
-      await expectAsync(fixture.nativeElement).toBeAccessible();
-    });
-
-    it('should be accessible (icon: "info-circle", iconType: "fa", size: "3x", fixedWidth: true, variant: "solid")', async () => {
-      setupIcon('info-circle', 'fa', '3x', true, 'solid');
-
-      await expectAsync(fixture.nativeElement).toBeAccessible();
-    });
-
-    it('should be accessible (icon: "notification", iconType: "skyux", size: "3x", fixedWidth: true, variant: "solid")', async () => {
-      setupIcon('notification', 'skyux', '3x', true, 'solid');
-
-      await expectAsync(fixture.nativeElement).toBeAccessible();
-    });
-
-    it('should be accessible (icon: "info-circle", iconType: undefined, size: undefined, fixedWidth: undefined/false, variant: "line")', async () => {
-      setupIcon('info-circle', undefined, undefined, undefined, 'line');
-
-      await expectAsync(fixture.nativeElement).toBeAccessible();
-    });
-
-    it('should be accessible (icon: "info-circle", iconType: "fa", size: undefined, fixedWidth: undefined/false, variant: "line")', async () => {
-      setupIcon('info-circle', 'fa', undefined, undefined, 'line');
-
-      await expectAsync(fixture.nativeElement).toBeAccessible();
-    });
-
-    it('should be accessible (icon: "notification", iconType: "skyux", size: undefined, fixedWidth: undefined/false, variant: "line")', async () => {
-      setupIcon('notification', 'skyux', undefined, undefined, 'line');
-
-      await expectAsync(fixture.nativeElement).toBeAccessible();
-    });
-
-    it('should be accessible (icon: "info-circle", iconType: undefined, size: "3x", fixedWidth: undefined/false, variant: "line")', async () => {
-      setupIcon('info-circle', undefined, '3x', undefined, 'line');
-
-      await expectAsync(fixture.nativeElement).toBeAccessible();
-    });
-
-    it('should be accessible (icon: "info-circle", iconType: "fa", size: "3x", fixedWidth: undefined/false, variant: "line")', async () => {
-      setupIcon('info-circle', 'fa', '3x', undefined, 'line');
-
-      await expectAsync(fixture.nativeElement).toBeAccessible();
-    });
-
-    it('should be accessible (icon: "notification", iconType: "skyux", size: "3x", fixedWidth: undefined/false, variant: "line")', async () => {
-      setupIcon('notification', 'skyux', '3x', undefined, 'line');
-
-      await expectAsync(fixture.nativeElement).toBeAccessible();
-    });
-
-    it('should be accessible (icon: "info-circle", iconType: undefined, size: undefined, fixedWidth: true, variant: "line")', async () => {
-      setupIcon('info-circle', undefined, undefined, true, 'line');
-
-      await expectAsync(fixture.nativeElement).toBeAccessible();
-    });
-
-    it('should be accessible (icon: "info-circle", iconType: "fa", size: undefined, fixedWidth: true, variant: "line")', async () => {
-      setupIcon('info-circle', 'fa', undefined, true, 'line');
-
-      await expectAsync(fixture.nativeElement).toBeAccessible();
-    });
-
-    it('should be accessible (icon: "close", iconType: "skyux", size: undefined, fixedWidth: true, variant: "line")', async () => {
-      setupIcon('notification', 'skyux', undefined, true, 'line');
-
-      await expectAsync(fixture.nativeElement).toBeAccessible();
-    });
-
-    it('should be accessible (icon: "info-circle", iconType: undefined, size: "3x", fixedWidth: true, variant: "line")', async () => {
-      setupIcon('info-circle', undefined, '3x', true, 'line');
-
-      await expectAsync(fixture.nativeElement).toBeAccessible();
-    });
-
-    it('should be accessible (icon: "info-circle", iconType: "fa", size: "3x", fixedWidth: true, variant: "line")', async () => {
-      setupIcon('info-circle', 'fa', '3x', true, 'line');
-
-      await expectAsync(fixture.nativeElement).toBeAccessible();
-    });
-
-    it('should be accessible (icon: "notification", iconType: "skyux", size: "3x", fixedWidth: true, variant: "line")', async () => {
-      setupIcon('notification', 'skyux', '3x', true, 'line');
-
-      await expectAsync(fixture.nativeElement).toBeAccessible();
+        await expectAsync(fixture.nativeElement).toBeAccessible();
+      });
     });
   });
 });


### PR DESCRIPTION
:cherries: Cherry picked from #2688 [fix(components/icon): variant input is respected for SVG-based icons](https://github.com/blackbaud/skyux/pull/2688)