### PR TITLE
fix(components/modals): fix punctuation in error messages (#3589)

### DIFF
--- a/libs/components/forms/src/assets/locales/resources_en_US.json
+++ b/libs/components/forms/src/assets/locales/resources_en_US.json
@@ -9,7 +9,7 @@
   },
   "skyux_form_error_character_count": {
     "_description": "Error message for a field with a value that exceeds the character count limit",
-    "message": "Limit {0} to {1} character(s)."
+    "message": "Limit {0} to {1} characters."
   },
   "skyux_form_error_date": {
     "_description": "Error message for a field with an invalid date value",
@@ -25,7 +25,7 @@
   },
   "skyux_form_error_fuzzy_date_future_disabled": {
     "_description": "Error message for a field with a in invalid fuzzy date in the future",
-    "message": "Future dates are disabled, select or enter a date in the past."
+    "message": "Future dates are disabled. Select or enter a date in the past."
   },
   "skyux_form_error_fuzzy_date_invalid": {
     "_description": "Error message for a field with an invalid fuzzy date",
@@ -49,11 +49,11 @@
   },
   "skyux_form_error_maxlength": {
     "_description": "Error message for a field with a value that is too long",
-    "message": "Limit {0} to {1} character(s)."
+    "message": "Limit {0} to {1} characters."
   },
   "skyux_form_error_minlength": {
     "_description": "Error message for a field with a value that is not long enough",
-    "message": "{0} must be at least {1} character(s)."
+    "message": "{0} must be at least {1} characters."
   },
   "skyux_form_error_phone": {
     "_description": "Error message for a field with an invalid phone number",

--- a/libs/components/forms/src/lib/modules/shared/sky-forms-resources.module.ts
+++ b/libs/components/forms/src/lib/modules/shared/sky-forms-resources.module.ts
@@ -19,7 +19,7 @@ const RESOURCES: Record<string, SkyLibResources> = {
       message: 'You are over the character limit.',
     },
     skyux_form_error_character_count: {
-      message: 'Limit {0} to {1} character(s).',
+      message: 'Limit {0} to {1} characters.',
     },
     skyux_form_error_date: { message: 'Select or enter a valid date.' },
     skyux_form_error_date_max: {
@@ -29,7 +29,7 @@ const RESOURCES: Record<string, SkyLibResources> = {
       message: 'Select or enter a date on or after {0}.',
     },
     skyux_form_error_fuzzy_date_future_disabled: {
-      message: 'Future dates are disabled, select or enter a date in the past.',
+      message: 'Future dates are disabled. Select or enter a date in the past.',
     },
     skyux_form_error_fuzzy_date_invalid: {
       message: 'Select or enter a valid date.',
@@ -44,9 +44,9 @@ const RESOURCES: Record<string, SkyLibResources> = {
     skyux_form_error_email: {
       message: 'Enter an email address with a valid format.',
     },
-    skyux_form_error_maxlength: { message: 'Limit {0} to {1} character(s).' },
+    skyux_form_error_maxlength: { message: 'Limit {0} to {1} characters.' },
     skyux_form_error_minlength: {
-      message: '{0} must be at least {1} character(s).',
+      message: '{0} must be at least {1} characters.',
     },
     skyux_form_error_phone: {
       message:


### PR DESCRIPTION
:cherries: Cherry picked from #3589 [fix(components/modals): fix punctuation in error messages](https://github.com/blackbaud/skyux/pull/3589)