### PR TITLE
ci: auto retry e2e when build not finalized

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -364,10 +364,10 @@ jobs:
           # Timing setting recommended by https://docs.percy.io/docs/cypress#missing-assets
           npx percy exec -t 350 -- nx e2e ${{ matrix.project }} -c ci --no-parallel 2>&1 | tee ${{ runner.temp }}/percy-${{ matrix.project }}.log
           RESULT=$?
-          if [ $RESULT -ne 0 ]; then
+          FINALIZED=$(grep -cE '^\[percy] Finalized build ' ${{ runner.temp }}/percy-${{ matrix.project }}.log)
+          if [ $RESULT -ne 0 ] || [ $FINALIZED -eq 0 ]; then
             echo "Percy failed with exit code $RESULT"
             RETRY=$(grep -cE '(This is likely a client error|Error: Can only finalize pending builds|Module loop: this module is already being loaded|Failed to connect to the bus: Could not parse server address: Unknown address type)' ${{ runner.temp }}/percy-${{ matrix.project }}.log)
-            FINALIZED=$(grep -cE '^\[percy] Finalized build ' ${{ runner.temp }}/percy-${{ matrix.project }}.log)
             if [ $RETRY -gt 0 ] || [ $FINALIZED -eq 0 ]; then
               echo "Percy client error. Retrying..."
               set -eo pipefail


### PR DESCRIPTION
[Example retry](https://github.com/blackbaud/skyux/actions/runs/11406371346/job/31740043168)

Move the "Finalized" check up, covering cases where the job exits successfully but does not finalize with Percy.