### PR TITLE
feat(components/forms): add method to `SkyFormErrorHarness` to get error text (#2992)

### DIFF
--- a/libs/components/forms/testing/src/modules/form-error/form-error-harness.spec.ts
+++ b/libs/components/forms/testing/src/modules/form-error/form-error-harness.spec.ts
@@ -1,0 +1,79 @@
+import { HarnessLoader } from '@angular/cdk/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { Component } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { SKY_FORM_ERRORS_ENABLED, SkyFormErrorModule } from '@skyux/forms';
+
+import { SkyFormErrorHarness } from './form-error-harness';
+
+//#region Test component
+@Component({
+  selector: 'sky-form-error-test',
+  providers: [
+    {
+      provide: SKY_FORM_ERRORS_ENABLED,
+      useValue: true,
+    },
+  ],
+  template: `
+    <sky-form-error [errorName]="errorName" [errorText]="errorText" />
+    <sky-form-error
+      data-sky-id="other-error"
+      [errorName]="errorNameSkyId"
+      [errorText]="errorTextSkyId"
+    />
+  `,
+  standalone: false,
+})
+class TestComponent {
+  public errorName = 'error';
+  public errorText = 'some-error';
+  public errorNameSkyId = 'error-sky-id';
+  public errorTextSkyId = 'some-error-sky-id';
+}
+//#endregion Test component
+
+describe('Form error harness', () => {
+  async function setupTest(options: { dataSkyId?: string } = {}): Promise<{
+    formErrorHarness: SkyFormErrorHarness;
+    fixture: ComponentFixture<TestComponent>;
+    loader: HarnessLoader;
+    pageLoader: HarnessLoader;
+  }> {
+    await TestBed.configureTestingModule({
+      declarations: [TestComponent],
+      imports: [SkyFormErrorModule],
+    }).compileComponents();
+    const fixture = TestBed.createComponent(TestComponent);
+    const loader = TestbedHarnessEnvironment.loader(fixture);
+    const pageLoader = TestbedHarnessEnvironment.documentRootLoader(fixture);
+    const formErrorHarness: SkyFormErrorHarness = options.dataSkyId
+      ? await loader.getHarness(
+          SkyFormErrorHarness.with({ dataSkyId: options.dataSkyId }),
+        )
+      : await loader.getHarness(SkyFormErrorHarness);
+    return { formErrorHarness, fixture, loader, pageLoader };
+  }
+
+  it('should get form error text', async () => {
+    const { formErrorHarness, fixture } = await setupTest();
+
+    fixture.detectChanges();
+
+    await expectAsync(formErrorHarness.getErrorText()).toBeResolvedTo(
+      fixture.componentInstance.errorText,
+    );
+  });
+
+  it('should get form error text by its data-sky-id', async () => {
+    const { formErrorHarness, fixture } = await setupTest({
+      dataSkyId: 'other-error',
+    });
+
+    fixture.detectChanges();
+
+    await expectAsync(formErrorHarness.getErrorText()).toBeResolvedTo(
+      fixture.componentInstance.errorTextSkyId,
+    );
+  });
+});

--- a/libs/components/forms/testing/src/modules/form-error/form-error-harness.ts
+++ b/libs/components/forms/testing/src/modules/form-error/form-error-harness.ts
@@ -1,5 +1,6 @@
 import { HarnessPredicate } from '@angular/cdk/testing';
 import { SkyComponentHarness } from '@skyux/core/testing';
+import { SkyStatusIndicatorHarness } from '@skyux/indicators/testing';
 
 import { SkyFormErrorHarnessFilters } from './form-error-harness.filters';
 
@@ -8,6 +9,10 @@ export class SkyFormErrorHarness extends SkyComponentHarness {
    * @internal
    */
   public static hostSelector = 'sky-form-error';
+
+  async #getStatusIndicator(): Promise<SkyStatusIndicatorHarness> {
+    return await this.locatorFor(SkyStatusIndicatorHarness)();
+  }
 
   /**
    * Gets a `HarnessPredicate` that can be used to search for a
@@ -24,5 +29,12 @@ export class SkyFormErrorHarness extends SkyComponentHarness {
    */
   public async getErrorName(): Promise<string | null> {
     return await (await this.host()).getAttribute('errorName');
+  }
+
+  /**
+   * Gets the error text.
+   */
+  public async getErrorText(): Promise<string | null> {
+    return await (await this.#getStatusIndicator()).getText();
   }
 }

--- a/libs/components/forms/testing/src/modules/form-error/form-errors-harness.spec.ts
+++ b/libs/components/forms/testing/src/modules/form-error/form-errors-harness.spec.ts
@@ -32,7 +32,7 @@ import { SkyFormErrorsHarness } from './form-errors-harness';
       [touched]="true"
       [dirty]="true"
       [errors]="{ required: true }"
-    />"`,
+    />`,
 })
 class TestComponent {
   public errorText: string | undefined = 'Form';


### PR DESCRIPTION
Original contribution: https://github.com/blackbaud/skyux/pull/2992