### PR TITLE
build: fix update-dependencies on Windows (#3274)

### DIFF
--- a/libs/sdk/tools/src/generators/update-dependencies/generator.ts
+++ b/libs/sdk/tools/src/generators/update-dependencies/generator.ts
@@ -5,6 +5,7 @@ import {
   generateFiles,
   getProjects,
   joinPathFragments,
+  normalizePath,
   readJson,
   updateJson,
   updateProjectConfiguration,
@@ -140,6 +141,7 @@ function getImportedProjects(
   const importedProjects: string[] = [];
   const packages = Array.from(packagesToProjects.keys());
   visitNotIgnoredFiles(tree, `${projectConfig.root}/src`, (file) => {
+    file = normalizePath(file);
     if (
       file.endsWith('.ts') &&
       !file.endsWith('.spec.ts') &&


### PR DESCRIPTION
:cherries: Cherry picked from #3274 [build: fix update-dependencies on Windows](https://github.com/blackbaud/skyux/pull/3274)

[AB#3300184](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3300184) 