### PR TITLE
fix(components/split-view): add background color to split view drawer and remove right border in v2 modern (#3598)

### DIFF
--- a/libs/components/split-view/src/lib/modules/split-view/split-view-drawer.component.scss
+++ b/libs/components/split-view/src/lib/modules/split-view/split-view-drawer.component.scss
@@ -12,6 +12,7 @@
 }
 
 @include compatMixins.sky-modern-overrides('.sky-split-view-drawer') {
+  --sky-override-split-view-drawer-background-color: transparent;
   --sky-override-split-view-resize-handle-box-shadow-focus: var(
     --sky-elevation-focus
   );
@@ -20,7 +21,7 @@
 .sky-split-view-drawer {
   background: var(
     --sky-override-split-view-drawer-background-color,
-    transparent
+    var(--sky-color-background-container-base)
   );
   overflow: auto;
   height: 100%;

--- a/libs/components/split-view/src/lib/modules/split-view/split-view.component.scss
+++ b/libs/components/split-view/src/lib/modules/split-view/split-view.component.scss
@@ -7,6 +7,13 @@
     #{$sky-border-color-neutral-medium};
   --sky-override-split-view-border-left: 1px solid
     #{$sky-border-color-neutral-medium};
+  --sky-override-split-view-border-right: 1px solid
+    #{$sky-border-color-neutral-medium};
+}
+
+@include compatMixins.sky-modern-overrides('.sky-split-view') {
+  --sky-override-split-view-border-right: var(--sky-border-width-divider) solid
+    var(--sky-color-border-divider);
 }
 
 :host {
@@ -55,5 +62,6 @@
 @include mixins.sky-host-responsive-container-sm-min() {
   .sky-split-view {
     border-left: var(--sky-override-split-view-border-left, none);
+    border-right: var(--sky-override-split-view-border-right, none);
   }
 }


### PR DESCRIPTION
:cherries: Cherry picked from #3598 [fix(components/split-view): add background color to split view drawer and remove right border in v2 modern](https://github.com/blackbaud/skyux/pull/3598)

[AB#3429890](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3429890) 