### PR TITLE
fix(components/datetime): enable resetting fuzzy datepickers initialized with `undefined` after a value change

### DIFF
--- a/libs/components/datetime/src/lib/modules/datepicker/fuzzy/datepicker-input-fuzzy.directive.ts
+++ b/libs/components/datetime/src/lib/modules/datepicker/fuzzy/datepicker-input-fuzzy.directive.ts
@@ -578,9 +578,9 @@ export class SkyFuzzyDatepickerInputDirective
 
   /* istanbul ignore next */
   #fuzzyDatesEqual(dateA?: SkyFuzzyDate, dateB?: SkyFuzzyDate): boolean {
-    return (
-      dateA !== undefined &&
-      dateB !== undefined &&
+    return !!(
+      dateA &&
+      dateB &&
       ((!dateA.day && !dateB.day) || dateA.day === dateB.day) &&
       ((!dateA.month && !dateB.month) || dateA.month === dateB.month) &&
       ((!dateA.year && !dateB.year) || dateA.year === dateB.year)

--- a/libs/components/datetime/src/lib/modules/datepicker/fuzzy/fuzzy-datepicker.component.spec.ts
+++ b/libs/components/datetime/src/lib/modules/datepicker/fuzzy/fuzzy-datepicker.component.spec.ts
@@ -1328,6 +1328,24 @@ describe('fuzzy datepicker input', () => {
 
         flush();
       }));
+
+      it('should reset the value when initialized with undefined', () => {
+        // Initial value is undefined.
+        component.initialValue = undefined;
+        fixture.detectChanges();
+        expect(getInputElementValue(fixture)).toBe('');
+
+        // Set to date value.
+        component.dateControl.setValue(new Date('05/12/2017'));
+        fixture.detectChanges();
+        expect(getInputElementValue(fixture)).toBe('05/12/2017');
+
+        // Reset the value and confirm undefined.
+        component.dateControl.reset();
+        fixture.detectChanges();
+        expect(getInputElementValue(fixture)).toBe('');
+        expect(component.dateControl.value).toEqual(null);
+      });
     });
 
     describe('input change', () => {


### PR DESCRIPTION
[AB#3329746](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3329746)