### PR TITLE
fix: update `@skyux/dev-infra-private` to `10.0.0-alpha.18` to address issues with documentation generation (#2971)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -80,7 +80,7 @@
         "@ryansonshine/commitizen": "4.2.8",
         "@ryansonshine/cz-conventional-changelog": "3.3.4",
         "@schematics/angular": "18.2.12",
-        "@skyux/dev-infra-private": "github:blackbaud/skyux-dev-infra-private-builds#10.0.0-alpha.17",
+        "@skyux/dev-infra-private": "github:blackbaud/skyux-dev-infra-private-builds#10.0.0-alpha.18",
         "@storybook/addon-a11y": "8.4.7",
         "@storybook/addon-actions": "8.4.7",
         "@storybook/addon-controls": "8.4.7",
@@ -8086,10 +8086,9 @@
       }
     },
     "node_modules/@skyux/dev-infra-private": {
-      "version": "10.0.0-alpha.17",
-      "resolved": "git+ssh://git@github.com/blackbaud/skyux-dev-infra-private-builds.git#cbe855b49d6eae1c2dca8b5c0b7fffe2f9e0a450",
+      "version": "10.0.0-alpha.18",
+      "resolved": "git+ssh://git@github.com/blackbaud/skyux-dev-infra-private-builds.git#15a02dfb07deb00c5903d324fdb42ffaf516c05b",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "axios": "1.7.9",
         "cross-spawn": "7.0.6",
@@ -8110,7 +8109,6 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
       "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "foreground-child": "^3.1.0",
         "jackspeak": "^3.1.2",
@@ -8131,7 +8129,6 @@
       "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
       "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
       "dev": true,
-      "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/cliui": "^8.0.2"
       },
@@ -8146,15 +8143,13 @@
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "dev": true,
-      "license": "ISC"
+      "dev": true
     },
     "node_modules/@skyux/dev-infra-private/node_modules/minimatch": {
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
       "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -8170,7 +8165,6 @@
       "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
       "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
       "dev": true,
-      "license": "BlueOak-1.0.0",
       "dependencies": {
         "lru-cache": "^10.2.0",
         "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "@ryansonshine/commitizen": "4.2.8",
     "@ryansonshine/cz-conventional-changelog": "3.3.4",
     "@schematics/angular": "18.2.12",
-    "@skyux/dev-infra-private": "github:blackbaud/skyux-dev-infra-private-builds#10.0.0-alpha.17",
+    "@skyux/dev-infra-private": "github:blackbaud/skyux-dev-infra-private-builds#10.0.0-alpha.18",
     "@storybook/addon-a11y": "8.4.7",
     "@storybook/addon-actions": "8.4.7",
     "@storybook/addon-controls": "8.4.7",


### PR DESCRIPTION
:cherries: Cherry picked from #2971 [fix: update `@skyux/dev-infra-private` to `10.0.0-alpha.18` to address issues with documentation generation](https://github.com/blackbaud/skyux/pull/2971)

[AB#3195598](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3195598) 