### PR TITLE
feat(components/lists): add paging test harnesses (#3185)

### DIFF
--- a/apps/code-examples/src/app/code-examples/lists/paging/with-content/demo.component.spec.ts
+++ b/apps/code-examples/src/app/code-examples/lists/paging/with-content/demo.component.spec.ts
@@ -1,0 +1,80 @@
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { SkyPagingHarness, SkyRepeaterHarness } from '@skyux/lists/testing';
+
+import { DemoComponent } from './demo.component';
+
+describe('Paging demo', () => {
+  async function setupTest(
+    options: {
+      dataSkyId?: string;
+    } = {},
+  ): Promise<{
+    pagingHarness: SkyPagingHarness;
+    fixture: ComponentFixture<DemoComponent>;
+  }> {
+    await TestBed.configureTestingModule({
+      imports: [DemoComponent, NoopAnimationsModule],
+    }).compileComponents();
+
+    const fixture = TestBed.createComponent(DemoComponent);
+    const loader = TestbedHarnessEnvironment.documentRootLoader(fixture);
+
+    const pagingHarness: SkyPagingHarness = options.dataSkyId
+      ? await loader.getHarness(
+          SkyPagingHarness.with({
+            dataSkyId: options.dataSkyId,
+          }),
+        )
+      : await loader.getHarness(SkyPagingHarness);
+
+    return { pagingHarness, fixture };
+  }
+
+  it('should set up the paging content', async () => {
+    const { pagingHarness, fixture } = await setupTest({
+      dataSkyId: 'my-paging-content',
+    });
+
+    await expectAsync(pagingHarness.getCurrentPage()).toBeResolvedTo(1);
+
+    const contentHarness = await (
+      await pagingHarness.getPagingContent()
+    ).queryHarness(SkyRepeaterHarness);
+
+    let items = await contentHarness.getRepeaterItems();
+
+    await expectAsync(items[0].getTitleText()).toBeResolvedTo('Abed');
+
+    await pagingHarness.clickPageButton(3);
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    await expectAsync(pagingHarness.getCurrentPage()).toBeResolvedTo(3);
+
+    items = await contentHarness.getRepeaterItems();
+
+    await expectAsync(items[0].getTitleText()).toBeResolvedTo('Leonard');
+
+    await pagingHarness.clickNextButton();
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    await expectAsync(pagingHarness.getCurrentPage()).toBeResolvedTo(4);
+
+    items = await contentHarness.getRepeaterItems();
+
+    await expectAsync(items[0].getTitleText()).toBeResolvedTo('Shirley');
+
+    await expectAsync(pagingHarness.clickNextButton()).toBeRejectedWithError(
+      'Could not click the next button because it is disabled.',
+    );
+
+    await expectAsync(pagingHarness.clickPageButton(1)).toBeRejectedWithError(
+      'Could not find page button 1.',
+    );
+  });
+});

--- a/libs/components/code-examples/src/lib/modules/lists/paging/with-content/example.component.html
+++ b/libs/components/code-examples/src/lib/modules/lists/paging/with-content/example.component.html
@@ -1,4 +1,5 @@
 <sky-paging
+  data-sky-id="my-paging-content"
   [itemCount]="(pagedData | async)?.totalCount ?? 0"
   [maxPages]="3"
   [pageSize]="pageSize"

--- a/libs/components/code-examples/src/lib/modules/lists/paging/with-content/example.component.spec.ts
+++ b/libs/components/code-examples/src/lib/modules/lists/paging/with-content/example.component.spec.ts
@@ -5,7 +5,7 @@ import { SkyPagingHarness, SkyRepeaterHarness } from '@skyux/lists/testing';
 
 import { ListsPagingWithContentExampleComponent } from './example.component';
 
-describe('Paging demo', () => {
+describe('Paging example', () => {
   async function setupTest(
     options: {
       dataSkyId?: string;

--- a/libs/components/code-examples/src/lib/modules/lists/paging/with-content/example.component.spec.ts
+++ b/libs/components/code-examples/src/lib/modules/lists/paging/with-content/example.component.spec.ts
@@ -1,0 +1,82 @@
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { SkyPagingHarness, SkyRepeaterHarness } from '@skyux/lists/testing';
+
+import { ListsPagingWithContentExampleComponent } from './example.component';
+
+describe('Paging demo', () => {
+  async function setupTest(
+    options: {
+      dataSkyId?: string;
+    } = {},
+  ): Promise<{
+    pagingHarness: SkyPagingHarness;
+    fixture: ComponentFixture<ListsPagingWithContentExampleComponent>;
+  }> {
+    await TestBed.configureTestingModule({
+      imports: [ListsPagingWithContentExampleComponent, NoopAnimationsModule],
+    }).compileComponents();
+
+    const fixture = TestBed.createComponent(
+      ListsPagingWithContentExampleComponent,
+    );
+    const loader = TestbedHarnessEnvironment.documentRootLoader(fixture);
+
+    const pagingHarness: SkyPagingHarness = options.dataSkyId
+      ? await loader.getHarness(
+          SkyPagingHarness.with({
+            dataSkyId: options.dataSkyId,
+          }),
+        )
+      : await loader.getHarness(SkyPagingHarness);
+
+    return { pagingHarness, fixture };
+  }
+
+  it('should set up the paging content', async () => {
+    const { pagingHarness, fixture } = await setupTest({
+      dataSkyId: 'my-paging-content',
+    });
+
+    await expectAsync(pagingHarness.getCurrentPage()).toBeResolvedTo(1);
+
+    const contentHarness = await (
+      await pagingHarness.getPagingContent()
+    ).queryHarness(SkyRepeaterHarness);
+
+    let items = await contentHarness.getRepeaterItems();
+
+    await expectAsync(items[0].getTitleText()).toBeResolvedTo('Abed');
+
+    await pagingHarness.clickPageButton(3);
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    await expectAsync(pagingHarness.getCurrentPage()).toBeResolvedTo(3);
+
+    items = await contentHarness.getRepeaterItems();
+
+    await expectAsync(items[0].getTitleText()).toBeResolvedTo('Leonard');
+
+    await pagingHarness.clickNextButton();
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    await expectAsync(pagingHarness.getCurrentPage()).toBeResolvedTo(4);
+
+    items = await contentHarness.getRepeaterItems();
+
+    await expectAsync(items[0].getTitleText()).toBeResolvedTo('Shirley');
+
+    await expectAsync(pagingHarness.clickNextButton()).toBeRejectedWithError(
+      'Could not click the next button because it is disabled.',
+    );
+
+    await expectAsync(pagingHarness.clickPageButton(1)).toBeRejectedWithError(
+      'Could not find page button 1.',
+    );
+  });
+});

--- a/libs/components/lists/testing/src/modules/paging/fixtures/paging-harness-test.component.html
+++ b/libs/components/lists/testing/src/modules/paging/fixtures/paging-harness-test.component.html
@@ -1,8 +1,8 @@
 <sky-paging
-  data-sky-id="my-paging-content"
   [itemCount]="(pagedData | async)?.totalCount ?? 0"
-  [maxPages]="3"
+  [maxPages]="maxPages"
   [pageSize]="pageSize"
+  pagingLabel="Paging label"
   [(currentPage)]="currentPage"
   (contentChange)="contentChange.next($event)"
 >
@@ -30,3 +30,5 @@
     </sky-repeater>
   </sky-paging-content>
 </sky-paging>
+
+<sky-paging data-sky-id="other-paging"></sky-paging>

--- a/libs/components/lists/testing/src/modules/paging/fixtures/paging-harness-test.component.ts
+++ b/libs/components/lists/testing/src/modules/paging/fixtures/paging-harness-test.component.ts
@@ -1,0 +1,126 @@
+import { CommonModule } from '@angular/common';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { SkyDescriptionListModule } from '@skyux/layout';
+import {
+  SkyPagingContentChangeArgs,
+  SkyPagingModule,
+  SkyRepeaterModule,
+} from '@skyux/lists';
+
+import { Subject, of, shareReplay, switchMap } from 'rxjs';
+
+const people = [
+  {
+    name: 'Abed',
+    formal: 'Mr. Nadir',
+  },
+  {
+    name: 'Alex',
+    formal: 'Mr. Osbourne',
+  },
+  {
+    name: 'Ben',
+    formal: 'Mr. Chang',
+  },
+  {
+    name: 'Britta',
+    formal: 'Ms. Perry',
+  },
+  {
+    name: 'Buzz',
+    formal: 'Mr. Hickey',
+  },
+  {
+    name: 'Craig',
+    formal: 'Mr. Pelton',
+  },
+  {
+    name: 'Elroy',
+    formal: 'Mr. Patashnik',
+  },
+  {
+    name: 'Garrett',
+    formal: 'Mr. Lambert',
+  },
+  {
+    name: 'Ian',
+    formal: 'Mr. Duncan',
+  },
+  {
+    name: 'Jeff',
+    formal: 'Mr. Winger',
+  },
+  {
+    name: 'Leonard',
+    formal: 'Mr. Rodriguez',
+  },
+  {
+    name: 'Neil',
+    formal: 'Mr. Neil',
+  },
+  {
+    name: 'Pierce',
+    formal: 'Mr. Hawthorne',
+  },
+  {
+    name: 'Preston',
+    formal: 'Mr. Koogler',
+  },
+  {
+    name: 'Rachel',
+    formal: 'Ms. Rachel',
+  },
+  {
+    name: 'Shirley',
+    formal: 'Ms. Bennett',
+  },
+  {
+    name: 'Todd',
+    formal: 'Mr. Jacobson',
+  },
+  {
+    name: 'Troy',
+    formal: 'Mr. Barnes',
+  },
+  {
+    name: 'Vaughn',
+    formal: 'Mr. Miller',
+  },
+  {
+    name: 'Vicki',
+    formal: 'Ms. Jenkins',
+  },
+];
+
+@Component({
+  standalone: true,
+  selector: 'test-paging-harness',
+  templateUrl: './paging-harness-test.component.html',
+  imports: [
+    CommonModule,
+    SkyDescriptionListModule,
+    SkyPagingModule,
+    SkyRepeaterModule,
+  ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class PagingHarnessTestComponent {
+  public pageSize = 5;
+  public maxPages = 3;
+  protected currentPage = 1;
+  protected contentChange = new Subject<SkyPagingContentChangeArgs>();
+
+  protected pagedData = this.contentChange.pipe(
+    switchMap((args) => {
+      const startIndex = (args.currentPage - 1) * this.pageSize;
+
+      args.loadingComplete();
+
+      return of({
+        people: people.slice(startIndex, startIndex + this.pageSize),
+        totalCount: people.length,
+      });
+    }),
+    shareReplay(1),
+  );
+}

--- a/libs/components/lists/testing/src/modules/paging/page-control-harness-filters.ts
+++ b/libs/components/lists/testing/src/modules/paging/page-control-harness-filters.ts
@@ -1,0 +1,13 @@
+import { BaseHarnessFilters } from '@angular/cdk/testing';
+
+/**
+ * A set of criteria that can be used to filter a list of `SkyFileItemHarness` instances.
+ * @internal
+ */
+// eslint-disable-next-line @typescript-eslint/no-empty-interface, @typescript-eslint/no-empty-object-type
+export interface SkyPageControlHarnessFilters extends BaseHarnessFilters {
+  /**
+   * Finds files whose file name matches this value.
+   */
+  pageNumber: number;
+}

--- a/libs/components/lists/testing/src/modules/paging/page-control-harness.ts
+++ b/libs/components/lists/testing/src/modules/paging/page-control-harness.ts
@@ -1,0 +1,47 @@
+import { ComponentHarness, HarnessPredicate } from '@angular/cdk/testing';
+
+import { SkyPageControlHarnessFilters } from './page-control-harness-filters';
+
+/**
+ * Harness to interact with a page control element in tests.
+ * @internal
+ */
+export class SkyPageControlHarness extends ComponentHarness {
+  /**
+   * @internal
+   */
+  public static hostSelector = 'li.sky-list-paging-link';
+
+  #getButton = this.locatorFor('button.sky-paging-btn');
+
+  public static with(
+    filters: SkyPageControlHarnessFilters,
+  ): HarnessPredicate<SkyPageControlHarness> {
+    return new HarnessPredicate(SkyPageControlHarness, filters).addOption(
+      'pageNumber',
+      filters.pageNumber,
+      (harness, pageNumber) =>
+        harness
+          .getText()
+          .then(
+            (actualPageNumber) => parseInt(actualPageNumber) === pageNumber,
+          ),
+    );
+  }
+
+  /**
+   * Clicks the page button.
+   */
+  public async clickButton(): Promise<void> {
+    await (await this.#getButton()).click();
+  }
+
+  /**
+   * Gets the page button text.
+   */
+  public async getText(): Promise<string> {
+    const button = await this.#getButton();
+
+    return await button.text();
+  }
+}

--- a/libs/components/lists/testing/src/modules/paging/paging-content-harness.ts
+++ b/libs/components/lists/testing/src/modules/paging/paging-content-harness.ts
@@ -1,0 +1,11 @@
+import { SkyQueryableComponentHarness } from '@skyux/core/testing';
+
+/**
+ * Harness to interact with a paging content component in tests.
+ */
+export class SkyPagingContentHarness extends SkyQueryableComponentHarness {
+  /**
+   * @internal
+   */
+  public static hostSelector = 'sky-paging-content';
+}

--- a/libs/components/lists/testing/src/modules/paging/paging-harness-filters.ts
+++ b/libs/components/lists/testing/src/modules/paging/paging-harness-filters.ts
@@ -1,0 +1,7 @@
+import { SkyHarnessFilters } from '@skyux/core/testing';
+
+/**
+ * A set of criteria that can be used to filter a list of `SkyPagingHarness` instances.
+ */
+// eslint-disable-next-line @typescript-eslint/no-empty-interface, @typescript-eslint/no-empty-object-type
+export interface SkyPagingHarnessFilters extends SkyHarnessFilters {}

--- a/libs/components/lists/testing/src/modules/paging/paging-harness.spec.ts
+++ b/libs/components/lists/testing/src/modules/paging/paging-harness.spec.ts
@@ -1,0 +1,123 @@
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+import { PagingHarnessTestComponent } from './fixtures/paging-harness-test.component';
+import { SkyPagingHarness } from './paging-harness';
+
+describe('Paging test harness', () => {
+  async function setupTest(
+    options: {
+      dataSkyId?: string;
+      pageSize?: number;
+      maxPages?: number;
+    } = {},
+  ): Promise<{
+    pagingHarness: SkyPagingHarness;
+    fixture: ComponentFixture<PagingHarnessTestComponent>;
+  }> {
+    await TestBed.configureTestingModule({
+      imports: [PagingHarnessTestComponent, NoopAnimationsModule],
+    }).compileComponents();
+
+    const fixture = TestBed.createComponent(PagingHarnessTestComponent);
+    const loader = TestbedHarnessEnvironment.documentRootLoader(fixture);
+
+    if (options.pageSize) {
+      fixture.componentInstance.pageSize = options.pageSize;
+      fixture.detectChanges();
+    }
+
+    if (options.maxPages) {
+      fixture.componentInstance.maxPages = options.maxPages;
+      fixture.detectChanges();
+    }
+
+    const pagingHarness: SkyPagingHarness = options.dataSkyId
+      ? await loader.getHarness(
+          SkyPagingHarness.with({
+            dataSkyId: options.dataSkyId,
+          }),
+        )
+      : await loader.getHarness(SkyPagingHarness);
+
+    return { pagingHarness, fixture };
+  }
+
+  it('should get the paging component by data-sky-id', async () => {
+    const { pagingHarness } = await setupTest({ dataSkyId: 'other-paging' });
+
+    await expectAsync(pagingHarness.getPagingContent()).toBeRejected();
+  });
+
+  it('should get the current page', async () => {
+    const { pagingHarness } = await setupTest();
+
+    await expectAsync(pagingHarness.getCurrentPage()).toBeResolvedTo(1);
+  });
+
+  it('should click the next and previous buttons', async () => {
+    const { pagingHarness } = await setupTest({ pageSize: 10 });
+
+    await pagingHarness.clickNextButton();
+    await expectAsync(pagingHarness.getCurrentPage()).toBeResolvedTo(2);
+    await expectAsync(pagingHarness.clickNextButton()).toBeRejectedWithError(
+      'Could not click the next button because it is disabled.',
+    );
+
+    await pagingHarness.clickPreviousButton();
+    await expectAsync(pagingHarness.getCurrentPage()).toBeResolvedTo(1);
+    await expectAsync(
+      pagingHarness.clickPreviousButton(),
+    ).toBeRejectedWithError(
+      'Could not click the previous button because it is disabled.',
+    );
+  });
+
+  it('should select a specific page', async () => {
+    const { pagingHarness, fixture } = await setupTest();
+
+    await pagingHarness.clickPageButton(3);
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    await expectAsync(pagingHarness.getCurrentPage()).toBeResolvedTo(3);
+  });
+
+  it('should throw an error when trying to select page that is not currently displayed', async () => {
+    const { pagingHarness } = await setupTest();
+
+    await expectAsync(pagingHarness.clickPageButton(5)).toBeRejectedWithError(
+      'Could not find page button 5.',
+    );
+  });
+
+  it('should get the paging label', async () => {
+    const { pagingHarness } = await setupTest();
+
+    await expectAsync(pagingHarness.getPagingLabel()).toBeResolvedTo(
+      'Paging label',
+    );
+  });
+
+  it('should throw an error if the paging controls are not present', async () => {
+    const { pagingHarness } = await setupTest({ dataSkyId: 'other-paging' });
+
+    await expectAsync(pagingHarness.getPagingLabel()).toBeRejectedWithError(
+      'Could not find paging label.',
+    );
+    await expectAsync(pagingHarness.getCurrentPage()).toBeRejectedWithError(
+      'Could not find current page.',
+    );
+    await expectAsync(pagingHarness.clickPageButton(1)).toBeRejectedWithError(
+      'Could not find page button 1.',
+    );
+    await expectAsync(pagingHarness.clickNextButton()).toBeRejectedWithError(
+      'Could not find the next button.',
+    );
+    await expectAsync(
+      pagingHarness.clickPreviousButton(),
+    ).toBeRejectedWithError('Could not find the previous button.');
+  });
+});

--- a/libs/components/lists/testing/src/modules/paging/paging-harness.ts
+++ b/libs/components/lists/testing/src/modules/paging/paging-harness.ts
@@ -1,0 +1,121 @@
+import { HarnessPredicate, TestElement } from '@angular/cdk/testing';
+import { SkyComponentHarness } from '@skyux/core/testing';
+
+import { SkyPageControlHarness } from './page-control-harness';
+import { SkyPagingContentHarness } from './paging-content-harness';
+import { SkyPagingHarnessFilters } from './paging-harness-filters';
+
+/**
+ * Harness for interacting with a paging component in tests.
+ */
+export class SkyPagingHarness extends SkyComponentHarness {
+  /**
+   * @internal
+   */
+  public static hostSelector = 'sky-paging';
+
+  #getNextButton = this.locatorForOptional('li button.sky-paging-btn-next');
+  #getPreviousButton = this.locatorForOptional(
+    'li button.sky-paging-btn-previous',
+  );
+
+  /**
+   * Gets a `HarnessPredicate` that can be used to search for a
+   * `SkyPagingHarness` that meets certain criteria.
+   */
+  public static with(
+    filters: SkyPagingHarnessFilters,
+  ): HarnessPredicate<SkyPagingHarness> {
+    return SkyPagingHarness.getDataSkyIdPredicate(filters);
+  }
+
+  /**
+   * Clicks the next button.
+   */
+  public async clickNextButton(): Promise<void> {
+    const button = await this.#getNextButton();
+
+    if (button === null) {
+      throw new Error('Could not find the next button.');
+    }
+
+    if (await this.#buttonIsDisabled(button)) {
+      throw new Error(
+        'Could not click the next button because it is disabled.',
+      );
+    }
+
+    await button.click();
+  }
+
+  /**
+   * Clicks the page button with the requested number. Throws an error if that button is not present.
+   */
+  public async clickPageButton(pageNumber: number): Promise<void> {
+    const button = await this.locatorForOptional(
+      SkyPageControlHarness.with({ pageNumber: pageNumber }),
+    )();
+
+    if (button === null) {
+      throw new Error(`Could not find page button ${pageNumber}.`);
+    }
+
+    await button.clickButton();
+  }
+
+  /**
+   * Clicks the previous button.
+   */
+  public async clickPreviousButton(): Promise<void> {
+    const button = await this.#getPreviousButton();
+
+    if (button === null) {
+      throw new Error('Could not find the previous button.');
+    }
+
+    if (await this.#buttonIsDisabled(button)) {
+      throw new Error(
+        'Could not click the previous button because it is disabled.',
+      );
+    }
+
+    await button.click();
+  }
+
+  /**
+   * Gets the current page number.
+   */
+  public async getCurrentPage(): Promise<number> {
+    const currentPage = await this.locatorForOptional(
+      'button.sky-paging-current',
+    )();
+
+    if (currentPage === null) {
+      throw new Error('Could not find current page.');
+    }
+
+    return parseInt(await currentPage.text());
+  }
+
+  /**
+   * Gets the paging content.
+   */
+  public async getPagingContent(): Promise<SkyPagingContentHarness> {
+    return await this.locatorFor(SkyPagingContentHarness)();
+  }
+
+  public async getPagingLabel(): Promise<string> {
+    const pageNav = await this.locatorForOptional('nav.sky-paging')();
+
+    if (pageNav === null) {
+      throw new Error('Could not find paging label.');
+    }
+
+    return (await pageNav.getAttribute('aria-label')) as string;
+  }
+
+  async #buttonIsDisabled(button: TestElement): Promise<boolean> {
+    const disabled = await button.getAttribute('disabled');
+    return disabled !== null;
+  }
+}

--- a/libs/components/lists/testing/src/public-api.ts
+++ b/libs/components/lists/testing/src/public-api.ts
@@ -6,6 +6,10 @@ export { SkyPagingFixture } from './legacy/paging/paging-fixture';
 export { SkyPagingFixtureButton } from './legacy/paging/paging-fixture-button';
 export { SkyPagingTestingModule } from './legacy/paging/paging-testing.module';
 
+export { SkyPagingContentHarness } from './modules/paging/paging-content-harness';
+export { SkyPagingHarness } from './modules/paging/paging-harness';
+export { SkyPagingHarnessFilters } from './modules/paging/paging-harness-filters';
+
 export { SkyRepeaterHarness } from './modules/repeater/repeater-harness';
 export { SkyRepeaterHarnessFilters } from './modules/repeater/repeater-harness-filters';
 export { SkyRepeaterItemHarness } from './modules/repeater/repeater-item-harness';


### PR DESCRIPTION
:cherries: Cherry picked from #3185 [feat(components/lists): add paging test harnesses](https://github.com/blackbaud/skyux/pull/3185)

[AB#2195510](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/2195510) 