### PR TITLE
feat(components/layout): add harness for description list (#3124)

### DIFF
--- a/apps/code-examples/src/app/code-examples/layout/description-list/help-key/demo.component.spec.ts
+++ b/apps/code-examples/src/app/code-examples/layout/description-list/help-key/demo.component.spec.ts
@@ -1,0 +1,59 @@
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import {
+  SkyHelpTestingController,
+  SkyHelpTestingModule,
+} from '@skyux/core/testing';
+import { SkyDescriptionListHarness } from '@skyux/layout/testing';
+
+import { DemoComponent } from './demo.component';
+
+describe('Help key description list', () => {
+  async function setupTest(
+    options: {
+      dataSkyId?: string;
+    } = {},
+  ): Promise<{
+    descriptionListHarness: SkyDescriptionListHarness;
+    fixture: ComponentFixture<DemoComponent>;
+    helpController: SkyHelpTestingController;
+  }> {
+    await TestBed.configureTestingModule({
+      imports: [DemoComponent, SkyHelpTestingModule, NoopAnimationsModule],
+    }).compileComponents();
+
+    const fixture = TestBed.createComponent(DemoComponent);
+    const loader = TestbedHarnessEnvironment.documentRootLoader(fixture);
+    const helpController = TestBed.inject(SkyHelpTestingController);
+
+    const descriptionListHarness: SkyDescriptionListHarness =
+      await loader.getHarness(SkyDescriptionListHarness);
+
+    return { descriptionListHarness, fixture, helpController };
+  }
+
+  it('should set up the component', async () => {
+    const { descriptionListHarness, fixture, helpController } =
+      await setupTest();
+
+    await expectAsync(descriptionListHarness.getMode()).toBeResolvedTo(
+      'horizontal',
+    );
+
+    const content = await descriptionListHarness.getContent();
+
+    expect(content.length).toBe(4);
+
+    await expectAsync(content[0].getTermText()).toBeResolvedTo('College');
+    await expectAsync(content[0].getDescriptionText()).toBeResolvedTo(
+      'Humanities and Social Sciences',
+    );
+
+    await content[0].clickHelpInline();
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    helpController.expectCurrentHelpKey('college-help');
+  });
+});

--- a/apps/code-examples/src/app/code-examples/layout/description-list/horizontal/demo.component.spec.ts
+++ b/apps/code-examples/src/app/code-examples/layout/description-list/horizontal/demo.component.spec.ts
@@ -1,0 +1,54 @@
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { SkyHelpTestingModule } from '@skyux/core/testing';
+import { SkyDescriptionListHarness } from '@skyux/layout/testing';
+
+import { DemoComponent } from './demo.component';
+
+describe('Horizontal description list', () => {
+  async function setupTest(
+    options: {
+      dataSkyId?: string;
+    } = {},
+  ): Promise<{
+    descriptionListHarness: SkyDescriptionListHarness;
+    fixture: ComponentFixture<DemoComponent>;
+  }> {
+    await TestBed.configureTestingModule({
+      imports: [DemoComponent, SkyHelpTestingModule, NoopAnimationsModule],
+    }).compileComponents();
+
+    const fixture = TestBed.createComponent(DemoComponent);
+    const loader = TestbedHarnessEnvironment.documentRootLoader(fixture);
+
+    const descriptionListHarness: SkyDescriptionListHarness =
+      await loader.getHarness(SkyDescriptionListHarness);
+
+    return { descriptionListHarness, fixture };
+  }
+
+  it('should set up the component', async () => {
+    const { descriptionListHarness, fixture } = await setupTest();
+
+    await expectAsync(descriptionListHarness.getMode()).toBeResolvedTo(
+      'horizontal',
+    );
+
+    const content = await descriptionListHarness.getContent();
+
+    expect(content.length).toBe(4);
+
+    await expectAsync(content[0].getTermText()).toBeResolvedTo('College');
+    await expectAsync(content[0].getDescriptionText()).toBeResolvedTo(
+      'Humanities and Social Sciences',
+    );
+
+    await content[2].clickHelpInline();
+    fixture.detectChanges();
+    await fixture.whenStable();
+    await expectAsync(content[2].getHelpPopoverContent()).toBeResolvedTo(
+      'The faculty member who advises the student.',
+    );
+  });
+});

--- a/apps/code-examples/src/app/code-examples/layout/description-list/inline-help/demo.component.spec.ts
+++ b/apps/code-examples/src/app/code-examples/layout/description-list/inline-help/demo.component.spec.ts
@@ -1,0 +1,54 @@
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { SkyHelpTestingModule } from '@skyux/core/testing';
+import { SkyDescriptionListHarness } from '@skyux/layout/testing';
+
+import { DemoComponent } from './demo.component';
+
+describe('Horizontal description list', () => {
+  async function setupTest(
+    options: {
+      dataSkyId?: string;
+    } = {},
+  ): Promise<{
+    descriptionListHarness: SkyDescriptionListHarness;
+    fixture: ComponentFixture<DemoComponent>;
+  }> {
+    await TestBed.configureTestingModule({
+      imports: [DemoComponent, SkyHelpTestingModule, NoopAnimationsModule],
+    }).compileComponents();
+
+    const fixture = TestBed.createComponent(DemoComponent);
+    const loader = TestbedHarnessEnvironment.documentRootLoader(fixture);
+
+    const descriptionListHarness: SkyDescriptionListHarness =
+      await loader.getHarness(SkyDescriptionListHarness);
+
+    return { descriptionListHarness, fixture };
+  }
+
+  it('should set up the component', async () => {
+    const { descriptionListHarness, fixture } = await setupTest();
+
+    await expectAsync(descriptionListHarness.getMode()).toBeResolvedTo(
+      'horizontal',
+    );
+
+    const content = await descriptionListHarness.getContent();
+
+    expect(content.length).toBe(4);
+
+    await expectAsync(content[0].getTermText()).toBeResolvedTo('College');
+    await expectAsync(content[0].getDescriptionText()).toBeResolvedTo(
+      'Humanities and Social Sciences',
+    );
+
+    await content[2].clickHelpInline();
+    fixture.detectChanges();
+    await fixture.whenStable();
+    await expectAsync(content[2].getHelpPopoverContent()).toBeResolvedTo(
+      'The faculty member who advises the student.',
+    );
+  });
+});

--- a/apps/code-examples/src/app/code-examples/layout/description-list/long-description/demo.component.spec.ts
+++ b/apps/code-examples/src/app/code-examples/layout/description-list/long-description/demo.component.spec.ts
@@ -1,0 +1,49 @@
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { SkyHelpTestingModule } from '@skyux/core/testing';
+import { SkyDescriptionListHarness } from '@skyux/layout/testing';
+
+import { DemoComponent } from './demo.component';
+
+describe('Long description list', () => {
+  async function setupTest(
+    options: {
+      dataSkyId?: string;
+    } = {},
+  ): Promise<{
+    descriptionListHarness: SkyDescriptionListHarness;
+    fixture: ComponentFixture<DemoComponent>;
+  }> {
+    await TestBed.configureTestingModule({
+      imports: [DemoComponent, SkyHelpTestingModule, NoopAnimationsModule],
+    }).compileComponents();
+
+    const fixture = TestBed.createComponent(DemoComponent);
+    const loader = TestbedHarnessEnvironment.documentRootLoader(fixture);
+
+    const descriptionListHarness: SkyDescriptionListHarness =
+      await loader.getHarness(SkyDescriptionListHarness);
+
+    return { descriptionListHarness, fixture };
+  }
+
+  it('should set up the component', async () => {
+    const { descriptionListHarness } = await setupTest();
+
+    await expectAsync(descriptionListHarness.getMode()).toBeResolvedTo(
+      'longDescription',
+    );
+
+    const content = await descriptionListHarness.getContent();
+
+    expect(content.length).toBe(3);
+
+    await expectAsync(content[0].getTermText()).toBeResolvedTo(
+      'Good Health and Well-being',
+    );
+    await expectAsync(content[0].getDescriptionText()).toBeResolvedTo(
+      'Ensure healthy lives and promote well-being for all at all ages.',
+    );
+  });
+});

--- a/apps/code-examples/src/app/code-examples/layout/description-list/vertical/demo.component.spec.ts
+++ b/apps/code-examples/src/app/code-examples/layout/description-list/vertical/demo.component.spec.ts
@@ -1,0 +1,54 @@
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { SkyHelpTestingModule } from '@skyux/core/testing';
+import { SkyDescriptionListHarness } from '@skyux/layout/testing';
+
+import { DemoComponent } from './demo.component';
+
+describe('Vertical description list', () => {
+  async function setupTest(
+    options: {
+      dataSkyId?: string;
+    } = {},
+  ): Promise<{
+    descriptionListHarness: SkyDescriptionListHarness;
+    fixture: ComponentFixture<DemoComponent>;
+  }> {
+    await TestBed.configureTestingModule({
+      imports: [DemoComponent, SkyHelpTestingModule, NoopAnimationsModule],
+    }).compileComponents();
+
+    const fixture = TestBed.createComponent(DemoComponent);
+    const loader = TestbedHarnessEnvironment.documentRootLoader(fixture);
+
+    const descriptionListHarness: SkyDescriptionListHarness =
+      await loader.getHarness(SkyDescriptionListHarness);
+
+    return { descriptionListHarness, fixture };
+  }
+
+  it('should set up the component', async () => {
+    const { descriptionListHarness, fixture } = await setupTest();
+
+    await expectAsync(descriptionListHarness.getMode()).toBeResolvedTo(
+      'vertical',
+    );
+
+    const content = await descriptionListHarness.getContent();
+
+    expect(content.length).toBe(4);
+
+    await expectAsync(content[0].getTermText()).toBeResolvedTo('College');
+    await expectAsync(content[0].getDescriptionText()).toBeResolvedTo(
+      'Humanities and Social Sciences',
+    );
+
+    await content[2].clickHelpInline();
+    fixture.detectChanges();
+    await fixture.whenStable();
+    await expectAsync(content[2].getHelpPopoverContent()).toBeResolvedTo(
+      'The faculty member who advises the student.',
+    );
+  });
+});

--- a/libs/components/code-examples/src/lib/modules/layout/description-list/help-key/example.component.spec.ts
+++ b/libs/components/code-examples/src/lib/modules/layout/description-list/help-key/example.component.spec.ts
@@ -1,0 +1,65 @@
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import {
+  SkyHelpTestingController,
+  SkyHelpTestingModule,
+} from '@skyux/core/testing';
+import { SkyDescriptionListHarness } from '@skyux/layout/testing';
+
+import { LayoutDescriptionListHelpKeyExampleComponent } from './example.component';
+
+describe('Help key description list', () => {
+  async function setupTest(
+    options: {
+      dataSkyId?: string;
+    } = {},
+  ): Promise<{
+    descriptionListHarness: SkyDescriptionListHarness;
+    fixture: ComponentFixture<LayoutDescriptionListHelpKeyExampleComponent>;
+    helpController: SkyHelpTestingController;
+  }> {
+    await TestBed.configureTestingModule({
+      imports: [
+        LayoutDescriptionListHelpKeyExampleComponent,
+        SkyHelpTestingModule,
+        NoopAnimationsModule,
+      ],
+    }).compileComponents();
+
+    const fixture = TestBed.createComponent(
+      LayoutDescriptionListHelpKeyExampleComponent,
+    );
+    const loader = TestbedHarnessEnvironment.documentRootLoader(fixture);
+    const helpController = TestBed.inject(SkyHelpTestingController);
+
+    const descriptionListHarness: SkyDescriptionListHarness =
+      await loader.getHarness(SkyDescriptionListHarness);
+
+    return { descriptionListHarness, fixture, helpController };
+  }
+
+  it('should set up the component', async () => {
+    const { descriptionListHarness, fixture, helpController } =
+      await setupTest();
+
+    await expectAsync(descriptionListHarness.getMode()).toBeResolvedTo(
+      'horizontal',
+    );
+
+    const content = await descriptionListHarness.getContent();
+
+    expect(content.length).toBe(4);
+
+    await expectAsync(content[0].getTermText()).toBeResolvedTo('College');
+    await expectAsync(content[0].getDescriptionText()).toBeResolvedTo(
+      'Humanities and Social Sciences',
+    );
+
+    await content[0].clickHelpInline();
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    helpController.expectCurrentHelpKey('college-help');
+  });
+});

--- a/libs/components/code-examples/src/lib/modules/layout/description-list/horizontal/example.component.spec.ts
+++ b/libs/components/code-examples/src/lib/modules/layout/description-list/horizontal/example.component.spec.ts
@@ -1,0 +1,60 @@
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { SkyHelpTestingModule } from '@skyux/core/testing';
+import { SkyDescriptionListHarness } from '@skyux/layout/testing';
+
+import { LayoutDescriptionListHorizontalExampleComponent } from './example.component';
+
+describe('Horizontal description list', () => {
+  async function setupTest(
+    options: {
+      dataSkyId?: string;
+    } = {},
+  ): Promise<{
+    descriptionListHarness: SkyDescriptionListHarness;
+    fixture: ComponentFixture<LayoutDescriptionListHorizontalExampleComponent>;
+  }> {
+    await TestBed.configureTestingModule({
+      imports: [
+        LayoutDescriptionListHorizontalExampleComponent,
+        SkyHelpTestingModule,
+        NoopAnimationsModule,
+      ],
+    }).compileComponents();
+
+    const fixture = TestBed.createComponent(
+      LayoutDescriptionListHorizontalExampleComponent,
+    );
+    const loader = TestbedHarnessEnvironment.documentRootLoader(fixture);
+
+    const descriptionListHarness: SkyDescriptionListHarness =
+      await loader.getHarness(SkyDescriptionListHarness);
+
+    return { descriptionListHarness, fixture };
+  }
+
+  it('should set up the component', async () => {
+    const { descriptionListHarness, fixture } = await setupTest();
+
+    await expectAsync(descriptionListHarness.getMode()).toBeResolvedTo(
+      'horizontal',
+    );
+
+    const content = await descriptionListHarness.getContent();
+
+    expect(content.length).toBe(4);
+
+    await expectAsync(content[0].getTermText()).toBeResolvedTo('College');
+    await expectAsync(content[0].getDescriptionText()).toBeResolvedTo(
+      'Humanities and Social Sciences',
+    );
+
+    await content[2].clickHelpInline();
+    fixture.detectChanges();
+    await fixture.whenStable();
+    await expectAsync(content[2].getHelpPopoverContent()).toBeResolvedTo(
+      'The faculty member who advises the student.',
+    );
+  });
+});

--- a/libs/components/code-examples/src/lib/modules/layout/description-list/inline-help/example.component.spec.ts
+++ b/libs/components/code-examples/src/lib/modules/layout/description-list/inline-help/example.component.spec.ts
@@ -1,0 +1,60 @@
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { SkyHelpTestingModule } from '@skyux/core/testing';
+import { SkyDescriptionListHarness } from '@skyux/layout/testing';
+
+import { LayoutDescriptionListInlineHelpExampleComponent } from './example.component';
+
+describe('Horizontal description list', () => {
+  async function setupTest(
+    options: {
+      dataSkyId?: string;
+    } = {},
+  ): Promise<{
+    descriptionListHarness: SkyDescriptionListHarness;
+    fixture: ComponentFixture<LayoutDescriptionListInlineHelpExampleComponent>;
+  }> {
+    await TestBed.configureTestingModule({
+      imports: [
+        LayoutDescriptionListInlineHelpExampleComponent,
+        SkyHelpTestingModule,
+        NoopAnimationsModule,
+      ],
+    }).compileComponents();
+
+    const fixture = TestBed.createComponent(
+      LayoutDescriptionListInlineHelpExampleComponent,
+    );
+    const loader = TestbedHarnessEnvironment.documentRootLoader(fixture);
+
+    const descriptionListHarness: SkyDescriptionListHarness =
+      await loader.getHarness(SkyDescriptionListHarness);
+
+    return { descriptionListHarness, fixture };
+  }
+
+  it('should set up the component', async () => {
+    const { descriptionListHarness, fixture } = await setupTest();
+
+    await expectAsync(descriptionListHarness.getMode()).toBeResolvedTo(
+      'horizontal',
+    );
+
+    const content = await descriptionListHarness.getContent();
+
+    expect(content.length).toBe(4);
+
+    await expectAsync(content[0].getTermText()).toBeResolvedTo('College');
+    await expectAsync(content[0].getDescriptionText()).toBeResolvedTo(
+      'Humanities and Social Sciences',
+    );
+
+    await content[2].clickHelpInline();
+    fixture.detectChanges();
+    await fixture.whenStable();
+    await expectAsync(content[2].getHelpPopoverContent()).toBeResolvedTo(
+      'The faculty member who advises the student.',
+    );
+  });
+});

--- a/libs/components/code-examples/src/lib/modules/layout/description-list/long-description/example.component.spec.ts
+++ b/libs/components/code-examples/src/lib/modules/layout/description-list/long-description/example.component.spec.ts
@@ -1,0 +1,55 @@
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { SkyHelpTestingModule } from '@skyux/core/testing';
+import { SkyDescriptionListHarness } from '@skyux/layout/testing';
+
+import { LayoutDescriptionListLongDescriptionExampleComponent } from './example.component';
+
+describe('Long description list', () => {
+  async function setupTest(
+    options: {
+      dataSkyId?: string;
+    } = {},
+  ): Promise<{
+    descriptionListHarness: SkyDescriptionListHarness;
+    fixture: ComponentFixture<LayoutDescriptionListLongDescriptionExampleComponent>;
+  }> {
+    await TestBed.configureTestingModule({
+      imports: [
+        LayoutDescriptionListLongDescriptionExampleComponent,
+        SkyHelpTestingModule,
+        NoopAnimationsModule,
+      ],
+    }).compileComponents();
+
+    const fixture = TestBed.createComponent(
+      LayoutDescriptionListLongDescriptionExampleComponent,
+    );
+    const loader = TestbedHarnessEnvironment.documentRootLoader(fixture);
+
+    const descriptionListHarness: SkyDescriptionListHarness =
+      await loader.getHarness(SkyDescriptionListHarness);
+
+    return { descriptionListHarness, fixture };
+  }
+
+  it('should set up the component', async () => {
+    const { descriptionListHarness } = await setupTest();
+
+    await expectAsync(descriptionListHarness.getMode()).toBeResolvedTo(
+      'longDescription',
+    );
+
+    const content = await descriptionListHarness.getContent();
+
+    expect(content.length).toBe(3);
+
+    await expectAsync(content[0].getTermText()).toBeResolvedTo(
+      'Good Health and Well-being',
+    );
+    await expectAsync(content[0].getDescriptionText()).toBeResolvedTo(
+      'Ensure healthy lives and promote well-being for all at all ages.',
+    );
+  });
+});

--- a/libs/components/code-examples/src/lib/modules/layout/description-list/vertical/example.component.spec.ts
+++ b/libs/components/code-examples/src/lib/modules/layout/description-list/vertical/example.component.spec.ts
@@ -1,0 +1,60 @@
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { SkyHelpTestingModule } from '@skyux/core/testing';
+import { SkyDescriptionListHarness } from '@skyux/layout/testing';
+
+import { LayoutDescriptionListVerticalExampleComponent } from './example.component';
+
+describe('Vertical description list', () => {
+  async function setupTest(
+    options: {
+      dataSkyId?: string;
+    } = {},
+  ): Promise<{
+    descriptionListHarness: SkyDescriptionListHarness;
+    fixture: ComponentFixture<LayoutDescriptionListVerticalExampleComponent>;
+  }> {
+    await TestBed.configureTestingModule({
+      imports: [
+        LayoutDescriptionListVerticalExampleComponent,
+        SkyHelpTestingModule,
+        NoopAnimationsModule,
+      ],
+    }).compileComponents();
+
+    const fixture = TestBed.createComponent(
+      LayoutDescriptionListVerticalExampleComponent,
+    );
+    const loader = TestbedHarnessEnvironment.documentRootLoader(fixture);
+
+    const descriptionListHarness: SkyDescriptionListHarness =
+      await loader.getHarness(SkyDescriptionListHarness);
+
+    return { descriptionListHarness, fixture };
+  }
+
+  it('should set up the component', async () => {
+    const { descriptionListHarness, fixture } = await setupTest();
+
+    await expectAsync(descriptionListHarness.getMode()).toBeResolvedTo(
+      'vertical',
+    );
+
+    const content = await descriptionListHarness.getContent();
+
+    expect(content.length).toBe(4);
+
+    await expectAsync(content[0].getTermText()).toBeResolvedTo('College');
+    await expectAsync(content[0].getDescriptionText()).toBeResolvedTo(
+      'Humanities and Social Sciences',
+    );
+
+    await content[2].clickHelpInline();
+    fixture.detectChanges();
+    await fixture.whenStable();
+    await expectAsync(content[2].getHelpPopoverContent()).toBeResolvedTo(
+      'The faculty member who advises the student.',
+    );
+  });
+});

--- a/libs/components/layout/testing/src/modules/description-list/description-list-content-harness.ts
+++ b/libs/components/layout/testing/src/modules/description-list/description-list-content-harness.ts
@@ -1,0 +1,79 @@
+import { SkyComponentHarness } from '@skyux/core/testing';
+import { SkyHelpInlineHarness } from '@skyux/help-inline/testing';
+
+import { SkyDescriptionListDescriptionHarness } from './description-list-description-harness';
+import { SkyDescriptionListTermHarness } from './description-list-term-harness';
+
+/**
+ * Harness for interacting with a description list content component in tests.
+ */
+export class SkyDescriptionListContentHarness extends SkyComponentHarness {
+  /**
+   * @internal
+   */
+  public static hostSelector = 'div.sky-description-list-content';
+
+  #getDescription = this.locatorForOptional(
+    SkyDescriptionListDescriptionHarness,
+  );
+  #getTerm = this.locatorForOptional(SkyDescriptionListTermHarness);
+
+  /**
+   * Clicks the help inline button.
+   */
+  public async clickHelpInline(): Promise<void> {
+    await (await this.#getHelpInline()).click();
+  }
+
+  /**
+   * Gets the description component text.
+   */
+  public async getDescriptionText(): Promise<string> {
+    const description = await this.#getDescription();
+
+    if (description === null) {
+      throw Error('No description list description found.');
+    }
+
+    return await description.getText();
+  }
+
+  /**
+   * Gets the help popover content.
+   */
+  public async getHelpPopoverContent(): Promise<string | undefined> {
+    const content = await (await this.#getHelpInline()).getPopoverContent();
+
+    return content as string | undefined;
+  }
+
+  /**
+   * Gets the help popover title.
+   */
+  public async getHelpPopoverTitle(): Promise<string | undefined> {
+    return await (await this.#getHelpInline()).getPopoverTitle();
+  }
+
+  /**
+   * Gets the term component text.
+   */
+  public async getTermText(): Promise<string> {
+    const term = await this.#getTerm();
+
+    if (term === null) {
+      throw Error('No description list term found.');
+    }
+
+    return await term.getText();
+  }
+
+  async #getHelpInline(): Promise<SkyHelpInlineHarness> {
+    const harness = await this.locatorForOptional(SkyHelpInlineHarness)();
+
+    if (harness) {
+      return harness;
+    }
+
+    throw Error('No help inline found.');
+  }
+}

--- a/libs/components/layout/testing/src/modules/description-list/description-list-description-harness.ts
+++ b/libs/components/layout/testing/src/modules/description-list/description-list-description-harness.ts
@@ -1,0 +1,27 @@
+import { ComponentHarness } from '@angular/cdk/testing';
+
+/**
+ * Harness for interacting with a description list description component in tests.
+ * @internal
+ */
+export class SkyDescriptionListDescriptionHarness extends ComponentHarness {
+  /**
+   * @internal
+   */
+  public static hostSelector = 'dd';
+
+  public async getText(): Promise<string> {
+    const description = (
+      await (
+        await this.locatorFor('.sky-description-list-description')()
+      ).text()
+    ).trim();
+
+    if (description === '') {
+      return await (
+        await this.locatorFor('.sky-description-list-default-value')()
+      ).text();
+    }
+    return description;
+  }
+}

--- a/libs/components/layout/testing/src/modules/description-list/description-list-harness-filters.ts
+++ b/libs/components/layout/testing/src/modules/description-list/description-list-harness-filters.ts
@@ -1,0 +1,7 @@
+import { SkyHarnessFilters } from '@skyux/core/testing';
+
+/**
+ * A set of criteria that can be used to filter a list of `SkyDescriptionListHarness` instances.
+ */
+// eslint-disable-next-line @typescript-eslint/no-empty-interface, @typescript-eslint/no-empty-object-type
+export interface SkyDescriptionListHarnessFilters extends SkyHarnessFilters {}

--- a/libs/components/layout/testing/src/modules/description-list/description-list-harness.spec.ts
+++ b/libs/components/layout/testing/src/modules/description-list/description-list-harness.spec.ts
@@ -1,0 +1,157 @@
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { SkyHelpService } from '@skyux/core';
+import { SkyHelpTestingModule } from '@skyux/core/testing';
+
+import { SkyDescriptionListHarness } from './description-list-harness';
+import { DescriptionListHarnessTestComponent } from './fixtures/description-list-test.component';
+
+describe('Description list test harness', () => {
+  async function setupTest(
+    options: {
+      dataSkyId?: string;
+    } = {},
+  ): Promise<{
+    descriptionListHarness: SkyDescriptionListHarness;
+    fixture: ComponentFixture<DescriptionListHarnessTestComponent>;
+  }> {
+    await TestBed.configureTestingModule({
+      imports: [
+        DescriptionListHarnessTestComponent,
+        SkyHelpTestingModule,
+        NoopAnimationsModule,
+      ],
+    }).compileComponents();
+
+    const fixture = TestBed.createComponent(
+      DescriptionListHarnessTestComponent,
+    );
+    const loader = TestbedHarnessEnvironment.documentRootLoader(fixture);
+
+    const descriptionListHarness: SkyDescriptionListHarness = options.dataSkyId
+      ? await loader.getHarness(
+          SkyDescriptionListHarness.with({
+            dataSkyId: options.dataSkyId,
+          }),
+        )
+      : await loader.getHarness(SkyDescriptionListHarness);
+
+    return { descriptionListHarness, fixture };
+  }
+
+  it('should get a description list by data-sky-id and return the mode', async () => {
+    const { descriptionListHarness, fixture } = await setupTest({
+      dataSkyId: 'description-list',
+    });
+
+    await expectAsync(descriptionListHarness.getMode()).toBeResolvedTo(
+      'vertical',
+    );
+
+    fixture.componentInstance.mode = 'horizontal';
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    await expectAsync(descriptionListHarness.getMode()).toBeResolvedTo(
+      'horizontal',
+    );
+
+    fixture.componentInstance.mode = 'longDescription';
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    await expectAsync(descriptionListHarness.getMode()).toBeResolvedTo(
+      'longDescription',
+    );
+  });
+
+  it('should get the description list content, terms, and descriptions', async () => {
+    const { descriptionListHarness } = await setupTest({
+      dataSkyId: 'description-list',
+    });
+
+    const items = await descriptionListHarness.getContent();
+
+    expect(items.length).toBe(5);
+
+    await expectAsync(items[0].getTermText()).toBeResolvedTo('College');
+    await expectAsync(items[0].getDescriptionText()).toBeResolvedTo(
+      'Humanities and Social Sciences',
+    );
+    await expectAsync(items[1].getDescriptionText()).toBeResolvedTo(
+      'None found.',
+    );
+  });
+
+  it('should throw an error if description list terms or descriptions are not found', async () => {
+    const { descriptionListHarness } = await setupTest({
+      dataSkyId: 'description-list',
+    });
+
+    const items = await descriptionListHarness.getContent();
+
+    await expectAsync(items[2].getTermText()).toBeRejectedWithError(
+      'No description list term found.',
+    );
+    await expectAsync(items[2].getDescriptionText()).toBeRejectedWithError(
+      'No description list description found.',
+    );
+  });
+
+  it('should throw an error if no description list content items are found', async () => {
+    const { descriptionListHarness } = await setupTest({
+      dataSkyId: 'empty-list',
+    });
+
+    await expectAsync(
+      descriptionListHarness.getContent(),
+    ).toBeRejectedWithError('Unable to find any description list content.');
+  });
+
+  it('should throw an error if no help inline is found', async () => {
+    const { descriptionListHarness } = await setupTest({
+      dataSkyId: 'description-list',
+    });
+
+    const contentHarness = (await descriptionListHarness.getContent())[0];
+
+    await expectAsync(contentHarness.clickHelpInline()).toBeRejectedWithError(
+      'No help inline found.',
+    );
+  });
+
+  it('should get help popover content and title', async () => {
+    const { descriptionListHarness, fixture } = await setupTest();
+
+    const contentHarness = (await descriptionListHarness.getContent())[3];
+
+    await contentHarness.clickHelpInline();
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    await expectAsync(contentHarness.getHelpPopoverContent()).toBeResolvedTo(
+      'The faculty member who advises the student.',
+    );
+    await expectAsync(contentHarness.getHelpPopoverTitle()).toBeResolvedTo(
+      `Help inline title`,
+    );
+  });
+
+  it('should open help widget when clicked', async () => {
+    const { descriptionListHarness, fixture } = await setupTest({
+      dataSkyId: 'description-list',
+    });
+
+    const contentHarness = (await descriptionListHarness.getContent())[4];
+
+    const helpSvc = TestBed.inject(SkyHelpService);
+    const helpSpy = spyOn(helpSvc, 'openHelp');
+
+    await contentHarness.clickHelpInline();
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(helpSpy).toHaveBeenCalledWith({ helpKey: 'helpKey.html' });
+  });
+});

--- a/libs/components/layout/testing/src/modules/description-list/description-list-harness.ts
+++ b/libs/components/layout/testing/src/modules/description-list/description-list-harness.ts
@@ -1,0 +1,61 @@
+import { HarnessPredicate } from '@angular/cdk/testing';
+import { SkyComponentHarness } from '@skyux/core/testing';
+import { SkyDescriptionListModeType } from '@skyux/layout';
+
+import { SkyDescriptionListContentHarness } from './description-list-content-harness';
+import { SkyDescriptionListHarnessFilters } from './description-list-harness-filters';
+
+/**
+ * Harness for interacting with a description list component in tests.
+ */
+export class SkyDescriptionListHarness extends SkyComponentHarness {
+  /**
+   * @internal
+   */
+  public static hostSelector = 'sky-description-list';
+
+  #getListEl = this.locatorFor('.sky-description-list');
+  #getContentEls = this.locatorForAll(SkyDescriptionListContentHarness);
+
+  /**
+   * Gets a `HarnessPredicate` that can be used to search for a
+   * `SkyDescriptionListHarness` that meets certain criteria
+   */
+  public static with(
+    filters: SkyDescriptionListHarnessFilters,
+  ): HarnessPredicate<SkyDescriptionListHarness> {
+    return SkyDescriptionListHarness.getDataSkyIdPredicate(filters);
+  }
+
+  public async getContent(): Promise<SkyDescriptionListContentHarness[]> {
+    const items = await this.#getContentEls();
+
+    if (items.length === 0) {
+      throw new Error('Unable to find any description list content.');
+    }
+
+    return items;
+  }
+
+  /**
+   * Gets the mode of the description list.
+   */
+  public async getMode(): Promise<SkyDescriptionListModeType> {
+    const listEl = await this.#getListEl();
+
+    const longDescription = await listEl.hasClass(
+      'sky-description-list-long-description-mode',
+    );
+    const horizontal = await listEl.hasClass(
+      'sky-description-list-horizontal-mode',
+    );
+
+    if (longDescription) {
+      return 'longDescription';
+    } else if (horizontal) {
+      return 'horizontal';
+    } else {
+      return 'vertical';
+    }
+  }
+}

--- a/libs/components/layout/testing/src/modules/description-list/description-list-term-harness.ts
+++ b/libs/components/layout/testing/src/modules/description-list/description-list-term-harness.ts
@@ -1,0 +1,16 @@
+import { ComponentHarness } from '@angular/cdk/testing';
+
+/**
+ * Harness for interacting with a description list term component in tests.
+ * @internal
+ */
+export class SkyDescriptionListTermHarness extends ComponentHarness {
+  /**
+   * @internal
+   */
+  public static hostSelector = 'dt';
+
+  public async getText(): Promise<string> {
+    return await (await this.locatorFor('span.description-list-term')()).text();
+  }
+}

--- a/libs/components/layout/testing/src/modules/description-list/fixtures/description-list-test.component.html
+++ b/libs/components/layout/testing/src/modules/description-list/fixtures/description-list-test.component.html
@@ -1,0 +1,24 @@
+<sky-description-list data-sky-id="description-list" [mode]="mode">
+  @for (item of items; track item) {
+    <sky-description-list-content
+      [helpPopoverContent]="item.helpContent"
+      [helpPopoverTitle]="item.helpTitle"
+      [helpKey]="item.helpKey"
+    >
+      @if (item.term) {
+        <sky-description-list-term>
+          {{ item.term }}
+        </sky-description-list-term>
+      }
+      @if (!item.hideDescription) {
+        <sky-description-list-description>
+          @if (item.description) {
+            {{ item.description }}
+          }
+        </sky-description-list-description>
+      }
+    </sky-description-list-content>
+  }
+</sky-description-list>
+
+<sky-description-list data-sky-id="empty-list"></sky-description-list>

--- a/libs/components/layout/testing/src/modules/description-list/fixtures/description-list-test.component.ts
+++ b/libs/components/layout/testing/src/modules/description-list/fixtures/description-list-test.component.ts
@@ -1,0 +1,53 @@
+import { Component } from '@angular/core';
+import { SkyHelpInlineModule } from '@skyux/help-inline';
+import {
+  SkyDescriptionListModeType,
+  SkyDescriptionListModule,
+} from '@skyux/layout';
+
+@Component({
+  standalone: true,
+  selector: 'sky-description-list-fixture',
+  templateUrl: './description-list-test.component.html',
+  imports: [SkyDescriptionListModule, SkyHelpInlineModule],
+})
+export class DescriptionListHarnessTestComponent {
+  public mode: SkyDescriptionListModeType = 'vertical';
+
+  protected items: {
+    term?: string;
+    description?: string;
+    hideDescription?: boolean;
+    helpContent?: string;
+    helpTitle?: string;
+    helpKey?: string;
+    dataSkyId?: string;
+  }[] = [
+    {
+      term: 'College',
+      description: 'Humanities and Social Sciences',
+    },
+    {
+      term: 'Department',
+    },
+    {
+      description: 'Anthropology',
+      hideDescription: true,
+    },
+    {
+      term: 'Advisor',
+      description: 'Cathy Green',
+      helpContent: 'The faculty member who advises the student.',
+      helpTitle: 'Help inline title',
+    },
+    {
+      term: 'Class year',
+      description: '2024',
+      helpKey: 'helpKey.html',
+    },
+  ];
+
+  public onActionClick(): void {
+    alert('Help inline button clicked!');
+  }
+}

--- a/libs/components/layout/testing/src/public-api.ts
+++ b/libs/components/layout/testing/src/public-api.ts
@@ -5,6 +5,10 @@ export { SkyPageSummaryFixture } from './legacy/page-summary-fixture';
 export { SkyBoxHarness } from './modules/box/box-harness';
 export { SkyBoxHarnessFilters } from './modules/box/box-harness.filters';
 
+export { SkyDescriptionListContentHarness } from './modules/description-list/description-list-content-harness';
+export { SkyDescriptionListHarness } from './modules/description-list/description-list-harness';
+export { SkyDescriptionListHarnessFilters } from './modules/description-list/description-list-harness-filters';
+
 export { SkyColumnHarness } from './modules/fluid-grid/column-harness';
 export { SkyColumnHarnessFilters } from './modules/fluid-grid/column-harness-filters';
 export { SkyFluidGridHarness } from './modules/fluid-grid/fluid-grid-harness';


### PR DESCRIPTION
:cherries: Cherry picked from #3124 [feat(components/layout): add harness for description list](https://github.com/blackbaud/skyux/pull/3124)

[AB#2195422](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/2195422) 