### PR TITLE
fix(components/modals): update modal headers in v2 modern to use standard h2 font styles (#3554)

### DIFF
--- a/libs/components/modals/src/lib/modules/modal/modal-header.component.html
+++ b/libs/components/modals/src/lib/modules/modal/modal-header.component.html
@@ -1,11 +1,4 @@
-<h2
-  class="sky-modal-heading sky-font-emphasized"
-  skyTrim
-  [skyThemeClass]="{
-    'sky-font-heading-4': 'default',
-    'sky-font-display-3': 'modern'
-  }"
->
+<h2 class="sky-modal-heading" skyTrim>
   <ng-content />
 </h2>
 <span class="sky-control-help-container" skyTrim

--- a/libs/components/modals/src/lib/modules/modal/modal-header.component.scss
+++ b/libs/components/modals/src/lib/modules/modal/modal-header.component.scss
@@ -3,14 +3,31 @@
 @use 'libs/components/theme/src/lib/styles/compat-tokens-mixins' as compatMixins;
 
 @include compatMixins.sky-default-overrides('.sky-modal-heading') {
+  --sky-override-modal-h2-font-size: 16px;
+  --sky-override-modal-h2-font-weight: 600;
   --sky-override-modal-h2-line-height: 1.2;
 }
 
 @include compatMixins.sky-modern-overrides('.sky-modal-heading') {
+  --sky-override-modal-h2-font-size: var(--sky-font-size-display-3);
+  --sky-override-modal-h2-font-weight: var(--sky-font-weight-display-3);
   --sky-override-modal-h2-line-height: 1.2;
 }
 
-h2 {
-  line-height: var(--sky-override-modal-h2-line-height, inherit);
+h2.sky-modal-heading {
   display: inline;
+
+  // These font rules can be removed when default and modern v1 support is removed as the heading 2 styles are applied to the h2 tag.
+  line-height: var(
+    --sky-override-modal-h2-line-height,
+    var(--sky-font-line_height-heading-2)
+  );
+  font-size: var(
+    --sky-override-modal-h2-font-size,
+    var(--sky-font-size-heading-2)
+  );
+  font-weight: var(
+    --sky-override-modal-h2-font-weight,
+    var(--sky-font-weight-heading-2)
+  );
 }

--- a/libs/components/modals/src/lib/modules/modal/modal.component.html
+++ b/libs/components/modals/src/lib/modules/modal/modal.component.html
@@ -24,14 +24,7 @@
         'box-shadow': scrollShadow?.topShadow
       }"
     >
-      <div
-        #headerId="skyId"
-        class="sky-modal-header-content"
-        skyId
-        [ngClass]="{
-          'sky-font-heading-2': size === 'full-page'
-        }"
-      >
+      <div #headerId="skyId" class="sky-modal-header-content" skyId>
         @if (headingText) {
           <sky-modal-header>
             {{ headingText }}


### PR DESCRIPTION
:cherries: Cherry picked from #3554 [fix(components/modals): update modal headers in v2 modern to use standard h2 font styles](https://github.com/blackbaud/skyux/pull/3554)

[AB#3398055](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3398055) 