### PR TITLE
fix(components/ag-grid): refocus cell editors on api refresh (#3087)

### DIFF
--- a/libs/components/ag-grid/src/lib/modules/ag-grid/cell-editors/cell-editor-autocomplete/cell-editor-autocomplete.component.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/cell-editors/cell-editor-autocomplete/cell-editor-autocomplete.component.ts
@@ -43,9 +43,18 @@ export class SkyAgGridCellEditorAutocompleteComponent
   @ViewChild('skyCellEditorAutocomplete', { read: ElementRef })
   public input: ElementRef | undefined;
 
-  @HostListener('blur')
-  public onBlur(): void {
-    this.#stopEditingOnBlur();
+  @HostListener('focusout', ['$event'])
+  public onBlur(event: FocusEvent): void {
+    if (
+      event.relatedTarget &&
+      event.relatedTarget === this.#params?.eGridCell
+    ) {
+      // If focus is being set to the grid cell, schedule focus on the input.
+      // This happens when the refreshCells API is called.
+      this.afterGuiAttached();
+    } else {
+      this.#stopEditingOnBlur();
+    }
   }
 
   public agInit(params: SkyCellEditorAutocompleteParams): void {

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/cell-editors/cell-editor-currency/cell-editor-currency.component.spec.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/cell-editors/cell-editor-currency/cell-editor-currency.component.spec.ts
@@ -160,6 +160,7 @@ describe('SkyCellEditorCurrencyComponent', () => {
     describe('afterGuiAttached', () => {
       let cellEditorParams: Partial<SkyCellEditorCurrencyParams>;
       let column: AgColumn;
+      let gridCell: HTMLDivElement;
       const rowNode = new RowNode({} as BeanCollection);
       rowNode.rowHeight = 37;
       const value = 15;
@@ -174,16 +175,19 @@ describe('SkyCellEditorCurrencyComponent', () => {
           true,
         );
 
-        const api = {} as GridApi;
+        const api = jasmine.createSpyObj<GridApi>([
+          'getDisplayNameForColumn',
+          'stopEditing',
+        ]);
 
-        api.getDisplayNameForColumn = (): string => {
-          return '';
-        };
+        api.getDisplayNameForColumn.and.returnValue('');
+        gridCell = document.createElement('div');
 
         cellEditorParams = {
           api,
           value: value,
           column,
+          eGridCell: gridCell,
           node: rowNode,
           colDef: {},
           cellStartedEdit: true,
@@ -513,6 +517,24 @@ describe('SkyCellEditorCurrencyComponent', () => {
 
         expect(input).toBeVisible();
         expect(input.focus).toHaveBeenCalled();
+      }));
+
+      it('should respond to refocus', fakeAsync(() => {
+        currencyEditorComponent.agInit(cellEditorParams as ICellEditorParams);
+        currencyEditorFixture.detectChanges();
+
+        const input = currencyEditorFixture.nativeElement.querySelector(
+          'input',
+        ) as HTMLInputElement;
+        spyOn(input, 'focus');
+
+        currencyEditorComponent.onFocusOut({
+          relatedTarget: gridCell,
+        } as unknown as FocusEvent);
+        tick();
+        expect(input).toBeVisible();
+        expect(input.focus).toHaveBeenCalled();
+        expect(cellEditorParams.api?.stopEditing).not.toHaveBeenCalled();
       }));
     });
 

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/cell-editors/cell-editor-currency/cell-editor-currency.component.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/cell-editors/cell-editor-currency/cell-editor-currency.component.ts
@@ -3,6 +3,7 @@ import {
   ChangeDetectorRef,
   Component,
   ElementRef,
+  HostListener,
   ViewChild,
   inject,
 } from '@angular/core';
@@ -45,6 +46,15 @@ export class SkyAgGridCellEditorCurrencyComponent
 
   @ViewChild('skyCellEditorCurrency', { read: ElementRef })
   public input: ElementRef | undefined;
+
+  @HostListener('focusout', ['$event'])
+  public onFocusOut(event: FocusEvent): void {
+    if (event.relatedTarget && event.relatedTarget === this.params?.eGridCell) {
+      // If focus is being set to the grid cell, schedule focus on the input.
+      // This happens when the refreshCells API is called.
+      this.afterGuiAttached();
+    }
+  }
 
   #triggerType: SkyAgGridCellEditorInitialAction | undefined;
   readonly #changeDetector = inject(ChangeDetectorRef);

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/cell-editors/cell-editor-lookup/cell-editor-lookup.component.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/cell-editors/cell-editor-lookup/cell-editor-lookup.component.ts
@@ -52,9 +52,18 @@ export class SkyAgGridCellEditorLookupComponent
   #changeDetector = inject(ChangeDetectorRef);
   #elementRef = inject(ElementRef<HTMLElement>);
 
-  @HostListener('blur')
-  public onBlur(): void {
-    this.#stopEditingOnBlur();
+  @HostListener('focusout', ['$event'])
+  public onBlur(event: FocusEvent): void {
+    if (
+      event.relatedTarget &&
+      event.relatedTarget === this.#params?.eGridCell
+    ) {
+      // If focus is being set to the grid cell, schedule focus on the input.
+      // This happens when the refreshCells API is called.
+      this.afterGuiAttached();
+    } else {
+      this.#stopEditingOnBlur();
+    }
   }
 
   public agInit(params: SkyCellEditorLookupParams): void {

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/cell-editors/cell-editor-number/cell-editor-number.component.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/cell-editors/cell-editor-number/cell-editor-number.component.ts
@@ -2,6 +2,7 @@ import {
   ChangeDetectionStrategy,
   Component,
   ElementRef,
+  HostListener,
   ViewChild,
 } from '@angular/core';
 import { UntypedFormControl, UntypedFormGroup } from '@angular/forms';
@@ -38,6 +39,18 @@ export class SkyAgGridCellEditorNumberComponent
 
   @ViewChild('skyCellEditorNumber', { read: ElementRef })
   public input: ElementRef | undefined;
+
+  @HostListener('focusout', ['$event'])
+  public onFocusOut(event: FocusEvent): void {
+    if (
+      event.relatedTarget &&
+      event.relatedTarget === this.#params?.eGridCell
+    ) {
+      // If focus is being set to the grid cell, schedule focus on the input.
+      // This happens when the refreshCells API is called.
+      this.afterGuiAttached();
+    }
+  }
 
   #params: ICellEditorParams | undefined;
   #triggerType: SkyAgGridCellEditorInitialAction | undefined;
@@ -84,12 +97,17 @@ export class SkyAgGridCellEditorNumberComponent
    * afterGuiAttached is called by agGrid after the editor is rendered in the DOM. Once it is attached the editor is ready to be focused on.
    */
   public afterGuiAttached(): void {
-    if (this.input) {
-      this.input.nativeElement.focus();
-      if (this.#triggerType === SkyAgGridCellEditorInitialAction.Highlighted) {
-        this.input.nativeElement.select();
+    // AG Grid sets focus to the cell via setTimeout, and this queues the input to focus after that.
+    setTimeout(() => {
+      if (this.input) {
+        this.input.nativeElement.focus();
+        if (
+          this.#triggerType === SkyAgGridCellEditorInitialAction.Highlighted
+        ) {
+          this.input.nativeElement.select();
+        }
       }
-    }
+    });
   }
 
   /**

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/cell-editors/cell-editor-text/cell-editor-text.component.spec.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/cell-editors/cell-editor-text/cell-editor-text.component.spec.ts
@@ -69,6 +69,7 @@ describe('SkyCellEditorTextComponent', () => {
     ]);
     let cellEditorParams: Partial<SkyCellEditorTextParams>;
     let column: AgColumn;
+    let gridCell: HTMLDivElement;
     const rowNode = new RowNode({} as BeanCollection);
     rowNode.rowHeight = 37;
     const value = 'testing';
@@ -83,10 +84,13 @@ describe('SkyCellEditorTextComponent', () => {
         true,
       );
 
+      gridCell = document.createElement('div');
+
       cellEditorParams = {
         api,
         value: value,
         column,
+        eGridCell: gridCell,
         node: rowNode,
         colDef: {},
         cellStartedEdit: true,
@@ -122,6 +126,26 @@ describe('SkyCellEditorTextComponent', () => {
         'Editable text Testing for row 1',
       );
     });
+
+    it('should respond to refocus', fakeAsync(() => {
+      textEditorComponent.agInit(cellEditorParams as ICellEditorParams);
+      textEditorFixture.detectChanges();
+
+      const input = textEditorNativeElement.querySelector(
+        'input',
+      ) as HTMLInputElement;
+      spyOn(input, 'focus');
+
+      textEditorComponent.afterGuiAttached();
+      tick();
+
+      textEditorComponent.onFocusOut({
+        relatedTarget: gridCell,
+      } as unknown as FocusEvent);
+      tick();
+      expect(input).toBeVisible();
+      expect(input.focus).toHaveBeenCalled();
+    }));
 
     describe('cellStartedEdit is true', () => {
       it('initializes with a cleared value when Backspace triggers the edit', () => {

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/cell-editors/cell-editor-text/cell-editor-text.component.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/cell-editors/cell-editor-text/cell-editor-text.component.ts
@@ -2,6 +2,7 @@ import {
   ChangeDetectionStrategy,
   Component,
   ElementRef,
+  HostListener,
   ViewChild,
 } from '@angular/core';
 import { UntypedFormControl, UntypedFormGroup } from '@angular/forms';
@@ -38,6 +39,18 @@ export class SkyAgGridCellEditorTextComponent
 
   @ViewChild('skyCellEditorText', { read: ElementRef })
   public input: ElementRef | undefined;
+
+  @HostListener('focusout', ['$event'])
+  public onFocusOut(event: FocusEvent): void {
+    if (
+      event.relatedTarget &&
+      event.relatedTarget === this.#params?.eGridCell
+    ) {
+      // If focus is being set to the grid cell, schedule focus on the input.
+      // This happens when the refreshCells API is called.
+      this.afterGuiAttached();
+    }
+  }
 
   #params: ICellEditorParams | undefined;
   #triggerType: SkyAgGridCellEditorInitialAction | undefined;


### PR DESCRIPTION
:cherries: Cherry picked from #3087 [fix(components/ag-grid): refocus cell editors on api refresh](https://github.com/blackbaud/skyux/pull/3087)

[AB#3240868](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3240868) 