### PR TITLE
fix: run schematic to set VSCode plugin setting to not expect flat configs for ESLint 9 which was included in `11.x.x`

### DIFF
--- a/libs/components/packages/src/schematics/migrations/migration-collection.json
+++ b/libs/components/packages/src/schematics/migrations/migration-collection.json
@@ -61,7 +61,7 @@
       "description": "Remove ESLint deprecation plugin which is not compatible with ESLint 9."
     },
     "vscode-eslint-setting": {
-      "version": "11.10.0",
+      "version": "11.11.1",
       "factory": "./update-11/vscode-eslint-setting/vscode-eslint-setting.schematic",
       "description": "Update the VSCode workspace's settings so that the ESLint plugin works with ESLint 9 and a legacy config"
     }

--- a/libs/components/packages/src/schematics/migrations/migration-collection.json
+++ b/libs/components/packages/src/schematics/migrations/migration-collection.json
@@ -59,6 +59,11 @@
       "version": "11.2.0",
       "factory": "./update-11/remove-deprecation-eslint-plugin/remove-deprecation-eslint-plugin.schematic",
       "description": "Remove ESLint deprecation plugin which is not compatible with ESLint 9."
+    },
+    "vscode-eslint-setting": {
+      "version": "11.10.0",
+      "factory": "./update-11/vscode-eslint-setting/vscode-eslint-setting.schematic",
+      "description": "Update the VSCode workspace's settings so that the ESLint plugin works with ESLint 9 and a legacy config"
     }
   }
 }

--- a/libs/components/packages/src/schematics/migrations/update-11/vscode-eslint-setting/vscode-eslint-setting.schematic.spec.ts
+++ b/libs/components/packages/src/schematics/migrations/update-11/vscode-eslint-setting/vscode-eslint-setting.schematic.spec.ts
@@ -1,0 +1,261 @@
+import { Tree } from '@angular-devkit/schematics';
+import {
+  SchematicTestRunner,
+  UnitTestTree,
+} from '@angular-devkit/schematics/testing';
+
+describe('vscode-eslint-setting.schematic', () => {
+  const possibleLegacyConfigFiles = [
+    '.eslintrc.js',
+    '.eslintrc.cjs',
+    '.eslintrc.yaml',
+    '.eslintrc.yml',
+    '.eslintrc.json',
+  ];
+
+  possibleLegacyConfigFiles.forEach((possibleLegacyConfigFile) => {
+    it(`should run successfully (config: ${possibleLegacyConfigFile}, existingSettings: false)`, async () => {
+      const collectionPath = require.resolve('../../migration-collection.json');
+      jest.mock('child_process', () => ({
+        execSync: jest.fn(),
+      }));
+      const runner = new SchematicTestRunner('schematics', collectionPath);
+      const tree = new UnitTestTree(Tree.empty());
+      tree.create(possibleLegacyConfigFile, 'TESTING');
+      await runner.runSchematic('vscode-eslint-setting', undefined, tree);
+      expect(tree.readJson('.vscode/settings.json')).toEqual({
+        'eslint.useFlatConfig': false,
+      });
+    });
+
+    it(`should run successfully (config: ${possibleLegacyConfigFile}, existingSettings: true)`, async () => {
+      const collectionPath = require.resolve('../../migration-collection.json');
+      jest.mock('child_process', () => ({
+        execSync: jest.fn(),
+      }));
+      const runner = new SchematicTestRunner('schematics', collectionPath);
+      const tree = new UnitTestTree(Tree.empty());
+      tree.create(possibleLegacyConfigFile, 'TESTING');
+      tree.create('.vscode/settings.json', '{ "cSpell.enabled": true }');
+      await runner.runSchematic('vscode-eslint-setting', undefined, tree);
+      expect(tree.readJson('.vscode/settings.json')).toEqual({
+        'eslint.useFlatConfig': false,
+        'cSpell.enabled': true,
+      });
+    });
+
+    it(`should run successfully (config: ${possibleLegacyConfigFile}, existingSettings: true w/ plugin setting)`, async () => {
+      const collectionPath = require.resolve('../../migration-collection.json');
+      jest.mock('child_process', () => ({
+        execSync: jest.fn(),
+      }));
+      const runner = new SchematicTestRunner('schematics', collectionPath);
+      const tree = new UnitTestTree(Tree.empty());
+      tree.create(possibleLegacyConfigFile, 'TESTING');
+      tree.create(
+        '.vscode/settings.json',
+        '{ "cSpell.enabled": true, "eslint.useFlatConfig": false }',
+      );
+      await runner.runSchematic('vscode-eslint-setting', undefined, tree);
+      expect(tree.readJson('.vscode/settings.json')).toEqual({
+        'eslint.useFlatConfig': false,
+        'cSpell.enabled': true,
+      });
+    });
+  });
+
+  it(`should run successfully (config: package.json with config, existingSettings: false)`, async () => {
+    const collectionPath = require.resolve('../../migration-collection.json');
+    jest.mock('child_process', () => ({
+      execSync: jest.fn(),
+    }));
+    const packageJsonContents = {
+      eslintConfig: {},
+    };
+    const runner = new SchematicTestRunner('schematics', collectionPath);
+    const tree = new UnitTestTree(Tree.empty());
+    tree.create('/package.json', JSON.stringify(packageJsonContents));
+    await runner.runSchematic('vscode-eslint-setting', undefined, tree);
+    expect(tree.readJson('.vscode/settings.json')).toEqual({
+      'eslint.useFlatConfig': false,
+    });
+  });
+
+  it(`should run successfully (config: package.json with config, existingSettings: true)`, async () => {
+    const collectionPath = require.resolve('../../migration-collection.json');
+    jest.mock('child_process', () => ({
+      execSync: jest.fn(),
+    }));
+    const packageJsonContents = {
+      eslintConfig: {},
+    };
+    const runner = new SchematicTestRunner('schematics', collectionPath);
+    const tree = new UnitTestTree(Tree.empty());
+    tree.create('/package.json', JSON.stringify(packageJsonContents));
+    tree.create('.vscode/settings.json', '{ "cSpell.enabled": true }');
+    await runner.runSchematic('vscode-eslint-setting', undefined, tree);
+    expect(tree.readJson('.vscode/settings.json')).toEqual({
+      'eslint.useFlatConfig': false,
+      'cSpell.enabled': true,
+    });
+  });
+
+  it(`should run successfully (config: package.json with config, existingSettings: true w/ plugin setting)`, async () => {
+    const collectionPath = require.resolve('../../migration-collection.json');
+    jest.mock('child_process', () => ({
+      execSync: jest.fn(),
+    }));
+    const packageJsonContents = {
+      eslintConfig: {},
+    };
+    const runner = new SchematicTestRunner('schematics', collectionPath);
+    const tree = new UnitTestTree(Tree.empty());
+    tree.create('/package.json', JSON.stringify(packageJsonContents));
+    tree.create(
+      '.vscode/settings.json',
+      '{ "cSpell.enabled": true, "eslint.useFlatConfig": false }',
+    );
+    await runner.runSchematic('vscode-eslint-setting', undefined, tree);
+    expect(tree.readJson('.vscode/settings.json')).toEqual({
+      'eslint.useFlatConfig': false,
+      'cSpell.enabled': true,
+    });
+  });
+
+  it(`should run successfully (config: package.json with no config, existingSettings: false)`, async () => {
+    const collectionPath = require.resolve('../../migration-collection.json');
+    jest.mock('child_process', () => ({
+      execSync: jest.fn(),
+    }));
+    const packageJsonContents = {
+      dependencies: {},
+    };
+    const runner = new SchematicTestRunner('schematics', collectionPath);
+    const tree = new UnitTestTree(Tree.empty());
+    tree.create('/package.json', JSON.stringify(packageJsonContents));
+    await runner.runSchematic('vscode-eslint-setting', undefined, tree);
+    expect(tree.exists('.vscode/settings.json')).toBeFalsy();
+  });
+
+  it(`should run successfully (config: package.json with no config, existingSettings: true w/ plugin setting)`, async () => {
+    const collectionPath = require.resolve('../../migration-collection.json');
+    jest.mock('child_process', () => ({
+      execSync: jest.fn(),
+    }));
+    const packageJsonContents = {
+      dependencies: {},
+    };
+    const runner = new SchematicTestRunner('schematics', collectionPath);
+    const tree = new UnitTestTree(Tree.empty());
+    tree.create('/package.json', JSON.stringify(packageJsonContents));
+    tree.create(
+      '.vscode/settings.json',
+      '{ "cSpell.enabled": true, "eslint.useFlatConfig": false }',
+    );
+    await runner.runSchematic('vscode-eslint-setting', undefined, tree);
+    expect(tree.readJson('.vscode/settings.json')).toEqual({
+      'eslint.useFlatConfig': false,
+      'cSpell.enabled': true,
+    });
+  });
+
+  it(`should run successfully (config: none, existingSettings: false)`, async () => {
+    const collectionPath = require.resolve('../../migration-collection.json');
+    jest.mock('child_process', () => ({
+      execSync: jest.fn(),
+    }));
+    const runner = new SchematicTestRunner('schematics', collectionPath);
+    const tree = new UnitTestTree(Tree.empty());
+    await runner.runSchematic('vscode-eslint-setting', undefined, tree);
+    expect(tree.exists('.vscode/settings.json')).toBeFalsy();
+  });
+
+  it(`should run successfully (config: none, existingSettings: true)`, async () => {
+    const collectionPath = require.resolve('../../migration-collection.json');
+    jest.mock('child_process', () => ({
+      execSync: jest.fn(),
+    }));
+    const runner = new SchematicTestRunner('schematics', collectionPath);
+    const tree = new UnitTestTree(Tree.empty());
+    tree.create('.vscode/settings.json', '{ "cSpell.enabled": true }');
+    await runner.runSchematic('vscode-eslint-setting', undefined, tree);
+    expect(tree.readJson('.vscode/settings.json')).toEqual({
+      'cSpell.enabled': true,
+    });
+  });
+
+  it(`should run successfully (config: none, existingSettings: true w/ plugin setting)`, async () => {
+    const collectionPath = require.resolve('../../migration-collection.json');
+    jest.mock('child_process', () => ({
+      execSync: jest.fn(),
+    }));
+    const runner = new SchematicTestRunner('schematics', collectionPath);
+    const tree = new UnitTestTree(Tree.empty());
+    tree.create(
+      '.vscode/settings.json',
+      '{ "cSpell.enabled": true, "eslint.useFlatConfig": false }',
+    );
+    await runner.runSchematic('vscode-eslint-setting', undefined, tree);
+    expect(tree.readJson('.vscode/settings.json')).toEqual({
+      'eslint.useFlatConfig': false,
+      'cSpell.enabled': true,
+    });
+  });
+
+  const possibleFlatConfigFiles = [
+    'eslint.config.js',
+    'eslint.config.mjs',
+    'eslint.config.cjs',
+    'eslint.config.ts',
+    'eslint.config.mts',
+    'eslint.config.cts',
+  ];
+
+  possibleFlatConfigFiles.forEach((possibleFlatConfigFile) => {
+    it(`should run successfully (config: ${possibleFlatConfigFile}, existingSettings: false)`, async () => {
+      const collectionPath = require.resolve('../../migration-collection.json');
+      jest.mock('child_process', () => ({
+        execSync: jest.fn(),
+      }));
+      const runner = new SchematicTestRunner('schematics', collectionPath);
+      const tree = new UnitTestTree(Tree.empty());
+      tree.create(possibleFlatConfigFile, 'TESTING');
+      await runner.runSchematic('vscode-eslint-setting', undefined, tree);
+      expect(tree.exists('.vscode/settings.json')).toBeFalsy();
+    });
+
+    it(`should run successfully (config: ${possibleFlatConfigFile}, existingSettings: true)`, async () => {
+      const collectionPath = require.resolve('../../migration-collection.json');
+      jest.mock('child_process', () => ({
+        execSync: jest.fn(),
+      }));
+      const runner = new SchematicTestRunner('schematics', collectionPath);
+      const tree = new UnitTestTree(Tree.empty());
+      tree.create(possibleFlatConfigFile, 'TESTING');
+      tree.create('.vscode/settings.json', '{ "cSpell.enabled": true }');
+      await runner.runSchematic('vscode-eslint-setting', undefined, tree);
+      expect(tree.readJson('.vscode/settings.json')).toEqual({
+        'cSpell.enabled': true,
+      });
+    });
+
+    it(`should run successfully (config: ${possibleFlatConfigFile}, existingSettings: true w/ plugin setting)`, async () => {
+      const collectionPath = require.resolve('../../migration-collection.json');
+      jest.mock('child_process', () => ({
+        execSync: jest.fn(),
+      }));
+      const runner = new SchematicTestRunner('schematics', collectionPath);
+      const tree = new UnitTestTree(Tree.empty());
+      tree.create(possibleFlatConfigFile, 'TESTING');
+      tree.create(
+        '.vscode/settings.json',
+        '{ "cSpell.enabled": true, "eslint.useFlatConfig": true }',
+      );
+      await runner.runSchematic('vscode-eslint-setting', undefined, tree);
+      expect(tree.readJson('.vscode/settings.json')).toEqual({
+        'eslint.useFlatConfig': true,
+        'cSpell.enabled': true,
+      });
+    });
+  });
+});

--- a/libs/components/packages/src/schematics/migrations/update-11/vscode-eslint-setting/vscode-eslint-setting.schematic.ts
+++ b/libs/components/packages/src/schematics/migrations/update-11/vscode-eslint-setting/vscode-eslint-setting.schematic.ts
@@ -2,11 +2,14 @@ import { Rule, Tree } from '@angular-devkit/schematics';
 
 import { readRequiredFile, writeJsonFile } from '../../../utility/tree';
 
+const packageJsonPath = '/package.json';
+const vscodeSettingsPath = '.vscode/settings.json';
+
 function getVSCodeSettings(tree: Tree): {
   'eslint.useFlatConfig'?: boolean;
 } {
-  if (tree.exists('.vscode/settings.json')) {
-    return JSON.parse(readRequiredFile(tree, '.vscode/settings.json'));
+  if (tree.exists(vscodeSettingsPath)) {
+    return JSON.parse(readRequiredFile(tree, vscodeSettingsPath));
   } else {
     return {};
   }
@@ -28,8 +31,8 @@ function legacyEslintConfigExists(tree: Tree): boolean {
     }
   });
 
-  if (!found && tree.exists('/package.json')) {
-    found = !!JSON.parse(readRequiredFile(tree, '/package.json'))[
+  if (!found && tree.exists(packageJsonPath)) {
+    found = !!JSON.parse(readRequiredFile(tree, packageJsonPath))[
       'eslintConfig'
     ];
   }
@@ -43,7 +46,7 @@ export default function (): Rule {
       const currentSettings = getVSCodeSettings(tree);
 
       currentSettings['eslint.useFlatConfig'] = false;
-      writeJsonFile(tree, '.vscode/settings.json', currentSettings);
+      writeJsonFile(tree, vscodeSettingsPath, currentSettings);
     }
   };
 }

--- a/libs/components/packages/src/schematics/migrations/update-11/vscode-eslint-setting/vscode-eslint-setting.schematic.ts
+++ b/libs/components/packages/src/schematics/migrations/update-11/vscode-eslint-setting/vscode-eslint-setting.schematic.ts
@@ -1,0 +1,49 @@
+import { Rule, Tree } from '@angular-devkit/schematics';
+
+import { readRequiredFile, writeJsonFile } from '../../../utility/tree';
+
+function getVSCodeSettings(tree: Tree): {
+  'eslint.useFlatConfig'?: boolean;
+} {
+  if (tree.exists('.vscode/settings.json')) {
+    return JSON.parse(readRequiredFile(tree, '.vscode/settings.json'));
+  } else {
+    return {};
+  }
+}
+
+function legacyEslintConfigExists(tree: Tree): boolean {
+  const possibleConfigFiles = [
+    '.eslintrc.js',
+    '.eslintrc.cjs',
+    '.eslintrc.yaml',
+    '.eslintrc.yml',
+    '.eslintrc.json',
+  ];
+
+  let found = false;
+  possibleConfigFiles.forEach((possibleConfigFile) => {
+    if (tree.exists(possibleConfigFile)) {
+      found = true;
+    }
+  });
+
+  if (!found && tree.exists('/package.json')) {
+    found = !!JSON.parse(readRequiredFile(tree, '/package.json'))[
+      'eslintConfig'
+    ];
+  }
+
+  return found;
+}
+
+export default function (): Rule {
+  return (tree) => {
+    if (legacyEslintConfigExists(tree)) {
+      const currentSettings = getVSCodeSettings(tree);
+
+      currentSettings['eslint.useFlatConfig'] = false;
+      writeJsonFile(tree, '.vscode/settings.json', currentSettings);
+    }
+  };
+}

--- a/libs/components/packages/src/schematics/utility/tree.ts
+++ b/libs/components/packages/src/schematics/utility/tree.ts
@@ -1,8 +1,6 @@
 import { virtualFs } from '@angular-devkit/core';
 import { Tree } from '@angular-devkit/schematics';
 
-import commentJson from 'comment-json';
-
 /**
  * Returns the contents of a required file or throws an error if it doesn't exist.
  */
@@ -30,5 +28,5 @@ export function writeTextFile(
 }
 
 export function writeJsonFile<T>(tree: Tree, path: string, contents: T): void {
-  writeTextFile(tree, path, commentJson.stringify(contents, undefined, 2));
+  writeTextFile(tree, path, JSON.stringify(contents, undefined, 2));
 }

--- a/libs/components/packages/src/schematics/utility/tree.ts
+++ b/libs/components/packages/src/schematics/utility/tree.ts
@@ -1,6 +1,8 @@
 import { virtualFs } from '@angular-devkit/core';
 import { Tree } from '@angular-devkit/schematics';
 
+import commentJson from 'comment-json';
+
 /**
  * Returns the contents of a required file or throws an error if it doesn't exist.
  */
@@ -13,4 +15,20 @@ export function readRequiredFile(tree: Tree, filePath: string): string {
   }
 
   return virtualFs.fileBufferToString(data);
+}
+
+export function writeTextFile(
+  tree: Tree,
+  path: string,
+  contents: string,
+): void {
+  if (tree.exists(path)) {
+    tree.overwrite(path, contents);
+  } else {
+    tree.create(path, contents);
+  }
+}
+
+export function writeJsonFile<T>(tree: Tree, path: string, contents: T): void {
+  writeTextFile(tree, path, commentJson.stringify(contents, undefined, 2));
 }


### PR DESCRIPTION
[AB#3107723](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3107723)