### PR TITLE
fix(components/toast): toasts read to assistive technology on initial rendering (#3104)

### DIFF
--- a/libs/components/toast/src/lib/modules/toast/toast.component.html
+++ b/libs/components/toast/src/lib/modules/toast/toast.component.html
@@ -5,8 +5,6 @@
   <div
     class="sky-toast sky-shadow sky-rounded-corners sky-box sky-elevation-24"
     [ngClass]="classNames"
-    [attr.aria-live]="ariaLive"
-    [attr.role]="ariaRole"
   >
     <div aria-hidden="true" class="sky-toast-icon-theme-default">
       <sky-icon [icon]="icon" />
@@ -14,7 +12,12 @@
     <div aria-hidden="true" class="sky-toast-icon-theme-modern">
       <sky-icon-stack [baseIcon]="baseIcon" [topIcon]="topIcon" />
     </div>
-    <div #toastContent class="sky-toast-content" skyId="toastContent">
+    <div
+      #toastContent
+      class="sky-toast-content"
+      skyId="toastContent"
+      role="alert"
+    >
       <ng-content />
     </div>
     <button

--- a/libs/components/toast/src/lib/modules/toast/toast.component.spec.ts
+++ b/libs/components/toast/src/lib/modules/toast/toast.component.spec.ts
@@ -104,16 +104,6 @@ describe('Toast component', () => {
     expect(component.toastComponent?.isOpen).toEqual(false);
   });
 
-  it('should set aria attributes', () => {
-    setupTest();
-    expect(component.toastComponent?.ariaLive).toEqual('polite');
-    expect(component.toastComponent?.ariaRole).toEqual(undefined);
-    fixture.componentInstance.toastType = SkyToastType.Danger;
-    fixture.detectChanges();
-    expect(component.toastComponent?.ariaLive).toEqual('assertive');
-    expect(component.toastComponent?.ariaRole).toEqual('alert');
-  });
-
   it('should pass accessibility', async () => {
     setupTest();
     fixture.detectChanges();

--- a/libs/components/toast/src/lib/modules/toast/toast.component.ts
+++ b/libs/components/toast/src/lib/modules/toast/toast.component.ts
@@ -67,8 +67,6 @@ export class SkyToastComponent implements OnInit, OnDestroy {
     return this.#isOpen;
   }
 
-  public ariaLive = 'polite';
-  public ariaRole: string | undefined;
   public baseIcon: SkyIconStackItem | undefined;
   public classNames = '';
   public icon: string | undefined;
@@ -182,11 +180,6 @@ export class SkyToastComponent implements OnInit, OnDestroy {
     };
 
     this.icon = icon;
-
-    this.ariaLive =
-      this.toastTypeOrDefault === SkyToastType.Danger ? 'assertive' : 'polite';
-    this.ariaRole =
-      this.toastTypeOrDefault === SkyToastType.Danger ? 'alert' : undefined;
 
     let typeLabel: string;
     switch (this.toastTypeOrDefault) {


### PR DESCRIPTION
:cherries: Cherry picked from #3104 [fix(components/toast): toasts read to assistive technology on initial rendering](https://github.com/blackbaud/skyux/pull/3104)

[AB#3013092](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3013092) 