### PR TITLE
fix(components/ag-grid): datepicker cell editor should handle refresh refocus (#3056)

### DIFF
--- a/libs/components/ag-grid/src/lib/modules/ag-grid/cell-editors/cell-editor-datepicker/cell-editor-datepicker.component.spec.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/cell-editors/cell-editor-datepicker/cell-editor-datepicker.component.spec.ts
@@ -450,6 +450,7 @@ describe('SkyCellEditorDatepickerComponent', () => {
     ]);
     let cellEditorParams: Partial<SkyCellEditorDatepickerParams>;
     let column: AgColumn;
+    let gridCell: HTMLElement;
     const dateString = '01/01/2019';
     const date = new Date(dateString);
     const rowNode = new RowNode({} as BeanCollection);
@@ -464,6 +465,7 @@ describe('SkyCellEditorDatepickerComponent', () => {
         'col',
         true,
       );
+      gridCell = document.createElement('div');
 
       cellEditorParams = {
         api,
@@ -472,6 +474,7 @@ describe('SkyCellEditorDatepickerComponent', () => {
         node: rowNode,
         colDef: {},
         cellStartedEdit: true,
+        eGridCell: gridCell,
       };
     });
 
@@ -488,6 +491,24 @@ describe('SkyCellEditorDatepickerComponent', () => {
       spyOn(input, 'focus');
 
       datepickerEditorComponent.afterGuiAttached();
+      tick();
+
+      expect(input).toBeVisible();
+      expect(input.focus).toHaveBeenCalled();
+    }));
+
+    it('should respond to reset focus', fakeAsync(() => {
+      datepickerEditorComponent.agInit(
+        cellEditorParams as SkyCellEditorDatepickerParams,
+      );
+      datepickerEditorFixture.detectChanges();
+      const input = datepickerEditorNativeElement.querySelector(
+        'input',
+      ) as HTMLInputElement;
+      spyOn(input, 'focus');
+      datepickerEditorComponent.onFocusOut({
+        relatedTarget: gridCell,
+      } as unknown as FocusEvent);
       tick();
 
       expect(input).toBeVisible();

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/cell-editors/cell-editor-datepicker/cell-editor-datepicker.component.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/cell-editors/cell-editor-datepicker/cell-editor-datepicker.component.ts
@@ -65,7 +65,14 @@ export class SkyAgGridCellEditorDatepickerComponent
 
   @HostListener('focusout', ['$event'])
   public onFocusOut(event: FocusEvent): void {
-    if (event.target === this.datepickerInput?.nativeElement) {
+    if (
+      event.relatedTarget &&
+      event.relatedTarget === this.#params?.eGridCell
+    ) {
+      // If focus is being set to the grid cell, schedule focus on the datepicker input.
+      // This happens when the refreshCells API is called.
+      this.afterGuiAttached();
+    } else if (event.target === this.datepickerInput?.nativeElement) {
       this.#stopEditingOnBlur();
     }
   }


### PR DESCRIPTION
:cherries: Cherry picked from #3056 [fix(components/ag-grid): datepicker cell editor should handle refresh refocus](https://github.com/blackbaud/skyux/pull/3056)

[AB#3232221](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3232221) 