### PR TITLE
fix: mark all harness `hostSelector` properties as "internal" (#3180)

### DIFF
--- a/libs/components/core/testing/src/shared/harness-filters.ts
+++ b/libs/components/core/testing/src/shared/harness-filters.ts
@@ -2,7 +2,6 @@ import { BaseHarnessFilters } from '@angular/cdk/testing';
 
 /**
  * A set of criteria that can be used to filter a list of `SkyComponentHarness` instances.
- * @internal
  */
 export interface SkyHarnessFilters extends BaseHarnessFilters {
   /**

--- a/libs/components/core/testing/src/shared/input-harness.ts
+++ b/libs/components/core/testing/src/shared/input-harness.ts
@@ -2,7 +2,6 @@ import { ComponentHarness } from '@angular/cdk/testing';
 
 /**
  * Harness used to interact with native input elements in tests.
- * @internal
  */
 export class SkyInputHarness extends ComponentHarness {
   /**

--- a/libs/components/modals/testing/src/modules/confirm/confirm-button-harness.ts
+++ b/libs/components/modals/testing/src/modules/confirm/confirm-button-harness.ts
@@ -7,6 +7,9 @@ import { SkyConfirmButtonHarnessFilters } from './confirm-button-harness-filters
  * Harness for interacting with a confirm component in tests.
  */
 export class SkyConfirmButtonHarness extends ComponentHarness {
+  /**
+   * @internal
+   */
   public static hostSelector = '.sky-confirm-buttons .sky-btn';
 
   /**

--- a/libs/components/modals/testing/src/modules/confirm/confirm-harness.ts
+++ b/libs/components/modals/testing/src/modules/confirm/confirm-harness.ts
@@ -9,6 +9,9 @@ import { SkyConfirmButtonHarnessFilters } from './confirm-button-harness-filters
  * Harness for interacting with a confirm component in tests.
  */
 export class SkyConfirmHarness extends SkyComponentHarness {
+  /**
+   * @internal
+   */
   public static hostSelector = 'sky-confirm';
 
   #getBodyEl = this.locatorForOptional('.sky-confirm-body');

--- a/libs/components/pages/testing/src/modules/action-hub/action-hub-harness.ts
+++ b/libs/components/pages/testing/src/modules/action-hub/action-hub-harness.ts
@@ -13,6 +13,9 @@ import { SkyActionHubHarnessFilters } from './action-hub-harness-filters';
  * Harness for interacting with an action hub component in tests.
  */
 export class SkyActionHubHarness extends SkyComponentHarness {
+  /**
+   * @internal
+   */
   public static hostSelector = 'sky-action-hub';
 
   readonly #pageHeader = this.locatorFor(SkyPageHeaderHarness);

--- a/libs/components/router/testing/src/modules/href/href-harness.ts
+++ b/libs/components/router/testing/src/modules/href/href-harness.ts
@@ -7,6 +7,9 @@ import { SkyHrefHarnessFilters } from './href-harness-filters';
  * Allows interaction with a SkyHref directive during testing.
  */
 export class SkyHrefHarness extends SkyComponentHarness {
+  /**
+   * @internal
+   */
   public static hostSelector = '.sky-href';
 
   /**


### PR DESCRIPTION
:cherries: Cherry picked from #3180 [fix: mark all harness `hostSelector` properties as "internal"](https://github.com/blackbaud/skyux/pull/3180)