### PR TITLE
fix(components/modals): modal footers do not reserve space when an emtpy form error array is provided

### DIFF
--- a/libs/components/modals/src/lib/modules/modal/modal-footer.component.html
+++ b/libs/components/modals/src/lib/modules/modal/modal-footer.component.html
@@ -1,21 +1,23 @@
 <div class="sky-modal-footer-container sky-padding-even-large">
   <div aria-live="polite">
     @if (errorsSvc.formErrors | async; as formErrors) {
-      <div class="sky-modal-footer-errors sky-margin-stacked-lg">
-        @for (formError of formErrors; track formError) {
-          <sky-status-indicator
-            descriptionType="error"
-            indicatorType="danger"
-            [ngClass]="{
-              'sky-margin-stacked-lg':
-                formErrors.indexOf(formError) < formErrors.length - 1,
-              'footer-error': true
-            }"
-          >
-            {{ formError.message }}
-          </sky-status-indicator>
-        }
-      </div>
+      @if (formErrors.length > 0) {
+        <div class="sky-modal-footer-errors sky-margin-stacked-lg">
+          @for (formError of formErrors; track formError) {
+            <sky-status-indicator
+              descriptionType="error"
+              indicatorType="danger"
+              [ngClass]="{
+                'sky-margin-stacked-lg':
+                  formErrors.indexOf(formError) < formErrors.length - 1,
+                'footer-error': true
+              }"
+            >
+              {{ formError.message }}
+            </sky-status-indicator>
+          }
+        </div>
+      }
     }
   </div>
   <ng-content />

--- a/libs/components/modals/src/lib/modules/modal/modal.component.spec.ts
+++ b/libs/components/modals/src/lib/modules/modal/modal.component.spec.ts
@@ -1044,12 +1044,24 @@ describe('Modal component', () => {
       { message: 'Test error 2' },
     ];
 
+    let errorsComponent = document.querySelector('.sky-modal-footer-errors');
     let errorEls = document.querySelectorAll('.sky-status-indicator');
+    expect(errorsComponent).toBeNull();
+    expect(errorEls.length).toBe(0);
+
+    modalInstance.componentInstance.errors = [];
+    getApplicationRef().tick();
+
+    errorsComponent = document.querySelector('.sky-modal-footer-errors');
+    errorEls = document.querySelectorAll('.sky-status-indicator');
+    expect(errorsComponent).toBeNull();
     expect(errorEls.length).toBe(0);
 
     modalInstance.componentInstance.errors = errors;
     getApplicationRef().tick();
 
+    errorsComponent = document.querySelector('.sky-modal-footer-errors');
+    expect(errorsComponent).not.toBeNull();
     errorEls = document.querySelectorAll('.sky-status-indicator');
     errorEls.forEach((el, i) => {
       expect(el.textContent).toEqual(` Error: ${errors[i].message}`);


### PR DESCRIPTION
[AB#3053670](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3053670)

BEGIN_COMMIT_OVERRIDE
fix(components/modals): modal footers do not reserve space when an empty form error array is provided (#2730)
END_COMMIT_OVERRIDE