### PR TITLE
fix(components/lists): mark repeater item `reorderable` property as internal as a consumer setting this property has no affect

### DIFF
--- a/libs/components/lists/src/lib/modules/repeater/repeater-item.component.ts
+++ b/libs/components/lists/src/lib/modules/repeater/repeater-item.component.ts
@@ -156,6 +156,7 @@ export class SkyRepeaterItemComponent
   /**
    * Whether users can change the order of the repeater item.
    * The repeater component's `reorderable` property must also be set to `true`.
+   * @internal
    */
   @Input()
   public reorderable: boolean | undefined = false;


### PR DESCRIPTION
[AB#3247023](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3247023)