### PR TITLE
fix(sdk/eslint-config): alternatively look for `angular-eslint` dependency

### DIFF
--- a/libs/sdk/eslint-config/src/schematics/ng-add/ng-add.schematic.spec.ts
+++ b/libs/sdk/eslint-config/src/schematics/ng-add/ng-add.schematic.spec.ts
@@ -139,10 +139,24 @@ describe('ng-add.schematic', () => {
     });
 
     await expect(() => runSchematic()).rejects.toThrowError(
-      "The package '@angular-eslint/schematics' is not installed. " +
+      "The package 'angular-eslint' is not installed. " +
         "Run 'ng add @angular-eslint/schematics' and try this command again.\n" +
         'See: https://github.com/angular-eslint/angular-eslint#quick-start',
     );
+  });
+
+  it("should not abort if 'angular-eslint' is installed", async () => {
+    const { runSchematic, tree } = await setupTest({
+      esLintConfig: {},
+      packageJson: {
+        devDependencies: {
+          'angular-eslint': '*',
+        },
+      },
+    });
+
+    await runSchematic();
+    expect(readJsonFile(tree, ESLINT_CONFIG_PATH)).toEqual({});
   });
 
   it('should harden the version of the @skyux-sdk/eslint-config package', async () => {

--- a/libs/sdk/eslint-config/src/schematics/ng-add/ng-add.schematic.ts
+++ b/libs/sdk/eslint-config/src/schematics/ng-add/ng-add.schematic.ts
@@ -30,9 +30,12 @@ export default function ngAdd(): Rule {
   return (tree) => {
     const packageJson = getPackageJson(tree);
 
-    if (!packageJson.devDependencies?.['@angular-eslint/schematics']) {
+    if (
+      !packageJson.devDependencies?.['@angular-eslint/schematics'] &&
+      !packageJson.devDependencies?.['angular-eslint']
+    ) {
       throw new Error(
-        "The package '@angular-eslint/schematics' is not installed. " +
+        "The package 'angular-eslint' is not installed. " +
           "Run 'ng add @angular-eslint/schematics' and try this command again.\n" +
           'See: https://github.com/angular-eslint/angular-eslint#quick-start',
       );


### PR DESCRIPTION
With v18, `angular-eslint` has direct dependencies on the `@angular-eslint` packages, and the schematic only adds `angular-eslint` as a dependency.