### PR TITLE
fix(components/lookup): multi-select lookup does not have extra left value space in v2 modern when no tokens are present

### DIFF
--- a/libs/components/lookup/src/lib/modules/lookup/lookup.component.scss
+++ b/libs/components/lookup/src/lib/modules/lookup/lookup.component.scss
@@ -220,10 +220,13 @@ sky-input-box .sky-lookup {
       .sky-tokens {
         margin-top: 0;
         margin-bottom: 0;
-        padding-left: var(
-          --sky-override-lookup-tokens-padding-left,
-          var(--sky-comp-input-value-space-inset-left)
-        );
+
+        :has(sky-token) {
+          padding-left: var(
+            --sky-override-lookup-tokens-padding-left,
+            var(--sky-comp-input-value-space-inset-left)
+          );
+        }
         align-items: var(
           --sky-override-lookup-input-box-tokens-align-items,
           flex-start

--- a/libs/components/lookup/src/lib/modules/lookup/lookup.component.scss
+++ b/libs/components/lookup/src/lib/modules/lookup/lookup.component.scss
@@ -221,7 +221,7 @@ sky-input-box .sky-lookup {
         margin-top: 0;
         margin-bottom: 0;
 
-        :has(sky-token) {
+        &:has(sky-token) {
           padding-left: var(
             --sky-override-lookup-tokens-padding-left,
             var(--sky-comp-input-value-space-inset-left)


### PR DESCRIPTION
[AB#3424407](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3424407)