### PR TITLE
refactor(components/tiles): remove deprecated observers from tile control handlers (#3034)

### DIFF
--- a/libs/components/tiles/src/lib/modules/tiles/tile/tile.component.ts
+++ b/libs/components/tiles/src/lib/modules/tiles/tile/tile.component.ts
@@ -232,14 +232,14 @@ export class SkyTileComponent implements OnChanges, OnDestroy {
   }
 
   public get hasSettings(): boolean {
-    return this.settingsClick.observers.length > 0 && this.showSettings;
+    return this.settingsClick.observed && this.showSettings;
   }
 
   /**
    * @deprecated
    */
   public get hasHelp(): boolean {
-    return this.helpClick.observers.length > 0 && this.showHelp;
+    return this.helpClick.observed && this.showHelp;
   }
 
   public titleClick(evt: MouseEvent): void {


### PR DESCRIPTION
:cherries: Cherry picked from #3034 [refactor(components/tiles): remove deprecated observers from tile control handlers](https://github.com/blackbaud/skyux/pull/3034)