### PR TITLE
fix(components/packages): icon size schematic does not add extra property if size already exists and is the first property on the icon

### DIFF
--- a/libs/components/packages/src/schematics/migrations/update-12/icons-size/icons-size.schematic.spec.ts
+++ b/libs/components/packages/src/schematics/migrations/update-12/icons-size/icons-size.schematic.spec.ts
@@ -39,11 +39,16 @@ export class Icon3Component {}`,
 
     tree.create(
       '/icon4.component.html',
-      `<sky-icon icon="plus-circle" size="sm"></sky-icon>`,
+      `<sky-icon size="sm" icon="plus-circle"></sky-icon>`,
     );
 
     tree.create(
       '/icon5.component.html',
+      `<sky-icon variant="line" size="sm" icon="plus-circle"></sky-icon>`,
+    );
+
+    tree.create(
+      '/icon6.component.html',
       `<sky-icon iconName="eye"></sky-icon>`,
     );
 
@@ -97,14 +102,22 @@ export class Icon3Component {}`,
     const { tree } = await setupTest();
 
     expect(tree.readText('/icon4.component.html')).toBe(
-      `<sky-icon icon="plus-circle" size="sm"></sky-icon>`,
+      `<sky-icon size="sm" icon="plus-circle"></sky-icon>`,
+    );
+  });
+
+  it('should handle icon which already sets the size', async () => {
+    const { tree } = await setupTest();
+
+    expect(tree.readText('/icon5.component.html')).toBe(
+      `<sky-icon variant="line" size="sm" icon="plus-circle"></sky-icon>`,
     );
   });
 
   it('should handle iconName missing the size', async () => {
     const { tree } = await setupTest();
 
-    expect(tree.readText('/icon5.component.html')).toBe(
+    expect(tree.readText('/icon6.component.html')).toBe(
       `<sky-icon size="md" iconName="eye"></sky-icon>`,
     );
   });

--- a/libs/components/packages/src/schematics/migrations/update-12/icons-size/icons-size.schematic.spec.ts
+++ b/libs/components/packages/src/schematics/migrations/update-12/icons-size/icons-size.schematic.spec.ts
@@ -98,7 +98,7 @@ export class Icon3Component {}`,
     );
   });
 
-  it('should handle icon which already sets the size', async () => {
+  it('should handle icon which already sets the size and is the first property', async () => {
     const { tree } = await setupTest();
 
     expect(tree.readText('/icon4.component.html')).toBe(
@@ -106,7 +106,7 @@ export class Icon3Component {}`,
     );
   });
 
-  it('should handle icon which already sets the size', async () => {
+  it('should handle icon which already sets the size and is not the first property', async () => {
     const { tree } = await setupTest();
 
     expect(tree.readText('/icon5.component.html')).toBe(

--- a/libs/components/packages/src/schematics/migrations/update-12/icons-size/icons-size.schematic.ts
+++ b/libs/components/packages/src/schematics/migrations/update-12/icons-size/icons-size.schematic.ts
@@ -4,7 +4,7 @@ import { visitProjectFiles } from '../../../utility/visit-project-files';
 import { getWorkspace } from '../../../utility/workspace';
 
 const NO_SIZE_REGEX =
-  /(?<beforeEnd><sky-icon(?![^>]+ size=)(?![^>]+\[size\]=))/g;
+  /(?<beforeEnd><sky-icon(?![^>]* size=)(?![^>]*\[size\]=))/g;
 
 function addSize(html: string): string {
   return html.replaceAll(


### PR DESCRIPTION
[AB#3295970](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3295970)