### PR TITLE
fix(components/data-manager): toolbar should not overlap other elements (#3340)

### DIFF
--- a/libs/components/core/src/lib/modules/viewkeeper/viewkeeper.ts
+++ b/libs/components/core/src/lib/modules/viewkeeper/viewkeeper.ts
@@ -4,34 +4,11 @@ import { SkyViewkeeperOffset } from './viewkeeper-offset';
 import { SkyViewkeeperOptions } from './viewkeeper-options';
 
 const CLS_VIEWKEEPER_FIXED = 'sky-viewkeeper-fixed';
+const CLS_VIEWKEEPER_FIXED_NOT_LAST = 'sky-viewkeeper-fixed-not-last';
+const CLS_VIEWKEEPER_BOUNDARY = 'sky-viewkeeper-boundary';
 const EVT_AFTER_VIEWKEEPER_SYNC = 'afterViewkeeperSync';
 
-let styleEl: HTMLStyleElement;
 let nextIdIndex: number;
-
-function ensureStyleEl(): void {
-  if (!styleEl) {
-    styleEl = document.createElement('style');
-
-    const css = document.createTextNode(`
-.${CLS_VIEWKEEPER_FIXED} {
-  position: fixed !important;
-  z-index: 999;
-  opacity: 0.95;
-  overflow: hidden;
-}
-
-.sky-theme-modern .${CLS_VIEWKEEPER_FIXED} {
-  box-shadow: 0px 1px 8px -1px rgba(0, 0, 0, 0.3);
-  opacity: initial;
-}
-`);
-
-    styleEl.appendChild(css);
-
-    document.head.appendChild(styleEl);
-  }
-}
 
 function nextId(): string {
   nextIdIndex = (nextIdIndex || 0) + 1;
@@ -185,7 +162,7 @@ export class SkyViewkeeper {
     window.addEventListener('resize', this.#syncElPositionHandler);
     window.addEventListener('orientationchange', this.#syncElPositionHandler);
 
-    ensureStyleEl();
+    this.#boundaryEl.classList.add(CLS_VIEWKEEPER_BOUNDARY);
 
     this.syncElPosition(el, boundaryEl);
   }
@@ -206,8 +183,10 @@ export class SkyViewkeeper {
     if (this.#needsUpdating(doFixEl, fixedStyles)) {
       if (doFixEl) {
         this.#fixEl(el, boundaryInfo, fixedStyles);
+        this.#verticalOffsetEl?.classList.add(CLS_VIEWKEEPER_FIXED_NOT_LAST);
       } else {
         this.#unfixEl(el);
+        this.#verticalOffsetEl?.classList.remove(CLS_VIEWKEEPER_FIXED_NOT_LAST);
       }
     }
 
@@ -235,9 +214,11 @@ export class SkyViewkeeper {
           EVT_AFTER_VIEWKEEPER_SYNC,
           this.#syncElPositionHandler,
         );
+        this.#verticalOffsetEl.classList.remove(CLS_VIEWKEEPER_FIXED_NOT_LAST);
       }
 
       this.#spacerResizeObserver?.disconnect();
+      this.#boundaryEl?.classList.remove(CLS_VIEWKEEPER_BOUNDARY);
 
       this.#el =
         this.#boundaryEl =

--- a/libs/components/theme/src/lib/styles/_custom-properties.scss
+++ b/libs/components/theme/src/lib/styles/_custom-properties.scss
@@ -73,4 +73,8 @@
   /* switch */
   --sky-switch-size: #{$sky-switch-size};
   --sky-switch-margin: #{$sky-switch-margin};
+
+  /* viewkeeper */
+  --sky-viewkeeper-opacity: 0.95;
+  --sky-viewkeeper-box-shadow: none;
 }

--- a/libs/components/theme/src/lib/styles/_theme.scss
+++ b/libs/components/theme/src/lib/styles/_theme.scss
@@ -140,3 +140,19 @@ symbol[id^='sky-i-'] * {
     fill: var(--sky-icon-svg-path-2-color-input, #fff);
   }
 }
+
+.sky-viewkeeper-boundary {
+  isolation: isolate;
+}
+
+.sky-viewkeeper-fixed {
+  position: fixed !important;
+  z-index: 1000;
+  opacity: var(--sky-viewkeeper-opacity);
+  overflow: hidden;
+
+  &:not(.sky-viewkeeper-fixed-not-last) {
+    box-shadow: var(--sky-viewkeeper-box-shadow);
+    z-index: 999;
+  }
+}

--- a/libs/components/theme/src/lib/styles/themes/modern/_custom-properties.scss
+++ b/libs/components/theme/src/lib/styles/themes/modern/_custom-properties.scss
@@ -47,6 +47,10 @@
   /* switch */
   --sky-switch-size: #{$sky-switch-size-modern};
 
+  /* viewkeeper */
+  --sky-viewkeeper-opacity: 1;
+  --sky-viewkeeper-box-shadow: var(--modern-shadow-size-3);
+
   &.sky-theme-mode-dark {
     /* color */
     --sky-background-color-page-default: #{$sky-theme-modern-mode-dark-background-color-page-default};


### PR DESCRIPTION
:cherries: Cherry picked from #3340 [fix(components/data-manager): toolbar should not overlap other elements](https://github.com/blackbaud/skyux/pull/3340)

[AB#3311391](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3311391) 