### PR TITLE
refactor: enable '@typescript-eslint/consistent-indexed-object-style' ESLint rule

### DIFF
--- a/apps/e2e/layout-storybook/src/app/page/page.component.ts
+++ b/apps/e2e/layout-storybook/src/app/page/page.component.ts
@@ -11,12 +11,12 @@ import {
   standalone: false,
 })
 export class PageComponent implements OnInit, OnDestroy {
-  public spaces = {
+  public spaces: Record<SkyAppViewportReservedPositionType, number> = {
     left: 10,
     top: 40,
     right: 80,
     bottom: 120,
-  } as { [key in SkyAppViewportReservedPositionType]: number };
+  };
 
   #viewportSvc: SkyAppViewportService;
 

--- a/eslint-overrides-angular.config.js
+++ b/eslint-overrides-angular.config.js
@@ -1,10 +1,12 @@
 const overrides = require('./eslint-overrides.config');
 
 module.exports = [
+  ...overrides,
   {
     files: ['**/*.ts'],
     rules: {
-      '@angular-eslint/prefer-standalone': 'warn',
+      '@angular-eslint/prefer-standalone': 'off',
+      '@typescript-eslint/consistent-indexed-object-style': ['error', 'record'],
     },
   },
   {
@@ -51,5 +53,4 @@ module.exports = [
       '@angular-eslint/template/valid-aria': ['error'],
     },
   },
-  ...overrides,
 ];

--- a/libs/components/data-manager/src/lib/modules/data-manager/models/data-view-column-widths.ts
+++ b/libs/components/data-manager/src/lib/modules/data-manager/models/data-view-column-widths.ts
@@ -2,13 +2,9 @@ export interface SkyDataViewColumnWidths {
   /**
    * A map of columnIds to column widths at the xs breakpoint size.
    */
-  xs: {
-    [colId: string]: number;
-  };
+  xs: Record<string, number>;
   /**
    * A map of columnIds to column widths at the sm or larger breakpoint size.
    */
-  sm: {
-    [colId: string]: number;
-  };
+  sm: Record<string, number>;
 }

--- a/libs/components/docs-tools/src/lib/modules/type-definition/type-anchor-ids.service.ts
+++ b/libs/components/docs-tools/src/lib/modules/type-definition/type-anchor-ids.service.ts
@@ -9,7 +9,6 @@ export class SkyDocsTypeDefinitionAnchorIdsService {
   #anchorIds = new Map<string, string>();
 
   /**
-   *
    * @param anchorIds A collection of anchorIds, keyed by the definition's name.
    */
   public updateAnchorIds(anchorIds: Record<string, string>): void {

--- a/libs/components/docs-tools/src/lib/modules/type-definition/type-anchor-ids.service.ts
+++ b/libs/components/docs-tools/src/lib/modules/type-definition/type-anchor-ids.service.ts
@@ -8,7 +8,11 @@ import { Injectable } from '@angular/core';
 export class SkyDocsTypeDefinitionAnchorIdsService {
   #anchorIds = new Map<string, string>();
 
-  public updateAnchorIds(anchorIds: { [token: string]: string }): void {
+  /**
+   *
+   * @param anchorIds A collection of anchorIds, keyed by the definition's name.
+   */
+  public updateAnchorIds(anchorIds: Record<string, string>): void {
     this.#anchorIds = new Map(Object.entries(anchorIds));
   }
 

--- a/libs/components/theme/src/lib/viewport/viewport.service.ts
+++ b/libs/components/theme/src/lib/viewport/viewport.service.ts
@@ -92,14 +92,13 @@ export class SkyAppViewportService {
 
   #updateViewportArea(): void {
     this.#updateRequest ??= requestAnimationFrame(() => {
-      const reservedSpaces: {
-        [key in SkyAppViewportReservedPositionType]: number;
-      } = {
-        bottom: 0,
-        left: 0,
-        right: 0,
-        top: 0,
-      };
+      const reservedSpaces: Record<SkyAppViewportReservedPositionType, number> =
+        {
+          bottom: 0,
+          left: 0,
+          right: 0,
+          top: 0,
+        };
 
       for (const {
         position,


### PR DESCRIPTION
This enforces the use of `Record` instead of index signature objects and gives our documentation more consistency.