### PR TITLE
fix(components/core)!: remove live announcer message from DOM after a set duration

### DIFF
--- a/apps/playground/src/app/components/core/core.module.ts
+++ b/apps/playground/src/app/components/core/core.module.ts
@@ -31,6 +31,15 @@ const routes: Routes = [
       library: 'core',
     },
   },
+  {
+    path: 'live-announcer',
+    loadComponent: () => import('./live-announcer/live-announcer.component'),
+    data: {
+      name: 'Live announcer',
+      library: 'core',
+      icon: 'universal-access',
+    },
+  },
 ];
 
 @NgModule({

--- a/apps/playground/src/app/components/core/live-announcer/live-announcer.component.html
+++ b/apps/playground/src/app/components/core/live-announcer/live-announcer.component.html
@@ -1,0 +1,6 @@
+<sky-input-box labelText="Live announcer text" stacked="true">
+  <input type="text" [(ngModel)]="announcementMessage" />
+</sky-input-box>
+<button class="sky-btn sky-btn-primary" type="button" (click)="announce()">
+  Trigger live announcer
+</button>

--- a/apps/playground/src/app/components/core/live-announcer/live-announcer.component.ts
+++ b/apps/playground/src/app/components/core/live-announcer/live-announcer.component.ts
@@ -1,0 +1,20 @@
+import { Component, inject } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { SkyLiveAnnouncerService } from '@skyux/core';
+import { SkyInputBoxModule } from '@skyux/forms';
+
+@Component({
+  selector: 'app-live-announcer',
+  templateUrl: './live-announcer.component.html',
+  standalone: true,
+  imports: [FormsModule, SkyInputBoxModule],
+})
+export default class LiveAnnouncerComponent {
+  #liveAnnouncerSvc = inject(SkyLiveAnnouncerService);
+
+  protected announcementMessage = '';
+
+  protected announce(): void {
+    this.#liveAnnouncerSvc.announce(this.announcementMessage);
+  }
+}

--- a/libs/components/core/src/lib/modules/live-announcer/live-announcer.service.spec.ts
+++ b/libs/components/core/src/lib/modules/live-announcer/live-announcer.service.spec.ts
@@ -3,6 +3,7 @@ import {
   TestBed,
   fakeAsync,
   inject,
+  tick,
 } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
@@ -32,6 +33,34 @@ describe('SkyLiveAnnouncer', () => {
     const ariaLiveElement = getLiveElement();
 
     expect(ariaLiveElement?.textContent).toBe('Test');
+  }));
+
+  it('should clear the announcement after a given duration', fakeAsync(() => {
+    announcer.announce('Hey Google', { duration: 15000 });
+    const ariaLiveElement = getLiveElement();
+
+    expect(ariaLiveElement?.textContent).toBe('Hey Google');
+    tick(15000);
+    expect(ariaLiveElement?.textContent).toBe('');
+  }));
+
+  it('should clear the announcement after a calculated duration using the number of words if no duration is given', fakeAsync(() => {
+    announcer.announce('Hey Google');
+    const ariaLiveElement = getLiveElement();
+
+    expect(ariaLiveElement?.textContent).toBe('Hey Google');
+    tick(2249);
+    expect(ariaLiveElement?.textContent).toBe('Hey Google');
+    tick(1);
+    expect(ariaLiveElement?.textContent).toBe('');
+
+    announcer.announce('Hey Google I am testing');
+
+    expect(ariaLiveElement?.textContent).toBe('Hey Google I am testing');
+    tick(5624);
+    expect(ariaLiveElement?.textContent).toBe('Hey Google I am testing');
+    tick(1);
+    expect(ariaLiveElement?.textContent).toBe('');
   }));
 
   it('should correctly update the politeness attribute', fakeAsync(() => {

--- a/libs/components/core/src/lib/modules/live-announcer/types/live-announcer-args.ts
+++ b/libs/components/core/src/lib/modules/live-announcer/types/live-announcer-args.ts
@@ -6,5 +6,9 @@ import { SkyLiveAnnouncerPoliteness } from './live-announcer-politeness';
  */
 export interface SkyLiveAnnouncerArgs {
   politeness?: SkyLiveAnnouncerPoliteness;
+
+  /**
+   * Sets how long the live announcer text persists in DOM.
+   */
   duration?: number;
 }

--- a/libs/components/core/src/lib/modules/live-announcer/types/live-announcer-args.ts
+++ b/libs/components/core/src/lib/modules/live-announcer/types/live-announcer-args.ts
@@ -6,4 +6,5 @@ import { SkyLiveAnnouncerPoliteness } from './live-announcer-politeness';
  */
 export interface SkyLiveAnnouncerArgs {
   politeness?: SkyLiveAnnouncerPoliteness;
+  duration?: number;
 }


### PR DESCRIPTION
BREAKING CHANGE:
The `SkyLiveAnnouncerService` now removes messages from the DOM after a timeout which is calculated based on the number of words in the message. This new behavior is asynchronous. While no issues are anticipated, this change may cause unit tests which assumed this service was synchronous to fail.

[AB#3027395](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3027395)