### PR TITLE
feat(components/lookup)!: remove flag from country field input

### DIFF
--- a/apps/e2e/lookup-storybook-e2e/src/e2e/country-field.component.cy.ts
+++ b/apps/e2e/lookup-storybook-e2e/src/e2e/country-field.component.cy.ts
@@ -25,40 +25,36 @@ describe('lookup-storybook', () => {
           );
         });
       });
-      [
-        'empty',
-        'disabled',
-        'prepopulated',
-        'hide-flag-prepopulated',
-        'disabled-prepopulated',
-      ].forEach((mode) => {
-        describe(`in ${mode} country field`, () => {
-          beforeEach(() =>
-            cy
-              .visit(
-                `/iframe.html?globals=theme:${theme}&id=countryfieldcomponent-countryfield--${mode}-country-field`,
-              )
-              .get('#ready')
-              .should('exist')
-              .end(),
-          );
-
-          it('should render the component', () => {
-            cy.get('app-country-field')
-              .should('exist')
-              .should('be.visible')
-              .screenshot(
-                `countryfieldcomponent-countryfield--${mode}-country-field-${theme}`,
-              );
-            cy.get('app-country-field').percySnapshot(
-              `countryfieldcomponent-countryfield--${mode}-country-field-${theme}`,
-              {
-                widths: E2eVariations.DISPLAY_WIDTHS,
-              },
+      ['empty', 'disabled', 'prepopulated', 'disabled-prepopulated'].forEach(
+        (mode) => {
+          describe(`in ${mode} country field`, () => {
+            beforeEach(() =>
+              cy
+                .visit(
+                  `/iframe.html?globals=theme:${theme}&id=countryfieldcomponent-countryfield--${mode}-country-field`,
+                )
+                .get('#ready')
+                .should('exist')
+                .end(),
             );
+
+            it('should render the component', () => {
+              cy.get('app-country-field')
+                .should('exist')
+                .should('be.visible')
+                .screenshot(
+                  `countryfieldcomponent-countryfield--${mode}-country-field-${theme}`,
+                );
+              cy.get('app-country-field').percySnapshot(
+                `countryfieldcomponent-countryfield--${mode}-country-field-${theme}`,
+                {
+                  widths: E2eVariations.DISPLAY_WIDTHS,
+                },
+              );
+            });
           });
-        });
-      });
+        },
+      );
       beforeEach(() =>
         cy
           .visit(

--- a/apps/e2e/lookup-storybook/src/app/country-field/country-field.component.html
+++ b/apps/e2e/lookup-storybook/src/app/country-field/country-field.component.html
@@ -2,7 +2,6 @@
   <sky-input-box labelText="Country field input" [disabled]="disabledFlag">
     <sky-country-field
       formControlName="countryControl"
-      [hideSelectedCountryFlag]="hideCountryFlag"
       [includePhoneInfo]="phoneInfoFlag"
     />
   </sky-input-box>

--- a/apps/e2e/lookup-storybook/src/app/country-field/country-field.component.stories.ts
+++ b/apps/e2e/lookup-storybook/src/app/country-field/country-field.component.stories.ts
@@ -34,12 +34,6 @@ PrepopulatedCountryField.args = {
   prePopulatedFlag: true,
 };
 
-export const HideFlagPrepopulatedCountryField: Story = {};
-HideFlagPrepopulatedCountryField.args = {
-  hideCountryFlag: true,
-  prePopulatedFlag: true,
-};
-
 export const DisabledPrepopulatedCountryField: Story = {};
 DisabledPrepopulatedCountryField.args = {
   disabledFlag: true,

--- a/apps/e2e/lookup-storybook/src/app/country-field/country-field.component.ts
+++ b/apps/e2e/lookup-storybook/src/app/country-field/country-field.component.ts
@@ -27,9 +27,6 @@ export class CountryFieldComponent {
   }
 
   @Input()
-  public hideCountryFlag = false;
-
-  @Input()
   public set disabledFlag(value: boolean) {
     this.#_disabledFlag = value;
     if (value) {

--- a/libs/components/lookup/src/lib/modules/country-field/country-field.component.html
+++ b/libs/components/lookup/src/lib/modules/country-field/country-field.component.html
@@ -17,23 +17,7 @@
       [searchTextMinimumCharacters]="searchTextMinimumCharacters"
       (selectionChange)="onCountrySelected($event)"
     >
-      <div
-        class="sky-country-field-input"
-        [ngClass]="{
-          'sky-country-field-input-with-flag':
-            selectedCountry && selectedCountry.iso2 && !hideSelectedCountryFlag
-        }"
-      >
-        @if (
-          selectedCountry && selectedCountry.iso2 && !hideSelectedCountryFlag
-        ) {
-          <div class="sky-country-field-flag">
-            <div
-              class="iti__flag"
-              [ngClass]="'iti__' + selectedCountry.iso2.toLowerCase()"
-            ></div>
-          </div>
-        }
+      <div class="sky-country-field-input">
         <textarea
           class="sky-form-control"
           name="selectedCountry"

--- a/libs/components/lookup/src/lib/modules/country-field/country-field.component.scss
+++ b/libs/components/lookup/src/lib/modules/country-field/country-field.component.scss
@@ -87,10 +87,6 @@
   );
 }
 
-.sky-country-field-flag {
-  display: none;
-}
-
 .sky-country-field-disabled {
   .sky-country-field-input {
     cursor: default;
@@ -99,11 +95,6 @@
       transparent
     );
   }
-
-  // NOTE: This rule is set for non-input box country fields. Remove when support for this is fully removed.
-  .sky-country-field-flag {
-    opacity: 0.65;
-  }
 }
 
 .sky-country-field-input {
@@ -111,33 +102,10 @@
   display: flex;
   position: relative;
 
-  .sky-country-field-flag {
-    align-items: center;
-    margin-bottom: auto;
-    margin-top: auto;
-    position: absolute;
-
-    // NOTE: These styles are set for non-input box country fields. Remove when support for this is fully removed.
-    bottom: 0;
-    left: 13px;
-    height: 35px;
-  }
-
   textarea {
     overflow: hidden;
     resize: none !important;
     white-space: nowrap;
-  }
-}
-
-.sky-country-field-input-with-flag {
-  .sky-country-field-flag {
-    display: flex;
-  }
-
-  // NOTE: This rule is set for non-input box country fields. Remove when support for this is fully removed.
-  .sky-form-control {
-    padding-left: 40px;
   }
 }
 
@@ -148,56 +116,7 @@
   outline: none;
 }
 
-.sky-country-field-disabled {
-  .sky-country-field-flag {
-    filter: var(
-      --sky-override-country-field-disabled-flag-filter,
-      grayscale(100%)
-    );
-  }
-}
-
-.sky-input-box .sky-form-group {
-  .sky-country-field-input-with-flag {
-    .sky-country-field-flag {
-      height: var(
-        --sky-override-country-field-input-box-flag-height,
-        calc(
-          var(--sky-font-line_height-input-val) * var(--sky-font-size-input-val)
-        )
-      );
-      left: var(
-        --sky-override-country-field-input-box-flag-left,
-        var(--sky-space-inset-input-left-m)
-      );
-      bottom: var(
-        --sky-override-country-field-flag-bottom,
-        var(--sky-space-inset-input-bottom-m)
-      );
-    }
-
-    .sky-form-control {
-      padding-left: var(
-        --sky-override-country-field-input-box-form-control-padding-left,
-        calc(
-          var(--sky-space-inset-input-left-m) + var(--sky-size-icon-s) +
-            var(--sky-space-gap-icon-m)
-        )
-      );
-    }
-  }
-
-  .sky-country-field-disabled {
-    .sky-country-field-input-with-flag {
-      .sky-country-field-flag {
-        opacity: var(--sky-override-country-field-disabled-flag-opacity, 1);
-      }
-    }
-  }
-}
-
-.sky-country-field-search-result-flag .iti__flag,
-.sky-country-field-flag .iti__flag {
+.sky-country-field-search-result-flag .iti__flag {
   background-image: url(https://sky.blackbaudcdn.net/static/skyux-public-assets/1.0.0-beta.4/assets/images/intl-tel-input/flags@2x.webp) !important;
   max-width: var(--sky-override-country-field-max-width, inherit);
   max-height: var(--sky-override-country-field-max-height, inherit);

--- a/libs/components/lookup/src/lib/modules/country-field/country-field.component.spec.ts
+++ b/libs/components/lookup/src/lib/modules/country-field/country-field.component.spec.ts
@@ -564,36 +564,6 @@ describe('Country Field Component', () => {
           searchResults[0].querySelector('.sky-font-deemphasized'),
         ).toHaveText('61');
       }));
-
-      it('should not hide the flag in the input box if the `hideSelectedCountryFlag` is not set', fakeAsync(() => {
-        component.countryFieldComponent.hideSelectedCountryFlag = false;
-        component.modelValue = {
-          name: 'United States',
-          iso2: 'us',
-        };
-        fixture.detectChanges();
-        tick();
-        fixture.detectChanges();
-
-        expect(
-          nativeElement.querySelector('.sky-country-field-flag'),
-        ).not.toBeNull();
-      }));
-
-      it('should hide the flag in the input box if the `hideSelectedCountryFlag` is set', fakeAsync(() => {
-        component.countryFieldComponent.hideSelectedCountryFlag = true;
-        component.modelValue = {
-          name: 'United States',
-          iso2: 'us',
-        };
-        fixture.detectChanges();
-        tick();
-        fixture.detectChanges();
-
-        expect(
-          nativeElement.querySelector('.sky-country-field-flag'),
-        ).toBeNull();
-      }));
     });
 
     describe('validation', () => {
@@ -1203,34 +1173,6 @@ describe('Country Field Component', () => {
           searchResults[0].querySelector('.sky-font-deemphasized'),
         ).toHaveText('61');
       }));
-
-      it('should not hide the flag in the input box if the `hideSelectedCountryFlag` is not set', fakeAsync(() => {
-        component.countryFieldComponent.hideSelectedCountryFlag = false;
-        component.initialValue = {
-          name: 'United States',
-          iso2: 'us',
-        };
-        fixture.detectChanges();
-        tick();
-
-        expect(
-          nativeElement.querySelector('.sky-country-field-flag'),
-        ).not.toBeNull();
-      }));
-
-      it('should hide the flag in the input box if the `hideSelectedCountryFlag` is set', fakeAsync(() => {
-        component.countryFieldComponent.hideSelectedCountryFlag = true;
-        component.initialValue = {
-          name: 'United States',
-          iso2: 'us',
-        };
-        fixture.detectChanges();
-        tick();
-
-        expect(
-          nativeElement.querySelector('.sky-country-field-flag'),
-        ).toBeNull();
-      }));
     });
 
     describe('validation', () => {
@@ -1553,49 +1495,6 @@ describe('Country Field Component', () => {
         expect(
           searchResults[0].querySelector('.sky-font-deemphasized'),
         ).toHaveText('61');
-      }));
-
-      it('should not hide the flag in the input box if the `hideSelectedCountryFlag` is not set', fakeAsync(() => {
-        component.countryFieldComponent.hideSelectedCountryFlag = false;
-        fixture.detectChanges();
-        tick();
-        fixture.detectChanges();
-
-        searchAndSelect('Austr', 0, fixture);
-        fixture.detectChanges();
-        tick();
-
-        expect(
-          nativeElement.querySelector('.sky-country-field-flag'),
-        ).not.toBeNull();
-
-        component.countryFieldComponent.hideSelectedCountryFlag = undefined;
-        fixture.detectChanges();
-        tick();
-        fixture.detectChanges();
-
-        searchAndSelect('Austr', 0, fixture);
-        fixture.detectChanges();
-        tick();
-
-        expect(
-          nativeElement.querySelector('.sky-country-field-flag'),
-        ).not.toBeNull();
-      }));
-
-      it('should hide the flag in the input box if the `hideSelectedCountryFlag` is set', fakeAsync(() => {
-        component.countryFieldComponent.hideSelectedCountryFlag = true;
-        fixture.detectChanges();
-        tick();
-        fixture.detectChanges();
-
-        searchAndSelect('Austr', 0, fixture);
-        fixture.detectChanges();
-        tick();
-
-        expect(
-          nativeElement.querySelector('.sky-country-field-flag'),
-        ).toBeNull();
       }));
     });
 

--- a/libs/components/lookup/src/lib/modules/country-field/country-field.component.spec.ts
+++ b/libs/components/lookup/src/lib/modules/country-field/country-field.component.spec.ts
@@ -119,21 +119,8 @@ describe('Country Field Component', () => {
   function validateSelectedCountry(
     nativeElement: HTMLElement,
     value: string,
-    flag?: string,
   ): void {
     expect(nativeElement.querySelector('textarea')?.value).toBe(value);
-
-    const flagEl = nativeElement.querySelector('.sky-country-field-flag');
-
-    if (!value) {
-      expect(flagEl).toBeNull();
-    }
-
-    if (flag) {
-      const flagInnerEl = flagEl?.querySelector('.iti__flag');
-
-      expect(flagInnerEl).toHaveCssClass('iti__' + flag);
-    }
   }
 
   //#endregion
@@ -170,7 +157,7 @@ describe('Country Field Component', () => {
         tick();
         fixture.detectChanges();
 
-        validateSelectedCountry(nativeElement, 'United States', 'us');
+        validateSelectedCountry(nativeElement, 'United States');
       }));
 
       it('should initialize with a set country but only the iso2 code', fakeAsync(() => {
@@ -181,7 +168,7 @@ describe('Country Field Component', () => {
         tick();
         fixture.detectChanges();
 
-        validateSelectedCountry(nativeElement, 'United States', 'us');
+        validateSelectedCountry(nativeElement, 'United States');
       }));
 
       it('should initialize with a set country and fix an invalid name', fakeAsync(() => {
@@ -193,7 +180,7 @@ describe('Country Field Component', () => {
         tick();
         fixture.detectChanges();
 
-        validateSelectedCountry(nativeElement, 'United States', 'us');
+        validateSelectedCountry(nativeElement, 'United States');
       }));
 
       it('should initialize without a set country', fakeAsync(() => {
@@ -202,10 +189,6 @@ describe('Country Field Component', () => {
         fixture.detectChanges();
 
         validateSelectedCountry(nativeElement, '');
-
-        expect(
-          nativeElement.querySelector('.sky-country-field-flag'),
-        ).toBeNull();
       }));
     });
 
@@ -219,13 +202,13 @@ describe('Country Field Component', () => {
         tick();
         fixture.detectChanges();
 
-        validateSelectedCountry(nativeElement, 'United States', 'us');
+        validateSelectedCountry(nativeElement, 'United States');
 
         searchAndSelect('Austr', 0, fixture);
 
         fixture.detectChanges();
 
-        validateSelectedCountry(nativeElement, 'Australia', 'au');
+        validateSelectedCountry(nativeElement, 'Australia');
       }));
 
       it('should change countries correctly via a model change', fakeAsync(() => {
@@ -237,7 +220,7 @@ describe('Country Field Component', () => {
         tick();
         fixture.detectChanges();
 
-        validateSelectedCountry(nativeElement, 'United States', 'us');
+        validateSelectedCountry(nativeElement, 'United States');
 
         component.modelValue = {
           name: 'Australia',
@@ -248,7 +231,7 @@ describe('Country Field Component', () => {
         tick();
         fixture.detectChanges();
 
-        validateSelectedCountry(nativeElement, 'Australia', 'au');
+        validateSelectedCountry(nativeElement, 'Australia');
       }));
 
       it('should change countries correctly via a model change with an invalid name', fakeAsync(() => {
@@ -260,7 +243,7 @@ describe('Country Field Component', () => {
         tick();
         fixture.detectChanges();
 
-        validateSelectedCountry(nativeElement, 'United States', 'us');
+        validateSelectedCountry(nativeElement, 'United States');
 
         component.modelValue = {
           name: 'Test Name',
@@ -271,7 +254,7 @@ describe('Country Field Component', () => {
         tick();
         fixture.detectChanges();
 
-        validateSelectedCountry(nativeElement, 'Australia', 'au');
+        validateSelectedCountry(nativeElement, 'Australia');
       }));
 
       it('should change countries correctly via a model change with only a iso2 code', fakeAsync(() => {
@@ -283,7 +266,7 @@ describe('Country Field Component', () => {
         tick();
         fixture.detectChanges();
 
-        validateSelectedCountry(nativeElement, 'United States', 'us');
+        validateSelectedCountry(nativeElement, 'United States');
 
         component.modelValue = {
           name: 'Australia',
@@ -294,7 +277,7 @@ describe('Country Field Component', () => {
         tick();
         fixture.detectChanges();
 
-        validateSelectedCountry(nativeElement, 'Australia', 'au');
+        validateSelectedCountry(nativeElement, 'Australia');
       }));
 
       it('should display the default country first in the result list with not selection', fakeAsync(() => {
@@ -717,7 +700,7 @@ describe('Country Field Component', () => {
         tick();
         fixture.detectChanges();
 
-        validateSelectedCountry(nativeElement, 'United States', 'us');
+        validateSelectedCountry(nativeElement, 'United States');
       }));
 
       it('should initialize with a set country but only the iso2 code', fakeAsync(() => {
@@ -728,7 +711,7 @@ describe('Country Field Component', () => {
         tick();
         fixture.detectChanges();
 
-        validateSelectedCountry(nativeElement, 'United States', 'us');
+        validateSelectedCountry(nativeElement, 'United States');
       }));
 
       it('should initialize with a set country and fix an invalid name', fakeAsync(() => {
@@ -740,7 +723,7 @@ describe('Country Field Component', () => {
         tick();
         fixture.detectChanges();
 
-        validateSelectedCountry(nativeElement, 'United States', 'us');
+        validateSelectedCountry(nativeElement, 'United States');
       }));
 
       it('should initialize without a set country', fakeAsync(() => {
@@ -749,9 +732,6 @@ describe('Country Field Component', () => {
         fixture.detectChanges();
 
         expect(nativeElement.querySelector('textarea')?.value).toBe('');
-        expect(
-          nativeElement.querySelector('.sky-country-field-flag'),
-        ).toBeNull();
       }));
     });
 
@@ -765,13 +745,13 @@ describe('Country Field Component', () => {
         tick();
         fixture.detectChanges();
 
-        validateSelectedCountry(nativeElement, 'United States', 'us');
+        validateSelectedCountry(nativeElement, 'United States');
 
         searchAndSelect('Austr', 0, fixture);
 
         fixture.detectChanges();
 
-        validateSelectedCountry(nativeElement, 'Australia', 'au');
+        validateSelectedCountry(nativeElement, 'Australia');
       }));
 
       it('should change countries correctly via a model change, even when disabled', fakeAsync(() => {
@@ -783,7 +763,7 @@ describe('Country Field Component', () => {
         tick();
         fixture.detectChanges();
 
-        validateSelectedCountry(nativeElement, 'United States', 'us');
+        validateSelectedCountry(nativeElement, 'United States');
 
         component.countryControl?.setValue({
           name: 'Australia',
@@ -794,7 +774,7 @@ describe('Country Field Component', () => {
         tick();
         fixture.detectChanges();
 
-        validateSelectedCountry(nativeElement, 'Australia', 'au');
+        validateSelectedCountry(nativeElement, 'Australia');
 
         component.countryFieldComponent.disabled = true;
 
@@ -811,7 +791,7 @@ describe('Country Field Component', () => {
         tick();
         fixture.detectChanges();
 
-        validateSelectedCountry(nativeElement, 'United States', 'us');
+        validateSelectedCountry(nativeElement, 'United States');
       }));
 
       it('should change countries correctly via a model change with an invalid name', fakeAsync(() => {
@@ -823,7 +803,7 @@ describe('Country Field Component', () => {
         tick();
         fixture.detectChanges();
 
-        validateSelectedCountry(nativeElement, 'United States', 'us');
+        validateSelectedCountry(nativeElement, 'United States');
 
         component.countryControl?.setValue({
           name: 'Test Name',
@@ -834,7 +814,7 @@ describe('Country Field Component', () => {
         tick();
         fixture.detectChanges();
 
-        validateSelectedCountry(nativeElement, 'Australia', 'au');
+        validateSelectedCountry(nativeElement, 'Australia');
       }));
 
       it('should change countries correctly via a model change with only a iso2 code', fakeAsync(() => {
@@ -846,7 +826,7 @@ describe('Country Field Component', () => {
         tick();
         fixture.detectChanges();
 
-        validateSelectedCountry(nativeElement, 'United States', 'us');
+        validateSelectedCountry(nativeElement, 'United States');
 
         component.countryControl?.setValue({
           name: 'Australia',
@@ -857,7 +837,7 @@ describe('Country Field Component', () => {
         tick();
         fixture.detectChanges();
 
-        validateSelectedCountry(nativeElement, 'Australia', 'au');
+        validateSelectedCountry(nativeElement, 'Australia');
       }));
 
       it('should display the default country first in the result list with not selection', fakeAsync(() => {
@@ -1004,9 +984,6 @@ describe('Country Field Component', () => {
 
         expect(component.countryControl?.value).toBeUndefined();
         expect(nativeElement.querySelector('textarea')?.value).toBe('');
-        expect(
-          nativeElement.querySelector('.sky-country-field-flag'),
-        ).toBeNull();
       }));
 
       it('should mark the form as touched when the form loses focus', fakeAsync(() => {
@@ -1327,7 +1304,7 @@ describe('Country Field Component', () => {
 
         fixture.detectChanges();
 
-        validateSelectedCountry(nativeElement, 'Australia', 'au');
+        validateSelectedCountry(nativeElement, 'Australia');
       }));
 
       it('should display the default country first in the result list with not selection', fakeAsync(() => {
@@ -1424,9 +1401,6 @@ describe('Country Field Component', () => {
         fixture.detectChanges();
 
         expect(nativeElement.querySelector('textarea')?.value).toBe('');
-        expect(
-          nativeElement.querySelector('.sky-country-field-flag'),
-        ).toBeNull();
       }));
 
       it('should emit the countryChange event correctly', fakeAsync(() => {

--- a/libs/components/lookup/src/lib/modules/country-field/country-field.component.ts
+++ b/libs/components/lookup/src/lib/modules/country-field/country-field.component.ts
@@ -123,19 +123,6 @@ export class SkyCountryFieldComponent
   }
 
   /**
-   * Whether to hide the flag in the input element.
-   * @default false
-   */
-  @Input()
-  public set hideSelectedCountryFlag(value: boolean | undefined) {
-    this.#_hideSelectedCountryFlag = value ?? false;
-  }
-
-  public get hideSelectedCountryFlag(): boolean {
-    return this.#_hideSelectedCountryFlag;
-  }
-
-  /**
    * Whether to include phone information in the selected country and country dropdown.
    * @default false
    * @internal
@@ -286,8 +273,6 @@ export class SkyCountryFieldComponent
   #_defaultCountry: string | undefined;
 
   #_disabled = false;
-
-  #_hideSelectedCountryFlag = false;
 
   #_includePhoneInfo = false;
 
@@ -464,14 +449,13 @@ export class SkyCountryFieldComponent
 
     // Ignoring coverage here as this will be removed in the next release.
     // istanbul ignore next
-    if (!this.includePhoneInfo && !this.hideSelectedCountryFlag) {
+    if (!this.includePhoneInfo) {
       if (
         (
           this.#elRef.nativeElement.parentElement as HTMLElement
         )?.classList?.contains('sky-phone-field-country-search')
       ) {
         this.includePhoneInfo = true;
-        this.hideSelectedCountryFlag = true;
       }
     }
 

--- a/libs/components/lookup/testing/src/legacy/country-field/country-field-fixture.spec.ts
+++ b/libs/components/lookup/testing/src/legacy/country-field/country-field-fixture.spec.ts
@@ -22,7 +22,6 @@ const DATA_SKY_ID = 'test-country-field';
       formControlName="countryControl"
       [autocompleteAttribute]="autocompleteAttribute"
       [disabled]="disabled"
-      [hideSelectedCountryFlag]="hideSelectedCountryFlag"
       (selectedCountryChange)="selectedCountryChange($event)"
     />
   `,
@@ -31,7 +30,6 @@ const DATA_SKY_ID = 'test-country-field';
 class CountryFieldTestComponent {
   public autocompleteAttribute: string | undefined;
   public disabled: boolean | undefined;
-  public hideSelectedCountryFlag: boolean | undefined;
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-empty-function
   public selectedCountryChange(query: string): void {}
@@ -113,26 +111,6 @@ describe('Country field fixture', () => {
     // verify selection state
     expect(selectedCountryChangeSpy).toHaveBeenCalledTimes(0);
     expect(countryFieldFixture.searchText).toBe(invalidCountryName);
-  });
-
-  it('should show country flag by default', async () => {
-    // make a selection so the flag appears
-    await countryFieldFixture.searchAndSelectFirstResult(COUNTRY.name);
-
-    // verify country flag state
-    expect(countryFieldFixture.countryFlagIsVisible).toBe(true);
-  });
-
-  it('should hide country flag when requested', async () => {
-    // modify to non-default values
-    testComponent.hideSelectedCountryFlag = true;
-    fixture.detectChanges();
-
-    // make a selection
-    await countryFieldFixture.searchAndSelectFirstResult(COUNTRY.name);
-
-    // verify country flag state
-    expect(countryFieldFixture.countryFlagIsVisible).toBe(false);
   });
 
   it('should be able to clear when there is no selection', async () => {

--- a/libs/components/lookup/testing/src/legacy/country-field/country-field-fixture.ts
+++ b/libs/components/lookup/testing/src/legacy/country-field/country-field-fixture.ts
@@ -19,16 +19,6 @@ export class SkyCountryFieldFixture {
   }
 
   /**
-   * A flag indicating if the country flag is currently visible.
-   * The flag will be visible only if a selection has been made
-   * and if the hideSelectedCountryFlag option is false.
-   */
-  public get countryFlagIsVisible(): boolean {
-    const flag = this.#getCountryFlag();
-    return flag !== null;
-  }
-
-  /**
    * A flag indicating whether or not the input has been disabled.
    */
   public get disabled(): boolean {

--- a/libs/components/lookup/testing/src/legacy/country-field/country-field-fixture.ts
+++ b/libs/components/lookup/testing/src/legacy/country-field/country-field-fixture.ts
@@ -90,11 +90,6 @@ export class SkyCountryFieldFixture {
   }
 
   //#region helpers
-
-  #getCountryFlag(): DebugElement {
-    return this.#debugEl.query(By.css('.sky-country-field-flag'));
-  }
-
   #getAutocompleteElement(): HTMLElement {
     return document.querySelector('.sky-autocomplete-results') as HTMLElement;
   }

--- a/libs/components/phone-field/src/lib/modules/phone-field/phone-field.component.html
+++ b/libs/components/phone-field/src/lib/modules/phone-field/phone-field.component.html
@@ -69,7 +69,6 @@
         <sky-country-field
           formControlName="countrySearch"
           [defaultCountry]="defaultCountry"
-          [hideSelectedCountryFlag]="true"
           [includePhoneInfo]="true"
           [supportedCountryISOs]="supportedCountryISOs"
           (selectedCountryChange)="onCountrySelected($event)"


### PR DESCRIPTION
BREAKING CHANGE:
The flag has been removed from the country field's input box. Due to this change, the component's `hideSelectedCountryFlag` input has been removed along with the test harness' `countryFlagIsVisible` method. 

[AB#3213321](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3213321)