### PR TITLE
fix(components/i18n): generate assets for library resources in the same directory as the entry point

### DIFF
--- a/libs/components/i18n/schematics/ng-generate/lib-resources-module/lib-resources-module.schematic.spec.ts
+++ b/libs/components/i18n/schematics/ng-generate/lib-resources-module/lib-resources-module.schematic.spec.ts
@@ -230,4 +230,18 @@ export class FoobarResourcesModule {}
       runSchematic({ project: undefined }),
     ).toBeRejectedWithError(`A project name is required.`);
   });
+
+  it('should generate assets in the same directory as the entry point', async () => {
+    tree.delete(defaultResourcesJsonPath);
+
+    // Remove "src" from the sourceRoot property to confirm assets are still
+    // placed in the correct directory.
+    const angularJson = JSON.parse(tree.readText('/angular.json'));
+    angularJson.projects[defaultProjectName].sourceRoot = '';
+    tree.overwrite('/angular.json', JSON.stringify(angularJson));
+
+    const updatedTree = await runSchematic();
+
+    expect(updatedTree.exists(defaultResourcesJsonPath)).toEqual(true);
+  });
 });

--- a/libs/components/i18n/schematics/ng-generate/lib-resources-module/lib-resources-module.schematic.ts
+++ b/libs/components/i18n/schematics/ng-generate/lib-resources-module/lib-resources-module.schematic.ts
@@ -1,4 +1,4 @@
-import { normalize, strings } from '@angular-devkit/core';
+import { Path, dirname, normalize, strings } from '@angular-devkit/core';
 import { ProjectDefinition } from '@angular-devkit/core/src/workspace';
 import {
   MergeStrategy,
@@ -34,10 +34,22 @@ function parseLocaleIdFromFileName(fileName: string): string {
     .replace('_', '-');
 }
 
+function getLibrarySourceRoot(tree: Tree, project: ProjectDefinition): Path {
+  const ngPackageJson = JSON.parse(
+    readRequiredFile(tree, normalize(`${project.root}/ng-package.json`)),
+  );
+
+  const entryPath = normalize(`${project.root}/${ngPackageJson.lib.entryFile}`);
+
+  return dirname(entryPath);
+}
+
 function getResources(tree: Tree, project: ProjectDefinition): string {
   let resourcesVar = 'const RESOURCES: Record<string, SkyLibResources> = {';
 
-  const localesPath = normalize(`${project.sourceRoot}/assets/locales`);
+  const sourceRoot = getLibrarySourceRoot(tree, project);
+
+  const localesPath = normalize(`${sourceRoot}/assets/locales`);
   const localesDir = tree.getDir(localesPath);
 
   localesDir.subfiles.forEach((file) => {
@@ -81,8 +93,10 @@ function addI18nPeerDependency(project: ProjectDefinition): Rule {
 
 function ensureDefaultResourcesFileExists(project: ProjectDefinition): Rule {
   return (tree) => {
+    const sourceRoot = getLibrarySourceRoot(tree, project);
+
     const defaultResourcePath = normalize(
-      `${project.sourceRoot}/assets/locales/resources_en_US.json`,
+      `${sourceRoot}/assets/locales/resources_en_US.json`,
     );
 
     if (tree.exists(defaultResourcePath)) {
@@ -115,8 +129,9 @@ function generateTemplateFiles(
   return (tree) => {
     const modulePath = options.name || '';
 
+    const sourceRoot = getLibrarySourceRoot(tree, project);
     const parsedPath = path.parse(options.name || '');
-    const movePath = normalize(project.sourceRoot + '/' + parsedPath.dir);
+    const movePath = normalize(`${sourceRoot}/${parsedPath.dir}`);
 
     const resources = getResources(tree, project);
 

--- a/libs/components/i18n/schematics/ng-generate/lib-resources-module/lib-resources-module.schematic.ts
+++ b/libs/components/i18n/schematics/ng-generate/lib-resources-module/lib-resources-module.schematic.ts
@@ -48,7 +48,6 @@ function getResources(tree: Tree, project: ProjectDefinition): string {
   let resourcesVar = 'const RESOURCES: Record<string, SkyLibResources> = {';
 
   const sourceRoot = getLibrarySourceRoot(tree, project);
-
   const localesPath = normalize(`${sourceRoot}/assets/locales`);
   const localesDir = tree.getDir(localesPath);
 
@@ -94,7 +93,6 @@ function addI18nPeerDependency(project: ProjectDefinition): Rule {
 function ensureDefaultResourcesFileExists(project: ProjectDefinition): Rule {
   return (tree) => {
     const sourceRoot = getLibrarySourceRoot(tree, project);
-
     const defaultResourcePath = normalize(
       `${sourceRoot}/assets/locales/resources_en_US.json`,
     );


### PR DESCRIPTION
[AB#3316859](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3316859)