### PR TITLE
feat(components/help-inline)!: remove TemplateRef return type on getPopoverContent

### DIFF
--- a/libs/components/colorpicker/testing/src/modules/colorpicker/colorpicker-harness.ts
+++ b/libs/components/colorpicker/testing/src/modules/colorpicker/colorpicker-harness.ts
@@ -114,9 +114,7 @@ export class SkyColorpickerHarness extends SkyComponentHarness {
    * Gets the help inline popover content.
    */
   public async getHelpPopoverContent(): Promise<string | undefined> {
-    const content = await (await this.#getHelpInline()).getPopoverContent();
-
-    return content as string | undefined;
+    return await (await this.#getHelpInline()).getPopoverContent();
   }
 
   /**

--- a/libs/components/forms/testing/src/modules/checkbox/checkbox-group-harness.ts
+++ b/libs/components/forms/testing/src/modules/checkbox/checkbox-group-harness.ts
@@ -62,9 +62,7 @@ export class SkyCheckboxGroupHarness extends SkyComponentHarness {
    * Gets the help popover content.
    */
   public async getHelpPopoverContent(): Promise<string | undefined> {
-    const content = await (await this.#getHelpInline()).getPopoverContent();
-
-    return content as string | undefined;
+    return await (await this.#getHelpInline()).getPopoverContent();
   }
 
   /**

--- a/libs/components/forms/testing/src/modules/checkbox/checkbox-harness.ts
+++ b/libs/components/forms/testing/src/modules/checkbox/checkbox-harness.ts
@@ -85,9 +85,7 @@ export class SkyCheckboxHarness extends SkyComponentHarness {
    * Gets the help popover content.
    */
   public async getHelpPopoverContent(): Promise<string | undefined> {
-    const content = await (await this.#getHelpInline()).getPopoverContent();
-
-    return content as string | undefined;
+    return await (await this.#getHelpInline()).getPopoverContent();
   }
 
   /**

--- a/libs/components/forms/testing/src/modules/field-group/field-group-harness.ts
+++ b/libs/components/forms/testing/src/modules/field-group/field-group-harness.ts
@@ -1,5 +1,4 @@
 import { HarnessPredicate } from '@angular/cdk/testing';
-import { TemplateRef } from '@angular/core';
 import { SkyComponentHarness } from '@skyux/core/testing';
 import {
   SkyFieldGroupHeadingLevel,
@@ -95,9 +94,7 @@ export class SkyFieldGroupHarness extends SkyComponentHarness {
   /**
    * Gets the help popover content.
    */
-  public async getHelpPopoverContent(): Promise<
-    TemplateRef<unknown> | string | undefined
-  > {
+  public async getHelpPopoverContent(): Promise<string | undefined> {
     return await (await this.#getHelpInline()).getPopoverContent();
   }
 

--- a/libs/components/forms/testing/src/modules/file-attachment/file-attachment/file-attachment-harness.ts
+++ b/libs/components/forms/testing/src/modules/file-attachment/file-attachment/file-attachment-harness.ts
@@ -109,9 +109,7 @@ export class SkyFileAttachmentHarness extends SkyComponentHarness {
    * Gets the help inline popover content.
    */
   public async getHelpPopoverContent(): Promise<string | undefined> {
-    const content = await (await this.#getHelpInline()).getPopoverContent();
-
-    return content as string | undefined;
+    return await (await this.#getHelpInline()).getPopoverContent();
   }
 
   /**

--- a/libs/components/forms/testing/src/modules/file-attachment/file-drop/file-drop-harness.ts
+++ b/libs/components/forms/testing/src/modules/file-attachment/file-drop/file-drop-harness.ts
@@ -78,9 +78,7 @@ export class SkyFileDropHarness extends SkyComponentHarness {
    * Gets the help inline popover content.
    */
   public async getHelpPopoverContent(): Promise<string | undefined> {
-    const content = await (await this.#getHelpInline()).getPopoverContent();
-
-    return content as string | undefined;
+    return await (await this.#getHelpInline()).getPopoverContent();
   }
 
   /**

--- a/libs/components/forms/testing/src/modules/input-box/input-box-harness.ts
+++ b/libs/components/forms/testing/src/modules/input-box/input-box-harness.ts
@@ -1,5 +1,4 @@
 import { HarnessPredicate, TestElement } from '@angular/cdk/testing';
-import { TemplateRef } from '@angular/core';
 import { SkyQueryableComponentHarness } from '@skyux/core/testing';
 import { SkyHelpInlineHarness } from '@skyux/help-inline/testing';
 import { SkyStatusIndicatorHarness } from '@skyux/indicators/testing';
@@ -195,9 +194,7 @@ export class SkyInputBoxHarness extends SkyQueryableComponentHarness {
   /**2
    * Gets the help popover content.
    */
-  public async getHelpPopoverContent(): Promise<
-    TemplateRef<unknown> | string | undefined
-  > {
+  public async getHelpPopoverContent(): Promise<string | undefined> {
     return await (await this.#getHelpInline()).getPopoverContent();
   }
 

--- a/libs/components/forms/testing/src/modules/radio/radio-group-harness.ts
+++ b/libs/components/forms/testing/src/modules/radio/radio-group-harness.ts
@@ -117,14 +117,7 @@ export class SkyRadioGroupHarness extends SkyComponentHarness {
    * Gets the help popover content.
    */
   public async getHelpPopoverContent(): Promise<string | undefined> {
-    const content = await (await this.#getHelpInline()).getPopoverContent();
-
-    /* istanbul ignore if */
-    if (typeof content === 'object') {
-      throw Error('Unexpected template ref');
-    }
-
-    return content;
+    return await (await this.#getHelpInline()).getPopoverContent();
   }
 
   /**

--- a/libs/components/forms/testing/src/modules/radio/radio-harness.ts
+++ b/libs/components/forms/testing/src/modules/radio/radio-harness.ts
@@ -86,14 +86,7 @@ export class SkyRadioHarness extends SkyComponentHarness {
    * Gets the help popover content.
    */
   public async getHelpPopoverContent(): Promise<string | undefined> {
-    const content = await (await this.#getHelpInline()).getPopoverContent();
-
-    /* istanbul ignore if */
-    if (typeof content === 'object') {
-      throw Error('Unexpected template ref');
-    }
-
-    return content;
+    return await (await this.#getHelpInline()).getPopoverContent();
   }
 
   /**

--- a/libs/components/help-inline/testing/src/modules/help-inline/help-inline-harness.ts
+++ b/libs/components/help-inline/testing/src/modules/help-inline/help-inline-harness.ts
@@ -1,5 +1,4 @@
 import { HarnessPredicate } from '@angular/cdk/testing';
-import { TemplateRef } from '@angular/core';
 import { SkyComponentHarness } from '@skyux/core/testing';
 import {
   SkyPopoverContentHarness,
@@ -107,9 +106,7 @@ export class SkyHelpInlineHarness extends SkyComponentHarness {
   /**
    * Gets the help popover content.
    */
-  public async getPopoverContent(): Promise<
-    TemplateRef<unknown> | string | undefined
-  > {
+  public async getPopoverContent(): Promise<string | undefined> {
     return await (await this.#getPopoverHarnessContent())?.getBodyText();
   }
 

--- a/libs/components/indicators/testing/src/modules/status-indicator/status-indicator-harness.ts
+++ b/libs/components/indicators/testing/src/modules/status-indicator/status-indicator-harness.ts
@@ -141,9 +141,7 @@ export class SkyStatusIndicatorHarness extends SkyComponentHarness {
    * Gets the help inline popover content.
    */
   public async getHelpPopoverContent(): Promise<string | undefined> {
-    const content = await (await this.#getHelpInline()).getPopoverContent();
-
-    return content as string | undefined;
+    return await (await this.#getHelpInline()).getPopoverContent();
   }
 
   /**

--- a/libs/components/layout/testing/src/modules/box/box-harness.ts
+++ b/libs/components/layout/testing/src/modules/box/box-harness.ts
@@ -1,5 +1,4 @@
 import { HarnessPredicate } from '@angular/cdk/testing';
-import { TemplateRef } from '@angular/core';
 import { SkyComponentHarness } from '@skyux/core/testing';
 import { SkyHelpInlineHarness } from '@skyux/help-inline/testing';
 import { SkyBoxHeadingLevel, SkyBoxHeadingStyle } from '@skyux/layout';
@@ -40,9 +39,7 @@ export class SkyBoxHarness extends SkyComponentHarness {
   /**
    * Gets the help popover content.
    */
-  public async getHelpPopoverContent(): Promise<
-    TemplateRef<unknown> | string | undefined
-  > {
+  public async getHelpPopoverContent(): Promise<string | undefined> {
     return await (await this.#getHelpInline()).getPopoverContent();
   }
 

--- a/libs/components/layout/testing/src/modules/description-list/description-list-content-harness.ts
+++ b/libs/components/layout/testing/src/modules/description-list/description-list-content-harness.ts
@@ -42,9 +42,7 @@ export class SkyDescriptionListContentHarness extends SkyComponentHarness {
    * Gets the help popover content.
    */
   public async getHelpPopoverContent(): Promise<string | undefined> {
-    const content = await (await this.#getHelpInline()).getPopoverContent();
-
-    return content as string | undefined;
+    return await (await this.#getHelpInline()).getPopoverContent();
   }
 
   /**

--- a/libs/components/modals/testing/src/modules/modal/modal-harness.ts
+++ b/libs/components/modals/testing/src/modules/modal/modal-harness.ts
@@ -1,5 +1,4 @@
 import { HarnessPredicate } from '@angular/cdk/testing';
-import { TemplateRef } from '@angular/core';
 import { SkyComponentHarness } from '@skyux/core/testing';
 import { SkyHelpInlineHarness } from '@skyux/help-inline/testing';
 
@@ -70,9 +69,7 @@ export class SkyModalHarness extends SkyComponentHarness {
   /**
    * Gets the help popover content.
    */
-  public async getHelpPopoverContent(): Promise<
-    TemplateRef<unknown> | string | undefined
-  > {
+  public async getHelpPopoverContent(): Promise<string | undefined> {
     return await (await this.#getHelpInline()).getPopoverContent();
   }
 

--- a/libs/components/progress-indicator/testing/src/modules/progress-indicator/progress-indicator-item-harness.ts
+++ b/libs/components/progress-indicator/testing/src/modules/progress-indicator/progress-indicator-item-harness.ts
@@ -37,9 +37,7 @@ export class SkyProgressIndicatorItemHarness extends SkyComponentHarness {
    * Gets the help inline popover content.
    */
   public async getHelpPopoverContent(): Promise<string | undefined> {
-    const content = await (await this.#getHelpInline()).getPopoverContent();
-
-    return content as string | undefined;
+    return await (await this.#getHelpInline()).getPopoverContent();
   }
 
   /**

--- a/libs/components/tiles/testing/src/modules/tiles/tile-harness.ts
+++ b/libs/components/tiles/testing/src/modules/tiles/tile-harness.ts
@@ -82,9 +82,7 @@ export class SkyTileHarness extends SkyComponentHarness {
    * Gets the help popover content.
    */
   public async getHelpPopoverContent(): Promise<string | undefined> {
-    const content = await (await this.#getHelpInline()).getPopoverContent();
-
-    return content as string | undefined;
+    return await (await this.#getHelpInline()).getPopoverContent();
   }
 
   /**


### PR DESCRIPTION
[AB#3089502](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3089502)

BREAKING CHANGE

The `getPopoverContent()` method on the help inline harness had a return type of `TemplateRef | string | undefined` despite only returning strings if they existed. This has been corrected and reflected in all consuming component harnesses.