### PR TITLE
fix(components/forms): help inline is aligned with field group text in v2 modern

### DIFF
--- a/libs/components/forms/src/lib/modules/field-group/field-group.component.scss
+++ b/libs/components/forms/src/lib/modules/field-group/field-group.component.scss
@@ -2,9 +2,14 @@
 @use 'libs/components/theme/src/lib/styles/compat-tokens-mixins' as compatMixins;
 
 @include compatMixins.sky-default-overrides('.sky-field-group') {
+  --sky-override-field-group-align-items: normal;
   --sky-override-field-group-content-space: #{$sky-space-sm};
   --sky-override-field-group-content-with-hint-text-space: #{$sky-space-md};
   --sky-override-field-group-hint-text-space: #{$sky-space-xs};
+}
+
+@include compatMixins.sky-modern-overrides('.sky-field-group') {
+  --sky-override-field-group-align-items: normal;
 }
 
 :host {
@@ -13,6 +18,7 @@
 
 legend {
   display: flex;
+  align-items: var(--sky-override-field-group-align-items, baseline);
 
   h3,
   h4 {


### PR DESCRIPTION
[AB#3416495](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3416495)