### PR TITLE
fix(components/layout): exclude controls text content when returning heading text for the box harness

### DIFF
--- a/libs/components/layout/testing/src/modules/box/box-harness.spec.ts
+++ b/libs/components/layout/testing/src/modules/box/box-harness.spec.ts
@@ -53,6 +53,16 @@ describe('Box test harness', () => {
     await expectAsync(boxHarness.getHeadingText()).toBeResolvedTo('Box header');
   });
 
+  it('should get the heading text and exclude the text content of controls', async () => {
+    const { boxHarness, fixture } = await setupTest();
+
+    fixture.componentInstance.headingText = 'Box header';
+    fixture.componentRef.setInput('showControls', true);
+    fixture.detectChanges();
+
+    await expectAsync(boxHarness.getHeadingText()).toBeResolvedTo('Box header');
+  });
+
   it('should get the heading text when heading text is hidden', async () => {
     const { boxHarness, fixture } = await setupTest();
 

--- a/libs/components/layout/testing/src/modules/box/box-harness.ts
+++ b/libs/components/layout/testing/src/modules/box/box-harness.ts
@@ -13,11 +13,12 @@ export class SkyBoxHarness extends SkyComponentHarness {
   public static hostSelector = 'sky-box';
 
   #getBox = this.locatorFor('.sky-box');
-  #getHeading = this.locatorFor('.sky-box-header-content');
+  #getHeading = this.locatorForOptional(
+    '.sky-box-header-content h2, .sky-box-header-content h3, .sky-box-header-content h4, .sky-box-header-content h5',
+  );
   #getH2 = this.locatorForOptional('.sky-box-header-content h2');
   #getH3 = this.locatorForOptional('.sky-box-header-content h3');
   #getH4 = this.locatorForOptional('.sky-box-header-content h4');
-  #getH5 = this.locatorForOptional('.sky-box-header-content h5');
 
   /**
    * Gets a `HarnessPredicate` that can be used to search for a
@@ -57,18 +58,14 @@ export class SkyBoxHarness extends SkyComponentHarness {
    * the text will still be returned.
    */
   public async getHeadingText(): Promise<string | undefined> {
-    return await (await this.#getHeading()).text();
+    return await (await this.#getHeading())?.text();
   }
 
   /**
    * Whether the heading is hidden.
    */
   public async getHeadingHidden(): Promise<boolean> {
-    const heading =
-      (await this.#getH2()) ||
-      (await this.#getH3()) ||
-      (await this.#getH4()) ||
-      (await this.#getH5());
+    const heading = await this.#getHeading();
     return (await heading?.hasClass('sky-screen-reader-only')) ?? false;
   }
 
@@ -89,11 +86,7 @@ export class SkyBoxHarness extends SkyComponentHarness {
    * The heading style used for the checkbox group.
    */
   public async getHeadingStyle(): Promise<SkyBoxHeadingStyle> {
-    const heading =
-      (await this.#getH2()) ||
-      (await this.#getH3()) ||
-      (await this.#getH4()) ||
-      (await this.#getH5());
+    const heading = await this.#getHeading();
 
     const isHeadingStyle2 = await heading?.hasClass('sky-font-heading-2');
     const isHeadingStyle3 = await heading?.hasClass('sky-font-heading-3');

--- a/libs/components/layout/testing/src/modules/box/fixtures/box-harness-test.component.html
+++ b/libs/components/layout/testing/src/modules/box/fixtures/box-harness-test.component.html
@@ -9,6 +9,12 @@
   [helpKey]="helpKey"
   [helpPopoverContent]="helpPopoverContent"
   [helpPopoverTitle]="helpPopoverTitle"
-  ><sky-box> </sky-box
-></sky-box>
+>
+  @if (showControls()) {
+    <sky-box-controls>
+      <button class="sky-btn sky-btn-default" type="button">Edit</button>
+    </sky-box-controls>
+  }
+  <sky-box-content> This is the box content. </sky-box-content>
+</sky-box>
 <sky-box data-sky-id="other-box" [ariaLabel]="otherBox"></sky-box>

--- a/libs/components/layout/testing/src/modules/box/fixtures/box-harness-test.component.ts
+++ b/libs/components/layout/testing/src/modules/box/fixtures/box-harness-test.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, booleanAttribute, input } from '@angular/core';
 
 // #region Test component
 @Component({
@@ -18,5 +18,7 @@ export class BoxHarnessTestComponent {
   public helpPopoverContent: string | undefined;
   public helpPopoverTitle: string | undefined;
   public otherBox = 'otherBox';
+
+  public showControls = input(false, { transform: booleanAttribute });
 }
 // #endregion Test component


### PR DESCRIPTION
Putting this in the `main` branch since it could be considered a breaking change. The `getHeadingText` method was returning the entire header's text content, including the buttons' text in the `sky-box-controls` component. This PR will only return the text from the `h*` tag.