### PR TITLE
fix(components/modals): make modal footer error message focusable (#3026)

### DIFF
--- a/libs/components/modals/src/lib/modules/modal/modal-footer.component.html
+++ b/libs/components/modals/src/lib/modules/modal/modal-footer.component.html
@@ -2,7 +2,7 @@
   <div aria-live="polite">
     @if (errorsSvc.formErrors | async; as formErrors) {
       @if (formErrors.length > 0) {
-        <div class="sky-modal-footer-errors sky-margin-stacked-lg">
+        <div class="sky-modal-footer-errors sky-margin-stacked-lg" tabindex="0">
           @for (formError of formErrors; track formError) {
             <sky-status-indicator
               descriptionType="error"


### PR DESCRIPTION
:cherries: Cherry picked from #3026 [fix(components/modals): make modal footer error message focusable](https://github.com/blackbaud/skyux/pull/3026)