### PR TITLE
feat(components/layout): remove secondary button overrides in modern v2 toolbar (#3643)

### DIFF
--- a/apps/playground/src/app/components/layout/toolbar/toolbar.component.html
+++ b/apps/playground/src/app/components/layout/toolbar/toolbar.component.html
@@ -11,13 +11,15 @@
       <button class="sky-btn sky-btn-default" type="button">Button 1</button>
     </sky-toolbar-item>
     <sky-toolbar-item>
-      <button class="sky-btn sky-btn-default" type="button">Button 2</button>
+      <button class="sky-btn sky-btn-link" type="button">Link</button>
     </sky-toolbar-item>
     <sky-toolbar-item>
-      <button class="sky-btn sky-btn-default" type="button">Button 3</button>
+      <button class="sky-btn sky-btn-default" type="button">
+        Secondary/Default
+      </button>
     </sky-toolbar-item>
     <sky-toolbar-item>
-      <button class="sky-btn sky-btn-default" type="button">Button 4</button>
+      <button class="sky-btn sky-btn-primary" type="button">Primary</button>
     </sky-toolbar-item>
     <sky-toolbar-item>
       <button class="sky-btn sky-btn-primary" type="button" disabled>

--- a/libs/components/layout/src/lib/modules/toolbar/toolbar-item.component.scss
+++ b/libs/components/layout/src/lib/modules/toolbar/toolbar-item.component.scss
@@ -9,21 +9,7 @@
 
 @include compatMixins.sky-modern-overrides('.sky-toolbar-item') {
   --sky-override-toolbar-item-text-color: var(--sky-color-text-default);
-}
-
-.sky-toolbar-item {
-  margin-right: var(
-    --sky-override-toolbar-item-spacing-right,
-    var(--sky-space-gap-action_group-m)
-  );
-  margin-bottom: var(--sky-override-toolbar-item-spacing-bottom);
-}
-
-@include mixins.sky-theme-modern {
   ::ng-deep .sky-btn {
-    padding-left: var(--sky-comp-button-toolbar-space-inset-left);
-    padding-right: var(--sky-comp-button-toolbar-space-inset-right);
-
     &.sky-btn-default:not(:disabled):not(
         .sky-search-btn,
         .sky-search-btn-open,
@@ -47,5 +33,20 @@
         );
       }
     }
+  }
+}
+
+.sky-toolbar-item {
+  margin-right: var(
+    --sky-override-toolbar-item-spacing-right,
+    var(--sky-space-gap-action_group-m)
+  );
+  margin-bottom: var(--sky-override-toolbar-item-spacing-bottom);
+}
+
+@include mixins.sky-theme-modern {
+  ::ng-deep .sky-btn {
+    padding-left: var(--sky-comp-button-toolbar-space-inset-left);
+    padding-right: var(--sky-comp-button-toolbar-space-inset-right);
   }
 }


### PR DESCRIPTION
:cherries: Cherry picked from #3643 [feat(components/layout): remove secondary button overrides in modern v2 toolbar](https://github.com/blackbaud/skyux/pull/3643)

[AB#3436401](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3436401) 