### PR TITLE
ci: e2e read build id from logs (#3615)

### DIFF
--- a/.github/actions/e2e-affected/action.yml
+++ b/.github/actions/e2e-affected/action.yml
@@ -24,6 +24,9 @@ outputs:
   affected:
     description: 'Whether the e2e tests are affected by the changes'
     value: ${{ steps.affected.outputs.affected }}
+  percy_target_commit:
+    description: 'The target commit to use as the base for Percy'
+    value: ${{ steps.affected.outputs.percy_target_commit }}
 runs:
   using: 'composite'
   steps:
@@ -55,10 +58,25 @@ runs:
             workflow_id: 'e2e.yml',
             branch: '${{ inputs.branch }}',
             status: 'completed',
-          }).then(({data}) => data.workflow_runs.map(run => run.head_sha).filter(Boolean));
+          })
+            .then(({data}) => data.workflow_runs.map(run => run.head_sha).filter(Boolean))
+            .catch(() => []);
 
-          const { getLastGoodPercyBuild } = require('./dist/libs/sdk/e2e-schematics/src/workflow');
-          const lastGoodCommit = await getLastGoodPercyBuild(
+          // Getting 500 commits to the base branch, looking for one where this e2e test was affected and run.
+          const targetBranchCommits = await exec.getExecOutput('git', ['log', '--format=%H', '-500', '${{ inputs.base }}'])
+            .then(({stdout}) => stdout.trim().split('\n'))
+            .catch(() => []);
+
+          const { getLastGoodPercyBuild, getPercyTargetCommit } = require('./dist/libs/sdk/e2e-schematics/src/workflow');
+          const targetCommit = await getPercyTargetCommit(
+            'skyux-${{ inputs.project }}',
+            targetBranchCommits,
+            core,
+            (url) => fetch(url, options)
+          )
+            .catch(() => '');
+          core.setOutput('percy_target_commit', targetCommit);
+          const { lastGoodCommit, buildId } = await getLastGoodPercyBuild(
             'skyux-${{ inputs.project }}',
             prBranchCommitsBuilt,
             '${{ inputs.allow-deleted-screenshots }}' !== 'false',
@@ -73,6 +91,8 @@ runs:
           }
 
           if (lastGoodCommit === '${{ inputs.head }}') {
+            const fs = require('fs');
+            fs.writeFileSync(`${{ runner.temp }}/percy-build-${{ inputs.project }}.txt`, buildId);
             core.info(`The build for ${lastGoodCommit.substring(0, 7)} already passed.`);
             core.setOutput('affected', 'false');
             process.exit(0);

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -320,6 +320,7 @@ jobs:
           set +o pipefail
 
           echo '# PERCY_TARGET_BRANCH' $PERCY_TARGET_BRANCH
+          echo '# PERCY_TARGET_COMMIT' $PERCY_TARGET_COMMIT
 
           separator() {
             echo ''; echo $(printf "=%.s" {1..80}); echo '';
@@ -362,9 +363,10 @@ jobs:
             fi
           fi
           # Extract the Percy build number from the log
-          fgrep '[percy] Finalized build' ${{ runner.temp }}/percy-${{ matrix.project }}.log | node -e "const rl=require('readline').createInterface({ input: process.stdin }); rl.on('line', (input) => console.log(input.split('/').pop()))" > ${{ runner.temp }}/percy-build-${{ matrix.project }}.txt
+          node -e "const wf = require('./dist/libs/sdk/e2e-schematics/src/workflow/index.js'); console.log(wf.readPercyBuildNumberFromLogFile('${{ runner.temp }}/percy-${{ matrix.project }}.log') ?? '');" > ${{ runner.temp }}/percy-build-${{ matrix.project }}.txt
         env:
           PERCY_TARGET_BRANCH: ${{ needs.install-deps.outputs.base-branch }}
+          PERCY_TARGET_COMMIT: ${{ steps.affected.outputs.percy_target_commit }}
           PERCY_BRANCH: ${{ github.head_ref || github.ref_name || github.event.ref }}
           PERCY_COMMIT: ${{ needs.install-deps.outputs.head }}
           PERCY_TOKEN: ${{ secrets[matrix.token] }}
@@ -379,7 +381,7 @@ jobs:
           retention-days: 4
       - name: Upload build number
         uses: actions/upload-artifact@v4
-        if: ${{ matrix.project != 'skip' && steps.affected.outputs.affected == 'true' }}
+        if: ${{ matrix.project != 'skip' }}
         with:
           name: percy-build-${{ matrix.project }}.txt
           path: ${{ runner.temp }}/percy-build-${{ matrix.project }}.txt
@@ -446,6 +448,7 @@ jobs:
       - name: Download Percy Build Numbers
         uses: actions/download-artifact@v4
         with:
+          github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
           path: ${{ runner.temp }}/percy-builds
           pattern: percy-build-*
           merge-multiple: true
@@ -488,17 +491,32 @@ jobs:
 
               const listJobsForWorkflowRun = async () => {
                 try {
-                  return await github.paginate('GET /repos/{owner}/{repo}/actions/runs/{run_id}/jobs', {
+                  return await Promise.all(
+                    Array.from(Array(context.runAttempt).keys(),i=>++i).reverse().map((attempt) =>
+                      github.paginate('GET /repos/{owner}/{repo}/actions/runs/{run_id}/attempts/{attempt}/jobs', {
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        run_id: context.runId,
+                        attempt,
+                        headers: { 'X-GitHub-Api-Version': '2022-11-28' }
+                      })
+                    )
+                  );
+                } catch (e) {
+                  core.warning(`Error getting workflow jobs for this run: ${e}`);
+                  return [];
+                }
+              }
+              const downloadJobLogs = async (job_id) => {
+                try {
+                  return await github.rest.actions.downloadJobLogsForWorkflowRun({
                     owner: context.repo.owner,
                     repo: context.repo.repo,
-                    run_id: context.runId,
-                    headers: {
-                      'X-GitHub-Api-Version': '2022-11-28'
-                    }
+                    job_id,
                   });
                 } catch (e) {
-                  core.warn(`Error getting workflow jobs for this run: ${e}`);
-                  return [];
+                  core.warning(`Error getting logs for job ${job_id}: ${e}`);
+                  return '';
                 }
               }
 
@@ -509,7 +527,7 @@ jobs:
                 e2eProjects,
                 buildIdFiles,
                 core,
-                { listJobsForWorkflowRun },
+                { listJobsForWorkflowRun, downloadJobLogs },
                 ${{ github.event_name == 'push' || contains( fromJSON( needs.install-deps.outputs.pr-labels ), 'screenshot removed' ) }},
                 (url) => fetch(url, options),
                 (number) => process.exit(number)

--- a/libs/sdk/e2e-schematics/src/workflow/index.ts
+++ b/libs/sdk/e2e-schematics/src/workflow/index.ts
@@ -3,4 +3,5 @@ export {
   getLastGoodPercyBuild,
   getPercyTargetCommit,
 } from './percy-api/percy-api';
+export { readPercyBuildNumberFromLogFile } from './percy-api/read-build-number-from-logs';
 export { verifyE2e } from './verify-e2e/verify-e2e';

--- a/libs/sdk/e2e-schematics/src/workflow/percy-api/percy-api.spec.ts
+++ b/libs/sdk/e2e-schematics/src/workflow/percy-api/percy-api.spec.ts
@@ -91,7 +91,10 @@ describe('percy-api', () => {
       logger,
       fetchClient,
     );
-    expect(result).toEqual('');
+    expect(result).toEqual({
+      buildId: 0,
+      lastGoodCommit: '',
+    });
   });
 
   it('should get last good build', async () => {
@@ -114,6 +117,7 @@ describe('percy-api', () => {
                     'review-state': 'approved',
                     state: 'finished',
                     'commit-html-url': 'https://.../commitSha',
+                    'web-url': 'https://.../321',
                   },
                 },
               ],
@@ -129,7 +133,7 @@ describe('percy-api', () => {
       logger,
       fetchClient,
     );
-    expect(result).toEqual('commitSha');
+    expect(result).toEqual({ lastGoodCommit: 'commitSha', buildId: 321 });
   });
 
   it('should get target commit', async () => {
@@ -289,7 +293,10 @@ describe('percy-api', () => {
       logger,
       fetchClient,
     );
-    expect(result).toEqual('');
+    expect(result).toEqual({
+      buildId: 0,
+      lastGoodCommit: '',
+    });
   });
 
   it('should handle no good builds', async () => {
@@ -317,7 +324,10 @@ describe('percy-api', () => {
       logger,
       fetchClient,
     );
-    expect(result).toEqual('');
+    expect(result).toEqual({
+      buildId: 0,
+      lastGoodCommit: '',
+    });
   });
 
   it('should handle incomplete response', async () => {
@@ -335,7 +345,10 @@ describe('percy-api', () => {
         logger,
         fetchClient,
       ),
-    ).resolves.toEqual('');
+    ).resolves.toEqual({
+      buildId: 0,
+      lastGoodCommit: '',
+    });
     expect(logger.error).toHaveBeenCalledWith(
       'Error checking Percy: Percy project ID response for test-storybook-e2e: {}',
     );
@@ -372,7 +385,10 @@ describe('percy-api', () => {
         logger,
         fetchClient,
       ),
-    ).resolves.toEqual('');
+    ).resolves.toEqual({
+      buildId: 0,
+      lastGoodCommit: '',
+    });
     expect(logger.error).toHaveBeenCalledWith(
       `Error checking Percy: Percy project ID response for test-storybook-e2e: ${JSON.stringify(
         [

--- a/libs/sdk/e2e-schematics/src/workflow/percy-api/percy-api.ts
+++ b/libs/sdk/e2e-schematics/src/workflow/percy-api/percy-api.ts
@@ -150,9 +150,9 @@ export async function getLastGoodPercyBuild(
   logger: Logger,
   /* istanbul ignore next */
   fetchClient: Fetch = fetch,
-): Promise<string> {
+): Promise<{ lastGoodCommit: string; buildId: number }> {
   if (shaArray.length === 0) {
-    return '';
+    return { lastGoodCommit: '', buildId: 0 };
   }
   const fetchJson = getFetchJson(fetchClient);
   try {
@@ -176,21 +176,24 @@ export async function getLastGoodPercyBuild(
           logger.warning(
             `Percy build ${previousBuild?.id} has removed screenshots. Re-running.`,
           );
-          return '';
+          return { lastGoodCommit: '', buildId: 0 };
         }
       }
-      return previousBuild.attributes['commit-html-url']
+      const lastGoodCommit = previousBuild.attributes['commit-html-url']
         .split('/')
         .pop() as string;
+      const buildId = Number(
+        previousBuild.attributes['web-url'].split('/').pop(),
+      );
+      return { lastGoodCommit, buildId };
     }
     logger.warning(
       `The last build was not finished and/or approved. Re-running.`,
     );
-    return '';
   } catch (error) {
     logger.error(`Error checking Percy: ${error}`);
-    return '';
   }
+  return { lastGoodCommit: '', buildId: 0 };
 }
 
 /**

--- a/libs/sdk/e2e-schematics/src/workflow/percy-api/read-build-number-from-logs.spec.ts
+++ b/libs/sdk/e2e-schematics/src/workflow/percy-api/read-build-number-from-logs.spec.ts
@@ -1,0 +1,63 @@
+import { readPercyBuildNumberFromLogString } from './read-build-number-from-logs';
+
+describe('read-build-number-from-logs', () => {
+  describe('readPercyBuildNumberFromLogString', () => {
+    it('should extract the buildId when the log contains a finalized build line', () => {
+      const log = `
+Some unrelated log output
+Checking for finalized build: [percy] Finalized build #6134: https://percy.io/82a32315/web/skyux-integration-e2e/builds/41420284
+More unrelated log output
+`;
+      expect(readPercyBuildNumberFromLogString(log)).toBe('41420284');
+    });
+
+    it('should return undefined when the log does not contain a finalized build line', () => {
+      const log = `
+Some unrelated log output
+No finalized build here
+More unrelated log output
+`;
+      expect(readPercyBuildNumberFromLogString(log)).toBeUndefined();
+    });
+  });
+
+  describe('readPercyBuildNumberFromLogFile', () => {
+    const mockLog = `
+Some unrelated log output
+Checking for finalized build: [percy] Finalized build #6134: https://percy.io/82a32315/web/skyux-integration-e2e/builds/41420284
+More unrelated log output
+`;
+
+    beforeEach(() => {
+      jest.resetModules();
+    });
+
+    it('should extract the buildId from a log file', () => {
+      jest.mock('node:fs', () => ({
+        readFileSync: jest.fn(() => mockLog),
+      }));
+      // Re-import after mocking
+      const {
+        readPercyBuildNumberFromLogFile,
+      } = require('./read-build-number-from-logs');
+      expect(readPercyBuildNumberFromLogFile('fake/path/to/log.txt')).toBe(
+        '41420284',
+      );
+    });
+
+    it('should handle an error', () => {
+      jest.mock('node:fs', () => ({
+        readFileSync: jest.fn(() => {
+          throw new Error('File not found');
+        }),
+      }));
+      // Re-import after mocking
+      const {
+        readPercyBuildNumberFromLogFile,
+      } = require('./read-build-number-from-logs');
+      expect(
+        readPercyBuildNumberFromLogFile('fake/path/to/log.txt'),
+      ).toBeUndefined();
+    });
+  });
+});

--- a/libs/sdk/e2e-schematics/src/workflow/percy-api/read-build-number-from-logs.ts
+++ b/libs/sdk/e2e-schematics/src/workflow/percy-api/read-build-number-from-logs.ts
@@ -1,0 +1,26 @@
+import { readFileSync } from 'node:fs';
+
+export function readPercyBuildNumberFromLogString(
+  log: string,
+): string | undefined {
+  const buildIdCheck = '[percy] Finalized build';
+  if (!log.includes(buildIdCheck)) {
+    return undefined;
+  }
+  const buildIdStart = log.indexOf(buildIdCheck);
+  const buildIdEol = log.indexOf(`\n`, buildIdStart);
+  const buildIdLine = log.substring(buildIdStart, buildIdEol);
+  return String(buildIdLine.split('/').pop()).trim();
+}
+
+export function readPercyBuildNumberFromLogFile(
+  logFilePath: string,
+): string | undefined {
+  try {
+    const logContent = readFileSync(logFilePath, 'utf-8');
+    return readPercyBuildNumberFromLogString(logContent);
+  } catch (error) {
+    console.error(`Error reading log file ${logFilePath}:`, error);
+    return undefined;
+  }
+}


### PR DESCRIPTION
:cherries: Cherry picked from #3615 [ci: e2e read build id from logs](https://github.com/blackbaud/skyux/pull/3615)

[AB#3436510](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3436510) 