### PR TITLE
feat(components/forms)!: revert `fileClick` event to no longer download attached file

### DIFF
--- a/apps/playground/src/app/components/forms/single-file-attachment/single-file-attachment.component.html
+++ b/apps/playground/src/app/components/forms/single-file-attachment/single-file-attachment.component.html
@@ -10,6 +10,7 @@
     [validateFn]="validateFile"
     [stacked]="true"
     (fileChange)="reactiveFileUpdated($event)"
+    (fileClick)="fileClick($event)"
   >
     <sky-file-attachment-label>
       Birth certificate

--- a/apps/playground/src/app/components/forms/single-file-attachment/single-file-attachment.component.ts
+++ b/apps/playground/src/app/components/forms/single-file-attachment/single-file-attachment.component.ts
@@ -6,7 +6,11 @@ import {
   UntypedFormGroup,
   Validators,
 } from '@angular/forms';
-import { SkyFileAttachmentChange, SkyFileItem } from '@skyux/forms';
+import {
+  SkyFileAttachmentChange,
+  SkyFileAttachmentClick,
+  SkyFileItem,
+} from '@skyux/forms';
 
 @Component({
   selector: 'app-single-file-attachment',
@@ -31,6 +35,13 @@ export class SingleFileAttachmentComponent implements OnInit {
   protected hintText = 'Please upload a file.';
 
   constructor(private formBuilder: UntypedFormBuilder) {}
+
+  public fileClick($event: SkyFileAttachmentClick): void {
+    const link = document.createElement('a');
+    link.download = $event.file.file.name;
+    link.href = $event.file.url;
+    link.click();
+  }
 
   public ngOnInit(): void {
     this.attachment = new UntypedFormControl(undefined, Validators.required);

--- a/libs/components/code-examples/src/lib/modules/forms/file-attachment/basic/example.component.html
+++ b/libs/components/code-examples/src/lib/modules/forms/file-attachment/basic/example.component.html
@@ -8,6 +8,7 @@
     labelText="Birth certificate"
     [helpPopoverContent]="helpInlinePopoverRef"
     [maxFileSize]="maxFileSize"
+    (fileClick)="onFileClick($event)"
   >
     @if (attachment.errors?.['invalidStartingLetter']) {
       <sky-form-error

--- a/libs/components/code-examples/src/lib/modules/forms/file-attachment/basic/example.component.ts
+++ b/libs/components/code-examples/src/lib/modules/forms/file-attachment/basic/example.component.ts
@@ -9,7 +9,11 @@ import {
   ValidationErrors,
   Validators,
 } from '@angular/forms';
-import { SkyFileAttachmentModule, SkyFileItem } from '@skyux/forms';
+import {
+  SkyFileAttachmentClick,
+  SkyFileAttachmentModule,
+  SkyFileItem,
+} from '@skyux/forms';
 
 /**
  * Demonstrates how to create a custom validator function for your form control.
@@ -49,5 +53,15 @@ export class FormsFileAttachmentBasicExampleComponent {
     this.formGroup = inject(FormBuilder).group({
       attachment: this.attachment,
     });
+  }
+
+  protected onFileClick($event: SkyFileAttachmentClick): void {
+    // Ensure we are only attempting to navigate to locally updated data for download.
+    if ($event.file.url.startsWith('data:')) {
+      const link = document.createElement('a');
+      link.download = $event.file.file.name;
+      link.href = $event.file.url;
+      link.click();
+    }
   }
 }

--- a/libs/components/code-examples/src/lib/modules/forms/file-attachment/help-key/example.component.html
+++ b/libs/components/code-examples/src/lib/modules/forms/file-attachment/help-key/example.component.html
@@ -6,6 +6,7 @@
     hintText="Attach a .pdf, .gif, .png, or .jpeg file."
     labelText="Birth certificate"
     [maxFileSize]="maxFileSize"
+    (fileClick)="fileClick($event)"
   >
     @if (attachment.errors?.['invalidStartingLetter']) {
       <sky-form-error

--- a/libs/components/code-examples/src/lib/modules/forms/file-attachment/help-key/example.component.html
+++ b/libs/components/code-examples/src/lib/modules/forms/file-attachment/help-key/example.component.html
@@ -6,7 +6,7 @@
     hintText="Attach a .pdf, .gif, .png, or .jpeg file."
     labelText="Birth certificate"
     [maxFileSize]="maxFileSize"
-    (fileClick)="fileClick($event)"
+    (fileClick)="onFileClick($event)"
   >
     @if (attachment.errors?.['invalidStartingLetter']) {
       <sky-form-error

--- a/libs/components/code-examples/src/lib/modules/forms/file-attachment/help-key/example.component.ts
+++ b/libs/components/code-examples/src/lib/modules/forms/file-attachment/help-key/example.component.ts
@@ -9,7 +9,11 @@ import {
   ValidationErrors,
   Validators,
 } from '@angular/forms';
-import { SkyFileAttachmentModule, SkyFileItem } from '@skyux/forms';
+import {
+  SkyFileAttachmentClick,
+  SkyFileAttachmentModule,
+  SkyFileItem,
+} from '@skyux/forms';
 
 /**
  * Demonstrates how to create a custom validator function for your form control.
@@ -49,5 +53,15 @@ export class FormsFileAttachmentHelpKeyExampleComponent {
     this.formGroup = inject(FormBuilder).group({
       attachment: this.attachment,
     });
+  }
+
+  protected onFileClick($event: SkyFileAttachmentClick): void {
+    // Ensure we are only attempting to navigate to locally updated data for download.
+    if ($event.file.url.startsWith('data:')) {
+      const link = document.createElement('a');
+      link.download = $event.file.file.name;
+      link.href = $event.file.url;
+      link.click();
+    }
   }
 }

--- a/libs/components/forms/src/lib/modules/file-attachment/file-attachment/file-attachment.component.html
+++ b/libs/components/forms/src/lib/modules/file-attachment/file-attachment/file-attachment.component.html
@@ -109,12 +109,7 @@
     @if (value || currentThemeName === 'default') {
       <span class="sky-file-attachment-file-link">
         @if (value) {
-          <a
-            [href]="isData ? value.url : undefined"
-            [download]="isData ? value.file.name : undefined"
-            [attr.title]="fileName"
-            (click)="emitClick()"
-          >
+          <a [attr.title]="fileName" (click)="emitClick()">
             {{ truncatedFileName }}
           </a>
         } @else {

--- a/libs/components/forms/src/lib/modules/file-attachment/file-attachment/file-attachment.component.ts
+++ b/libs/components/forms/src/lib/modules/file-attachment/file-attachment/file-attachment.component.ts
@@ -214,7 +214,8 @@ export class SkyFileAttachmentComponent
   public fileChange = new EventEmitter<SkyFileAttachmentChange>();
 
   /**
-   * Fires when users select the file name link.
+   * Fires when users select the file name link. Make sure to bind the event.
+   * If you do not, the file name link will be a dead link.
    */
   @Output()
   public fileClick = new EventEmitter<SkyFileAttachmentClick>();
@@ -243,10 +244,8 @@ export class SkyFileAttachmentComponent
 
     if (isNewValue) {
       if (value) {
-        this.isData = value.url?.startsWith('data:');
         this.isImage = this.#fileItemService.isImage(value);
       } else {
-        this.isData = false;
         this.isImage = false;
       }
       this.#setFileName(value);
@@ -278,8 +277,6 @@ export class SkyFileAttachmentComponent
     | undefined;
 
   public isImage = false;
-
-  protected isData = false;
 
   protected get isRequired(): boolean {
     return (


### PR DESCRIPTION
[AB#3299843](https://dev.azure.com/blackbaud/Products/_boards/board/t/SKY%20UX%20Program/Stories?System.AssignedTo=%40me&workitem=3299843)

BREAKING CHANGE

The file attachment `fileClick` event will no longer download files for consumer. This change is reverting back to previous interactions where if a consumer does want clicking the name of a file to download it, they will have to hook into the `fileClick` event. Code examples have been reverted to showcase how to accomplish this.