### PR TITLE
fix(components/lists): repeater title and checkbox are aligned in v2 when the item is selectable (#3603)

### DIFF
--- a/libs/components/lists/src/lib/modules/repeater/repeater-item.component.scss
+++ b/libs/components/lists/src/lib/modules/repeater/repeater-item.component.scss
@@ -12,6 +12,7 @@
   --sky-override-repeater-item-border-bottom: 1px dotted
     #{$sky-border-color-neutral-medium};
   --sky-override-repeater-item-border-radius: 0;
+  --sky-override-repeater-item-checkbox-margin: 0;
   --sky-override-repeater-item-checkbox-padding-right: #{$sky-padding-half};
   --sky-override-repeater-item-chevron-margin-left: #{$sky-margin};
   --sky-override-repeater-item-chevron-placeholder-height: 24px;
@@ -398,6 +399,14 @@ sky-repeater-item {
         var(--sky-space-gap-action_group-s)
       )
       0 0;
+
+    margin: var(
+      --sky-override-repeater-item-checkbox-margin,
+      var(--sky-comp-repeater_item-checkbox-space-offset-top)
+        var(--sky-comp-repeater_item-checkbox-space-offset-right)
+        var(--sky-comp-repeater_item-checkbox-space-offset-bottom)
+        var(--sky-comp-repeater_item-checkbox-space-offset-left)
+    );
   }
 
   .sky-repeater-item-selectable,


### PR DESCRIPTION
:cherries: Cherry picked from #3603 [fix(components/lists): repeater title and checkbox are aligned in v2 when the item is selectable](https://github.com/blackbaud/skyux/pull/3603)

[AB#3427763](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3427763) 