### PR TITLE
fix: dropdown menus and autocomplete result containers use medium border radius in v2 modern

### DIFF
--- a/libs/components/lookup/src/lib/modules/autocomplete/autocomplete.component.scss
+++ b/libs/components/lookup/src/lib/modules/autocomplete/autocomplete.component.scss
@@ -67,7 +67,7 @@
   );
   border-radius: var(
     --sky-override-autocomplete-results-container-border-radius,
-    var(--sky-border-radius-s)
+    var(--sky-border-radius-m)
   );
 }
 

--- a/libs/components/popovers/src/lib/modules/dropdown/dropdown-menu.component.scss
+++ b/libs/components/popovers/src/lib/modules/dropdown/dropdown-menu.component.scss
@@ -18,7 +18,7 @@
   );
   border-radius: var(
     --sky-override-dropdown-menu-border-radius,
-    var(--sky-border-radius-s)
+    var(--sky-border-radius-m)
   );
   padding: var(
     --sky-override-dropdown-menu-padding,


### PR DESCRIPTION
[AB#3414138](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3414138)