### PR TITLE
fix(components/toast): update toast box shadow and close button position in modern v2 (#3553)

### DIFF
--- a/libs/components/toast/src/lib/modules/toast/toast.component.html
+++ b/libs/components/toast/src/lib/modules/toast/toast.component.html
@@ -3,7 +3,7 @@
   (@skyAnimationEmerge.done)="onAnimationDone($event)"
 >
   <div
-    class="sky-toast sky-shadow sky-rounded-corners sky-box sky-elevation-24"
+    class="sky-toast sky-shadow sky-rounded-corners sky-box sky-elevation-16"
     [ngClass]="classNames"
   >
     <div *skyThemeIf="'modern'" aria-hidden="true" class="sky-toast-icon">

--- a/libs/components/toast/src/lib/modules/toast/toast.component.scss
+++ b/libs/components/toast/src/lib/modules/toast/toast.component.scss
@@ -4,6 +4,7 @@
 @include compatMixins.sky-default-overrides('.sky-toast') {
   --sky-override-toast-align-items: center;
   --sky-override-toast-border-left-width: 30px;
+  --sky-override-toast-box-shadow: 0 0 5px 0 rgba(0, 0, 0, 0.3);
   --sky-override-toast-close-button-border: none;
   --sky-override-toast-close-button-border-radius: #{$sky-border-radius};
   --sky-override-toast-close-button-box-sizing: border-box;
@@ -32,6 +33,7 @@
 }
 
 @include compatMixins.sky-modern-overrides('.sky-toast', false) {
+  --sky-override-toast-box-shadow: var(--sky-elevation-overlay-400);
   --sky-override-toast-close-button-box-sizing: border-box;
   --sky-override-toast-close-button-margin: -10px -10px 0 0;
   --sky-override-toast-close-button-padding: 1px;
@@ -80,6 +82,14 @@ sky-toast {
     flex-direction: row;
     align-items: var(--sky-override-toast-align-items, flex-start);
 
+    // This box shadow rule and both overrides can be removed when v1 modern support is dropped. The class on the element will handle the styles correctly then.
+    &.sky-elevation-16 {
+      box-shadow: var(
+        --sky-override-toast-box-shadow,
+        var(--sky-elevation-overlay-300)
+      );
+    }
+
     .sky-toast-btn-close {
       background-color: var(
         --sky-override-toast-close-button-color-background,
@@ -118,8 +128,8 @@ sky-toast {
       );
       margin: var(
         --sky-override-toast-close-button-margin,
-        calc(calc(var(--sky-comp-toaster-space-inset-top) * 0.5) * -1)
-          calc(calc(var(--sky-comp-toaster-space-inset-right) * 0.5) * -1) 0 0
+        calc(calc(var(--sky-comp-toast-space-inset-top) * 0.5) * -1)
+          calc(calc(var(--sky-comp-toast-space-inset-right) * 0.5) * -1) 0 0
       );
       padding: var(
         --sky-override-toast-close-button-padding,


### PR DESCRIPTION
:cherries: Cherry picked from #3553 [fix(components/toast): update toast box shadow and close button position in modern v2](https://github.com/blackbaud/skyux/pull/3553)

[AB#3104306](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3104306) 