### PR TITLE
fix(components/router): skyHref should shut down when the application is destroyed (#3134)

### DIFF
--- a/libs/components/router/src/lib/modules/href/fixtures/href-resolver-fixture.service.ts
+++ b/libs/components/router/src/lib/modules/href/fixtures/href-resolver-fixture.service.ts
@@ -39,6 +39,8 @@ export class HrefResolverFixtureService implements SkyHrefResolver {
       });
     } else if (url.startsWith('error://')) {
       throw new Error(`Error while resolving ${url}`);
+    } else if (url.startsWith('reject://')) {
+      return Promise.reject(`Unable to resolve ${url}`);
     } else {
       return Promise.resolve<SkyHref>({
         url,

--- a/libs/components/router/src/lib/modules/href/href.directive.spec.ts
+++ b/libs/components/router/src/lib/modules/href/href.directive.spec.ts
@@ -291,6 +291,18 @@ describe('SkyHref Directive', () => {
     tick();
 
     expect(element?.getAttribute('hidden')).toBeNull();
+
+    fixture.componentInstance.dynamicLink = 'reject://simple-app/example/page';
+    fixture.detectChanges();
+    tick();
+
+    expect(element?.getAttribute('hidden')).toBe('hidden');
+
+    fixture.componentInstance.dynamicLink = '1bb-nav://simple-app/fixed';
+    fixture.detectChanges();
+    tick();
+
+    expect(element?.getAttribute('hidden')).toBeNull();
   }));
 
   it('should handle the else parameter', fakeAsync(() => {


### PR DESCRIPTION
:cherries: Cherry picked from #3134 [fix(components/router): skyHref should shut down when the application is destroyed](https://github.com/blackbaud/skyux/pull/3134)

[AB#3248042](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3248042) 