### PR TITLE
feat(components/theme): add brand registry with URL and SRI hash (#3633)

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -10,6 +10,7 @@
     "ngsrc",
     "novalidate",
     "pillarbox",
+    "subresource",
     "tabindex",
     "tabstyle",
     "Tmpl",

--- a/libs/components/theme/src/lib/theming/theme-brand.spec.ts
+++ b/libs/components/theme/src/lib/theming/theme-brand.spec.ts
@@ -28,6 +28,65 @@ describe('Theme brand', () => {
     expect(brand.version).toBe('1.0.0');
   });
 
+  it('should set styleUrl correctly when provided', () => {
+    const styleUrl = 'https://example.com/styles.css';
+    const brand = new SkyThemeBrand(
+      'custom-brand',
+      '1.0.0',
+      undefined,
+      styleUrl,
+    );
+
+    expect(brand.styleUrl).toBe(styleUrl);
+  });
+
+  it('should set sriHash correctly when provided', () => {
+    const sriHash = 'sha384-abc123def456';
+    const brand = new SkyThemeBrand(
+      'custom-brand',
+      '1.0.0',
+      undefined,
+      undefined,
+      sriHash,
+    );
+
+    expect(brand.sriHash).toBe(sriHash);
+  });
+
+  it('should set both styleUrl and sriHash when provided', () => {
+    const styleUrl = 'https://example.com/styles.css';
+    const sriHash = 'sha384-abc123def456';
+    const brand = new SkyThemeBrand(
+      'custom-brand',
+      '1.0.0',
+      undefined,
+      styleUrl,
+      sriHash,
+    );
+
+    expect(brand.styleUrl).toBe(styleUrl);
+    expect(brand.sriHash).toBe(sriHash);
+  });
+
+  it('should set all parameters correctly when provided', () => {
+    const styleUrl = 'https://example.com/styles.css';
+    const sriHash = 'sha384-abc123def456';
+    const hostClass = 'custom-host-class';
+    const brand = new SkyThemeBrand(
+      'custom-brand',
+      '1.0.0',
+      hostClass,
+      styleUrl,
+      sriHash,
+    );
+
+    expect(brand.name).toBe('custom-brand');
+    expect(brand.version).toBe('1.0.0');
+    expect(brand.hostClass).toBe(hostClass);
+    expect(brand.styleUrl).toBe(styleUrl);
+    expect(brand.sriHash).toBe(sriHash);
+  });
+
   it('should set the version correctly when a version with an appropriate suffix is given', () => {
     const suffixes = ['alpha.1', 'beta.1', 'rc.1'];
 
@@ -94,6 +153,57 @@ describe('Theme brand', () => {
       });
     });
 
+    it('should serialize brand with styleUrl correctly', () => {
+      const styleUrl = 'https://example.com/styles.css';
+      const brand = new SkyThemeBrand('custom', '2.0.0', undefined, styleUrl);
+      const serialized = brand.serialize();
+
+      expect(serialized).toEqual({
+        name: 'custom',
+        version: '2.0.0',
+        styleUrl,
+      });
+    });
+
+    it('should serialize brand with sriHash correctly', () => {
+      const sriHash = 'sha384-abc123def456';
+      const brand = new SkyThemeBrand(
+        'custom',
+        '2.0.0',
+        undefined,
+        undefined,
+        sriHash,
+      );
+      const serialized = brand.serialize();
+
+      expect(serialized).toEqual({
+        name: 'custom',
+        version: '2.0.0',
+        sriHash,
+      });
+    });
+
+    it('should serialize brand with all properties correctly', () => {
+      const styleUrl = 'https://example.com/styles.css';
+      const sriHash = 'sha384-abc123def456';
+      const brand = new SkyThemeBrand(
+        'custom',
+        '2.0.0',
+        'custom-host-class',
+        styleUrl,
+        sriHash,
+      );
+      const serialized = brand.serialize();
+
+      expect(serialized).toEqual({
+        name: 'custom',
+        version: '2.0.0',
+        hostClass: 'custom-host-class',
+        styleUrl,
+        sriHash,
+      });
+    });
+
     it('should deserialize brand correctly', () => {
       const brand = SkyThemeBrand.deserialize({
         name: 'rainbow',
@@ -115,6 +225,52 @@ describe('Theme brand', () => {
       expect(brand.name).toBe('custom');
       expect(brand.version).toBe('2.0.0');
       expect(brand.hostClass).toBe('custom-host-class');
+    });
+
+    it('should deserialize brand with styleUrl correctly', () => {
+      const styleUrl = 'https://example.com/styles.css';
+      const brand = SkyThemeBrand.deserialize({
+        name: 'custom',
+        version: '2.0.0',
+        styleUrl,
+      });
+
+      expect(brand.name).toBe('custom');
+      expect(brand.version).toBe('2.0.0');
+      expect(brand.hostClass).toBe('sky-theme-brand-custom');
+      expect(brand.styleUrl).toBe(styleUrl);
+    });
+
+    it('should deserialize brand with sriHash correctly', () => {
+      const sriHash = 'sha384-abc123def456';
+      const brand = SkyThemeBrand.deserialize({
+        name: 'custom',
+        version: '2.0.0',
+        sriHash,
+      });
+
+      expect(brand.name).toBe('custom');
+      expect(brand.version).toBe('2.0.0');
+      expect(brand.hostClass).toBe('sky-theme-brand-custom');
+      expect(brand.sriHash).toBe(sriHash);
+    });
+
+    it('should deserialize brand with all properties correctly', () => {
+      const styleUrl = 'https://example.com/styles.css';
+      const sriHash = 'sha384-abc123def456';
+      const brand = SkyThemeBrand.deserialize({
+        name: 'custom',
+        version: '2.0.0',
+        hostClass: 'custom-host-class',
+        styleUrl,
+        sriHash,
+      });
+
+      expect(brand.name).toBe('custom');
+      expect(brand.version).toBe('2.0.0');
+      expect(brand.hostClass).toBe('custom-host-class');
+      expect(brand.styleUrl).toBe(styleUrl);
+      expect(brand.sriHash).toBe(sriHash);
     });
   });
 });

--- a/libs/components/theme/src/lib/theming/theme-brand.ts
+++ b/libs/components/theme/src/lib/theming/theme-brand.ts
@@ -17,13 +17,18 @@ export class SkyThemeBrand {
   /**
    * Creates a new theme brand.
    * @param name The name of the theme brand.
+   * @param version The version of the theme brand.
    * @param hostClass The class on the host element which child components should reference when
-   * adjusting for a specified theme brand. This defaults to `sky-theme-brand-<name>
+   * adjusting for a specified theme brand. This defaults to `sky-theme-brand-<name>`
+   * @param styleUrl The URL of the stylesheet to load for this brand
+   * @param sriHash The subresource integrity hash for the stylesheet
    */
   constructor(
     public readonly name: string,
     public readonly version: string,
     hostClass?: string,
+    public readonly styleUrl?: string,
+    public readonly sriHash?: string,
   ) {
     this.hostClass = hostClass;
 
@@ -51,6 +56,15 @@ export class SkyThemeBrand {
       result.hostClass = this.hostClass;
     }
 
+    // Include styleUrl and sriHash if they are provided
+    if (this.styleUrl) {
+      result.styleUrl = this.styleUrl;
+    }
+
+    if (this.sriHash) {
+      result.sriHash = this.sriHash;
+    }
+
     return result;
   }
 
@@ -59,7 +73,13 @@ export class SkyThemeBrand {
    * Deserializes a JSON object to a SkyThemeBrand instance.
    */
   public static deserialize(data: SkyThemeBrandData): SkyThemeBrand {
-    return new SkyThemeBrand(data.name, data.version, data.hostClass);
+    return new SkyThemeBrand(
+      data.name,
+      data.version,
+      data.hostClass,
+      data.styleUrl,
+      data.sriHash,
+    );
   }
 
   #buildDefaultHostClassName(): string {

--- a/libs/components/theme/src/lib/theming/theme-serialization-types.ts
+++ b/libs/components/theme/src/lib/theming/theme-serialization-types.ts
@@ -27,6 +27,8 @@ export interface SkyThemeBrandData {
   name: string;
   version: string;
   hostClass?: string;
+  styleUrl?: string;
+  sriHash?: string;
 }
 
 /**

--- a/libs/components/theme/src/lib/theming/theme.service.spec.ts
+++ b/libs/components/theme/src/lib/theming/theme.service.spec.ts
@@ -20,7 +20,7 @@ describe('Theme service', () => {
     createElement: jasmine.Spy;
     removeClass: jasmine.Spy;
     removeChild: jasmine.Spy;
-    setProperty: jasmine.Spy;
+    setAttribute: jasmine.Spy;
   };
 
   function validateSettingsApplied(
@@ -97,15 +97,21 @@ describe('Theme service', () => {
 
         if (current.brand.name !== 'blackbaud') {
           expect(mockRenderer.createElement).toHaveBeenCalledWith('link');
-          expect(mockRenderer.setProperty).toHaveBeenCalledWith(
+          expect(mockRenderer.setAttribute).toHaveBeenCalledWith(
             mockLinkElement,
             'rel',
             'stylesheet',
           );
-          expect(mockRenderer.setProperty).toHaveBeenCalledWith(
+
+          // Use styleUrl if provided, otherwise fallback to default CDN URL
+          const expectedHref =
+            current.brand.styleUrl ||
+            `https://sky.blackbaudcdn.net/static/skyux-brand-${current.brand.name}/${current.brand.version}/assets/scss/${current.brand.name}.css`;
+
+          expect(mockRenderer.setAttribute).toHaveBeenCalledWith(
             mockLinkElement,
             'href',
-            `https://sky.blackbaudcdn.net/static/skyux-brand-${current.brand.name}/${current.brand.version}/assets/scss/${current.brand.name}.css`,
+            expectedHref,
           );
           expect(mockRenderer.appendChild).toHaveBeenCalledWith(
             mockHostEl,
@@ -113,7 +119,7 @@ describe('Theme service', () => {
           );
         } else {
           expect(mockRenderer.createElement).not.toHaveBeenCalled();
-          expect(mockRenderer.setProperty).not.toHaveBeenCalled();
+          expect(mockRenderer.setAttribute).not.toHaveBeenCalled();
           expect(mockRenderer.appendChild).not.toHaveBeenCalled();
         }
       }
@@ -161,7 +167,7 @@ describe('Theme service', () => {
       'createElement',
       'removeClass',
       'removeChild',
-      'setProperty',
+      'setAttribute',
     ]);
 
     mockHostEl = {
@@ -256,6 +262,52 @@ describe('Theme service', () => {
 
   describe('setTheme()', () => {
     describe('with SkyThemeSettings parameter', () => {
+      function testBrandingWithSri(sriHash?: string): void {
+        const themeSvc = new SkyThemeService();
+
+        const settingsWithBranding = new SkyThemeSettings(
+          SkyTheme.presets.modern,
+          SkyThemeMode.presets.light,
+          SkyThemeSpacing.presets.compact,
+          new SkyThemeBrand('rainbow', '1.0.1', undefined, undefined, sriHash),
+        );
+
+        themeSvc.init(
+          mockHostEl,
+          mockRenderer as unknown as Renderer2,
+          settingsWithBranding,
+        );
+
+        // Validate basic branding is applied
+        validateSettingsApplied(settingsWithBranding);
+
+        if (sriHash) {
+          // Validate SRI-specific attributes are set
+          expect(mockRenderer.setAttribute).toHaveBeenCalledWith(
+            mockLinkElement,
+            'integrity',
+            sriHash,
+          );
+          expect(mockRenderer.setAttribute).toHaveBeenCalledWith(
+            mockLinkElement,
+            'crossorigin',
+            'anonymous',
+          );
+        } else {
+          // Validate SRI-specific attributes are NOT set
+          expect(mockRenderer.setAttribute).not.toHaveBeenCalledWith(
+            mockLinkElement,
+            'integrity',
+            jasmine.any(String),
+          );
+          expect(mockRenderer.setAttribute).not.toHaveBeenCalledWith(
+            mockLinkElement,
+            'crossorigin',
+            'anonymous',
+          );
+        }
+      }
+
       it('should error if settings are attempted to be changed prior to initialization', () => {
         const themeSvc = new SkyThemeService();
 
@@ -401,6 +453,55 @@ describe('Theme service', () => {
         themeSvc.setTheme(settingsWithoutBranding);
 
         validateSettingsApplied(settingsWithoutBranding, settingsWithBranding);
+      });
+
+      it('should apply branding with SRI hash', () => {
+        const sriHash =
+          'sha384-abc123def456ghi789jkl012mno345pqr678stu901vwx234yz567890abcdef';
+        testBrandingWithSri(sriHash);
+      });
+
+      it('should apply branding without SRI attributes when no SRI hash is provided', () => {
+        testBrandingWithSri();
+      });
+
+      it('should apply branding without SRI attributes when empty SRI hash is provided', () => {
+        testBrandingWithSri('');
+      });
+
+      it('should use a registered brand with the same name instead of the specified brand when it exists', () => {
+        const registeredBrand = new SkyThemeBrand(
+          'rainbow',
+          '2.0.0',
+          undefined,
+          'https://example.com/rainbow/registered/rainbow.css',
+          'abc123',
+        );
+
+        const themeSvc = new SkyThemeService();
+
+        const settingsWithBranding = new SkyThemeSettings(
+          SkyTheme.presets.modern,
+          SkyThemeMode.presets.light,
+          SkyThemeSpacing.presets.compact,
+          new SkyThemeBrand('rainbow', '1.0.1'),
+        );
+
+        themeSvc.init(
+          mockHostEl,
+          mockRenderer as unknown as Renderer2,
+          settingsWithBranding,
+          [registeredBrand],
+        );
+
+        validateSettingsApplied(
+          new SkyThemeSettings(
+            settingsWithBranding.theme,
+            settingsWithBranding.mode,
+            settingsWithBranding.spacing,
+            registeredBrand,
+          ),
+        );
       });
     });
 
@@ -750,6 +851,371 @@ describe('Theme service', () => {
       expect(() => {
         themeSvc.setThemeBrand(new SkyThemeBrand('rainbow', '1.0.1'));
       }).toThrowError('Branding is not supported for the given theme.');
+    });
+
+    it('should apply brand with SRI hash using setThemeBrand', () => {
+      const themeSvc = new SkyThemeService();
+      const sriHash =
+        'sha384-abc123def456ghi789jkl012mno345pqr678stu901vwx234yz567890abcdef';
+
+      const initialSettings = new SkyThemeSettings(
+        SkyTheme.presets.modern,
+        SkyThemeMode.presets.light,
+        SkyThemeSpacing.presets.compact,
+      );
+
+      themeSvc.init(
+        mockHostEl,
+        mockRenderer as unknown as Renderer2,
+        initialSettings,
+      );
+
+      mockRenderer.addClass.calls.reset();
+      mockRenderer.removeClass.calls.reset();
+      mockRenderer.createElement.calls.reset();
+      mockRenderer.setAttribute.calls.reset();
+
+      const newBrandWithSri = new SkyThemeBrand(
+        'rainbow',
+        '1.0.1',
+        undefined,
+        undefined,
+        sriHash,
+      );
+      themeSvc.setThemeBrand(newBrandWithSri);
+
+      expect(mockRenderer.addClass).toHaveBeenCalledWith(
+        mockHostEl,
+        'sky-theme-brand-base',
+      );
+      expect(mockRenderer.addClass).toHaveBeenCalledWith(
+        mockHostEl,
+        newBrandWithSri.hostClass,
+      );
+
+      // Validate SRI-specific attributes are set
+      expect(mockRenderer.setAttribute).toHaveBeenCalledWith(
+        mockLinkElement,
+        'integrity',
+        sriHash,
+      );
+      expect(mockRenderer.setAttribute).toHaveBeenCalledWith(
+        mockLinkElement,
+        'crossorigin',
+        'anonymous',
+      );
+    });
+
+    it('should use styleUrl when provided for brand stylesheet', () => {
+      const themeSvc = new SkyThemeService();
+      const customStyleUrl = 'https://custom.example.com/theme.css';
+
+      const settingsWithCustomStyleUrl = new SkyThemeSettings(
+        SkyTheme.presets.modern,
+        SkyThemeMode.presets.light,
+        SkyThemeSpacing.presets.compact,
+        new SkyThemeBrand('rainbow', '1.0.1', undefined, customStyleUrl),
+      );
+
+      themeSvc.init(
+        mockHostEl,
+        mockRenderer as unknown as Renderer2,
+        settingsWithCustomStyleUrl,
+      );
+
+      // Validate that the custom styleUrl is used
+      expect(mockRenderer.setAttribute).toHaveBeenCalledWith(
+        mockLinkElement,
+        'href',
+        customStyleUrl,
+      );
+
+      // Validate other branding is applied correctly
+      validateSettingsApplied(settingsWithCustomStyleUrl);
+    });
+
+    it('should use styleUrl with SRI when both are provided', () => {
+      const themeSvc = new SkyThemeService();
+      const customStyleUrl = 'https://custom.example.com/theme.css';
+      const sriHash = 'sha384-abc123';
+
+      const settingsWithCustomStyleUrlAndSri = new SkyThemeSettings(
+        SkyTheme.presets.modern,
+        SkyThemeMode.presets.light,
+        SkyThemeSpacing.presets.compact,
+        new SkyThemeBrand(
+          'rainbow',
+          '1.0.1',
+          undefined,
+          customStyleUrl,
+          sriHash,
+        ),
+      );
+
+      themeSvc.init(
+        mockHostEl,
+        mockRenderer as unknown as Renderer2,
+        settingsWithCustomStyleUrlAndSri,
+      );
+
+      // Validate that the custom styleUrl is used
+      expect(mockRenderer.setAttribute).toHaveBeenCalledWith(
+        mockLinkElement,
+        'href',
+        customStyleUrl,
+      );
+
+      // Validate SRI attributes are set
+      expect(mockRenderer.setAttribute).toHaveBeenCalledWith(
+        mockLinkElement,
+        'integrity',
+        sriHash,
+      );
+      expect(mockRenderer.setAttribute).toHaveBeenCalledWith(
+        mockLinkElement,
+        'crossorigin',
+        'anonymous',
+      );
+
+      // Validate other branding is applied correctly
+      validateSettingsApplied(settingsWithCustomStyleUrlAndSri);
+    });
+
+    it('should use a registered brand with the same name instead of the specified brand when it exists', () => {
+      const registeredBrand = new SkyThemeBrand(
+        'rainbow',
+        '2.0.0',
+        undefined,
+        'https://example.com/rainbow/registered/rainbow.css',
+        'abc123',
+      );
+
+      const specifiedBrand = new SkyThemeBrand('rainbow', '1.0.1');
+
+      const themeSvc = new SkyThemeService();
+
+      themeSvc.registerBrand(registeredBrand);
+
+      const initialSettings = new SkyThemeSettings(
+        SkyTheme.presets.modern,
+        SkyThemeMode.presets.light,
+        SkyThemeSpacing.presets.compact,
+      );
+
+      themeSvc.init(
+        mockHostEl,
+        mockRenderer as unknown as Renderer2,
+        initialSettings,
+      );
+
+      themeSvc.setThemeBrand(specifiedBrand);
+
+      const settingsWithRegisteredBrand = new SkyThemeSettings(
+        initialSettings.theme,
+        initialSettings.mode,
+        initialSettings.spacing,
+        registeredBrand,
+      );
+
+      validateSettingsApplied(settingsWithRegisteredBrand, initialSettings);
+
+      themeSvc.unregisterBrand('rainbow');
+
+      themeSvc.setThemeBrand(specifiedBrand);
+
+      validateSettingsApplied(
+        new SkyThemeSettings(
+          initialSettings.theme,
+          initialSettings.mode,
+          initialSettings.spacing,
+          specifiedBrand,
+        ),
+        settingsWithRegisteredBrand,
+      );
+    });
+
+    it('should remove old stylesheet when switching from one brand to another brand', () => {
+      const themeSvc = new SkyThemeService();
+
+      const brand1 = new SkyThemeBrand('brand1', '1.0.0');
+      const brand2 = new SkyThemeBrand('brand2', '1.0.0');
+
+      const initialSettingsWithBrand1 = new SkyThemeSettings(
+        SkyTheme.presets.modern,
+        SkyThemeMode.presets.light,
+        SkyThemeSpacing.presets.compact,
+        brand1,
+      );
+
+      themeSvc.init(
+        mockHostEl,
+        mockRenderer as unknown as Renderer2,
+        initialSettingsWithBrand1,
+      );
+
+      // Reset calls to focus on the brand switching
+      mockRenderer.removeChild.calls.reset();
+      mockRenderer.createElement.calls.reset();
+      mockRenderer.appendChild.calls.reset();
+
+      // Switch to brand2
+      themeSvc.setThemeBrand(brand2);
+
+      // Verify that the old stylesheet was removed first
+      expect(mockRenderer.removeChild).toHaveBeenCalledWith(
+        mockHostEl,
+        mockLinkElement,
+      );
+
+      // Verify that a new stylesheet was created and added
+      expect(mockRenderer.createElement).toHaveBeenCalledWith('link');
+      expect(mockRenderer.appendChild).toHaveBeenCalledWith(
+        mockHostEl,
+        mockLinkElement,
+      );
+    });
+
+    it('should remove old stylesheet when switching from brand to blackbaud brand', () => {
+      const themeSvc = new SkyThemeService();
+
+      const customBrand = new SkyThemeBrand('custom', '1.0.0');
+      const blackbaudBrand = new SkyThemeBrand('blackbaud', '1.0.0');
+
+      const initialSettingsWithCustomBrand = new SkyThemeSettings(
+        SkyTheme.presets.modern,
+        SkyThemeMode.presets.light,
+        SkyThemeSpacing.presets.compact,
+        customBrand,
+      );
+
+      themeSvc.init(
+        mockHostEl,
+        mockRenderer as unknown as Renderer2,
+        initialSettingsWithCustomBrand,
+      );
+
+      // Reset calls to focus on the brand switching
+      mockRenderer.removeChild.calls.reset();
+      mockRenderer.createElement.calls.reset();
+      mockRenderer.appendChild.calls.reset();
+
+      // Switch to blackbaud brand
+      themeSvc.setThemeBrand(blackbaudBrand);
+
+      // Verify that the old stylesheet was removed
+      expect(mockRenderer.removeChild).toHaveBeenCalledWith(
+        mockHostEl,
+        mockLinkElement,
+      );
+
+      // Verify that no new stylesheet was created (blackbaud doesn't need one)
+      expect(mockRenderer.createElement).not.toHaveBeenCalled();
+      expect(mockRenderer.appendChild).not.toHaveBeenCalled();
+    });
+
+    it('should remove old stylesheet when switching from blackbaud to custom brand', () => {
+      const themeSvc = new SkyThemeService();
+
+      const blackbaudBrand = new SkyThemeBrand('blackbaud', '1.0.0');
+      const customBrand = new SkyThemeBrand('custom', '1.0.0');
+
+      const initialSettingsWithBlackbaud = new SkyThemeSettings(
+        SkyTheme.presets.modern,
+        SkyThemeMode.presets.light,
+        SkyThemeSpacing.presets.compact,
+        blackbaudBrand,
+      );
+
+      themeSvc.init(
+        mockHostEl,
+        mockRenderer as unknown as Renderer2,
+        initialSettingsWithBlackbaud,
+      );
+
+      // Blackbaud brand shouldn't create a stylesheet initially
+      expect(mockRenderer.createElement).not.toHaveBeenCalled();
+
+      // Reset calls to focus on the brand switching
+      mockRenderer.removeChild.calls.reset();
+      mockRenderer.createElement.calls.reset();
+      mockRenderer.appendChild.calls.reset();
+
+      // Switch to custom brand
+      themeSvc.setThemeBrand(customBrand);
+
+      // Verify that no old stylesheet was removed (blackbaud doesn't have one)
+      expect(mockRenderer.removeChild).not.toHaveBeenCalled();
+
+      // Verify that a new stylesheet was created and added
+      expect(mockRenderer.createElement).toHaveBeenCalledWith('link');
+      expect(mockRenderer.appendChild).toHaveBeenCalledWith(
+        mockHostEl,
+        mockLinkElement,
+      );
+    });
+
+    it('should properly handle switching between brands with custom styleUrls', () => {
+      const themeSvc = new SkyThemeService();
+
+      const brand1 = new SkyThemeBrand(
+        'brand1',
+        '1.0.0',
+        undefined,
+        'https://example.com/brand1.css',
+      );
+      const brand2 = new SkyThemeBrand(
+        'brand2',
+        '1.0.0',
+        undefined,
+        'https://example.com/brand2.css',
+      );
+
+      const initialSettingsWithBrand1 = new SkyThemeSettings(
+        SkyTheme.presets.modern,
+        SkyThemeMode.presets.light,
+        SkyThemeSpacing.presets.compact,
+        brand1,
+      );
+
+      themeSvc.init(
+        mockHostEl,
+        mockRenderer as unknown as Renderer2,
+        initialSettingsWithBrand1,
+      );
+
+      // Verify brand1 stylesheet was set
+      expect(mockRenderer.setAttribute).toHaveBeenCalledWith(
+        mockLinkElement,
+        'href',
+        'https://example.com/brand1.css',
+      );
+
+      // Reset calls to focus on the brand switching
+      mockRenderer.removeChild.calls.reset();
+      mockRenderer.createElement.calls.reset();
+      mockRenderer.appendChild.calls.reset();
+      mockRenderer.setAttribute.calls.reset();
+
+      // Switch to brand2
+      themeSvc.setThemeBrand(brand2);
+
+      // Verify that the old stylesheet was removed first
+      expect(mockRenderer.removeChild).toHaveBeenCalledWith(
+        mockHostEl,
+        mockLinkElement,
+      );
+
+      // Verify that a new stylesheet was created and added with the correct URL
+      expect(mockRenderer.createElement).toHaveBeenCalledWith('link');
+      expect(mockRenderer.appendChild).toHaveBeenCalledWith(
+        mockHostEl,
+        mockLinkElement,
+      );
+      expect(mockRenderer.setAttribute).toHaveBeenCalledWith(
+        mockLinkElement,
+        'href',
+        'https://example.com/brand2.css',
+      );
     });
   });
 });


### PR DESCRIPTION
:cherries: Cherry picked from #3633 [feat(components/theme): add brand registry with URL and SRI hash](https://github.com/blackbaud/skyux/pull/3633)