### PR TITLE
fix(components/datetime): month and year buttons in datepicker calendar use specific component tokens for padding (#3661)

### DIFF
--- a/apps/e2e/datetime-storybook-e2e/src/e2e/datepicker.component.cy.ts
+++ b/apps/e2e/datetime-storybook-e2e/src/e2e/datepicker.component.cy.ts
@@ -12,7 +12,11 @@ describe('Date picker', () => {
       });
 
       it('should show day picker', () => {
-        cy.get('#screenshot-datepicker').skyVisualTest(
+        cy.get('.sky-datepicker-calendar-table-container').blur({
+          force: true,
+        });
+
+        cy.get('#screenshot-datepicker-calendar').skyVisualTest(
           `datepicker-day-picker-${theme}`,
           {
             overwrite: true,
@@ -26,11 +30,15 @@ describe('Date picker', () => {
           '#screenshot-datepicker-calendar .sky-datepicker-calendar-title',
         ).click();
 
+        cy.get(
+          '#screenshot-datepicker-calendar .sky-datepicker-calendar-title',
+        ).blur();
+
         cy.get('#screenshot-datepicker-calendar .sky-datepicker-calendar-title')
           .invoke('text')
           .should('match', /^\d{4}$/);
 
-        cy.get('#screenshot-datepicker').skyVisualTest(
+        cy.get('#screenshot-datepicker-calendar').skyVisualTest(
           `datepicker-month-picker-${theme}`,
           {
             overwrite: true,
@@ -56,7 +64,7 @@ describe('Date picker', () => {
           .invoke('text')
           .should('match', /^\d{4} - \d{4}$/);
 
-        cy.get('#screenshot-datepicker').skyVisualTest(
+        cy.get('#screenshot-datepicker-calendar').skyVisualTest(
           `datepicker-year-picker-${theme}`,
           {
             overwrite: true,

--- a/libs/components/datetime/src/lib/modules/datepicker/calendar/datepicker-calendar-inner.component.scss
+++ b/libs/components/datetime/src/lib/modules/datepicker/calendar/datepicker-calendar-inner.component.scss
@@ -374,10 +374,10 @@ sky-monthpicker {
   .sky-btn.sky-btn-default {
     padding: var(
       --sky-override-datepicker-month-year-button-padding,
-      var(--sky-comp-button-borderless-space-inset-top)
-        var(--sky-comp-button-borderless-space-inset-right)
-        var(--sky-comp-button-borderless-space-inset-bottom)
-        var(--sky-comp-button-borderless-space-inset-left)
+      var(--sky-comp-datepicker-m_y_button-space-inset-top)
+        var(--sky-comp-datepicker-m_y_button-space-inset-right)
+        var(--sky-comp-datepicker-m_y_button-space-inset-bottom)
+        var(--sky-comp-datepicker-m_y_button-space-inset-left)
     );
   }
 }


### PR DESCRIPTION
:cherries: Cherry picked from #3661 [fix(components/datetime): month and year buttons in datepicker calendar use specific component tokens for padding](https://github.com/blackbaud/skyux/pull/3661)

[AB#3416449](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3416449) 