### PR TITLE
feat(components/core): add SkyViewkeeper support for SkyAppViewportService properties (#3120)

### DIFF
--- a/libs/components/core/src/lib/modules/dock/dock.component.spec.ts
+++ b/libs/components/core/src/lib/modules/dock/dock.component.spec.ts
@@ -24,6 +24,12 @@ const STYLE_ELEMENT_SELECTOR =
 
 const isIE = window.navigator.userAgent.indexOf('rv:11.0') >= 0;
 
+// 16ms is the fakeAsync time for requestAnimationFrame, simulating ~60fps.
+// https://github.com/angular/angular/blob/19.1.x/packages/zone.js/lib/zone-spec/fake-async-test.ts#L682-L693
+function tickForAnimationFrame(): void {
+  tick(16);
+}
+
 describe('Dock component', () => {
   let fixture: ComponentFixture<DockFixtureComponent>;
   let mutationCallbacks: (() => void)[];
@@ -38,7 +44,7 @@ describe('Dock component', () => {
     fixture.detectChanges();
     fixture.componentInstance.itemConfigs = itemConfigs;
     fixture.detectChanges();
-    tick();
+    tickForAnimationFrame();
   }
 
   /**
@@ -70,7 +76,7 @@ describe('Dock component', () => {
     fixture.detectChanges();
     tick(250); // Respect the RxJS debounceTime.
     fixture.detectChanges();
-    tick();
+    tickForAnimationFrame();
   }
 
   function getStyleElement(): HTMLStyleElement {
@@ -343,6 +349,7 @@ describe('Dock component', () => {
       reserveSpace('left', 20);
 
       fixture.detectChanges();
+      tickForAnimationFrame();
 
       const dockEl = getDockEl();
       const actionBarBounds = dockEl.getBoundingClientRect();
@@ -370,7 +377,7 @@ describe('Dock component', () => {
         ]);
 
         fixture.detectChanges();
-        tick();
+        tickForAnimationFrame();
 
         const dockStyle = getDockStyle();
 
@@ -398,7 +405,7 @@ describe('Dock component', () => {
       ]);
 
       fixture.detectChanges();
-      tick();
+      tickForAnimationFrame();
 
       const dockStyle = getDockStyle();
 

--- a/libs/components/core/src/lib/modules/viewkeeper/viewkeeper-host-options.ts
+++ b/libs/components/core/src/lib/modules/viewkeeper/viewkeeper-host-options.ts
@@ -17,4 +17,6 @@ export class SkyViewkeeperHostOptions implements SkyViewkeeperOptions {
   public verticalOffsetEl?: HTMLElement;
 
   public viewportMarginTop?: number;
+
+  public viewportMarginProperty?: `--${string}`;
 }

--- a/libs/components/core/src/lib/modules/viewkeeper/viewkeeper-options.ts
+++ b/libs/components/core/src/lib/modules/viewkeeper/viewkeeper-options.ts
@@ -44,4 +44,9 @@ export interface SkyViewkeeperOptions {
    * Reserved space in pixels at the top of the viewport.
    */
   viewportMarginTop?: number;
+
+  /**
+   * Custom CSS property for reserved space at the top of the viewport.
+   */
+  viewportMarginProperty?: `--${string}`;
 }

--- a/libs/components/core/src/lib/modules/viewkeeper/viewkeeper.spec.ts
+++ b/libs/components/core/src/lib/modules/viewkeeper/viewkeeper.spec.ts
@@ -9,12 +9,20 @@ describe('Viewkeeper', () => {
   let vks: SkyViewkeeper[];
 
   function scrollWindowTo(x: number, y: number): void {
-    window.scrollTo(x, y);
+    window.scrollTo({
+      top: y,
+      left: x,
+      behavior: 'instant',
+    });
     SkyAppTestUtility.fireDomEvent(window, 'scroll');
   }
 
   function scrollScrollableHost(x: number, y: number): void {
-    scrollableHostEl.scrollTo(x, y);
+    scrollableHostEl.scrollTo({
+      top: y,
+      left: x,
+      behavior: 'instant',
+    });
     SkyAppTestUtility.fireDomEvent(scrollableHostEl, 'scroll');
   }
 
@@ -211,6 +219,32 @@ describe('Viewkeeper', () => {
       expect(() => new SkyViewkeeper({ el })).toThrowError(
         '[SkyViewkeeper] The option `boundaryEl` is required.',
       );
+    });
+
+    it('should support viewportMarginProperty', () => {
+      vks.push(
+        new SkyViewkeeper({
+          el,
+          boundaryEl,
+          viewportMarginProperty: '--test-viewport-top',
+          setWidth: true,
+        }),
+      );
+
+      scrollWindowTo(0, 10);
+      validatePinned(el, false);
+      document.documentElement.style.setProperty('--test-viewport-top', '2px');
+      scrollWindowTo(40, 100);
+      validatePinned(el, true, 0, 2);
+      expect(el.style.marginTop).toBe(
+        'calc(0px + var(--test-viewport-top, 0))',
+      );
+
+      document.documentElement.style.setProperty('--test-viewport-top', '12px');
+      validatePinned(el, true, 0, 12);
+
+      document.documentElement.style.removeProperty('--test-viewport-top');
+      document.body.style.removeProperty('--test-viewport-top');
     });
 
     describe('ResizeObserver', () => {

--- a/libs/components/theme/src/lib/viewport/viewport-reserve-args.ts
+++ b/libs/components/theme/src/lib/viewport/viewport-reserve-args.ts
@@ -18,4 +18,9 @@ export interface SkyAppViewportReserveArgs {
    * The number of pixels to reserve.
    */
   size: number;
+
+  /**
+   * Only reserve space when this element is in view.
+   */
+  reserveForElement?: HTMLElement;
 }

--- a/libs/components/theme/src/lib/viewport/viewport.service.spec.ts
+++ b/libs/components/theme/src/lib/viewport/viewport.service.spec.ts
@@ -1,3 +1,5 @@
+import { TestBed, waitForAsync } from '@angular/core/testing';
+
 import { ReplaySubject } from 'rxjs';
 
 import { SkyAppViewportReservedPositionType } from './viewport-reserve-position-type';
@@ -18,14 +20,14 @@ describe('Viewport service', () => {
   }
 
   beforeEach(() => {
-    svc = new SkyAppViewportService(document);
+    svc = TestBed.inject(SkyAppViewportService);
   });
 
   it('should return an observable when the content is visible', () => {
     expect(svc.visible instanceof ReplaySubject).toEqual(true);
   });
 
-  it('should reserve and unreserve space', () => {
+  it('should reserve and unreserve space', async () => {
     svc.reserveSpace({
       id: 'left-test',
       position: 'left',
@@ -50,6 +52,7 @@ describe('Viewport service', () => {
       size: 50,
     });
 
+    await new Promise((resolve) => requestAnimationFrame(resolve));
     validateViewportSpace('left', 20);
     validateViewportSpace('top', 30);
     validateViewportSpace('right', 40);
@@ -60,9 +63,104 @@ describe('Viewport service', () => {
     svc.unreserveSpace('right-test');
     svc.unreserveSpace('bottom-test');
 
+    await new Promise((resolve) => requestAnimationFrame(resolve));
     validateViewportSpace('left', 0);
     validateViewportSpace('top', 0);
     validateViewportSpace('right', 0);
     validateViewportSpace('bottom', 0);
   });
+
+  it('should reserve and unreserve space for elements that scroll out of view', waitForAsync(async () => {
+    const viewportHeight = window.innerHeight;
+
+    expect(viewportHeight).toBeGreaterThan(50);
+
+    function isInViewport(element: Element): boolean {
+      const rect = element.getBoundingClientRect();
+      return (
+        rect.top >= 0 &&
+        rect.left >= 0 &&
+        rect.bottom <=
+          (window.innerHeight || document.documentElement.clientHeight) &&
+        rect.right <=
+          (window.innerWidth || document.documentElement.clientWidth)
+      );
+    }
+
+    const container = document.createElement('div');
+    container.style.height = '200vh';
+    container.style.position = 'relative';
+    container.style.marginTop = '20px';
+    container.appendChild(document.createTextNode('Scroll down'));
+
+    const item1 = document.createElement('div');
+    item1.style.backgroundColor = 'lightblue';
+    item1.style.height = '50px';
+    item1.style.width = '100px';
+    item1.style.overflow = 'hidden';
+    item1.style.position = 'absolute';
+    item1.style.top = '0';
+    item1.style.left = '0';
+    item1.appendChild(document.createTextNode('Item 1'));
+    container.appendChild(item1);
+
+    const item2 = document.createElement('div');
+    // eslint-disable-next-line @cspell/spellchecker
+    item2.style.backgroundColor = 'lightgreen';
+    item2.style.height = '54px';
+    item2.style.width = '100px';
+    item2.style.overflow = 'hidden';
+    item2.style.position = 'absolute';
+    item2.style.top = `${viewportHeight + 50}px`;
+    item2.style.left = '0';
+    item2.appendChild(document.createTextNode('Item 2'));
+    container.appendChild(item2);
+
+    document.body.appendChild(container);
+
+    svc.reserveSpace({
+      id: 'item1-test',
+      position: 'top',
+      size: 50,
+      reserveForElement: item1,
+    });
+
+    svc.reserveSpace({
+      id: 'item2-test',
+      position: 'top',
+      size: 54,
+      reserveForElement: item2,
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 32));
+    await new Promise((resolve) => requestAnimationFrame(resolve));
+    expect(isInViewport(item1)).toBeTrue();
+    validateViewportSpace('top', 50);
+    window.scrollTo({
+      top: viewportHeight + 50,
+      behavior: 'instant',
+    });
+    await new Promise((resolve) => requestAnimationFrame(resolve));
+    await new Promise((resolve) => requestAnimationFrame(resolve));
+    expect(isInViewport(item1)).toBeFalse();
+    expect(isInViewport(item2)).toBeTrue();
+    validateViewportSpace('top', 54);
+
+    svc.unreserveSpace('item2-test');
+    await new Promise((resolve) => requestAnimationFrame(resolve));
+    validateViewportSpace('top', 0);
+    window.scrollTo({
+      top: 0,
+      behavior: 'instant',
+    });
+    await new Promise((resolve) => setTimeout(resolve, 32));
+    await new Promise((resolve) => requestAnimationFrame(resolve));
+    expect(isInViewport(item1)).toBeTrue();
+    validateViewportSpace('top', 50);
+    svc.unreserveSpace('item1-test');
+    await new Promise((resolve) => requestAnimationFrame(resolve));
+    validateViewportSpace('top', 0);
+
+    document.body.removeChild(container);
+  }));
 });

--- a/scripts/publish-local.ts
+++ b/scripts/publish-local.ts
@@ -40,6 +40,7 @@ async function skyuxDevCommand(
     const npmConfig = [
       [`@skyux:registry`, `http:${localRepo}`],
       [`@skyux-sdk:registry`, `http:${localRepo}`],
+      [`registry`, `http:${localRepo}`],
       // Having an auth token is required for publishing to a local registry, even if it's not used.
       [`${localRepo}:_authToken`, `YXV0aFRva2Vu`],
     ];


### PR DESCRIPTION
:cherries: Cherry picked from #3120 [feat(components/core): add SkyViewkeeper support for SkyAppViewportService properties](https://github.com/blackbaud/skyux/pull/3120)

[AB#3248387](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3248387) 