### PR TITLE
fix(components/forms): indeterminate checkboxes use small icons in v2 modern

### DIFF
--- a/libs/components/forms/src/lib/modules/checkbox/checkbox.component.html
+++ b/libs/components/forms/src/lib/modules/checkbox/checkbox.component.html
@@ -53,6 +53,7 @@
             class="sky-checkbox-icon-indeterminate sky-checkbox-icon-modern-indeterminate"
             iconName="square"
             variant="solid"
+            iconSize="s"
           />
         } @else if (checked) {
           <sky-icon


### PR DESCRIPTION
[AB#3414116](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3414116)