### PR TITLE
fix(components/flyout): flyout header resize button uses `ew-resize` cursor

### DIFF
--- a/libs/components/flyout/src/lib/modules/flyout/flyout.component.scss
+++ b/libs/components/flyout/src/lib/modules/flyout/flyout.component.scss
@@ -380,7 +380,7 @@
 }
 
 .sky-flyout-header-grab-handle {
-  cursor: move;
+  cursor: ew-resize;
   cursor: -webkit-grab;
   cursor: -moz-grab;
   margin-right: var(--sky-space-gap-action_group-m);


### PR DESCRIPTION
[AB#3420484](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3420484)