### PR TITLE
fix(components/ag-grid): row delete confirmation event handling (#3078)

### DIFF
--- a/libs/components/ag-grid/src/lib/modules/ag-grid/ag-grid-row-delete.directive.spec.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/ag-grid-row-delete.directive.spec.ts
@@ -1,4 +1,9 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import {
+  ComponentFixture,
+  TestBed,
+  fakeAsync,
+  tick,
+} from '@angular/core/testing';
 import { SKY_STACKING_CONTEXT, SkyScrollableHostService } from '@skyux/core';
 
 import { BehaviorSubject, Observable, of } from 'rxjs';
@@ -158,18 +163,18 @@ describe('SkyAgGridRowDeleteDirective', () => {
       ).toBe(2);
     });
 
-    it('should respond dataset changes', async () => {
+    it('should respond dataset changes', fakeAsync(() => {
       setupTest();
-      await fixture.whenStable();
+      tick(16);
 
       fixture.componentInstance.rowDeleteIds = ['0', '2'];
       fixture.detectChanges();
-      await fixture.whenStable();
+      tick(16);
 
       fixture.componentInstance.removeFirstItem();
 
       fixture.detectChanges();
-      await fixture.whenStable();
+      tick(16);
 
       expect(fixture.componentInstance.rowDeleteIds).toEqual(['2']);
       expect(document.querySelector('#row-delete-ref-0')).toBeNull();
@@ -177,7 +182,7 @@ describe('SkyAgGridRowDeleteDirective', () => {
       expect(
         document.querySelectorAll('.sky-inline-delete-standard').length,
       ).toBe(1);
-    });
+    }));
   });
 
   it('should cancel row delete elements correctly via them being removed from the id array', async () => {

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/fixtures/ag-grid-row-delete.component.fixture.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/fixtures/ag-grid-row-delete.component.fixture.ts
@@ -111,6 +111,7 @@ export class SkyAgGridRowDeleteFixtureComponent implements OnInit {
 
   public changeToLongData(): void {
     this.gridData = SKY_AG_GRID_LONG_DATA;
+    this.gridApi?.setGridOption('rowData', this.gridData);
   }
 
   public filterName(): Promise<void> {
@@ -160,6 +161,7 @@ export class SkyAgGridRowDeleteFixtureComponent implements OnInit {
 
   public removeFirstItem(): void {
     this.gridData = this.gridData.slice(1);
+    this.gridApi?.setGridOption('rowData', this.gridData);
   }
 
   public sortName(): Promise<void> {


### PR DESCRIPTION
:cherries: Cherry picked from #3078 [fix(components/ag-grid): row delete confirmation event handling](https://github.com/blackbaud/skyux/pull/3078)

[AB#3239317](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3239317) 