### PR TITLE
fix: use alias instead of property name for directive inputs in the manifest (#3160)

### DIFF
--- a/libs/components/manifest/src/generator/__snapshots__/generate-manifest.test.ts.snap
+++ b/libs/components/manifest/src/generator/__snapshots__/generate-manifest.test.ts.snap
@@ -439,6 +439,17 @@ exports[`generate-manifest should generate manifest 1`] = `
             \\"type\\": \\"InputSignal<boolean>\\"
           },
           {
+            \\"description\\": \\"This describes an input with an alias.\\",
+            \\"kind\\": \\"directive-input\\",
+            \\"name\\": \\"alias1\\",
+            \\"type\\": \\"undefined | TemplateRef<unknown>\\"
+          },
+          {
+            \\"kind\\": \\"directive-input\\",
+            \\"name\\": \\"alias2\\",
+            \\"type\\": \\"undefined | TemplateRef<unknown>\\"
+          },
+          {
             \\"description\\": \\"This describes an input with a setter.\\",
             \\"defaultValue\\": \\"true\\",
             \\"kind\\": \\"directive-input\\",

--- a/libs/components/manifest/src/generator/plugins/typedoc-plugin-decorators.mjs
+++ b/libs/components/manifest/src/generator/plugins/typedoc-plugin-decorators.mjs
@@ -76,13 +76,20 @@ function addDecoratorInfo(context, decl) {
             };
             break;
 
-          case 'Input':
-            if (args.text) {
+          case 'Input': {
+            const alias =
+              args.text ??
+              args.symbol?.members.get('alias')?.valueDeclaration.initializer
+                .text;
+
+            if (alias) {
               decorator.arguments = {
-                bindingPropertyName: args.text,
+                bindingPropertyName: alias,
               };
             }
+
             break;
+          }
         }
       }
 

--- a/libs/components/manifest/src/generator/testing/fixtures/example-packages/foo/src/lib/foo.directive.ts
+++ b/libs/components/manifest/src/generator/testing/fixtures/example-packages/foo/src/lib/foo.directive.ts
@@ -3,6 +3,7 @@ import {
   EventEmitter,
   Input,
   Output,
+  TemplateRef,
   input,
   output,
 } from '@angular/core';
@@ -70,6 +71,15 @@ export class FooWithInputsOutputsDirective {
   public get inputD(): boolean {
     return this.#_inputD;
   }
+
+  /**
+   * This describes an input with an alias.
+   */
+  @Input('alias1')
+  public inputWithAlias1: TemplateRef<unknown> | undefined;
+
+  @Input({ alias: 'alias2' })
+  public inputWithAlias2: TemplateRef<unknown> | undefined;
 
   /**
    * This describes a decorated output.

--- a/libs/components/manifest/src/generator/utility/get-directive.ts
+++ b/libs/components/manifest/src/generator/utility/get-directive.ts
@@ -15,7 +15,7 @@ import { remapLambdaName } from './remap-lambda-names';
 
 export function isInput(
   reflection: DeclarationReflectionWithDecorators,
-): boolean {
+): reflection is DeclarationReflectionWithDecorators {
   return (
     getDecorator(reflection) === 'Input' ||
     (reflection.type instanceof ReferenceType &&
@@ -39,10 +39,16 @@ function getInput(
   const property = getProperty(reflection);
   const { isRequired } = getComment(reflection);
 
+  // Use the input's alias, if provided.
+  const inputName =
+    reflection.decorators?.[0]?.arguments?.['bindingPropertyName'] ??
+    property.name;
+
   const input: SkyManifestDirectiveInputDefinition = {
     ...property,
     kind: 'directive-input',
     isRequired,
+    name: inputName,
   };
 
   return input;


### PR DESCRIPTION
:cherries: Cherry picked from #3160 [fix: use alias instead of property name for directive inputs in the manifest](https://github.com/blackbaud/skyux/pull/3160)