### PR TITLE
fix(components/forms): file attachment code examples fix double download (#3267)

### DIFF
--- a/apps/playground/src/app/components/forms/single-file-attachment/single-file-attachment.component.html
+++ b/apps/playground/src/app/components/forms/single-file-attachment/single-file-attachment.component.html
@@ -10,7 +10,6 @@
     [validateFn]="validateFile"
     [stacked]="true"
     (fileChange)="reactiveFileUpdated($event)"
-    (fileClick)="fileClick($event)"
   >
     <sky-file-attachment-label>
       Birth certificate

--- a/apps/playground/src/app/components/forms/single-file-attachment/single-file-attachment.component.ts
+++ b/apps/playground/src/app/components/forms/single-file-attachment/single-file-attachment.component.ts
@@ -6,11 +6,7 @@ import {
   UntypedFormGroup,
   Validators,
 } from '@angular/forms';
-import {
-  SkyFileAttachmentChange,
-  SkyFileAttachmentClick,
-  SkyFileItem,
-} from '@skyux/forms';
+import { SkyFileAttachmentChange, SkyFileItem } from '@skyux/forms';
 
 @Component({
   selector: 'app-single-file-attachment',
@@ -35,13 +31,6 @@ export class SingleFileAttachmentComponent implements OnInit {
   protected hintText = 'Please upload a file.';
 
   constructor(private formBuilder: UntypedFormBuilder) {}
-
-  public fileClick($event: SkyFileAttachmentClick): void {
-    const link = document.createElement('a');
-    link.download = $event.file.file.name;
-    link.href = $event.file.url;
-    link.click();
-  }
 
   public ngOnInit(): void {
     this.attachment = new UntypedFormControl(undefined, Validators.required);

--- a/libs/components/code-examples/src/lib/modules/forms/file-attachment/basic/example.component.html
+++ b/libs/components/code-examples/src/lib/modules/forms/file-attachment/basic/example.component.html
@@ -8,7 +8,6 @@
     labelText="Birth certificate"
     [helpPopoverContent]="helpInlinePopoverRef"
     [maxFileSize]="maxFileSize"
-    (fileClick)="onFileClick($event)"
   >
     @if (attachment.errors?.['invalidStartingLetter']) {
       <sky-form-error

--- a/libs/components/code-examples/src/lib/modules/forms/file-attachment/basic/example.component.ts
+++ b/libs/components/code-examples/src/lib/modules/forms/file-attachment/basic/example.component.ts
@@ -9,11 +9,7 @@ import {
   ValidationErrors,
   Validators,
 } from '@angular/forms';
-import {
-  SkyFileAttachmentClick,
-  SkyFileAttachmentModule,
-  SkyFileItem,
-} from '@skyux/forms';
+import { SkyFileAttachmentModule, SkyFileItem } from '@skyux/forms';
 
 /**
  * Demonstrates how to create a custom validator function for your form control.
@@ -53,15 +49,5 @@ export class FormsFileAttachmentBasicExampleComponent {
     this.formGroup = inject(FormBuilder).group({
       attachment: this.attachment,
     });
-  }
-
-  protected onFileClick($event: SkyFileAttachmentClick): void {
-    // Ensure we are only attempting to navigate to locally updated data for download.
-    if ($event.file.url.startsWith('data:')) {
-      const link = document.createElement('a');
-      link.download = $event.file.file.name;
-      link.href = $event.file.url;
-      link.click();
-    }
   }
 }

--- a/libs/components/code-examples/src/lib/modules/forms/file-attachment/help-key/example.component.html
+++ b/libs/components/code-examples/src/lib/modules/forms/file-attachment/help-key/example.component.html
@@ -6,7 +6,6 @@
     hintText="Attach a .pdf, .gif, .png, or .jpeg file."
     labelText="Birth certificate"
     [maxFileSize]="maxFileSize"
-    (fileClick)="onFileClick($event)"
   >
     @if (attachment.errors?.['invalidStartingLetter']) {
       <sky-form-error

--- a/libs/components/code-examples/src/lib/modules/forms/file-attachment/help-key/example.component.ts
+++ b/libs/components/code-examples/src/lib/modules/forms/file-attachment/help-key/example.component.ts
@@ -9,11 +9,7 @@ import {
   ValidationErrors,
   Validators,
 } from '@angular/forms';
-import {
-  SkyFileAttachmentClick,
-  SkyFileAttachmentModule,
-  SkyFileItem,
-} from '@skyux/forms';
+import { SkyFileAttachmentModule, SkyFileItem } from '@skyux/forms';
 
 /**
  * Demonstrates how to create a custom validator function for your form control.
@@ -53,15 +49,5 @@ export class FormsFileAttachmentHelpKeyExampleComponent {
     this.formGroup = inject(FormBuilder).group({
       attachment: this.attachment,
     });
-  }
-
-  protected onFileClick($event: SkyFileAttachmentClick): void {
-    // Ensure we are only attempting to navigate to locally updated data for download.
-    if ($event.file.url.startsWith('data:')) {
-      const link = document.createElement('a');
-      link.download = $event.file.file.name;
-      link.href = $event.file.url;
-      link.click();
-    }
   }
 }


### PR DESCRIPTION
:cherries: Cherry picked from #3267 [fix(components/forms): file attachment code examples fix double download](https://github.com/blackbaud/skyux/pull/3267)

[AB#3291383](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3291383) 