### PR TITLE
feat(components/tabs): add vertical tabs harness (#3241)

### DIFF
--- a/apps/code-examples/src/app/code-examples/tabs/vertical-tabs/basic/demo.component.html
+++ b/apps/code-examples/src/app/code-examples/tabs/vertical-tabs/basic/demo.component.html
@@ -1,7 +1,9 @@
-<sky-vertical-tabset>
+<sky-vertical-tabset data-sky-id="vertical-tabs-basic">
   <sky-vertical-tab tabHeading="Tab 1"> Tab 1 content </sky-vertical-tab>
   <sky-vertical-tab tabHeading="Tab 2" [active]="true">
     Tab 2 content
   </sky-vertical-tab>
-  <sky-vertical-tab tabHeading="Tab 3"> Tab 3 content </sky-vertical-tab>
+  <sky-vertical-tab tabHeading="Tab 3" [disabled]="true">
+    Tab 3 content
+  </sky-vertical-tab>
 </sky-vertical-tabset>

--- a/apps/code-examples/src/app/code-examples/tabs/vertical-tabs/basic/demo.component.spec.ts
+++ b/apps/code-examples/src/app/code-examples/tabs/vertical-tabs/basic/demo.component.spec.ts
@@ -1,0 +1,43 @@
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { SkyVerticalTabsetHarness } from '@skyux/tabs/testing';
+
+import { DemoComponent } from './demo.component';
+
+describe('Basic vertical tabs demo', () => {
+  async function setupTest(options: { dataSkyId?: string }): Promise<{
+    harness: SkyVerticalTabsetHarness;
+    fixture: ComponentFixture<DemoComponent>;
+  }> {
+    const fixture = TestBed.createComponent(DemoComponent);
+    const loader = TestbedHarnessEnvironment.loader(fixture);
+
+    const harness = await loader.getHarness(
+      SkyVerticalTabsetHarness.with({ dataSkyId: options.dataSkyId }),
+    );
+
+    return { harness, fixture };
+  }
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [DemoComponent, NoopAnimationsModule],
+    });
+  });
+
+  it('should set up vertical tabs', async () => {
+    const { harness } = await setupTest({ dataSkyId: 'vertical-tabs-basic' });
+
+    const allTabs = await harness.getTabs();
+    expect(allTabs.length).toBe(3);
+
+    const activeTab = await harness.getActiveTab();
+    expect(await activeTab?.getTabHeading()).toBe('Tab 2');
+    const activeTabContent = await activeTab?.getTabContent();
+    expect(await activeTabContent?.isVisible()).toBeTrue();
+
+    const disabledTab = await harness.getTab({ tabHeading: 'Tab 3' });
+    expect(await disabledTab?.isDisabled()).toBeTrue();
+  });
+});

--- a/apps/code-examples/src/app/code-examples/tabs/vertical-tabs/grouped/demo.component.html
+++ b/apps/code-examples/src/app/code-examples/tabs/vertical-tabs/grouped/demo.component.html
@@ -1,4 +1,4 @@
-<sky-vertical-tabset showTabsText="Tab list">
+<sky-vertical-tabset data-sky-id="vertical-tabs-group" showTabsText="Tab list">
   @for (group of groups; track group) {
     <sky-vertical-tabset-group
       [groupHeading]="group.heading"

--- a/apps/code-examples/src/app/code-examples/tabs/vertical-tabs/grouped/demo.component.spec.ts
+++ b/apps/code-examples/src/app/code-examples/tabs/vertical-tabs/grouped/demo.component.spec.ts
@@ -1,0 +1,66 @@
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { SkyVerticalTabsetHarness } from '@skyux/tabs/testing';
+
+import { DemoComponent } from './demo.component';
+
+describe('Group vertical tabs demo', () => {
+  async function setupTest(options: { dataSkyId?: string }): Promise<{
+    harness: SkyVerticalTabsetHarness;
+    fixture: ComponentFixture<DemoComponent>;
+  }> {
+    const fixture = TestBed.createComponent(DemoComponent);
+    const loader = TestbedHarnessEnvironment.loader(fixture);
+
+    const harness = await loader.getHarness(
+      SkyVerticalTabsetHarness.with({ dataSkyId: options.dataSkyId }),
+    );
+
+    return { harness, fixture };
+  }
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [DemoComponent, NoopAnimationsModule],
+    });
+  });
+
+  it('should set up vertical tabs', async () => {
+    const { harness } = await setupTest({ dataSkyId: 'vertical-tabs-group' });
+
+    const allTabs = await harness.getTabs();
+    expect(allTabs.length).toBe(4);
+
+    const groups = await harness.getGroups();
+    expect(groups.length).toBe(3);
+
+    const disabledGroup = await harness.getGroup({
+      groupHeading: 'Disabled',
+    });
+    await expectAsync(disabledGroup?.isDisabled()).toBeResolvedTo(true);
+
+    const group1Tab2 = await harness.getTab({ tabHeading: 'Group 1 — Tab 2' });
+    await expectAsync(group1Tab2.getTabHeaderCount()).toBeResolvedTo(7);
+  });
+
+  it('should have active tab as the first tab in group 2', async () => {
+    const { harness } = await setupTest({ dataSkyId: 'vertical-tabs-group' });
+
+    // Two ways to get a tab inside a group
+    // Through tabset harness
+    const activeTab = await harness.getActiveTab();
+
+    // Through group harness
+    const group2 = await harness.getGroup({ groupHeading: 'Group 2' });
+    await expectAsync(group2?.isActive()).toBeResolvedTo(true);
+
+    const tab1 = await group2?.getVerticalTab({
+      tabHeading: 'Group 2 — Tab 1',
+    });
+
+    const check =
+      (await activeTab?.getTabHeading()) === (await tab1?.getTabHeading());
+    expect(check).toBe(true);
+  });
+});

--- a/libs/components/code-examples/src/lib/modules/tabs/vertical-tabs/basic/example.component.html
+++ b/libs/components/code-examples/src/lib/modules/tabs/vertical-tabs/basic/example.component.html
@@ -3,7 +3,7 @@
   <sky-vertical-tab tabHeading="Tab 2" [active]="true">
     Tab 2 content
   </sky-vertical-tab>
-  <sky-vertical-tab tabHeading="Tab 3" disabled="true">
+  <sky-vertical-tab tabHeading="Tab 3" [disabled]="true">
     Tab 3 content
   </sky-vertical-tab>
 </sky-vertical-tabset>

--- a/libs/components/code-examples/src/lib/modules/tabs/vertical-tabs/basic/example.component.html
+++ b/libs/components/code-examples/src/lib/modules/tabs/vertical-tabs/basic/example.component.html
@@ -1,7 +1,9 @@
-<sky-vertical-tabset>
+<sky-vertical-tabset data-sky-id="vertical-tabs-basic">
   <sky-vertical-tab tabHeading="Tab 1"> Tab 1 content </sky-vertical-tab>
   <sky-vertical-tab tabHeading="Tab 2" [active]="true">
     Tab 2 content
   </sky-vertical-tab>
-  <sky-vertical-tab tabHeading="Tab 3"> Tab 3 content </sky-vertical-tab>
+  <sky-vertical-tab tabHeading="Tab 3" disabled="true">
+    Tab 3 content
+  </sky-vertical-tab>
 </sky-vertical-tabset>

--- a/libs/components/code-examples/src/lib/modules/tabs/vertical-tabs/basic/example.component.spec.ts
+++ b/libs/components/code-examples/src/lib/modules/tabs/vertical-tabs/basic/example.component.spec.ts
@@ -1,0 +1,45 @@
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { SkyVerticalTabsetHarness } from '@skyux/tabs/testing';
+
+import { TabsVerticalTabsBasicExampleComponent } from './example.component';
+
+describe('Basic vertical tabs example', () => {
+  async function setupTest(options: { dataSkyId?: string }): Promise<{
+    harness: SkyVerticalTabsetHarness;
+    fixture: ComponentFixture<TabsVerticalTabsBasicExampleComponent>;
+  }> {
+    const fixture = TestBed.createComponent(
+      TabsVerticalTabsBasicExampleComponent,
+    );
+    const loader = TestbedHarnessEnvironment.loader(fixture);
+
+    const harness = await loader.getHarness(
+      SkyVerticalTabsetHarness.with({ dataSkyId: options.dataSkyId }),
+    );
+
+    return { harness, fixture };
+  }
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [TabsVerticalTabsBasicExampleComponent, NoopAnimationsModule],
+    });
+  });
+
+  it('should set up vertical tabs', async () => {
+    const { harness } = await setupTest({ dataSkyId: 'vertical-tabs-basic' });
+
+    const allTabs = await harness.getTabs();
+    expect(allTabs.length).toBe(3);
+
+    const activeTab = await harness.getActiveTab();
+    expect(await activeTab?.getTabHeading()).toBe('Tab 2');
+    const activeTabContent = await activeTab?.getTabContent();
+    expect(await activeTabContent?.isVisible()).toBeTrue();
+
+    const disabledTab = await harness.getTab({ tabHeading: 'Tab 3' });
+    expect(await disabledTab?.isDisabled()).toBeTrue();
+  });
+});

--- a/libs/components/code-examples/src/lib/modules/tabs/vertical-tabs/grouped/example.component.html
+++ b/libs/components/code-examples/src/lib/modules/tabs/vertical-tabs/grouped/example.component.html
@@ -1,4 +1,4 @@
-<sky-vertical-tabset showTabsText="Tab list">
+<sky-vertical-tabset data-sky-id="vertical-tabs-group" showTabsText="Tab list">
   @for (group of groups; track group) {
     <sky-vertical-tabset-group
       [groupHeading]="group.heading"

--- a/libs/components/code-examples/src/lib/modules/tabs/vertical-tabs/grouped/example.component.spec.ts
+++ b/libs/components/code-examples/src/lib/modules/tabs/vertical-tabs/grouped/example.component.spec.ts
@@ -1,0 +1,68 @@
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { SkyVerticalTabsetHarness } from '@skyux/tabs/testing';
+
+import { TabsVerticalTabsGroupedExampleComponent } from './example.component';
+
+describe('Group vertical tabs example', () => {
+  async function setupTest(options: { dataSkyId?: string }): Promise<{
+    harness: SkyVerticalTabsetHarness;
+    fixture: ComponentFixture<TabsVerticalTabsGroupedExampleComponent>;
+  }> {
+    const fixture = TestBed.createComponent(
+      TabsVerticalTabsGroupedExampleComponent,
+    );
+    const loader = TestbedHarnessEnvironment.loader(fixture);
+
+    const harness = await loader.getHarness(
+      SkyVerticalTabsetHarness.with({ dataSkyId: options.dataSkyId }),
+    );
+
+    return { harness, fixture };
+  }
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [TabsVerticalTabsGroupedExampleComponent, NoopAnimationsModule],
+    });
+  });
+
+  it('should set up vertical tabs', async () => {
+    const { harness } = await setupTest({ dataSkyId: 'vertical-tabs-group' });
+
+    const allTabs = await harness.getTabs();
+    expect(allTabs.length).toBe(4);
+
+    const groups = await harness.getGroups();
+    expect(groups.length).toBe(3);
+
+    const disabledGroup = await harness.getGroup({
+      groupHeading: 'Disabled',
+    });
+    await expectAsync(disabledGroup?.isDisabled()).toBeResolvedTo(true);
+
+    const group1Tab2 = await harness.getTab({ tabHeading: 'Group 1 — Tab 2' });
+    await expectAsync(group1Tab2.getTabHeaderCount()).toBeResolvedTo(7);
+  });
+
+  it('should have active tab as the first tab in group 2', async () => {
+    const { harness } = await setupTest({ dataSkyId: 'vertical-tabs-group' });
+
+    // Two ways to get a tab inside a group
+    // Through tabset harness
+    const activeTab = await harness.getActiveTab();
+
+    // Through group harness
+    const group2 = await harness.getGroup({ groupHeading: 'Group 2' });
+    await expectAsync(group2?.isActive()).toBeResolvedTo(true);
+
+    const tab1 = await group2?.getVerticalTab({
+      tabHeading: 'Group 2 — Tab 1',
+    });
+
+    const check =
+      (await activeTab?.getTabHeading()) === (await tab1?.getTabHeading());
+    expect(check).toBe(true);
+  });
+});

--- a/libs/components/tabs/src/lib/modules/vertical-tabset/vertical-tabset-group.component.ts
+++ b/libs/components/tabs/src/lib/modules/vertical-tabset/vertical-tabset-group.component.ts
@@ -89,7 +89,7 @@ export class SkyVerticalTabsetGroupComponent implements OnInit, OnDestroy {
   #groupService = inject(SkyVerticalTabsetGroupService);
 
   #_disabled: boolean | undefined;
-  #_open: boolean | undefined;
+  #_open: boolean | undefined = false;
 
   constructor(
     tabService: SkyVerticalTabsetService,

--- a/libs/components/tabs/testing/src/modules/tabs/tab-button-harness.ts
+++ b/libs/components/tabs/testing/src/modules/tabs/tab-button-harness.ts
@@ -94,6 +94,7 @@ export class SkyTabButtonHarness extends SkyComponentHarness {
   }
 
   /**
+   * Gets the id of the content controlled by this tab.
    * @internal
    */
   public async getTabId(): Promise<string> {

--- a/libs/components/tabs/testing/src/modules/tabs/tab-content-harness-filters.ts
+++ b/libs/components/tabs/testing/src/modules/tabs/tab-content-harness-filters.ts
@@ -3,7 +3,6 @@ import { SkyHarnessFilters } from '@skyux/core/testing';
 /**
  * A set of criteria that can be used to filter a list of `SkyTabContentHarness` instances.
  */
-// eslint-disable-next-line @typescript-eslint/no-empty-interface, @typescript-eslint/no-empty-object-type
 export interface SkyTabContentHarnessFilters extends SkyHarnessFilters {
   /**
    * Finds tabs whose id matches given value.

--- a/libs/components/tabs/testing/src/modules/vertical-tabset/vertical-tab-button-harness-filters.ts
+++ b/libs/components/tabs/testing/src/modules/vertical-tabset/vertical-tab-button-harness-filters.ts
@@ -1,0 +1,11 @@
+import { SkyHarnessFilters } from '@skyux/core/testing';
+
+/**
+ * A set of criteria that can be used to filter a list of  `SkyVerticalTabButtonHarness` instances.
+ */
+export interface SkyVerticalTabButtonHarnessFilters extends SkyHarnessFilters {
+  /**
+   * Find a tab whose heading matches the given value.
+   */
+  tabHeading?: string;
+}

--- a/libs/components/tabs/testing/src/modules/vertical-tabset/vertical-tab-button-harness.ts
+++ b/libs/components/tabs/testing/src/modules/vertical-tabset/vertical-tab-button-harness.ts
@@ -1,0 +1,101 @@
+import { HarnessPredicate } from '@angular/cdk/testing';
+import { SkyComponentHarness } from '@skyux/core/testing';
+
+import { SkyVerticalTabButtonHarnessFilters } from './vertical-tab-button-harness-filters';
+import { SkyVerticalTabContentHarness } from './vertical-tab-content-harness';
+
+/**
+ * Harness for interacting with a vertical tab button in tests.
+ */
+export class SkyVerticalTabButtonHarness extends SkyComponentHarness {
+  /**
+   * @internal
+   */
+  public static hostSelector = 'sky-vertical-tab';
+
+  #tabButton = this.locatorFor('a.sky-vertical-tab');
+
+  /**
+   * Gets a `HarnessPredicate` that can be used to search for a
+   * `SkyVerticalTabButtonHarness` that meets certain criteria.
+   */
+  public static with(
+    filters: SkyVerticalTabButtonHarnessFilters,
+  ): HarnessPredicate<SkyVerticalTabButtonHarness> {
+    return new HarnessPredicate(SkyVerticalTabButtonHarness, filters).addOption(
+      'tabHeading',
+      filters.tabHeading,
+      async (harness, heading) => {
+        const tabHeading = await harness.getTabHeading();
+        return tabHeading === heading;
+      },
+    );
+  }
+
+  /**
+   * Clicks the tab button to activate the tab.
+   */
+  public async click(): Promise<void> {
+    return await (await this.#tabButton()).click();
+  }
+
+  /**
+   * Gets the `SkyVerticalTabContentHarness` for this tab.
+   */
+  public async getTabContent(): Promise<SkyVerticalTabContentHarness> {
+    return await this.documentRootLocatorFactory().locatorFor(
+      SkyVerticalTabContentHarness.with({ tabId: await this.getTabId() }),
+    )();
+  }
+
+  /**
+   * Gets the tab header count.
+   */
+  public async getTabHeaderCount(): Promise<number> {
+    const value = (
+      await (await this.locatorFor('.sky-vertical-tab-count')()).text()
+    ).trim();
+
+    // get value between parentheses
+    const rx = /\(([^)]+)\)/;
+
+    return Number(value.match(rx)?.[1]);
+  }
+
+  /**
+   * Gets the tab heading text.
+   */
+  public async getTabHeading(): Promise<string> {
+    return (
+      await (await this.locatorFor('.sky-vertical-tab-heading-value')()).text()
+    ).trim();
+  }
+
+  /**
+   * Gets the id of the content controlled by this tab.
+   * @internal
+   */
+  public async getTabId(): Promise<string> {
+    return (
+      (await (await this.#tabButton()).getAttribute('aria-controls')) ||
+      /* istanbul ignore next */
+      ''
+    );
+  }
+
+  /**
+   * Whether the tab is active.
+   */
+  public async isActive(): Promise<boolean> {
+    return await (await this.#tabButton()).hasClass('sky-vertical-tab-active');
+  }
+
+  /**
+   * Whether the tab is disabled.
+   */
+  public async isDisabled(): Promise<boolean> {
+    return await (
+      await this.#tabButton()
+    ).hasClass('sky-vertical-tabset-button-disabled');
+  }
+}

--- a/libs/components/tabs/testing/src/modules/vertical-tabset/vertical-tab-content-harness-filters.ts
+++ b/libs/components/tabs/testing/src/modules/vertical-tabset/vertical-tab-content-harness-filters.ts
@@ -1,0 +1,12 @@
+import { SkyHarnessFilters } from '@skyux/core/testing';
+
+/**
+ * A set of criteria that can be used to filter a list of `SkyVerticalTabContentHarness` instances.
+ */
+export interface SkyVerticalTabContentHarnessFilters extends SkyHarnessFilters {
+  /**
+   * Finds tabs whose id matches given value.
+   * @internal
+   */
+  tabId: string;
+}

--- a/libs/components/tabs/testing/src/modules/vertical-tabset/vertical-tab-content-harness.ts
+++ b/libs/components/tabs/testing/src/modules/vertical-tabset/vertical-tab-content-harness.ts
@@ -1,0 +1,44 @@
+import { HarnessPredicate } from '@angular/cdk/testing';
+import { SkyQueryableComponentHarness } from '@skyux/core/testing';
+
+import { SkyVerticalTabContentHarnessFilters } from './vertical-tab-content-harness-filters';
+
+/**
+ * Harness for interacting with a vertical tab content in tests.
+ */
+export class SkyVerticalTabContentHarness extends SkyQueryableComponentHarness {
+  /**
+   * @internal
+   */
+  public static hostSelector = '.sky-vertical-tab-content-pane';
+
+  /**
+   * Gets a `HarnessPredicate` that can be used to search for a
+   * `SkyVerticalTabContentHarness` that meets certain criteria.
+   */
+  public static with(
+    filters: SkyVerticalTabContentHarnessFilters,
+  ): HarnessPredicate<SkyVerticalTabContentHarness> {
+    return SkyVerticalTabContentHarness.getDataSkyIdPredicate(
+      filters,
+    ).addOption('tabId', filters.tabId, async (harness, tabId) => {
+      const harnessId = await harness.getTabId();
+      return await HarnessPredicate.stringMatches(harnessId, tabId);
+    });
+  }
+
+  /**
+   * Gets the tab content's id.
+   * @internal
+   */
+  public async getTabId(): Promise<string | null> {
+    return await (await this.host()).getAttribute('id');
+  }
+
+  /**
+   * Whether the tab content is visible.
+   */
+  public async isVisible(): Promise<boolean> {
+    return !(await (await this.host()).hasClass('sky-vertical-tab-hidden'));
+  }
+}

--- a/libs/components/tabs/testing/src/modules/vertical-tabset/vertical-tabset-group-harness-filters.ts
+++ b/libs/components/tabs/testing/src/modules/vertical-tabset/vertical-tabset-group-harness-filters.ts
@@ -1,0 +1,12 @@
+import { SkyHarnessFilters } from '@skyux/core/testing';
+
+/**
+ * A set of criteria that can be used to filter a list of  `SkyVerticalTabsetGroupHarness` instances.
+ */
+export interface SkyVerticalTabsetGroupHarnessFilters
+  extends SkyHarnessFilters {
+  /**
+   * Find tabset groups whose heading matches the given value.
+   */
+  groupHeading?: string;
+}

--- a/libs/components/tabs/testing/src/modules/vertical-tabset/vertical-tabset-group-harness.ts
+++ b/libs/components/tabs/testing/src/modules/vertical-tabset/vertical-tabset-group-harness.ts
@@ -1,0 +1,96 @@
+import { HarnessPredicate } from '@angular/cdk/testing';
+import { SkyComponentHarness } from '@skyux/core/testing';
+
+import { SkyVerticalTabButtonHarness } from './vertical-tab-button-harness';
+import { SkyVerticalTabButtonHarnessFilters } from './vertical-tab-button-harness-filters';
+import { SkyVerticalTabsetGroupHarnessFilters } from './vertical-tabset-group-harness-filters';
+
+/**
+ * Harness for interacting with a vertical tabset group in tests.
+ */
+export class SkyVerticalTabsetGroupHarness extends SkyComponentHarness {
+  /**
+   * @internal
+   */
+  public static hostSelector = 'sky-vertical-tabset-group';
+
+  #button = this.locatorFor('button.sky-vertical-tabset-button');
+  #header = this.locatorFor('.sky-vertical-tabset-group-header');
+
+  /**
+   * Gets a `HarnessPredicate` that can be used to search for a
+   * `SkyVerticalTabsetGroupHarness` that meets certain criteria.
+   */
+  public static with(
+    filters: SkyVerticalTabsetGroupHarnessFilters,
+  ): HarnessPredicate<SkyVerticalTabsetGroupHarness> {
+    return new HarnessPredicate(
+      SkyVerticalTabsetGroupHarness,
+      filters,
+    ).addOption(
+      'groupHeading',
+      filters.groupHeading,
+      async (harness, heading) => {
+        return (await harness.getGroupHeading()) === heading;
+      },
+    );
+  }
+
+  /**
+   * Clicks the group button to toggle its expanded state.
+   */
+  public async click(): Promise<void> {
+    return await (await this.#button()).click();
+  }
+
+  /**
+   * Gets the group heading text.
+   */
+  public async getGroupHeading(): Promise<string> {
+    return (await (await this.#button()).text()).trim();
+  }
+
+  /**
+   * Gets the `SkyVerticalTabButtonHarness` for a specific tab under this group based on filters.
+   */
+  public async getVerticalTab(
+    filters: SkyVerticalTabButtonHarnessFilters,
+  ): Promise<SkyVerticalTabButtonHarness> {
+    return await this.locatorFor(SkyVerticalTabButtonHarness.with(filters))();
+  }
+
+  /**
+   * Gets the `SkyVerticalTabButtonHarness` for all tabs under this group.
+   */
+  public async getVerticalTabs(): Promise<SkyVerticalTabButtonHarness[]> {
+    return await this.locatorForAll(SkyVerticalTabButtonHarness)();
+  }
+
+  /**
+   * Whether a tab under this group is active.
+   */
+  public async isActive(): Promise<boolean> {
+    return await (
+      await this.#header()
+    ).hasClass('sky-vertical-tabset-group-header-active');
+  }
+
+  /**
+   * Whether the group is disabled.
+   */
+  public async isDisabled(): Promise<boolean> {
+    return await (
+      await this.#button()
+    ).hasClass('sky-vertical-tabset-button-disabled');
+  }
+
+  /**
+   * Whether the group is expanded.
+   * todo ask other engineers if checking for a class or property is better. my vote is property.
+   */
+  public async isOpen(): Promise<boolean> {
+    return (
+      (await (await this.#button()).getAttribute('aria-expanded')) === 'true'
+    );
+  }
+}

--- a/libs/components/tabs/testing/src/modules/vertical-tabset/vertical-tabset-harness-filters.ts
+++ b/libs/components/tabs/testing/src/modules/vertical-tabset/vertical-tabset-harness-filters.ts
@@ -1,0 +1,7 @@
+import { SkyHarnessFilters } from '@skyux/core/testing';
+
+/**
+ * A set of criteria that can be used to filter a list of `SkyVerticalTabsetHarness` instances.
+ */
+// eslint-disable-next-line @typescript-eslint/no-empty-interface, @typescript-eslint/no-empty-object-type
+export interface SkyVerticalTabsetHarnessFilters extends SkyHarnessFilters {}

--- a/libs/components/tabs/testing/src/modules/vertical-tabset/vertical-tabset-harness.spec.ts
+++ b/libs/components/tabs/testing/src/modules/vertical-tabset/vertical-tabset-harness.spec.ts
@@ -1,0 +1,319 @@
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { Component } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import {
+  SkyMediaQueryTestingController,
+  provideSkyMediaQueryTesting,
+} from '@skyux/core/testing';
+import { SkyVerticalTabsetModule } from '@skyux/tabs';
+
+import { SkyVerticalTabsetHarness } from './vertical-tabset-harness';
+
+@Component({
+  standalone: true,
+  imports: [SkyVerticalTabsetModule],
+  template: `
+    <sky-vertical-tabset
+      ariaLabel="Vertical tabset"
+      ariaLabelledBy="Tabset label"
+      [showTabsText]="showTabsText"
+    >
+      <sky-vertical-tab
+        tabHeading="Tab 1"
+        [active]="active"
+        [tabHeaderCount]="15"
+      >
+        Tab 1 content
+      </sky-vertical-tab>
+      <sky-vertical-tab
+        data-sky-id="disabled-tab"
+        tabHeading="Tab 2"
+        [disabled]="true"
+      >
+        Tab 2 content
+      </sky-vertical-tab>
+      @for (group of groups; track group) {
+        <sky-vertical-tabset-group
+          [groupHeading]="group.heading"
+          [disabled]="group.isDisabled"
+          [open]="group.isOpen"
+        >
+          @for (tab of group.subTabs; track tab) {
+            <sky-vertical-tab
+              [active]="tab.active"
+              [tabHeading]="tab.tabHeading"
+              [tabHeaderCount]="tab.tabHeaderCount"
+              [disabled]="tab.disabled"
+            >
+              {{ tab.content }}
+            </sky-vertical-tab>
+          }
+        </sky-vertical-tabset-group>
+      }
+    </sky-vertical-tabset>
+    <sky-vertical-tabset
+      ariaLabel="Vertical tabset 2"
+      data-sky-id="other-tabset"
+    >
+      <sky-vertical-tab tabHeading="Other tabset"></sky-vertical-tab>
+    </sky-vertical-tabset>
+  `,
+})
+class TestComponent {
+  public active = true;
+  public showTabsText: string | undefined;
+  public groups: TabGroup[] = [
+    {
+      heading: 'Group 1',
+      isOpen: false,
+      subTabs: [
+        {
+          tabHeading: 'Tab 3',
+          content: 'Tab 3 content',
+        },
+        {
+          tabHeading: 'Tab 4',
+          content: 'Tab 4 content',
+          disabled: true,
+        },
+      ],
+    },
+    {
+      heading: 'Disabled group',
+      isDisabled: true,
+      subTabs: [],
+    },
+  ];
+}
+interface TabGroup {
+  heading: string;
+  isOpen?: boolean;
+  isDisabled?: boolean;
+  subTabs: {
+    tabHeading: string;
+    content: string;
+    tabHeaderCount?: number;
+    active?: boolean;
+    disabled?: boolean;
+  }[];
+}
+
+describe('Vertical Tabset harness', () => {
+  async function setupTest(options: { dataSkyId?: string } = {}): Promise<{
+    tabsetHarness: SkyVerticalTabsetHarness;
+    fixture: ComponentFixture<TestComponent>;
+  }> {
+    await TestBed.configureTestingModule({
+      imports: [TestComponent, NoopAnimationsModule],
+      providers: [provideSkyMediaQueryTesting()],
+    }).compileComponents();
+    const fixture = TestBed.createComponent(TestComponent);
+    const loader = TestbedHarnessEnvironment.loader(fixture);
+    const tabsetHarness: SkyVerticalTabsetHarness = options.dataSkyId
+      ? await loader.getHarness(
+          SkyVerticalTabsetHarness.with({ dataSkyId: options.dataSkyId }),
+        )
+      : await loader.getHarness(SkyVerticalTabsetHarness);
+
+    return { tabsetHarness, fixture };
+  }
+
+  it('should get vertical tabset by data-sky-id', async () => {
+    const { tabsetHarness } = await setupTest({
+      dataSkyId: 'other-tabset',
+    });
+
+    await expectAsync(tabsetHarness.getAriaLabel()).toBeResolvedTo(
+      'Vertical tabset 2',
+    );
+  });
+
+  it('should get the active tab', async () => {
+    const { tabsetHarness } = await setupTest();
+    const activeTab = await tabsetHarness.getActiveTab();
+    await expectAsync(activeTab?.getTabHeading()).toBeResolvedTo('Tab 1');
+  });
+
+  it('should get the active tab from inside a group', async () => {
+    const { tabsetHarness } = await setupTest();
+    const tabInsideGroup = await tabsetHarness.getTab({ tabHeading: 'Tab 3' });
+    await tabInsideGroup.click();
+
+    const activeTab = await tabsetHarness.getActiveTab();
+    await expectAsync(activeTab?.getTabHeading()).toBeResolvedTo('Tab 3');
+  });
+
+  it('should return undefined when no tab is active', async () => {
+    const { tabsetHarness, fixture } = await setupTest();
+    fixture.componentInstance.active = false;
+    fixture.detectChanges();
+
+    await expectAsync(tabsetHarness.getActiveTab()).toBeResolvedTo(undefined);
+  });
+
+  it('should get the active tab content harness', async () => {
+    const { tabsetHarness } = await setupTest();
+    const activeTabContent = await tabsetHarness.getActiveTabContent();
+    await expectAsync(activeTabContent?.isVisible()).toBeResolvedTo(true);
+  });
+
+  it('should return no content when there is no active tab', async () => {
+    const { tabsetHarness, fixture } = await setupTest();
+    fixture.componentInstance.active = false;
+    fixture.detectChanges();
+
+    await expectAsync(tabsetHarness.getActiveTabContent()).toBeResolvedTo(
+      undefined,
+    );
+  });
+
+  it('should get the vertical tabset aria-label', async () => {
+    const { tabsetHarness } = await setupTest();
+    await expectAsync(tabsetHarness.getAriaLabel()).toBeResolvedTo(
+      'Vertical tabset',
+    );
+  });
+
+  it('should get the vertical tabset aria-labelledby', async () => {
+    const { tabsetHarness } = await setupTest();
+    await expectAsync(tabsetHarness.getAriaLabelledBy()).toBeResolvedTo(
+      'Tabset label',
+    );
+  });
+
+  it('should get the vertical tabset group by heading', async () => {
+    const { tabsetHarness } = await setupTest();
+    const disabledGroup = await tabsetHarness.getGroup({
+      groupHeading: 'Disabled group',
+    });
+    await expectAsync(disabledGroup?.isDisabled()).toBeResolvedTo(true);
+  });
+
+  it('should get the vertical tabset groups', async () => {
+    const { tabsetHarness } = await setupTest();
+    const groups = await tabsetHarness.getGroups();
+    expect(groups.length).toBe(2);
+  });
+
+  it('should get tab harness by heading', async () => {
+    const { tabsetHarness } = await setupTest();
+    const tab = await tabsetHarness.getTab({ tabHeading: 'Tab 2' });
+    await expectAsync(tab.isDisabled()).toBeResolvedTo(true);
+  });
+
+  it('should get all tabs in tabset', async () => {
+    const { tabsetHarness } = await setupTest();
+    const tabs = await tabsetHarness.getTabs();
+    expect(tabs.length).toBe(4);
+  });
+
+  it('should not return show tab text when not in mobile view', async () => {
+    const { tabsetHarness } = await setupTest();
+    await expectAsync(tabsetHarness.getShowTabsText()).toBeResolvedTo(
+      undefined,
+    );
+  });
+
+  it('should get the tab header count', async () => {
+    const { tabsetHarness } = await setupTest();
+
+    const activeTab = await tabsetHarness.getActiveTab();
+
+    await expectAsync(activeTab?.getTabHeaderCount()).toBeResolvedTo(15);
+  });
+
+  describe('vertical tabset group', () => {
+    it('should click the group header to open and close the group', async () => {
+      const { tabsetHarness } = await setupTest();
+      const group1 = await tabsetHarness.getGroup({ groupHeading: 'Group 1' });
+      await expectAsync(group1?.isOpen()).toBeResolvedTo(false);
+
+      await group1?.click();
+      await expectAsync(group1?.isOpen()).toBeResolvedTo(true);
+    });
+
+    it('should get a tab harness inside a group by filter', async () => {
+      const { tabsetHarness } = await setupTest();
+      const group1 = await tabsetHarness.getGroup({ groupHeading: 'Group 1' });
+      const tab = await group1?.getVerticalTab({ tabHeading: 'Tab 4' });
+      await expectAsync(tab?.isDisabled()).toBeResolvedTo(true);
+    });
+
+    it('should get all tab harnesses inside a group', async () => {
+      const { tabsetHarness } = await setupTest();
+      const group1 = await tabsetHarness.getGroup({ groupHeading: 'Group 1' });
+      const tabs = await group1?.getVerticalTabs();
+      expect(tabs?.length).toBe(2);
+    });
+
+    it('should get if the group is active', async () => {
+      const { tabsetHarness } = await setupTest();
+      const group1 = await tabsetHarness.getGroup({ groupHeading: 'Group 1' });
+      await expectAsync(group1?.isActive()).toBeResolvedTo(false);
+
+      const tab = await group1?.getVerticalTab({ tabHeading: 'Tab 3' });
+      await tab?.click();
+
+      await expectAsync(group1?.isActive()).toBeResolvedTo(true);
+    });
+  });
+
+  describe('in mobile view', () => {
+    let mediaQueryController: SkyMediaQueryTestingController;
+
+    function shrinkScreen(fixture: ComponentFixture<TestComponent>): void {
+      mediaQueryController = TestBed.inject(SkyMediaQueryTestingController);
+      mediaQueryController.setBreakpoint('xs');
+      fixture.detectChanges();
+    }
+
+    it('should click the show tabs button', async () => {
+      const { tabsetHarness, fixture } = await setupTest();
+      shrinkScreen(fixture);
+      await expectAsync(tabsetHarness.isTabsVisible()).toBeResolvedTo(false);
+
+      await tabsetHarness.clickShowTabsButton();
+      await expectAsync(tabsetHarness.isTabsVisible()).toBeResolvedTo(true);
+    });
+
+    it('should get the active content', async () => {
+      const { tabsetHarness, fixture } = await setupTest();
+      shrinkScreen(fixture);
+
+      const content = await tabsetHarness.getActiveTabContent();
+      await expectAsync(content?.isVisible()).toBeResolvedTo(true);
+    });
+
+    it('should click the show tab button and get groups', async () => {
+      const { tabsetHarness, fixture } = await setupTest();
+      shrinkScreen(fixture);
+      await expectAsync(tabsetHarness.isTabsVisible()).toBeResolvedTo(false);
+
+      const groups = await tabsetHarness.getGroups();
+      await expectAsync(tabsetHarness.isTabsVisible()).toBeResolvedTo(true);
+      expect(groups.length).toBe(2);
+    });
+
+    it('should get the show tabs text', async () => {
+      const { tabsetHarness, fixture } = await setupTest();
+      fixture.componentInstance.showTabsText = 'Test button';
+      fixture.detectChanges();
+      shrinkScreen(fixture);
+
+      await expectAsync(tabsetHarness.getShowTabsText()).toBeResolvedTo(
+        'Test button',
+      );
+    });
+
+    it('should click the show tabs button and get all tabs', async () => {
+      const { tabsetHarness, fixture } = await setupTest();
+      shrinkScreen(fixture);
+      await expectAsync(tabsetHarness.isTabsVisible()).toBeResolvedTo(false);
+
+      const tabs = await tabsetHarness.getTabs();
+      await expectAsync(tabsetHarness.isTabsVisible()).toBeResolvedTo(true);
+      expect(tabs.length).toBe(4);
+    });
+  });
+});

--- a/libs/components/tabs/testing/src/modules/vertical-tabset/vertical-tabset-harness.ts
+++ b/libs/components/tabs/testing/src/modules/vertical-tabset/vertical-tabset-harness.ts
@@ -1,0 +1,170 @@
+import { HarnessPredicate } from '@angular/cdk/testing';
+import { SkyComponentHarness } from '@skyux/core/testing';
+
+import { SkyVerticalTabButtonHarness } from './vertical-tab-button-harness';
+import { SkyVerticalTabButtonHarnessFilters } from './vertical-tab-button-harness-filters';
+import { SkyVerticalTabContentHarness } from './vertical-tab-content-harness';
+import { SkyVerticalTabsetGroupHarness } from './vertical-tabset-group-harness';
+import { SkyVerticalTabsetGroupHarnessFilters } from './vertical-tabset-group-harness-filters';
+import { SkyVerticalTabsetHarnessFilters } from './vertical-tabset-harness-filters';
+
+/**
+ * Harness for interacting with the vertical tabset component in tests.
+ */
+export class SkyVerticalTabsetHarness extends SkyComponentHarness {
+  /**
+   * @internal
+   */
+  public static hostSelector = 'sky-vertical-tabset';
+
+  #showTabsButton = this.locatorForOptional(
+    '.sky-vertical-tabset-content > button.sky-vertical-tabset-show-tabs-btn',
+  );
+
+  /**
+   * Gets a `HarnessPredicate` that can be used to search for a
+   * `SkyVerticalTabsetHarness` that meets certain criteria.
+   */
+  public static with(
+    filters: SkyVerticalTabsetHarnessFilters,
+  ): HarnessPredicate<SkyVerticalTabsetHarness> {
+    return SkyVerticalTabsetHarness.getDataSkyIdPredicate(filters);
+  }
+
+  /**
+   * Click the show tabs button in mobile view.
+   */
+  public async clickShowTabsButton(): Promise<void> {
+    const showTabsButton = await this.#showTabsButton();
+    if (showTabsButton) {
+      await showTabsButton.click();
+    }
+  }
+
+  /**
+   * Gets the `SkyVerticalTabButtonHarness` of the currently active tab.
+   */
+  public async getActiveTab(): Promise<
+    SkyVerticalTabButtonHarness | undefined
+  > {
+    const tabs = await this.getTabs();
+    if (tabs) {
+      for (const tab of tabs) {
+        if (await tab.isActive()) {
+          return tab;
+        }
+      }
+    }
+    return undefined;
+  }
+
+  /**
+   * Gets the `SkyVerticalTabContentHarness` for the currently active tab.
+   */
+  public async getActiveTabContent(): Promise<
+    SkyVerticalTabContentHarness | undefined
+  > {
+    // in mobile view tabs are not rendered.
+    if (!(await this.isTabsVisible())) {
+      const contents = await this.locatorForAll(SkyVerticalTabContentHarness)();
+      for (const content of contents) {
+        if (await content.isVisible()) {
+          return content;
+        }
+      }
+    }
+
+    const activeTab = await this.getActiveTab();
+    if (activeTab) {
+      return await activeTab.getTabContent();
+    }
+    return undefined;
+  }
+
+  /**
+   * Gets the aria-label.
+   */
+  public async getAriaLabel(): Promise<string | null> {
+    return await (
+      await this.locatorFor('span.sky-vertical-tabset-tablist')()
+    ).getAttribute('aria-label');
+  }
+
+  /**
+   * Gets the aria-labelledby.
+   */
+  public async getAriaLabelledBy(): Promise<string | null> {
+    return await (
+      await this.locatorFor('span.sky-vertical-tabset-tablist')()
+    ).getAttribute('aria-labelledby');
+  }
+
+  /**
+   * Get the vertical tabset group by `SkyVerticalTabsetGroupHarnessFilters`
+   */
+  public async getGroup(
+    filters: SkyVerticalTabsetGroupHarnessFilters,
+  ): Promise<SkyVerticalTabsetGroupHarness | undefined> {
+    return await this.locatorFor(SkyVerticalTabsetGroupHarness.with(filters))();
+  }
+
+  /**
+   * Gets an array of `SkyVerticalTabsetGroupHarness` in this tabset.
+   */
+  public async getGroups(): Promise<SkyVerticalTabsetGroupHarness[]> {
+    // open tablist if in mobile view
+    if (!(await this.isTabsVisible())) {
+      await this.clickShowTabsButton();
+    }
+
+    return await this.locatorForAll(SkyVerticalTabsetGroupHarness)();
+  }
+
+  /**
+   * Gets the text in the show tabs button in mobile view.
+   */
+  public async getShowTabsText(): Promise<string | undefined> {
+    const showTabsButton = await this.#showTabsButton();
+
+    // check if it is in mobile view
+    if (showTabsButton) {
+      return (await await showTabsButton.text()).trim();
+    }
+
+    return undefined;
+  }
+
+  /**
+   * Gets a `SkyVerticalTabButtonHarness` that matches the filter.
+   */
+  public async getTab(
+    filters: SkyVerticalTabButtonHarnessFilters,
+  ): Promise<SkyVerticalTabButtonHarness> {
+    return await this.locatorFor(SkyVerticalTabButtonHarness.with(filters))();
+  }
+
+  /**
+   * Gets an array of `SkyVerticalTabButtonHarness` in this tabset.
+   */
+  public async getTabs(): Promise<SkyVerticalTabButtonHarness[]> {
+    // open tablist if in mobile view
+    if (!(await this.isTabsVisible())) {
+      await this.clickShowTabsButton();
+    }
+
+    return await this.locatorForAll(SkyVerticalTabButtonHarness)();
+  }
+
+  /**
+   * Whether the tabs are visible.
+   * In mobile view, vertical tabsets collapse to just the content pane
+   * with a button to show the tabs.
+   */
+  public async isTabsVisible(): Promise<boolean> {
+    const showTabsButton = await this.#showTabsButton();
+    if (showTabsButton) {
+      return false;
+    }
+    return true;
+  }
+}

--- a/libs/components/tabs/testing/src/public-api.ts
+++ b/libs/components/tabs/testing/src/public-api.ts
@@ -6,3 +6,12 @@ export { SkyTabsetHarnessFilters } from './modules/tabs/tabset-harness-filters';
 export { SkyTabButtonHarness } from './modules/tabs/tab-button-harness';
 export { SkyTabButtonHarnessFilters } from './modules/tabs/tab-button-harness-filters';
 export { SkyTabContentHarness } from './modules/tabs/tab-content-harness';
+
+export { SkyVerticalTabButtonHarness } from './modules/vertical-tabset/vertical-tab-button-harness';
+export { SkyVerticalTabButtonHarnessFilters } from './modules/vertical-tabset/vertical-tab-button-harness-filters';
+export { SkyVerticalTabContentHarness } from './modules/vertical-tabset/vertical-tab-content-harness';
+export { SkyVerticalTabContentHarnessFilters } from './modules/vertical-tabset/vertical-tab-content-harness-filters';
+export { SkyVerticalTabsetGroupHarness } from './modules/vertical-tabset/vertical-tabset-group-harness';
+export { SkyVerticalTabsetGroupHarnessFilters } from './modules/vertical-tabset/vertical-tabset-group-harness-filters';
+export { SkyVerticalTabsetHarness } from './modules/vertical-tabset/vertical-tabset-harness';
+export { SkyVerticalTabsetHarnessFilters } from './modules/vertical-tabset/vertical-tabset-harness-filters';


### PR DESCRIPTION
:cherries: Cherry picked from #3241 [feat(components/tabs): add vertical tabs harness](https://github.com/blackbaud/skyux/pull/3241)

[AB#2195598](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/2195598) 