### PR TITLE
feat(components/core): add SkyViewkeeper support for SkyAppViewportService properties

### DIFF
--- a/libs/components/core/src/lib/modules/dock/dock.component.spec.ts
+++ b/libs/components/core/src/lib/modules/dock/dock.component.spec.ts
@@ -38,7 +38,7 @@ describe('Dock component', () => {
     fixture.detectChanges();
     fixture.componentInstance.itemConfigs = itemConfigs;
     fixture.detectChanges();
-    tick();
+    tick(16);
   }
 
   /**
@@ -70,7 +70,7 @@ describe('Dock component', () => {
     fixture.detectChanges();
     tick(250); // Respect the RxJS debounceTime.
     fixture.detectChanges();
-    tick();
+    tick(16);
   }
 
   function getStyleElement(): HTMLStyleElement {
@@ -343,6 +343,7 @@ describe('Dock component', () => {
       reserveSpace('left', 20);
 
       fixture.detectChanges();
+      tick(16);
 
       const dockEl = getDockEl();
       const actionBarBounds = dockEl.getBoundingClientRect();
@@ -370,7 +371,7 @@ describe('Dock component', () => {
         ]);
 
         fixture.detectChanges();
-        tick();
+        tick(16);
 
         const dockStyle = getDockStyle();
 
@@ -398,7 +399,7 @@ describe('Dock component', () => {
       ]);
 
       fixture.detectChanges();
-      tick();
+      tick(16);
 
       const dockStyle = getDockStyle();
 

--- a/libs/components/core/src/lib/modules/dock/dock.component.spec.ts
+++ b/libs/components/core/src/lib/modules/dock/dock.component.spec.ts
@@ -24,6 +24,12 @@ const STYLE_ELEMENT_SELECTOR =
 
 const isIE = window.navigator.userAgent.indexOf('rv:11.0') >= 0;
 
+// 16ms is the fakeAsync time for requestAnimationFrame, simulating ~60fps.
+// https://github.com/angular/angular/blob/19.1.x/packages/zone.js/lib/zone-spec/fake-async-test.ts#L682-L693
+function tickForAnimationFrame(): void {
+  tick(16);
+}
+
 describe('Dock component', () => {
   let fixture: ComponentFixture<DockFixtureComponent>;
   let mutationCallbacks: (() => void)[];
@@ -38,7 +44,7 @@ describe('Dock component', () => {
     fixture.detectChanges();
     fixture.componentInstance.itemConfigs = itemConfigs;
     fixture.detectChanges();
-    tick(16);
+    tickForAnimationFrame();
   }
 
   /**
@@ -70,7 +76,7 @@ describe('Dock component', () => {
     fixture.detectChanges();
     tick(250); // Respect the RxJS debounceTime.
     fixture.detectChanges();
-    tick(16);
+    tickForAnimationFrame();
   }
 
   function getStyleElement(): HTMLStyleElement {
@@ -343,7 +349,7 @@ describe('Dock component', () => {
       reserveSpace('left', 20);
 
       fixture.detectChanges();
-      tick(16);
+      tickForAnimationFrame();
 
       const dockEl = getDockEl();
       const actionBarBounds = dockEl.getBoundingClientRect();
@@ -371,7 +377,7 @@ describe('Dock component', () => {
         ]);
 
         fixture.detectChanges();
-        tick(16);
+        tickForAnimationFrame();
 
         const dockStyle = getDockStyle();
 
@@ -399,7 +405,7 @@ describe('Dock component', () => {
       ]);
 
       fixture.detectChanges();
-      tick(16);
+      tickForAnimationFrame();
 
       const dockStyle = getDockStyle();
 

--- a/libs/components/core/src/lib/modules/viewkeeper/viewkeeper-host-options.ts
+++ b/libs/components/core/src/lib/modules/viewkeeper/viewkeeper-host-options.ts
@@ -17,4 +17,6 @@ export class SkyViewkeeperHostOptions implements SkyViewkeeperOptions {
   public verticalOffsetEl?: HTMLElement;
 
   public viewportMarginTop?: number;
+
+  public viewportMarginProperty?: `--${string}`;
 }

--- a/libs/components/core/src/lib/modules/viewkeeper/viewkeeper-options.ts
+++ b/libs/components/core/src/lib/modules/viewkeeper/viewkeeper-options.ts
@@ -44,4 +44,9 @@ export interface SkyViewkeeperOptions {
    * Reserved space in pixels at the top of the viewport.
    */
   viewportMarginTop?: number;
+
+  /**
+   * Custom CSS property for reserved space at the top of the viewport.
+   */
+  viewportMarginProperty?: `--${string}`;
 }

--- a/libs/components/core/src/lib/modules/viewkeeper/viewkeeper.spec.ts
+++ b/libs/components/core/src/lib/modules/viewkeeper/viewkeeper.spec.ts
@@ -213,6 +213,31 @@ describe('Viewkeeper', () => {
       );
     });
 
+    it('should support viewportMarginProperty', () => {
+      boundaryEl.style.setProperty('--test-viewport-top', '14px');
+
+      vks.push(
+        new SkyViewkeeper({
+          el,
+          boundaryEl,
+          viewportMarginProperty: '--test-viewport-top',
+          setWidth: true,
+        }),
+      );
+
+      scrollWindowTo(0, 20);
+      validatePinned(el, true, 0, 14);
+      expect(el.style.marginTop).toBe(
+        'calc(0px + var(--test-viewport-top, 0))',
+      );
+
+      scrollWindowTo(50, 890);
+      validatePinned(el, true, 0, 14);
+      expect(el.style.marginTop).toBe(
+        'calc(0px + var(--test-viewport-top, 0))',
+      );
+    });
+
     describe('ResizeObserver', () => {
       const NativeResizeObserver = ResizeObserver;
 

--- a/libs/components/core/src/lib/modules/viewkeeper/viewkeeper.spec.ts
+++ b/libs/components/core/src/lib/modules/viewkeeper/viewkeeper.spec.ts
@@ -9,12 +9,20 @@ describe('Viewkeeper', () => {
   let vks: SkyViewkeeper[];
 
   function scrollWindowTo(x: number, y: number): void {
-    window.scrollTo(x, y);
+    window.scrollTo({
+      top: y,
+      left: x,
+      behavior: 'instant',
+    });
     SkyAppTestUtility.fireDomEvent(window, 'scroll');
   }
 
   function scrollScrollableHost(x: number, y: number): void {
-    scrollableHostEl.scrollTo(x, y);
+    scrollableHostEl.scrollTo({
+      top: y,
+      left: x,
+      behavior: 'instant',
+    });
     SkyAppTestUtility.fireDomEvent(scrollableHostEl, 'scroll');
   }
 
@@ -214,8 +222,6 @@ describe('Viewkeeper', () => {
     });
 
     it('should support viewportMarginProperty', () => {
-      boundaryEl.style.setProperty('--test-viewport-top', '14px');
-
       vks.push(
         new SkyViewkeeper({
           el,
@@ -225,17 +231,20 @@ describe('Viewkeeper', () => {
         }),
       );
 
-      scrollWindowTo(0, 20);
-      validatePinned(el, true, 0, 14);
+      scrollWindowTo(0, 10);
+      validatePinned(el, false);
+      document.documentElement.style.setProperty('--test-viewport-top', '2px');
+      scrollWindowTo(40, 100);
+      validatePinned(el, true, 0, 2);
       expect(el.style.marginTop).toBe(
         'calc(0px + var(--test-viewport-top, 0))',
       );
 
-      scrollWindowTo(50, 890);
-      validatePinned(el, true, 0, 14);
-      expect(el.style.marginTop).toBe(
-        'calc(0px + var(--test-viewport-top, 0))',
-      );
+      document.documentElement.style.setProperty('--test-viewport-top', '12px');
+      validatePinned(el, true, 0, 12);
+
+      document.documentElement.style.removeProperty('--test-viewport-top');
+      document.body.style.removeProperty('--test-viewport-top');
     });
 
     describe('ResizeObserver', () => {

--- a/libs/components/core/src/lib/modules/viewkeeper/viewkeeper.ts
+++ b/libs/components/core/src/lib/modules/viewkeeper/viewkeeper.ts
@@ -310,9 +310,19 @@ export class SkyViewkeeper {
       anchorTop = getOffset(el, this.#scrollableHost).top;
     }
 
+    let viewportMarginTop = this.#viewportMarginTop;
+    if (this.#viewportMarginProperty) {
+      viewportMarginTop += parseInt(
+        document.documentElement.style.getPropertyValue(
+          this.#viewportMarginProperty,
+        ) ??
+          document.body.style.getPropertyValue(this.#viewportMarginProperty) ??
+          '0',
+      );
+    }
+
     const doFixEl =
-      boundaryInfo.scrollTop + verticalOffset + this.#viewportMarginTop >
-      anchorTop;
+      boundaryInfo.scrollTop + verticalOffset + viewportMarginTop > anchorTop;
 
     return doFixEl;
   }

--- a/libs/components/core/src/lib/modules/viewkeeper/viewkeeper.ts
+++ b/libs/components/core/src/lib/modules/viewkeeper/viewkeeper.ts
@@ -68,12 +68,16 @@ function setElPosition(
   top: number | string,
   width: number | string,
   marginTop: number | string,
+  marginTopProperty: string | undefined,
   clipTop: number | string,
   clipLeft: number | string,
 ): void {
   el.style.top = px(top);
   el.style.left = px(left);
-  el.style.marginTop = px(marginTop);
+  const marginTopStyle = marginTopProperty
+    ? `calc(${px(marginTop)} + var(${marginTopProperty}, 0))`
+    : px(marginTop);
+  el.style.marginTop = `${marginTopStyle}`;
   el.style.clipPath =
     clipTop || clipLeft ? `inset(${px(clipTop)} 0 0 ${px(clipLeft)})` : 'none';
 
@@ -116,6 +120,8 @@ export class SkyViewkeeper {
   #verticalOffsetEl: HTMLElement | undefined;
 
   #viewportMarginTop = 0;
+
+  #viewportMarginProperty: `--${string}` | undefined;
 
   #currentElFixedLeft: number | undefined;
 
@@ -163,6 +169,7 @@ export class SkyViewkeeper {
     // Only set viewport margin if the scrollable host is undefined.
     if (!this.#scrollableHost) {
       this.#viewportMarginTop = options.viewportMarginTop ?? 0;
+      this.#viewportMarginProperty = options.viewportMarginProperty;
     }
 
     this.#syncElPositionHandler = (): void =>
@@ -272,7 +279,7 @@ export class SkyViewkeeper {
       width = 'auto';
     }
 
-    setElPosition(el, '', '', width, '', 0, 0);
+    setElPosition(el, '', '', width, '', '', 0, 0);
   }
 
   #calculateVerticalOffset(): number {
@@ -413,6 +420,7 @@ export class SkyViewkeeper {
       fixedStyles.elFixedTop,
       width,
       this.#viewportMarginTop,
+      this.#viewportMarginProperty,
       fixedStyles.elClipTop,
       fixedStyles.elClipLeft,
     );

--- a/libs/components/core/src/lib/modules/viewkeeper/viewkeeper.ts
+++ b/libs/components/core/src/lib/modules/viewkeeper/viewkeeper.ts
@@ -9,11 +9,11 @@ const EVT_AFTER_VIEWKEEPER_SYNC = 'afterViewkeeperSync';
 let styleEl: HTMLStyleElement;
 let nextIdIndex: number;
 
-function ensureStyleEl(doc: Document): void {
+function ensureStyleEl(): void {
   if (!styleEl) {
-    styleEl = doc.createElement('style');
+    styleEl = document.createElement('style');
 
-    const css = doc.createTextNode(`
+    const css = document.createTextNode(`
 .${CLS_VIEWKEEPER_FIXED} {
   position: fixed !important;
   z-index: 999;
@@ -29,7 +29,7 @@ function ensureStyleEl(doc: Document): void {
 
     styleEl.appendChild(css);
 
-    doc.head.appendChild(styleEl);
+    document.head.appendChild(styleEl);
   }
 }
 
@@ -41,10 +41,10 @@ function nextId(): string {
 
 function getOffset(
   el: HTMLElement,
-  scrollableHost: HTMLElement | undefined,
+  scrollableHost?: HTMLElement,
 ): SkyViewkeeperOffset {
   const rect = el.getBoundingClientRect();
-  const parent = scrollableHost ?? el.ownerDocument.documentElement;
+  const parent = scrollableHost ? scrollableHost : document.documentElement;
 
   return {
     top: rect.top + parent.scrollTop,
@@ -97,8 +97,8 @@ function getHeightWithMargin(el: HTMLElement): number {
   );
 }
 
-function createCustomEvent(doc: Document, name: any): CustomEvent<any> {
-  const evt = doc.createEvent('CustomEvent');
+function createCustomEvent(name: any): CustomEvent<any> {
+  const evt = document.createEvent('CustomEvent');
 
   evt.initCustomEvent(name, false, false, undefined);
 
@@ -185,7 +185,7 @@ export class SkyViewkeeper {
     window.addEventListener('resize', this.#syncElPositionHandler);
     window.addEventListener('orientationchange', this.#syncElPositionHandler);
 
-    ensureStyleEl(el.ownerDocument);
+    ensureStyleEl();
 
     this.syncElPosition(el, boundaryEl);
   }
@@ -211,7 +211,7 @@ export class SkyViewkeeper {
       }
     }
 
-    const evt = createCustomEvent(el.ownerDocument, EVT_AFTER_VIEWKEEPER_SYNC);
+    const evt = createCustomEvent(EVT_AFTER_VIEWKEEPER_SYNC);
 
     el.dispatchEvent(evt);
   }
@@ -254,7 +254,7 @@ export class SkyViewkeeper {
   }
 
   #unfixEl(el: HTMLElement): void {
-    const spacerEl = el.ownerDocument.getElementById(this.#getSpacerId());
+    const spacerEl = document.getElementById(this.#getSpacerId());
 
     if (spacerEl) {
       this.#spacerResizeObserver?.unobserve(spacerEl);
@@ -312,7 +312,7 @@ export class SkyViewkeeper {
     let viewportMarginTop = this.#viewportMarginTop;
     const viewportMarginProperty =
       this.#viewportMarginProperty &&
-      el.ownerDocument.documentElement.style.getPropertyValue(
+      getComputedStyle(document.body).getPropertyValue(
         this.#viewportMarginProperty,
       );
     if (viewportMarginProperty) {
@@ -390,7 +390,7 @@ export class SkyViewkeeper {
     if (!boundaryInfo.spacerEl) {
       const spacerHeight = boundaryInfo.elHeight;
 
-      const spacerEl = el.ownerDocument.createElement('div');
+      const spacerEl = document.createElement('div');
       spacerEl.id = boundaryInfo.spacerId;
       spacerEl.style.height = px(spacerHeight);
 
@@ -440,7 +440,7 @@ export class SkyViewkeeper {
   ): SkyViewkeeperBoundaryInfo {
     const spacerId = this.#getSpacerId();
 
-    const spacerEl = el.ownerDocument.getElementById(spacerId);
+    const spacerEl = document.getElementById(spacerId);
 
     const boundaryOffset = getOffset(boundaryEl, this.#scrollableHost);
     const boundaryTop = boundaryOffset.top;
@@ -449,10 +449,10 @@ export class SkyViewkeeper {
 
     const scrollLeft = this.#scrollableHost
       ? this.#scrollableHost.scrollLeft
-      : el.ownerDocument.documentElement.scrollLeft;
+      : document.documentElement.scrollLeft;
     const scrollTop = this.#scrollableHost
       ? this.#scrollableHost.scrollTop
-      : el.ownerDocument.documentElement.scrollTop;
+      : document.documentElement.scrollTop;
 
     const elHeight = getHeightWithMargin(el);
 

--- a/libs/components/theme/src/lib/viewport/viewport-reserve-args.ts
+++ b/libs/components/theme/src/lib/viewport/viewport-reserve-args.ts
@@ -18,4 +18,9 @@ export interface SkyAppViewportReserveArgs {
    * The number of pixels to reserve.
    */
   size: number;
+
+  /**
+   * Only reserve space when this element is in view.
+   */
+  reserveForElement?: HTMLElement;
 }

--- a/libs/components/theme/src/lib/viewport/viewport.service.spec.ts
+++ b/libs/components/theme/src/lib/viewport/viewport.service.spec.ts
@@ -27,7 +27,7 @@ describe('Viewport service', () => {
     expect(svc.visible instanceof ReplaySubject).toEqual(true);
   });
 
-  it('should reserve and unreserve space', () => {
+  it('should reserve and unreserve space', async () => {
     svc.reserveSpace({
       id: 'left-test',
       position: 'left',
@@ -52,6 +52,7 @@ describe('Viewport service', () => {
       size: 50,
     });
 
+    await new Promise((resolve) => requestAnimationFrame(resolve));
     validateViewportSpace('left', 20);
     validateViewportSpace('top', 30);
     validateViewportSpace('right', 40);
@@ -62,6 +63,7 @@ describe('Viewport service', () => {
     svc.unreserveSpace('right-test');
     svc.unreserveSpace('bottom-test');
 
+    await new Promise((resolve) => requestAnimationFrame(resolve));
     validateViewportSpace('left', 0);
     validateViewportSpace('top', 0);
     validateViewportSpace('right', 0);
@@ -129,7 +131,7 @@ describe('Viewport service', () => {
       reserveForElement: item2,
     });
 
-    await new Promise((resolve) => requestAnimationFrame(resolve));
+    await new Promise((resolve) => setTimeout(resolve, 32));
     await new Promise((resolve) => requestAnimationFrame(resolve));
     expect(isInViewport(item1)).toBeTrue();
     validateViewportSpace('top', 50);
@@ -137,6 +139,7 @@ describe('Viewport service', () => {
       top: viewportHeight + 50,
       behavior: 'instant',
     });
+    await new Promise((resolve) => requestAnimationFrame(resolve));
     await new Promise((resolve) => requestAnimationFrame(resolve));
     expect(isInViewport(item1)).toBeFalse();
     expect(isInViewport(item2)).toBeTrue();
@@ -149,6 +152,7 @@ describe('Viewport service', () => {
       top: 0,
       behavior: 'instant',
     });
+    await new Promise((resolve) => setTimeout(resolve, 32));
     await new Promise((resolve) => requestAnimationFrame(resolve));
     expect(isInViewport(item1)).toBeTrue();
     validateViewportSpace('top', 50);

--- a/libs/components/theme/src/lib/viewport/viewport.service.spec.ts
+++ b/libs/components/theme/src/lib/viewport/viewport.service.spec.ts
@@ -75,7 +75,7 @@ describe('Viewport service', () => {
 
     expect(viewportHeight).toBeGreaterThan(50);
 
-    function isInViewport(element: Element) {
+    function isInViewport(element: Element): boolean {
       const rect = element.getBoundingClientRect();
       return (
         rect.top >= 0 &&
@@ -105,6 +105,7 @@ describe('Viewport service', () => {
     container.appendChild(item1);
 
     const item2 = document.createElement('div');
+    // eslint-disable-next-line @cspell/spellchecker
     item2.style.backgroundColor = 'lightgreen';
     item2.style.height = '54px';
     item2.style.width = '100px';

--- a/libs/components/theme/src/lib/viewport/viewport.service.spec.ts
+++ b/libs/components/theme/src/lib/viewport/viewport.service.spec.ts
@@ -1,3 +1,5 @@
+import { TestBed, waitForAsync } from '@angular/core/testing';
+
 import { ReplaySubject } from 'rxjs';
 
 import { SkyAppViewportReservedPositionType } from './viewport-reserve-position-type';
@@ -18,7 +20,7 @@ describe('Viewport service', () => {
   }
 
   beforeEach(() => {
-    svc = new SkyAppViewportService(document);
+    svc = TestBed.inject(SkyAppViewportService);
   });
 
   it('should return an observable when the content is visible', () => {
@@ -65,4 +67,95 @@ describe('Viewport service', () => {
     validateViewportSpace('right', 0);
     validateViewportSpace('bottom', 0);
   });
+
+  it('should reserve and unreserve space for elements that scroll out of view', waitForAsync(async () => {
+    const viewportHeight = window.innerHeight;
+
+    expect(viewportHeight).toBeGreaterThan(50);
+
+    function isInViewport(element: Element) {
+      const rect = element.getBoundingClientRect();
+      return (
+        rect.top >= 0 &&
+        rect.left >= 0 &&
+        rect.bottom <=
+          (window.innerHeight || document.documentElement.clientHeight) &&
+        rect.right <=
+          (window.innerWidth || document.documentElement.clientWidth)
+      );
+    }
+
+    const container = document.createElement('div');
+    container.style.height = '200vh';
+    container.style.position = 'relative';
+    container.style.marginTop = '20px';
+    container.appendChild(document.createTextNode('Scroll down'));
+
+    const item1 = document.createElement('div');
+    item1.style.backgroundColor = 'lightblue';
+    item1.style.height = '50px';
+    item1.style.width = '100px';
+    item1.style.overflow = 'hidden';
+    item1.style.position = 'absolute';
+    item1.style.top = '0';
+    item1.style.left = '0';
+    item1.appendChild(document.createTextNode('Item 1'));
+    container.appendChild(item1);
+
+    const item2 = document.createElement('div');
+    item2.style.backgroundColor = 'lightgreen';
+    item2.style.height = '54px';
+    item2.style.width = '100px';
+    item2.style.overflow = 'hidden';
+    item2.style.position = 'absolute';
+    item2.style.top = `${viewportHeight + 50}px`;
+    item2.style.left = '0';
+    item2.appendChild(document.createTextNode('Item 2'));
+    container.appendChild(item2);
+
+    document.body.appendChild(container);
+
+    svc.reserveSpace({
+      id: 'item1-test',
+      position: 'top',
+      size: 50,
+      reserveForElement: item1,
+    });
+
+    svc.reserveSpace({
+      id: 'item2-test',
+      position: 'top',
+      size: 54,
+      reserveForElement: item2,
+    });
+
+    await new Promise((resolve) => requestAnimationFrame(resolve));
+    await new Promise((resolve) => requestAnimationFrame(resolve));
+    expect(isInViewport(item1)).toBeTrue();
+    validateViewportSpace('top', 50);
+    window.scrollTo({
+      top: viewportHeight + 50,
+      behavior: 'instant',
+    });
+    await new Promise((resolve) => requestAnimationFrame(resolve));
+    expect(isInViewport(item1)).toBeFalse();
+    expect(isInViewport(item2)).toBeTrue();
+    validateViewportSpace('top', 54);
+
+    svc.unreserveSpace('item2-test');
+    await new Promise((resolve) => requestAnimationFrame(resolve));
+    validateViewportSpace('top', 0);
+    window.scrollTo({
+      top: 0,
+      behavior: 'instant',
+    });
+    await new Promise((resolve) => requestAnimationFrame(resolve));
+    expect(isInViewport(item1)).toBeTrue();
+    validateViewportSpace('top', 50);
+    svc.unreserveSpace('item1-test');
+    await new Promise((resolve) => requestAnimationFrame(resolve));
+    validateViewportSpace('top', 0);
+
+    document.body.removeChild(container);
+  }));
 });

--- a/libs/components/theme/src/lib/viewport/viewport.service.ts
+++ b/libs/components/theme/src/lib/viewport/viewport.service.ts
@@ -25,7 +25,9 @@ export class SkyAppViewportService {
    */
   public visible = new ReplaySubject<boolean>(1);
 
-  #updateRequest: number | undefined;
+  // ESLint doesn't recognize how this is used.
+  // eslint-disable-next-line no-unused-private-class-members
+  #updateRequest: number | undefined = undefined;
   readonly #reserveItems = new Map<string, ReserveItemType>();
   readonly #conditionallyReserveItems = new Map<Element, ReserveItemType>();
   readonly #document = inject(DOCUMENT);
@@ -46,7 +48,7 @@ export class SkyAppViewportService {
   );
 
   constructor() {
-    const onScroll = () => {
+    const onScroll = (): void => {
       if (this.#conditionallyReserveItems.size > 0) {
         this.#updateViewportArea();
       }

--- a/scripts/publish-local.ts
+++ b/scripts/publish-local.ts
@@ -40,6 +40,7 @@ async function skyuxDevCommand(
     const npmConfig = [
       [`@skyux:registry`, `http:${localRepo}`],
       [`@skyux-sdk:registry`, `http:${localRepo}`],
+      [`registry`, `http:${localRepo}`],
       // Having an auth token is required for publishing to a local registry, even if it's not used.
       [`${localRepo}:_authToken`, `YXV0aFRva2Vu`],
     ];


### PR DESCRIPTION
[AB#3248387](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3248387)

- [ ] add a `marginTopProperty` option to viewkeeper to use with e.g., `--sky-viewport-top`
- [ ] allow viewport reserve space entries to be associated with an element
  - [ ] only reserve space when the top left of the element is within the viewport and not obscured by another element stacked on top of it