### PR TITLE
fix(components/lookup): autocomplete results have a border radius in v2 modern (#3559)

### DIFF
--- a/libs/components/lookup/src/lib/modules/autocomplete/autocomplete.component.scss
+++ b/libs/components/lookup/src/lib/modules/autocomplete/autocomplete.component.scss
@@ -15,6 +15,7 @@
   --sky-override-autocomplete-no-results-font-size: 15px;
   --sky-override-autocomplete-no-results-padding: #{$sky-padding-squish-default};
   --sky-override-autocomplete-result-background-color: transparent;
+  --sky-override-autocomplete-result-border-radius: 0;
   --sky-override-autocomplete-result-box-shadow: none;
   --sky-override-autocomplete-result-focus-background-color: #{$sky-background-color-neutral-light};
   --sky-override-autocomplete-result-focus-box-shadow: none;
@@ -39,6 +40,7 @@
     --sky-override-autocomplete-dropdown-hint-text-padding: 7px 13px;
     --sky-override-autocomplete-no-results-font-size: 15px;
     --sky-override-autocomplete-no-results-padding: #{$sky-padding-squish-default};
+    --sky-override-autocomplete-result-border-radius: 0;
     --sky-override-autocomplete-result-focus-box-shadow:
       inset 0 0 0 var(--sky-border-width-action-focus)
         var(--sky-color-border-action-tertiary-focus),
@@ -97,6 +99,10 @@
   background-color: var(
     --sky-override-autocomplete-result-background-color,
     var(--sky-color-background-action-tertiary-base)
+  );
+  border-radius: var(
+    --sky-override-autocomplete-result-border-radius,
+    var(--sky-border-radius-s)
   );
   box-shadow: var(
     --sky-override-autocomplete-result-box-shadow,


### PR DESCRIPTION
:cherries: Cherry picked from #3559 [fix(components/lookup): autocomplete results have a border radius in v2 modern](https://github.com/blackbaud/skyux/pull/3559)

[AB#3414145](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3414145) 