### PR TITLE
fix(components/lists): mark repeater item `reorderable` property as internal as a consumer setting this property has no affect (#3106)

### DIFF
--- a/libs/components/lists/src/lib/modules/repeater/repeater-item.component.ts
+++ b/libs/components/lists/src/lib/modules/repeater/repeater-item.component.ts
@@ -157,6 +157,7 @@ export class SkyRepeaterItemComponent
   /**
    * Whether users can change the order of the repeater item.
    * The repeater component's `reorderable` property must also be set to `true`.
+   * @internal
    */
   @Input()
   public reorderable: boolean | undefined = false;


### PR DESCRIPTION
:cherries: Cherry picked from #3106 [fix(components/lists): mark repeater item `reorderable` property as internal as a consumer setting this property has no affect](https://github.com/blackbaud/skyux/pull/3106)

[AB#3247023](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3247023) 