### PR TITLE
fix(components/action-bars): account for left nav in summary action bar position (#3028)

### DIFF
--- a/libs/components/action-bars/src/lib/modules/summary-action-bar/summary-action-bar.component.scss
+++ b/libs/components/action-bars/src/lib/modules/summary-action-bar/summary-action-bar.component.scss
@@ -2,13 +2,15 @@
 @use 'libs/components/theme/src/lib/styles/variables' as *;
 
 .sky-summary-action-bar {
+  --sky-summary-action-bar-left: var(--sky-viewport-left);
+
   display: flex;
   align-items: center;
   width: 100%;
   margin-top: $sky-margin-double;
   position: fixed;
   bottom: 0;
-  left: 0;
+  left: var(--sky-summary-action-bar-left, 0);
   z-index: 999;
   background-color: $sky-color-white;
   box-shadow: 0 -3px 3px 0 $sky-color-gray-20;
@@ -18,6 +20,7 @@
 .sky-summary-action-bar-split-view {
   position: relative;
   margin-top: 0;
+  --sky-summary-action-bar-left: 0;
 }
 
 .sky-summary-action-bar-split-view {


### PR DESCRIPTION
:cherries: Cherry picked from #3028 [fix(components/action-bars): account for left nav in summary action bar position](https://github.com/blackbaud/skyux/pull/3028)