### PR TITLE
fix: selected horizontal and vertical tabs use medium border in v2 modern

### DIFF
--- a/libs/components/tabs/src/lib/modules/vertical-tabset/vertical-tab.component.scss
+++ b/libs/components/tabs/src/lib/modules/vertical-tabset/vertical-tab.component.scss
@@ -44,6 +44,10 @@
 @include compatMixins.sky-modern-overrides('.sky-vertical-tab') {
   --sky-override-vertical-tab-background-color-disabled: transparent;
   --sky-override-vertical-tab-background-color-selected: transparent;
+  --sky-override-vertical-tab-border-left-selected: var(
+      --sky-border-width-selected-l
+    )
+    solid var(--sky-color-border-selected);
   --sky-override-vertical-tab-border-left-active: var(--modern-size-4) solid
     var(--modern-color-blue-50);
   --sky-override-vertical-tab-border-left-hover: var(--modern-size-1) solid
@@ -62,6 +66,11 @@
     var(--modern-size-15) var(--modern-size-10);
   --sky-override-vertical-tab-padding: var(--modern-size-10)
     var(--modern-size-10) var(--modern-size-10) var(--modern-size-15);
+  --sky-override-vertical-tab-padding-left-selected: calc(
+    var(--sky-comp-tab-vertical-space-inset-left) - var(
+        --sky-border-width-selected-l
+      )
+  );
   --sky-override-vertical-tab-right-arrow-color: var(--modern-color-gray-20);
   --sky-override-vertical-tab-right-arrow-color-active: var(
     --modern-color-gray-20

--- a/libs/components/tabs/src/lib/modules/vertical-tabset/vertical-tab.component.scss
+++ b/libs/components/tabs/src/lib/modules/vertical-tabset/vertical-tab.component.scss
@@ -222,13 +222,13 @@
     --sky-override-vertical-tab-padding-left-selected,
     calc(
       var(--sky-comp-tab-vertical-space-inset-left) - var(
-          --sky-border-width-selected-l
+          --sky-border-width-selected-m
         )
     )
   );
   border-left: var(
     --sky-override-vertical-tab-border-left-selected,
-    var(--sky-border-width-selected-l) solid var(--sky-color-border-selected)
+    var(--sky-border-width-selected-m) solid var(--sky-color-border-selected)
   );
 
   .sky-vertical-tab-right-arrow {

--- a/libs/components/theme/src/lib/styles/themes/modern/_buttons.scss
+++ b/libs/components/theme/src/lib/styles/themes/modern/_buttons.scss
@@ -640,13 +640,13 @@
     &:not(:active) {
       border-bottom: var(
           --sky-override-tab-selected-border-bottom-size,
-          var(--sky-border-width-selected-l)
+          var(--sky-border-width-selected-m)
         )
         var(--sky-border-style-accent) var(--sky-color-border-selected);
       padding-bottom: calc(
         var(--sky-comp-tab-horizontal-space-inset-bottom) - var(
             --sky-override-tab-selected-border-bottom-size,
-            var(--sky-border-width-selected-l)
+            var(--sky-border-width-selected-m)
           )
       );
     }


### PR DESCRIPTION
[AB#3433502](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3433502)
[AB#3433505](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3433505)