### PR TITLE
fix(components/colorpicker): set `aria-expanded` to false when closed with `cancel` button

### DIFF
--- a/libs/components/colorpicker/src/lib/modules/colorpicker/colorpicker.component.spec.ts
+++ b/libs/components/colorpicker/src/lib/modules/colorpicker/colorpicker.component.spec.ts
@@ -842,6 +842,28 @@ describe('Colorpicker Component', () => {
       verifyColorpicker(nativeElement, '#2b7230', '43, 114, 48');
     }));
 
+    it('should set aria-expanded appropriately when closed with `cancel` button', fakeAsync(() => {
+      const colorpickerButton = getColorpickerButton(nativeElement);
+      expect(colorpickerButton.getAttribute('aria-expanded')).toBeFalsy();
+
+      openColorpicker(nativeElement);
+      expect(colorpickerButton.getAttribute('aria-expanded')).toBe('true');
+
+      closeColorpicker(nativeElement, fixture);
+      expect(colorpickerButton.getAttribute('aria-expanded')).toBe('false');
+    }));
+
+    it('should set aria-expanded appropriately when closed with `apply` button', fakeAsync(() => {
+      const colorpickerButton = getColorpickerButton(nativeElement);
+      expect(colorpickerButton.getAttribute('aria-expanded')).toBeFalsy();
+
+      openColorpicker(nativeElement);
+      expect(colorpickerButton.getAttribute('aria-expanded')).toBe('true');
+
+      applyColorpicker();
+      expect(colorpickerButton.getAttribute('aria-expanded')).toBe('false');
+    }));
+
     it('should emit a selectedColorChanged and selectedColorApplied event on submit', fakeAsync(() => {
       spyOn(
         component.colorpickerComponent.selectedColorChanged,

--- a/libs/components/colorpicker/src/lib/modules/colorpicker/colorpicker.component.ts
+++ b/libs/components/colorpicker/src/lib/modules/colorpicker/colorpicker.component.ts
@@ -545,6 +545,8 @@ export class SkyColorpickerComponent
     // Revert picker values back to previous color.
     this.updatePickerValues(this.backgroundColorForDisplay);
     this.closePicker();
+
+    this.#changeDetector.markForCheck();
   }
 
   public onPresetClick(value: string): void {


### PR DESCRIPTION
[AB#3091564](https://dev.azure.com/blackbaud/Products/_boards/board/t/SKY%20UX%20Program/Stories/?workitem=3091564)