### PR TITLE
feat: update composite icons to use the new matte variables (#3555)

### DIFF
--- a/libs/components/help-inline/src/lib/modules/help-inline/help-inline.modern.component.scss
+++ b/libs/components/help-inline/src/lib/modules/help-inline/help-inline.modern.component.scss
@@ -15,6 +15,7 @@
       10%
     )};
   --sky-override-help-inline-font-size: #{$sky-font-size-base};
+  --sky-override-help-inline-icon-color: var(--sky-color-icon-action);
   --sky-override-help-inline-padding-sides: var(--modern-size-6);
 }
 
@@ -37,7 +38,10 @@
     --sky-override-help-inline-border-radius,
     var(--sky-border-radius-s)
   );
-  color: var(--sky-color-icon-action);
+  color: var(
+    --sky-override-help-inline-icon-color,
+    var(--sky-color-background-icon_matte-action-heavy)
+  );
   background-color: var(--sky-color-background-action-tertiary-base);
   display: inline-block;
   box-shadow: inset 0 0 0 var(--sky-border-width-action-base)

--- a/libs/components/indicators/src/lib/modules/alert/alert.modern.component.scss
+++ b/libs/components/indicators/src/lib/modules/alert/alert.modern.component.scss
@@ -9,6 +9,7 @@
 @include compatMixins.sky-modern-overrides('.sky-alert') {
   --sky-override-alert-button-padding: 0;
   --sky-override-alert-button-size: 32px;
+  --sky-override-alert-info-icon-color: var(--sky-color-icon-info);
   --sky-override-alert-inner-icon-color: var(--sky-color-icon-default);
   --sky-override-alert-padding: 0 var(--modern-size-10);
   --sky-override-alert-text-link-color: #212327cc;
@@ -132,18 +133,21 @@
   }
 
   &.sky-alert-info .sky-alert-icon {
-    color: var(--sky-color-icon-info);
+    color: var(
+      --sky-override-alert-info-icon-color,
+      var(--sky-color-background-icon_matte-action-heavy)
+    );
   }
 
   &.sky-alert-success .sky-alert-icon {
-    color: var(--sky-color-icon-success);
+    color: var(--sky-color-background-icon_matte-success);
   }
 
   &.sky-alert-warning .sky-alert-icon {
-    color: var(--sky-color-icon-warning);
+    color: var(--sky-color-background-icon_matte-warning);
   }
 
   &.sky-alert-danger .sky-alert-icon {
-    color: var(--sky-color-icon-danger);
+    color: var(--sky-color-background-icon_matte-danger);
   }
 }

--- a/libs/components/indicators/src/lib/modules/label/label.component.scss
+++ b/libs/components/indicators/src/lib/modules/label/label.component.scss
@@ -18,6 +18,7 @@
     --sky-background-color-warning
   );
   --sky-override-label-display: inline;
+  --sky-override-label-icon-info-color: var(--sky-color-icon-info);
   --sky-override-label-icon-modern-display: none;
   --sky-override-label-inner-icon-path-color-danger: var(
     --sky-background-color-danger
@@ -39,6 +40,7 @@
 
 @include compatMixins.sky-modern-overrides('.sky-label') {
   --sky-override-sky-icon-svg-size-s: 21px;
+  --sky-override-label-icon-info-color: var(--sky-color-icon-info);
   --sky-override-label-line-height: 1;
   --sky-override-label-margin: 0 3px;
   --sky-override-label-inner-icon-path-color-info: var(--modern-color-gray-105);
@@ -60,19 +62,22 @@
 /* Modern theme */
 @include mixins.sky-theme-modern {
   .sky-label-info .sky-label-icon {
-    color: var(--sky-color-icon-info);
+    color: var(
+      --sky-override-label-icon-info-color,
+      var(--sky-color-background-icon_matte-action-heavy)
+    );
   }
 
   .sky-label-success .sky-label-icon {
-    color: var(--sky-color-icon-success);
+    color: var(--sky-color-background-icon_matte-success);
   }
 
   .sky-label-warning .sky-label-icon {
-    color: var(--sky-color-icon-warning);
+    color: var(--sky-color-background-icon_matte-warning);
   }
 
   .sky-label-danger .sky-label-icon {
-    color: var(--sky-color-icon-danger);
+    color: var(--sky-color-background-icon_matte-danger);
   }
 }
 

--- a/libs/components/indicators/src/lib/modules/status-indicator/status-indicator.component.scss
+++ b/libs/components/indicators/src/lib/modules/status-indicator/status-indicator.component.scss
@@ -12,6 +12,7 @@
 }
 
 @include compatMixins.sky-modern-overrides('.sky-status-indicator') {
+  --sky-override-status-indicator-icon-color-info: var(--sky-color-icon-info);
   --sky-override-status-indicator-info-success-exclamation-path-color: var(
     --modern-color-gray-105
   );
@@ -36,28 +37,28 @@
 .sky-status-indicator-icon-info {
   color: var(
     --sky-override-status-indicator-icon-color-info,
-    var(--sky-color-icon-info)
+    var(--sky-color-background-icon_matte-action-heavy)
   );
 }
 
 .sky-status-indicator-icon-success {
   color: var(
     --sky-override-status-indicator-icon-color-success,
-    var(--sky-color-icon-success)
+    var(--sky-color-background-icon_matte-success)
   );
 }
 
 .sky-status-indicator-icon-warning {
   color: var(
     --sky-override-status-indicator-icon-color-warning,
-    var(--sky-color-icon-warning)
+    var(--sky-color-background-icon_matte-warning)
   );
 }
 
 .sky-status-indicator-icon-danger {
   color: var(
     --sky-override-status-indicator-icon-color-danger,
-    var(--sky-color-icon-danger)
+    var(--sky-color-background-icon_matte-danger)
   );
 }
 

--- a/libs/components/toast/src/lib/modules/toast/toast.component.scss
+++ b/libs/components/toast/src/lib/modules/toast/toast.component.scss
@@ -23,7 +23,10 @@
   --sky-override-toast-color-border-info: #{$sky-highlight-color-info};
   --sky-override-toast-color-border-success: #{$sky-highlight-color-success};
   --sky-override-toast-color-border-warning: #{$sky-highlight-color-warning};
-  --sky-override-toast-color-icon: #{$sky-color-white};
+  --sky-override-toast-color-icon-danger: #{$sky-color-white};
+  --sky-override-toast-color-icon-info: #{$sky-color-white};
+  --sky-override-toast-color-icon-success: #{$sky-color-white};
+  --sky-override-toast-color-icon-warning: #{$sky-color-white};
   --sky-override-toast-content-link-color: #212327cc;
   --sky-override-toast-content-link-decoration: underline;
   --sky-override-toast-content-padding: #{$sky-padding} 0;
@@ -39,6 +42,7 @@
   --sky-override-toast-close-button-padding: 1px;
   --sky-override-toast-close-button-size: 26px;
   --sky-override-toast-content-link-color: #212327cc;
+  --sky-override-toast-color-icon-info: var(--sky-color-icon-info);
   --sky-override-toast-icon-top-padding: calc(var(--modern-size-5) * -1);
   --sky-override-toast-info-success-exclamation-path-color: var(
     --modern-color-gray-105
@@ -188,7 +192,10 @@ sky-toast {
           --sky-override-toast-color-border-info,
           var(--sky-color-border-info)
         ),
-        var(--sky-override-toast-color-icon, var(--sky-color-icon-info)),
+        var(
+          --sky-override-toast-color-icon-info,
+          var(--sky-color-background-icon_matte-action-heavy)
+        ),
         var(
           --sky-override-toast-info-success-exclamation-path-color,
           var(--sky-color-icon-inverse)
@@ -206,7 +213,10 @@ sky-toast {
           --sky-override-toast-color-border-success,
           var(--sky-color-border-success)
         ),
-        var(--sky-override-toast-color-icon, var(--sky-color-icon-success)),
+        var(
+          --sky-override-toast-color-icon-success,
+          var(--sky-color-background-icon_matte-success)
+        ),
         var(
           --sky-override-toast-color-border-success,
           var(
@@ -227,7 +237,10 @@ sky-toast {
           --sky-override-toast-color-border-warning,
           var(--sky-color-border-warning)
         ),
-        var(--sky-override-toast-color-icon, var(--sky-color-icon-warning)),
+        var(
+          --sky-override-toast-color-icon-warning,
+          var(--sky-color-background-icon_matte-warning)
+        ),
         var(
           --sky-override-toast-color-border-warning,
           var(--sky-color-icon-default)
@@ -245,7 +258,10 @@ sky-toast {
           --sky-override-toast-color-border-danger,
           var(--sky-color-border-danger)
         ),
-        var(--sky-override-toast-color-icon, var(--sky-color-icon-danger)),
+        var(
+          --sky-override-toast-color-icon-danger,
+          var(--sky-color-background-icon_matte-danger)
+        ),
         var(
           --sky-override-toast-color-border-danger,
           var(--sky-color-icon-inverse)


### PR DESCRIPTION
:cherries: Cherry picked from #3555 [feat: update composite icons to use the new matte variables](https://github.com/blackbaud/skyux/pull/3555)

[AB#3297217](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3297217) 