### PR TITLE
fix(sdk/skyux-eslint): remove `.sky-form-control` classname from inputs when fixing `prefer-label-text` rule

### DIFF
--- a/libs/sdk/eslint-config-skyux/src/index.ts
+++ b/libs/sdk/eslint-config-skyux/src/index.ts
@@ -158,7 +158,10 @@ const config = tseslint.config(
       '@typescript-eslint/dot-notation': 'error',
       '@typescript-eslint/non-nullable-type-assertion-style': 'error',
       '@typescript-eslint/prefer-includes': 'error',
-      '@typescript-eslint/prefer-nullish-coalescing': 'error',
+      '@typescript-eslint/prefer-nullish-coalescing': [
+        'error',
+        { ignorePrimitives: { bigint: true, number: true, string: true } },
+      ],
       '@typescript-eslint/prefer-optional-chain': 'error',
       '@typescript-eslint/prefer-string-starts-ends-with': 'error',
     },

--- a/libs/sdk/skyux-eslint/src/rules/template/prefer-label-text.spec.ts
+++ b/libs/sdk/skyux-eslint/src/rules/template/prefer-label-text.spec.ts
@@ -12,6 +12,11 @@ ruleTester.run(RULE_NAME, rule, {
     `<sky-checkbox labelText="foo">`,
     `<sky-checkbox [labelText]="foo">`,
     `<sky-checkbox labelText="{{ foo }}">`,
+    `
+    <sky-input-box>
+      <label [for]="myInput.id">My label</label>
+      <input #myInput="skyId" skyId class="sky-form-control" type="text" />
+    </sky-input-box>`,
   ],
   invalid: [
     convertAnnotatedSourceToFailureCase({
@@ -183,36 +188,6 @@ ruleTester.run(RULE_NAME, rule, {
       },
     }),
     convertAnnotatedSourceToFailureCase({
-      description: 'should remove skyId from sky-input-box inputs',
-      annotatedSource: `
-        <sky-input-box>
-        ~~~~~~~~~~~~~~~~
-          <label>My label</label>
-          ~~~~~~~~~~~~~~~~~~~~~~~
-          <input #myInput="skyId" skyId type="text" />
-          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-        </sky-input-box>
-        ~~~~~~~~~~~~~~~~
-      `,
-      annotatedOutput: `
-        <sky-input-box labelText="My label">
-        ~
-          ~
-          ~
-          <input   type="text" />
-          ~
-        </sky-input-box>
-        ~
-      `,
-
-      messageId,
-      data: {
-        selector: 'sky-input-box',
-        labelInputName: 'labelText',
-        labelSelector: 'label',
-      },
-    }),
-    convertAnnotatedSourceToFailureCase({
       description:
         'should fail if labelText not set and has child elements within label',
       annotatedSource: `
@@ -223,14 +198,6 @@ ruleTester.run(RULE_NAME, rule, {
             <h2 class="sky-heading-1">Foo</h2>
             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           </sky-checkbox-label>
-          ~~~~~~~~~~~~~~~~~~~~~
-        </sky-checkbox>
-        ~~~~~~~~~~~~~~~
-      `,
-      annotatedOutput: `
-        <sky-checkbox labelText="Foo">
-        ~~~~~~~~~~~~~~
-          ~~~~~~~~~~~~~~~~~~~~
           ~~~~~~~~~~~~~~~~~~~~~
         </sky-checkbox>
         ~~~~~~~~~~~~~~~

--- a/libs/sdk/skyux-eslint/src/rules/template/prefer-label-text.spec.ts
+++ b/libs/sdk/skyux-eslint/src/rules/template/prefer-label-text.spec.ts
@@ -91,6 +91,128 @@ ruleTester.run(RULE_NAME, rule, {
       },
     }),
     convertAnnotatedSourceToFailureCase({
+      description: 'should remove `sky-form-control` class from inputs',
+      annotatedSource: `
+        <sky-input-box>
+        ~~~~~~~~~~~~~~~~
+          <label>My label</label>
+          ~~~~~~~~~~~~~~~~~~~~~~~
+          <input class="sky-form-control" type="text" />
+          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        </sky-input-box>
+        ~~~~~~~~~~~~~~~~
+      `,
+      annotatedOutput: `
+        <sky-input-box labelText="My label">
+        ~
+          ~
+          ~
+          <input  type="text" />
+          ~
+        </sky-input-box>
+        ~
+      `,
+
+      messageId,
+      data: {
+        selector: 'sky-input-box',
+        labelInputName: 'labelText',
+        labelSelector: 'label',
+      },
+    }),
+    convertAnnotatedSourceToFailureCase({
+      description:
+        'should remove `sky-form-control` class from inputs with multiple classes',
+      annotatedSource: `
+        <sky-input-box>
+        ~~~~~~~~~~~~~~~~
+          <label>My label</label>
+          ~~~~~~~~~~~~~~~~~~~~~~~
+          <textarea class="my-input sky-form-control foobar"></textarea>
+          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        </sky-input-box>
+        ~~~~~~~~~~~~~~~~
+      `,
+      annotatedOutput: `
+        <sky-input-box labelText="My label">
+        ~
+          ~
+          ~
+          <textarea class="my-input foobar"></textarea>
+          ~
+        </sky-input-box>
+        ~
+      `,
+
+      messageId,
+      data: {
+        selector: 'sky-input-box',
+        labelInputName: 'labelText',
+        labelSelector: 'label',
+      },
+    }),
+    convertAnnotatedSourceToFailureCase({
+      description:
+        'should remove `sky-form-control` class from inputs if first in list of classes',
+      annotatedSource: `
+        <sky-input-box>
+        ~~~~~~~~~~~~~~~~
+          <label>My label</label>
+          ~~~~~~~~~~~~~~~~~~~~~~~
+          <select class="sky-form-control foo"></select>
+          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        </sky-input-box>
+        ~~~~~~~~~~~~~~~~
+      `,
+      annotatedOutput: `
+        <sky-input-box labelText="My label">
+        ~
+          ~
+          ~
+          <select class="foo"></select>
+          ~
+        </sky-input-box>
+        ~
+      `,
+
+      messageId,
+      data: {
+        selector: 'sky-input-box',
+        labelInputName: 'labelText',
+        labelSelector: 'label',
+      },
+    }),
+    convertAnnotatedSourceToFailureCase({
+      description: 'should remove skyId from sky-input-box inputs',
+      annotatedSource: `
+        <sky-input-box>
+        ~~~~~~~~~~~~~~~~
+          <label>My label</label>
+          ~~~~~~~~~~~~~~~~~~~~~~~
+          <input #myInput="skyId" skyId type="text" />
+          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        </sky-input-box>
+        ~~~~~~~~~~~~~~~~
+      `,
+      annotatedOutput: `
+        <sky-input-box labelText="My label">
+        ~
+          ~
+          ~
+          <input   type="text" />
+          ~
+        </sky-input-box>
+        ~
+      `,
+
+      messageId,
+      data: {
+        selector: 'sky-input-box',
+        labelInputName: 'labelText',
+        labelSelector: 'label',
+      },
+    }),
+    convertAnnotatedSourceToFailureCase({
       description:
         'should fail if labelText not set and has child elements within label',
       annotatedSource: `

--- a/libs/sdk/skyux-eslint/src/rules/template/prefer-label-text.ts
+++ b/libs/sdk/skyux-eslint/src/rules/template/prefer-label-text.ts
@@ -156,9 +156,9 @@ export const rule = createESLintTemplateRule({
         const inputEl = getChildNodeOf(el, ['input', 'select', 'textarea']);
 
         if (labelEl) {
-          // Abort if the `skyId` directive is used on a child input element of
-          // the `<sky-input-box />` component since its inclusion usually means
-          // that the user wishes to use "hard mode".
+          // Abort if the `skyId` directive is used on a child input of the
+          // `<sky-input-box />` component since its inclusion usually means the
+          // user wishes to implement "hard mode".
           if (
             el.name === 'sky-input-box' &&
             inputEl &&

--- a/libs/sdk/skyux-eslint/src/rules/utils/ast-utils.ts
+++ b/libs/sdk/skyux-eslint/src/rules/utils/ast-utils.ts
@@ -82,8 +82,6 @@ export function getTextContent(el: TmplAstElement): string {
       text += child.value.trim();
     } else if (child instanceof TmplAstBoundText) {
       text += child.sourceSpan.toString().trim();
-    } else if (child instanceof TmplAstElement) {
-      text += getTextContent(child);
     }
   });
 

--- a/libs/sdk/skyux-eslint/src/rules/utils/ast-utils.ts
+++ b/libs/sdk/skyux-eslint/src/rules/utils/ast-utils.ts
@@ -11,16 +11,16 @@ import {
  */
 export function getChildNodeOf(
   el: TmplAstElement,
-  childNodeName: string,
+  childNodeNames: string[],
 ): TmplAstElement | undefined {
   return el.children.find((child) => {
     if (child instanceof TmplAstElement) {
-      if (child.name === childNodeName) {
+      if (childNodeNames.includes(child.name)) {
         return true;
       }
 
       /* istanbul ignore next: safety check */
-      return getChildNodeOf(child, childNodeName);
+      return getChildNodeOf(child, childNodeNames);
     }
 
     return false;


### PR DESCRIPTION
[AB#3382385](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3382385)