### PR TITLE
fix(components/datetime): date range picker emits touched status when focus leaves composite control

### DIFF
--- a/libs/components/datetime/src/lib/modules/date-range-picker/date-range-picker.component.html
+++ b/libs/components/datetime/src/lib/modules/date-range-picker/date-range-picker.component.html
@@ -18,11 +18,7 @@
         ('skyux_date_range_picker_default_label' | skyLibResources)
       "
     >
-      <select
-        formControlName="calculatorId"
-        (blur)="onBlur()"
-        (change)="onCalculatorIdChange()"
-      >
+      <select formControlName="calculatorId" (change)="onCalculatorIdChange()">
         @for (calculator of calculators; track calculator.calculatorId) {
           <option [value]="calculator.calculatorId">
             {{

--- a/libs/components/datetime/src/lib/modules/date-range-picker/date-range-picker.component.spec.ts
+++ b/libs/components/datetime/src/lib/modules/date-range-picker/date-range-picker.component.spec.ts
@@ -58,12 +58,6 @@ describe('Date range picker', function () {
     return fixture.nativeElement.querySelector('select');
   }
 
-  function openStartDatepickerCalendar(): void {
-    fixture.nativeElement
-      .querySelector('.sky-date-range-picker-start-date button')
-      ?.click();
-  }
-
   function getHelpInlinePopover(): HTMLSelectElement {
     return fixture.nativeElement.querySelectorAll('sky-help-inline');
   }
@@ -95,6 +89,12 @@ describe('Date range picker', function () {
       fixture.detectChanges();
       tick();
     }
+  }
+
+  function openStartDatepickerCalendar(): void {
+    fixture.nativeElement
+      .querySelector('.sky-date-range-picker-start-date button')
+      ?.click();
   }
 
   function verifyVisiblePickers(

--- a/libs/components/datetime/src/lib/modules/date-range-picker/date-range-picker.component.spec.ts
+++ b/libs/components/datetime/src/lib/modules/date-range-picker/date-range-picker.component.spec.ts
@@ -44,8 +44,24 @@ describe('Date range picker', function () {
     tick();
   }
 
+  function getActiveDatepickerCalendar(): HTMLElement {
+    const calendarEl = document.querySelector('sky-datepicker-calendar');
+
+    if (!calendarEl) {
+      throw new Error('Datepicker calendar not found.');
+    }
+
+    return calendarEl as HTMLElement;
+  }
+
   function getCalculatorSelect(): HTMLSelectElement {
     return fixture.nativeElement.querySelector('select');
+  }
+
+  function openStartDatepickerCalendar(): void {
+    fixture.nativeElement
+      .querySelector('.sky-date-range-picker-start-date button')
+      ?.click();
   }
 
   function getHelpInlinePopover(): HTMLSelectElement {
@@ -375,13 +391,20 @@ describe('Date range picker', function () {
     const startDateInput = getStartDateInput();
     const endDateInput = getEndDateInput();
 
-    // Blur the select and expect untouched.
+    // Move focus to the start date input.
     blurElement(selectElement, startDateInput);
     detectChanges();
     expect(component.reactiveForm?.touched).toEqual(false);
 
-    // Blur the start date input and expect untouched.
-    blurElement(startDateInput, endDateInput);
+    // Move focus to the opened datepicker calendar.
+    openStartDatepickerCalendar();
+    const startDateCalendarEl = getActiveDatepickerCalendar();
+    blurElement(startDateInput, startDateCalendarEl);
+    detectChanges();
+    expect(component.reactiveForm?.touched).toEqual(false);
+
+    // Move focus to the end date input.
+    blurElement(startDateCalendarEl, endDateInput);
     detectChanges();
     expect(component.reactiveForm?.touched).toEqual(false);
 

--- a/libs/components/datetime/src/lib/modules/date-range-picker/date-range-picker.component.spec.ts
+++ b/libs/components/datetime/src/lib/modules/date-range-picker/date-range-picker.component.spec.ts
@@ -22,12 +22,17 @@ describe('Date range picker', function () {
   let fixture: ComponentFixture<DateRangePickerTestComponent>;
   let component: DateRangePickerTestComponent;
 
-  function blurInput(inputEl: Element): void {
-    inputEl.dispatchEvent(
+  /**
+   * Dispatches a focusout event on the specified element.
+   * @param el The element losing focus.
+   * @param relatedTarget The element receiving focus.
+   */
+  function blurElement(el?: Element, relatedTarget?: EventTarget): void {
+    el?.dispatchEvent(
       new FocusEvent('focusout', {
         bubbles: true,
         cancelable: true,
-        relatedTarget: null,
+        relatedTarget,
       }),
     );
   }
@@ -357,16 +362,32 @@ describe('Date range picker', function () {
     verifyFormFieldsDisabledStatus(false);
   }));
 
-  it('should mark the control as touched when select is blurred', fakeAsync(function () {
+  it('should mark the control as touched when composite control loses focus', fakeAsync(() => {
     detectChanges();
 
     expect(component.reactiveForm?.touched).toEqual(false);
 
-    const selectElement = fixture.nativeElement.querySelector('select');
-    SkyAppTestUtility.fireDomEvent(selectElement, 'blur');
-
+    // Show both date pickers.
+    selectCalculator(SkyDateRangeCalculatorId.SpecificRange);
     detectChanges();
 
+    const selectElement = fixture.nativeElement.querySelector('select');
+    const startDateInput = getStartDateInput();
+    const endDateInput = getEndDateInput();
+
+    // Blur the select and expect untouched.
+    blurElement(selectElement, startDateInput);
+    detectChanges();
+    expect(component.reactiveForm?.touched).toEqual(false);
+
+    // Blur the start date input and expect untouched.
+    blurElement(startDateInput, endDateInput);
+    detectChanges();
+    expect(component.reactiveForm?.touched).toEqual(false);
+
+    // Blur the end date input and expect touched.
+    blurElement(endDateInput, document.body);
+    detectChanges();
     expect(component.reactiveForm?.touched).toEqual(true);
   }));
 
@@ -401,7 +422,7 @@ describe('Date range picker', function () {
       fixture.nativeElement as HTMLElement
     ).querySelectorAll('.sky-input-group input');
 
-    blurInput(datepickerInputs.item(0));
+    blurElement(datepickerInputs.item(0));
 
     fixture.detectChanges();
 
@@ -416,7 +437,7 @@ describe('Date range picker', function () {
       '.sky-input-group input',
     );
 
-    blurInput(datepickerInputs.item(1));
+    blurElement(datepickerInputs.item(1));
 
     fixture.detectChanges();
 

--- a/libs/components/datetime/src/lib/modules/date-range-picker/date-range-picker.component.spec.ts
+++ b/libs/components/datetime/src/lib/modules/date-range-picker/date-range-picker.component.spec.ts
@@ -24,11 +24,11 @@ describe('Date range picker', function () {
 
   /**
    * Dispatches a focusout event on the specified element.
-   * @param el The element losing focus.
+   * @param target The element losing focus.
    * @param relatedTarget The element receiving focus.
    */
-  function blurElement(el?: Element, relatedTarget?: EventTarget): void {
-    el?.dispatchEvent(
+  function blurElement(target?: Element, relatedTarget?: EventTarget): void {
+    target?.dispatchEvent(
       new FocusEvent('focusout', {
         bubbles: true,
         cancelable: true,
@@ -378,7 +378,7 @@ describe('Date range picker', function () {
     verifyFormFieldsDisabledStatus(false);
   }));
 
-  it('should mark the control as touched when composite control loses focus', fakeAsync(() => {
+  it('should mark the control as touched when the composite control loses focus', fakeAsync(() => {
     detectChanges();
 
     expect(component.reactiveForm?.touched).toEqual(false);

--- a/libs/components/datetime/src/lib/modules/datepicker/datepicker.component.ts
+++ b/libs/components/datetime/src/lib/modules/datepicker/datepicker.component.ts
@@ -232,6 +232,7 @@ export class SkyDatepickerComponent
   readonly #zIndex: Observable<number> | undefined;
 
   readonly #datepickerHostSvc = inject(SkyDatepickerHostService);
+  readonly #elementRef = inject(ElementRef);
 
   constructor(
     affixService: SkyAffixService,
@@ -350,6 +351,17 @@ export class SkyDatepickerComponent
         }
       }
     }
+  }
+
+  /**
+   * Whether the datepicker component contains the event target.
+   * @internal
+   */
+  public containsTarget(target: EventTarget): boolean {
+    return (
+      this.#elementRef.nativeElement.contains(target) ||
+      this.getPickerRef()?.nativeElement.contains(target)
+    );
   }
 
   /**

--- a/libs/components/datetime/src/lib/modules/datepicker/datepicker.component.ts
+++ b/libs/components/datetime/src/lib/modules/datepicker/datepicker.component.ts
@@ -354,7 +354,7 @@ export class SkyDatepickerComponent
   }
 
   /**
-   * Whether the datepicker component contains the event target.
+   * Whether the datepicker component contains the provided focus event target.
    * @internal
    */
   public containsTarget(target: EventTarget): boolean {


### PR DESCRIPTION
[AB#3150017](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3150017)

Related: https://github.com/blackbaud/skyux/pull/2909