### PR TITLE
fix(components/help-inline): help inline uses line icon for modern v2

### DIFF
--- a/libs/components/help-inline/src/lib/modules/help-inline/help-inline.component.html
+++ b/libs/components/help-inline/src/lib/modules/help-inline/help-inline.component.html
@@ -42,7 +42,18 @@
 }
 
 <ng-template #icon>
-  <sky-icon iconName="info" iconSize="s" variant="solid" />
+  <sky-icon
+    *skyThemeIf="'default'"
+    iconName="info"
+    iconSize="s"
+    variant="solid"
+  />
+  <sky-icon
+    *skyThemeIf="'modern'"
+    iconName="info"
+    iconSize="s"
+    variant="line"
+  />
 </ng-template>
 
 <span #labelledByPrefixRef="skyId" hidden skyId>{{


### PR DESCRIPTION
[AB#3429604](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3429604)