### PR TITLE
fix(components/lists): selected sort item uses medium border width in v2 modern (#3656)

### DIFF
--- a/libs/components/lists/src/lib/modules/sort/sort-item.component.scss
+++ b/libs/components/lists/src/lib/modules/sort/sort-item.component.scss
@@ -150,7 +150,7 @@
     solid
       var(
         --sky-override-sort-item-width-border-selected,
-        var(--sky-border-width-selected-l)
+        var(--sky-border-width-selected-m)
       )
       var(--sky-color-border-selected)
   );
@@ -167,7 +167,7 @@
       calc(
         var(--sky-comp-dropdown-option-space-inset-left) - var(
             --sky-override-sort-item-width-border-selected,
-            var(--sky-border-width-selected-l)
+            var(--sky-border-width-selected-m)
           )
       )
     );


### PR DESCRIPTION
:cherries: Cherry picked from #3656 [fix(components/lists): selected sort item uses medium border width in v2 modern](https://github.com/blackbaud/skyux/pull/3656)

[AB#3429874](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3429874) 