### PR TITLE
fix(components/ag-grid): hide AG Grid row dragging icon (#3332)

### DIFF
--- a/apps/playground/src/app/components/ag-grid/data-manager-large/data-manager-large.component.ts
+++ b/apps/playground/src/app/components/ag-grid/data-manager-large/data-manager-large.component.ts
@@ -199,7 +199,12 @@ export class DataManagerLargeComponent implements OnInit {
             : []),
           ...(this.useColumnGroups
             ? columnDefinitionsGrouped
-            : columnDefinitions),
+            : columnDefinitions.map((col) => {
+                if (col.field === 'object_name') {
+                  col.rowDrag = this.domLayout === 'normal';
+                }
+                return col;
+              })),
         ],
         columnTypes: {
           custom_link: {
@@ -214,6 +219,7 @@ export class DataManagerLargeComponent implements OnInit {
           wrapText: this.wrapText,
           autoHeight: this.autoHeightColumns,
         },
+        rowDragManaged: !this.useColumnGroups && this.domLayout === 'normal',
       },
     });
   }

--- a/libs/components/ag-grid/src/lib/styles/_base.scss
+++ b/libs/components/ag-grid/src/lib/styles/_base.scss
@@ -318,3 +318,7 @@ sky-ag-grid-wrapper + sky-infinite-scroll {
     height: 100%;
   }
 }
+
+.ag-dnd-ghost.ag-unselectable {
+  display: none;
+}


### PR DESCRIPTION
:cherries: Cherry picked from #3332 [fix(components/ag-grid): hide AG Grid row dragging icon](https://github.com/blackbaud/skyux/pull/3332)

[AB#3294969](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3294969) 