### PR TITLE
feat(components/popovers): add support for custom trigger buttons to dropdown harness (#3129)

### DIFF
--- a/libs/components/popovers/testing/src/modules/dropdown/dropdown-harness.ts
+++ b/libs/components/popovers/testing/src/modules/dropdown/dropdown-harness.ts
@@ -12,7 +12,12 @@ export class SkyDropdownHarness extends SkyComponentHarness {
 
   #documentRootLocator = this.documentRootLocatorFactory();
 
-  #getDropdownButton = this.locatorFor('.sky-dropdown-button');
+  #getDropdownButton = this.locatorFor(
+    // Default trigger button
+    '.sky-dropdown-button',
+    // Custom trigger button
+    '[skyDropdownTrigger]',
+  );
 
   /**
    * Gets a `HarnessPredicate` that can be used to search for a


### PR DESCRIPTION
:cherries: Cherry picked from #3129 [feat(components/popovers): add support for custom trigger buttons to dropdown harness](https://github.com/blackbaud/skyux/pull/3129)