### PR TITLE
fix: remove node_modules prefix from SCSS imports

### DIFF
--- a/libs/components/ag-grid/src/lib/styles/_ag-grid-extra.scss
+++ b/libs/components/ag-grid/src/lib/styles/_ag-grid-extra.scss
@@ -1,4 +1,4 @@
-@use 'node_modules/ag-grid-community/styles' as ag;
+@use 'ag-grid-community/styles' as ag;
 @use 'libs/components/theme/src/lib/styles/variables' as variables;
 
 /**

--- a/libs/components/lookup/src/lib/modules/country-field/country-field.component.scss
+++ b/libs/components/lookup/src/lib/modules/country-field/country-field.component.scss
@@ -1,7 +1,7 @@
 @use 'libs/components/theme/src/lib/styles/mixins' as mixins;
 @use 'libs/components/theme/src/lib/styles/variables' as *;
 @use 'libs/components/theme/src/lib/styles/compat-tokens-mixins' as compatMixins;
-@import 'node_modules/intl-tel-input/build/css/intlTelInput.css';
+@import 'intl-tel-input/build/css/intlTelInput.css';
 
 @include compatMixins.sky-default-overrides('.sky-country-field-container') {
   --sky-override-country-field-disabled-flag-filter: none;

--- a/libs/components/phone-field/src/lib/modules/phone-field/phone-field.component.scss
+++ b/libs/components/phone-field/src/lib/modules/phone-field/phone-field.component.scss
@@ -1,7 +1,7 @@
 @use 'libs/components/theme/src/lib/styles/mixins' as mixins;
 @use 'libs/components/theme/src/lib/styles/variables' as *;
 @use 'libs/components/theme/src/lib/styles/compat-tokens-mixins' as compatMixins;
-@import 'node_modules/intl-tel-input/build/css/intlTelInput.css';
+@import 'intl-tel-input/build/css/intlTelInput.css';
 
 @include compatMixins.sky-default-overrides('.sky-phone-field-country-btn') {
   --sky-override-phone-field-flag-transform: scaleX(1.25) translateX(2px);

--- a/libs/components/theme/src/lib/styles/_mixins.scss
+++ b/libs/components/theme/src/lib/styles/_mixins.scss
@@ -3,7 +3,7 @@
 
 @forward '_public-api/_compat/mixins';
 @forward '_public-api/mixins';
-@forward 'node_modules/@blackbaud/skyux-design-tokens/scss/mixins';
+@forward '@blackbaud/skyux-design-tokens/scss/mixins';
 
 @use 'variables' as *;
 

--- a/libs/components/theme/src/lib/styles/_public-api/_mixins.scss
+++ b/libs/components/theme/src/lib/styles/_public-api/_mixins.scss
@@ -1,6 +1,6 @@
 // This file is included as-is with the @skyux/theme NPM package to be used by our consumers.
 
-@forward 'node_modules/@blackbaud/skyux-design-tokens/scss/mixins';
+@forward '@blackbaud/skyux-design-tokens/scss/mixins';
 
 @use 'variables' as vars;
 

--- a/libs/components/theme/src/lib/styles/_public-api/_variables.scss
+++ b/libs/components/theme/src/lib/styles/_public-api/_variables.scss
@@ -1,3 +1,3 @@
 // This file is included as-is with the @skyux/theme NPM package to be used by our consumers.
-@forward 'node_modules/@blackbaud/skyux-design-tokens/scss/variables';
-@forward 'node_modules/@blackbaud/skyux-design-tokens/scss/themes/modern/variables';
+@forward '@blackbaud/skyux-design-tokens/scss/variables';
+@forward '@blackbaud/skyux-design-tokens/scss/themes/modern/variables';

--- a/libs/components/theme/src/lib/styles/sky.scss
+++ b/libs/components/theme/src/lib/styles/sky.scss
@@ -1,7 +1,7 @@
 // This file is compiled down to CSS and included in the @skyux/theme NPM package to provide
 // global styles for our consumers.
 
-@forward 'node_modules/normalize-scss/sass/normalize/import-now';
+@forward 'normalize-scss/sass/normalize/import-now';
 
 @forward 'normalize-compat';
 @forward 'custom-properties';

--- a/libs/components/theme/src/lib/styles/themes/modern/styles.scss
+++ b/libs/components/theme/src/lib/styles/themes/modern/styles.scss
@@ -1,5 +1,5 @@
-@forward 'node_modules/@blackbaud/skyux-design-tokens/assets/scss/blackbaud';
-@forward 'node_modules/@blackbaud/skyux-design-tokens/assets/scss/modern';
+@forward '@blackbaud/skyux-design-tokens/assets/scss/blackbaud';
+@forward '@blackbaud/skyux-design-tokens/assets/scss/modern';
 
 @forward 'custom-properties';
 @forward 'box';

--- a/scripts/postbuild-ag-grid.ts
+++ b/scripts/postbuild-ag-grid.ts
@@ -1,6 +1,6 @@
-import fs from 'fs-extra';
 import path from 'path';
-import sass from 'sass';
+
+import { renderScss } from './utils/render-scss';
 
 const STYLES_ROOT = path.resolve(
   __dirname,
@@ -8,21 +8,16 @@ const STYLES_ROOT = path.resolve(
 );
 const DEST_ROOT = path.resolve(__dirname, '../dist/libs/components/ag-grid');
 
-function copyScss() {
-  const result = sass.renderSync({
-    file: path.join(STYLES_ROOT, 'ag-grid-styles.scss'),
-  });
-
+async function copyScss(): Promise<void> {
   const target = path.join(DEST_ROOT, 'css/sky-ag-grid.css');
 
-  fs.ensureFileSync(target);
-  fs.writeFileSync(target, result.css);
+  await renderScss(path.join(STYLES_ROOT, 'ag-grid-styles.scss'), target);
 }
 
-function postBuildAgGrid() {
+async function postBuildAgGrid(): Promise<void> {
   console.log('Running @skyux/ag-grid postbuild step...');
   try {
-    copyScss();
+    await copyScss();
 
     console.log('Done running @skyux/ag-grid postbuild.');
   } catch (err) {
@@ -31,4 +26,4 @@ function postBuildAgGrid() {
   }
 }
 
-postBuildAgGrid();
+void postBuildAgGrid();

--- a/scripts/postbuild-theme.ts
+++ b/scripts/postbuild-theme.ts
@@ -1,16 +1,18 @@
 import fs from 'fs-extra';
-import path from 'path';
-import sass from 'sass';
+import path from 'node:path';
+
+import { renderScss } from './utils/render-scss';
 
 const STYLES_ROOT = path.resolve(
   __dirname,
   '../libs/components/theme/src/lib/styles',
 );
+
 const DEST_ROOT = path.resolve(__dirname, '../dist/libs/components/theme');
 
 const skyScssPath = path.join(STYLES_ROOT, 'sky.scss');
 
-function addPackageExport(filePath: string) {
+function addPackageExport(filePath: string): void {
   const rootRelativePath = filePath.replace(DEST_ROOT, '.').replace(/\\/g, '/');
   const filePathNoExtension = rootRelativePath.substring(
     0,
@@ -31,7 +33,7 @@ function addPackageExport(filePath: string) {
   fs.writeJsonSync(packageJsonPath, packageJson, { spaces: 2 });
 }
 
-function validateSkyuxIconVersionMatch() {
+function validateSkyuxIconVersionMatch(): void {
   console.log('Validating SKY UX icon font version...');
 
   const scssContents = fs.readFileSync(skyScssPath, 'utf8').toString();
@@ -72,35 +74,28 @@ function validateSkyuxIconVersionMatch() {
   console.log('Done.');
 }
 
-function renderScss(scssFilePath: string, cssDestPath: string) {
-  const result = sass.renderSync({
-    file: scssFilePath,
-    quietDeps: true,
-  });
-  fs.ensureFileSync(cssDestPath);
-  fs.writeFileSync(cssDestPath, result.css);
-  addPackageExport(cssDestPath);
-}
-
-function compileScss() {
+async function compileScss(): Promise<void> {
   console.log('Preparing SCSS and CSS files...');
 
-  renderScss(skyScssPath, path.join(DEST_ROOT, 'css/sky.css'));
+  const skyCssDest = path.join(DEST_ROOT, 'css/sky.css');
+  const modernScssPath = path.join(STYLES_ROOT, 'themes/modern/styles.scss');
+  const modernCssDest = path.join(DEST_ROOT, 'css/themes/modern/styles.css');
 
-  renderScss(
-    path.join(STYLES_ROOT, 'themes/modern/styles.scss'),
-    path.join(DEST_ROOT, 'css/themes/modern/styles.css'),
-  );
+  await renderScss(skyScssPath, skyCssDest);
+  addPackageExport(skyCssDest);
+
+  await renderScss(modernScssPath, modernCssDest);
+  addPackageExport(modernCssDest);
 
   console.log('Done.');
 }
 
-function copyScss(sourcePath: string, destPath: string) {
+function copyScss(sourcePath: string, destPath: string): void {
   fs.copySync(sourcePath, destPath);
   addPackageExport(destPath);
 }
 
-function copyPublicScssFiles() {
+function copyPublicScssFiles(): void {
   console.log('Copying public SCSS files...');
 
   copyScss(
@@ -116,7 +111,7 @@ function copyPublicScssFiles() {
   console.log('Done.');
 }
 
-function copyCompatScssFiles() {
+function copyCompatScssFiles(): void {
   console.log('Copying compatibility SCSS files...');
 
   copyScss(
@@ -142,11 +137,11 @@ function copyCompatScssFiles() {
   console.log('Done.');
 }
 
-function postBuildTheme() {
+async function postBuildTheme(): Promise<void> {
   console.log('Running @skyux/theme postbuild step...');
   try {
     validateSkyuxIconVersionMatch();
-    compileScss();
+    await compileScss();
     copyPublicScssFiles();
     copyCompatScssFiles();
 
@@ -157,4 +152,4 @@ function postBuildTheme() {
   }
 }
 
-postBuildTheme();
+void postBuildTheme();

--- a/scripts/utils/render-scss.ts
+++ b/scripts/utils/render-scss.ts
@@ -1,0 +1,14 @@
+import fs from 'fs-extra';
+import sass from 'sass';
+
+export async function renderScss(
+  scssFilePath: string,
+  cssDestPath: string,
+): Promise<void> {
+  const result = await sass.compileAsync(scssFilePath, {
+    loadPaths: ['./', 'node_modules'],
+  });
+
+  fs.ensureFileSync(cssDestPath);
+  fs.writeFileSync(cssDestPath, result.css);
+}


### PR DESCRIPTION
This work is being done in preparation for esbuild support. Esbuild does not resolve SCSS imports the same way that webpack does, and cannot parse paths prefixed with `node_modules`.

These changes have been manually tested on external projects.