### PR TITLE
fix(components/ag-grid): sort icons use the small icon size

### DIFF
--- a/libs/components/ag-grid/src/lib/modules/ag-grid/ag-grid.service.spec.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/ag-grid.service.spec.ts
@@ -226,7 +226,7 @@ describe('SkyAgGridService', () => {
       });
 
       expect((options.icons?.['sortDescending'] as () => string)()).toBe(
-        `<svg height="16" width="16"><use xlink:href="#sky-i-chevron-down-24-solid"></use></svg>`,
+        `<svg height="16" width="16"><use xlink:href="#sky-i-chevron-down-16-solid"></use></svg>`,
       );
     });
 

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/header/header.component.html
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/header/header.component.html
@@ -45,7 +45,7 @@
           >
             @if (sortDirection === 'desc') {
               <span class="ag-header-icon ag-header-label-icon">
-                <sky-icon iconName="chevron-down" />
+                <sky-icon iconName="chevron-down" iconSize="s" />
                 <span class="sky-screen-reader-only">{{
                   'sky_ag_grid_column_header_sort_button_aria_label_currently_desc'
                     | skyLibResources: displayName() ?? accessibleHeaderText()
@@ -54,7 +54,7 @@
             }
             @if (sortDirection === 'asc') {
               <span class="ag-header-icon ag-header-label-icon">
-                <sky-icon iconName="chevron-up" />
+                <sky-icon iconName="chevron-up" iconSize="s" />
                 <span class="sky-screen-reader-only">{{
                   'sky_ag_grid_column_header_sort_button_aria_label_currently_asc'
                     | skyLibResources: displayName() ?? accessibleHeaderText()

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/icons/icon-map.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/icons/icon-map.ts
@@ -429,13 +429,13 @@ export const iconMap: Record<
   // show on column header when column is sorted ascending
   sortAscending: {
     name: 'chevron-up',
-    size: 24,
+    size: 16,
   },
 
   // show on column header when column is sorted descending
   sortDescending: {
     name: 'chevron-down',
-    size: 24,
+    size: 16,
   },
 
   // show on column header when column has no sort, only when


### PR DESCRIPTION
[AB#3415215](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3415215)

Confirmed with design that it is ok to change default too. 