### PR TITLE
fix(components/autonumeric): support negativeBracketsTypeOnBlur option (#3049)

### DIFF
--- a/libs/components/autonumeric/src/lib/modules/autonumeric/autonumeric.directive.spec.ts
+++ b/libs/components/autonumeric/src/lib/modules/autonumeric/autonumeric.directive.spec.ts
@@ -211,6 +211,22 @@ describe('Autonumeric directive', () => {
     expect(formattedValue).toEqual('1,000.00000');
   }));
 
+  it('should support negativeBracketsTypeOnBlur', fakeAsync(() => {
+    setOptions({
+      currencySymbol: '$',
+      decimalPlaces: 2,
+      negativeBracketsTypeOnBlur: '(,)',
+    });
+
+    setValue(1000);
+
+    const modelValue = getModelValue();
+    const formattedValue = getFormattedValue();
+
+    expect(modelValue).toEqual(1000);
+    expect(formattedValue).toEqual('$1,000.00');
+  }));
+
   it('should update numeric value on keyup', fakeAsync(() => {
     detectChangesTick();
 

--- a/libs/components/autonumeric/src/lib/modules/autonumeric/autonumeric.directive.ts
+++ b/libs/components/autonumeric/src/lib/modules/autonumeric/autonumeric.directive.ts
@@ -149,9 +149,9 @@ export class SkyAutonumericDirective
 
     if (typeof value === 'number') {
       if (this.skyAutonumericFormChangesUnformatted) {
-        this.#autonumericInstance.setUnformatted(value);
+        this.#autonumericInstance.setUnformatted(value.toString());
       } else {
-        this.#autonumericInstance.set(value);
+        this.#autonumericInstance.set(value.toString());
       }
     } else {
       this.#autonumericInstance.clear();


### PR DESCRIPTION
:cherries: Cherry picked from #3049 [fix(components/autonumeric): support negativeBracketsTypeOnBlur option](https://github.com/blackbaud/skyux/pull/3049)

[AB#3230187](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3230187) 