### PR TITLE
chore(components/forms): add more robust logic to showing error states in checkbox visual tests (#3652)

### DIFF
--- a/apps/e2e/forms-storybook-e2e/src/e2e/checkbox.component.cy.ts
+++ b/apps/e2e/forms-storybook-e2e/src/e2e/checkbox.component.cy.ts
@@ -11,12 +11,22 @@ describe('forms-storybook - checkbox', () => {
 
       it('should render the standard components', () => {
         cy.skyReady('app-checkbox');
-        cy.get('#touched-required-checkbox').click();
-        cy.get('#touched-required-checkbox').click();
-        cy.get('app-checkbox').should('exist').should('be.visible');
-        cy.get('#touched-easy-mode-checkbox').click();
-        cy.get('#touched-easy-mode-checkbox').click();
+        cy.get('#touched-required-checkbox .sky-switch').click();
+        cy.get('#touched-required-checkbox .sky-switch').click();
+        cy.get('#touched-required-checkbox input').blur();
+        cy.get(
+          '#touched-required-checkbox sky-form-error .sky-status-indicator-message',
+        )
+          .should('exist')
+          .should('be.visible');
+        cy.get('#touched-easy-mode-checkbox .sky-switch').click();
+        cy.get('#touched-easy-mode-checkbox .sky-switch').click();
         cy.get('#touched-easy-mode-checkbox input').blur();
+        cy.get(
+          '#touched-easy-mode-checkbox sky-form-error .sky-status-indicator-message',
+        )
+          .should('exist')
+          .should('be.visible');
         cy.get('app-checkbox')
           .get('#standard-checkboxes')
           .should('exist')


### PR DESCRIPTION
:cherries: Cherry picked from #3652 [chore(components/forms): add more robust logic to showing error states in checkbox visual tests](https://github.com/blackbaud/skyux/pull/3652)