### PR TITLE
fix(components/tabs): accessibility tests for sectioned-form in mobile view (#3326)

### DIFF
--- a/libs/components/tabs/src/lib/modules/sectioned-form/sectioned-form.component.html
+++ b/libs/components/tabs/src/lib/modules/sectioned-form/sectioned-form.component.html
@@ -11,8 +11,8 @@
     guidelines.
   -->
   <span
-    aria-orientation="vertical"
-    [attr.aria-owns]="ariaOwns"
+    [attr.aria-orientation]="ariaRole ? 'vertical' : undefined"
+    [attr.aria-owns]="ariaRole ? ariaOwns : undefined"
     [attr.role]="ariaRole"
   ></span>
   @if (maintainSectionContent || tabsVisible()) {

--- a/libs/components/tabs/src/lib/modules/sectioned-form/sectioned-form.component.spec.ts
+++ b/libs/components/tabs/src/lib/modules/sectioned-form/sectioned-form.component.spec.ts
@@ -443,6 +443,14 @@ describe('Sectioned form component', () => {
     await expectAsync(fixture.nativeElement).toBeAccessible();
   });
 
+  it('should be accessible in mobile view', async () => {
+    const fixture = createTestComponent();
+    mediaQueryController.setBreakpoint('xs');
+    fixture.detectChanges();
+    await fixture.whenStable();
+    await expectAsync(fixture.nativeElement).toBeAccessible();
+  });
+
   it('maintainSectionContent - tab content remains in same order', () => {
     const fixture = createTestComponent();
     fixture.componentInstance.maintainSectionContent = true;
@@ -495,10 +503,15 @@ describe('Sectioned form component', () => {
 });
 
 describe('Sectioned form component - no sections', () => {
+  let mediaQueryController: SkyMediaQueryTestingController;
+
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [SkySectionedFormFixturesModule],
+      providers: [provideSkyMediaQueryTesting()],
     });
+
+    mediaQueryController = TestBed.inject(SkyMediaQueryTestingController);
   });
 
   function createTestComponent() {
@@ -518,13 +531,33 @@ describe('Sectioned form component - no sections', () => {
     expect(allTabs.length).toBe(1);
     expect(allTabs[0].textContent.trim()).toBe('');
   });
+
+  it('should be accessible', async () => {
+    const fixture = createTestComponent();
+    fixture.detectChanges();
+    await fixture.whenStable();
+    await expectAsync(fixture.nativeElement).toBeAccessible();
+  });
+
+  it('should be accessible in mobile view', async () => {
+    const fixture = createTestComponent();
+    mediaQueryController.setBreakpoint('xs');
+    fixture.detectChanges();
+    await fixture.whenStable();
+    await expectAsync(fixture.nativeElement).toBeAccessible();
+  });
 });
 
 describe('Sectioned form component - no active sections', () => {
+  let mediaQueryController: SkyMediaQueryTestingController;
+
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [SkySectionedFormFixturesModule],
+      providers: [provideSkyMediaQueryTesting()],
     });
+
+    mediaQueryController = TestBed.inject(SkyMediaQueryTestingController);
   });
 
   function createTestComponent() {
@@ -549,6 +582,14 @@ describe('Sectioned form component - no active sections', () => {
 
   it('should be accessible', async () => {
     const fixture = createTestComponent();
+    fixture.detectChanges();
+    await fixture.whenStable();
+    await expectAsync(fixture.nativeElement).toBeAccessible();
+  });
+
+  it('should be accessible in mobile view', async () => {
+    const fixture = createTestComponent();
+    mediaQueryController.setBreakpoint('xs');
     fixture.detectChanges();
     await fixture.whenStable();
     await expectAsync(fixture.nativeElement).toBeAccessible();

--- a/libs/components/tabs/src/lib/modules/vertical-tabset/vertical-tabset.component.html
+++ b/libs/components/tabs/src/lib/modules/vertical-tabset/vertical-tabset.component.html
@@ -15,11 +15,13 @@
     guidelines.
   -->
   <span
-    aria-orientation="vertical"
     class="sky-vertical-tabset-tablist"
     [attr.aria-label]="ariaLabel"
     [attr.aria-labelledby]="ariaLabelledBy"
-    [attr.aria-owns]="(tabIdSvc.ids | async)?.join(' ') || undefined"
+    [attr.aria-orientation]="isMobile ? undefined : 'vertical'"
+    [attr.aria-owns]="
+      isMobile ? undefined : (tabIdSvc.ids | async)?.join(' ') || undefined
+    "
     [attr.role]="isMobile ? undefined : ariaRole"
   ></span>
   @if (maintainTabContent || tabService.tabsVisible()) {

--- a/libs/components/tabs/src/lib/modules/vertical-tabset/vertical-tabset.component.spec.ts
+++ b/libs/components/tabs/src/lib/modules/vertical-tabset/vertical-tabset.component.spec.ts
@@ -939,6 +939,18 @@ describe('Vertical tabset component', () => {
     await expectAsync(fixture.nativeElement).toBeAccessible();
   });
 
+  it('should be accessible in mobile', async () => {
+    const fixture = createTestComponent();
+
+    // Show the tab's panel for the test.
+    fixture.componentInstance.showScrollable = true;
+    mediaQueryController.setBreakpoint('xs');
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+    await expectAsync(fixture.nativeElement).toBeAccessible();
+  });
+
   it('maintainTabContent - tab content remains in same order', fakeAsync(() => {
     mediaQueryController.setBreakpoint('lg');
     const fixture = createTestComponent();
@@ -1073,6 +1085,18 @@ describe('Vertical tabset component', () => {
     await fixture.whenStable();
     await expectAsync(fixture.nativeElement).toBeAccessible();
   });
+
+  it('should be accessible when content pane is scrollable in mobile', async () => {
+    const fixture = createTestComponent();
+    fixture.detectChanges();
+
+    fixture.componentInstance.showScrollable = true;
+    mediaQueryController.setBreakpoint('xs');
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+    await expectAsync(fixture.nativeElement).toBeAccessible();
+  });
 });
 
 describe('Vertical tabset component - with ngFor', () => {
@@ -1082,10 +1106,13 @@ describe('Vertical tabset component - with ngFor', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [SkyVerticalTabsFixturesModule],
+      providers: [provideSkyMediaQueryTesting()],
     });
     fixture = TestBed.createComponent(VerticalTabsetWithNgForTestComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
+
+    mediaQueryController = TestBed.inject(SkyMediaQueryTestingController);
   });
 
   it('should dynamically show and hide tabs with structural directives', () => {
@@ -1163,9 +1190,12 @@ describe('Vertical tabset component - no subtabs', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [SkyVerticalTabsFixturesModule],
+      providers: [provideSkyMediaQueryTesting()],
     });
     fixture = TestBed.createComponent(VerticalTabsetEmptyGroupTestComponent);
     fixture.detectChanges();
+
+    mediaQueryController = TestBed.inject(SkyMediaQueryTestingController);
   });
 
   it('group without tab should load without failing', () => {
@@ -1180,9 +1210,12 @@ describe('Vertical tabset component - no groups', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [SkyVerticalTabsFixturesModule],
+      providers: [provideSkyMediaQueryTesting()],
     });
     fixture = TestBed.createComponent(VerticalTabsetNoGroupTestComponent);
     fixture.detectChanges();
+
+    mediaQueryController = TestBed.inject(SkyMediaQueryTestingController);
   });
 
   it('should load tabs without groups', () => {
@@ -1208,6 +1241,13 @@ describe('Vertical tabset component - no groups', () => {
     await fixture.whenStable();
     await expectAsync(fixture.nativeElement).toBeAccessible();
   });
+
+  it('should be accessible in mobile', async () => {
+    mediaQueryController.setBreakpoint('xs');
+    fixture.detectChanges();
+    await fixture.whenStable();
+    await expectAsync(fixture.nativeElement).toBeAccessible();
+  });
 });
 
 describe('Vertical tabset no active tabs', () => {
@@ -1216,9 +1256,12 @@ describe('Vertical tabset no active tabs', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [SkyVerticalTabsFixturesModule],
+      providers: [provideSkyMediaQueryTesting()],
     });
     fixture = TestBed.createComponent(VerticalTabsetNoActiveTestComponent);
     fixture.detectChanges();
+
+    mediaQueryController = TestBed.inject(SkyMediaQueryTestingController);
   });
 
   it('should not fail when trying to move active content when no tabs are active', () => {
@@ -1227,6 +1270,12 @@ describe('Vertical tabset no active tabs', () => {
   });
 
   it('should be accessible', async () => {
+    await fixture.whenStable();
+    await expectAsync(fixture.nativeElement).toBeAccessible();
+  });
+
+  it('should be accessible in mobile', async () => {
+    mediaQueryController.setBreakpoint('xs');
     await fixture.whenStable();
     await expectAsync(fixture.nativeElement).toBeAccessible();
   });


### PR DESCRIPTION
:cherries: Cherry picked from #3326 [fix(components/tabs): accessibility tests for sectioned-form in mobile view](https://github.com/blackbaud/skyux/pull/3326)

[AB#3307386](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3307386) 