### PR TITLE
fix(components/code-examples): selection modal add item example uses correct button classes and order

### DIFF
--- a/libs/components/code-examples/src/lib/modules/lookup/selection-modal/add-item/add-item-modal.component.html
+++ b/libs/components/code-examples/src/lib/modules/lookup/selection-modal/add-item/add-item-modal.component.html
@@ -12,10 +12,10 @@
       </sky-input-box>
     </sky-modal-content>
     <sky-modal-footer>
-      <button class="sky-btn sky-btn-default" type="button" (click)="close()">
+      <button class="sky-btn sky-btn-primary" type="submit">Add</button>
+      <button class="sky-btn sky-btn-link" type="button" (click)="close()">
         Cancel
       </button>
-      <button class="sky-btn sky-btn-primary" type="submit">Add</button>
     </sky-modal-footer>
   </sky-modal>
 </form>


### PR DESCRIPTION
[AB#3315309](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3315309)