### PR TITLE
fix(components/pages): hide blocks with hidden `[skyHref]` links (#3014)

### DIFF
--- a/libs/components/pages/src/lib/modules/link-list/link-list.component.scss
+++ b/libs/components/pages/src/lib/modules/link-list/link-list.component.scss
@@ -8,3 +8,7 @@ h2,
 li {
   margin: 0 0 var(--sky-margin-stacked-sm) 0;
 }
+
+ul.sky-link-list > li:has(> a[hidden]) {
+  display: none;
+}

--- a/libs/components/pages/src/lib/modules/modal-link-list/modal-link-list.component.scss
+++ b/libs/components/pages/src/lib/modules/modal-link-list/modal-link-list.component.scss
@@ -8,3 +8,7 @@ h2,
 li {
   margin: 0 0 var(--sky-margin-stacked-sm) 0;
 }
+
+ul.sky-link-list > li:has(> a[hidden]) {
+  display: none;
+}

--- a/libs/components/pages/src/lib/modules/needs-attention/needs-attention.component.scss
+++ b/libs/components/pages/src/lib/modules/needs-attention/needs-attention.component.scss
@@ -35,6 +35,10 @@ ul {
   }
 }
 
+.sky-needs-attention-item-wrapper:has(a[hidden]) {
+  display: none;
+}
+
 .sky-needs-attention-item {
   grid-area: action;
   text-align: left;

--- a/libs/components/pages/src/lib/modules/page-header/page-header.component.scss
+++ b/libs/components/pages/src/lib/modules/page-header/page-header.component.scss
@@ -23,6 +23,10 @@
     block-size: fit-content;
   }
 
+  &-parent-link-wrapper:has(a[hidden]) {
+    display: none;
+  }
+
   &-parent-link {
     color: $sky-text-color-action-primary;
   }


### PR DESCRIPTION
:cherries: Cherry picked from #3014 [fix(components/pages): hide blocks with hidden `[skyHref]` links](https://github.com/blackbaud/skyux/pull/3014)

[AB#3204291](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3204291) 