### PR TITLE
fix: buttons in toolbars use specific elevation tokens in v2 modern (#3664)

### DIFF
--- a/libs/components/layout/src/lib/modules/toolbar/toolbar-item.component.scss
+++ b/libs/components/layout/src/lib/modules/toolbar/toolbar-item.component.scss
@@ -42,6 +42,22 @@
     var(--sky-space-gap-action_group-m)
   );
   margin-bottom: var(--sky-override-toolbar-item-spacing-bottom);
+
+  --sky-comp-override-toolbar-button-elevation-base: var(
+    --sky-elevation-action-toolbar-base
+  );
+  --sky-comp-override-toolbar-button-elevation-hover: var(
+    --sky-elevation-action-toolbar-hover
+  );
+  --sky-comp-override-toolbar-button-elevation-focus: var(
+    --sky-elevation-action-toolbar-focus
+  );
+  --sky-comp-override-toolbar-button-elevation-active: var(
+    --sky-elevation-action-toolbar-active
+  );
+  --sky-comp-override-toolbar-button-elevation-disabled: var(
+    --sky-elevation-action-toolbar-disabled
+  );
 }
 
 @include mixins.sky-theme-modern {

--- a/libs/components/theme/src/lib/styles/themes/modern/_buttons.scss
+++ b/libs/components/theme/src/lib/styles/themes/modern/_buttons.scss
@@ -201,14 +201,20 @@
     box-shadow:
       inset 0 0 0 var(--sky-border-width-action-base)
         var(--sky-color-border-action-secondary-base),
-      var(--sky-elevation-action-secondary-base);
+      var(
+        --sky-comp-override-toolbar-button-elevation-base,
+        var(--sky-elevation-action-secondary-base)
+      );
 
     &:hover {
       background-color: var(--sky-color-background-action-secondary-hover);
       box-shadow:
         inset 0 0 0 var(--sky-border-width-action-hover)
           var(--sky-color-border-action-secondary-hover),
-        var(--sky-elevation-action-secondary-hover);
+        var(
+          --sky-comp-override-toolbar-button-elevation-hover,
+          var(--sky-elevation-action-secondary-hover)
+        );
     }
 
     &:active,
@@ -217,7 +223,10 @@
       box-shadow:
         inset 0 0 0 var(--sky-border-width-action-active)
           var(--sky-color-border-action-secondary-active),
-        var(--sky-elevation-action-secondary-active);
+        var(
+          --sky-comp-override-toolbar-button-elevation-active,
+          var(--sky-elevation-action-secondary-active)
+        );
       transition: var(--sky-override-button-box-shadow-hover-transition, none);
     }
 
@@ -227,7 +236,10 @@
         --sky-override-button-default-box-shadow-focus,
         inset 0 0 0 var(--sky-border-width-action-focus)
           var(--sky-color-border-action-secondary-focus),
-        var(--sky-elevation-action-secondary-focus)
+        var(
+          --sky-comp-override-toolbar-button-elevation-focus,
+          var(--sky-elevation-action-secondary-focus)
+        )
       );
     }
 
@@ -242,7 +254,10 @@
         box-shadow:
           inset 0 0 0 var(--sky-border-width-action-disabled)
             var(--sky-color-border-action-secondary-disabled),
-          var(--sky-elevation-action-secondary-disabled);
+          var(
+            --sky-comp-override-toolbar-button-elevation-disabled,
+            var(--sky-elevation-action-secondary-disabled)
+          );
         background-color: var(--sky-color-background-action-secondary-disabled);
 
         &:is(:focus-visible, .sky-btn-focus) {
@@ -250,7 +265,10 @@
             --sky-override-button-icon-disabled-box-shadow,
             inset 0 0 0 var(--sky-border-width-action-disabled)
               var(--sky-color-border-action-secondary-disabled),
-            var(--sky-elevation-action-secondary-disabled)
+            var(
+              --sky-comp-override-toolbar-button-elevation-disabled,
+              var(--sky-elevation-action-secondary-disabled)
+            )
           );
         }
       }
@@ -263,14 +281,20 @@
     box-shadow:
       inset 0 0 0 var(--sky-border-width-action-base)
         var(--sky-color-border-action-primary-base),
-      var(--sky-elevation-action-primary-base);
+      var(
+        --sky-comp-override-toolbar-button-elevation-base,
+        var(--sky-elevation-action-primary-base)
+      );
 
     &:hover {
       background-color: var(--sky-color-background-action-primary-hover);
       box-shadow:
         inset 0 0 0 var(--sky-border-width-action-hover)
           var(--sky-color-border-action-primary-hover),
-        var(--sky-elevation-action-primary-hover);
+        var(
+          --sky-comp-override-toolbar-button-elevation-hover,
+          var(--sky-elevation-action-primary-hover)
+        );
     }
 
     &:active,
@@ -279,7 +303,10 @@
       box-shadow:
         inset 0 0 0 var(--sky-border-width-action-active)
           var(--sky-color-border-action-primary-active),
-        var(--sky-elevation-action-primary-active);
+        var(
+          --sky-comp-override-toolbar-button-elevation-active,
+          var(--sky-elevation-action-primary-active)
+        );
       transition: var(--sky-override-button-box-shadow-hover-transition, none);
     }
 
@@ -289,7 +316,10 @@
         --sky-override-button-primary-box-shadow-focus,
         inset 0 0 0 var(--sky-border-width-action-focus)
           var(--sky-color-border-action-primary-focus),
-        var(--sky-elevation-action-primary-focus)
+        var(
+          --sky-comp-override-toolbar-button-elevation-focus,
+          var(--sky-elevation-action-primary-focus)
+        )
       );
     }
 
@@ -304,7 +334,10 @@
         box-shadow:
           inset 0 0 0 var(--sky-border-width-action-disabled)
             var(--sky-color-border-action-primary-disabled),
-          var(--sky-elevation-action-primary-disabled);
+          var(
+            --sky-comp-override-toolbar-button-elevation-disabled,
+            var(--sky-elevation-action-primary-disabled)
+          );
         background-color: var(--sky-color-background-action-primary-disabled);
 
         &:is(:focus-visible, .sky-btn-focus) {
@@ -312,7 +345,10 @@
             --sky-override-button-primary-disabled-box-shadow,
             inset 0 0 0 var(--sky-border-width-action-disabled)
               var(--sky-color-border-action-primary-disabled),
-            var(--sky-elevation-action-primary-disabled)
+            var(
+              --sky-comp-override-toolbar-button-elevation-disabled,
+              var(--sky-elevation-action-primary-disabled)
+            )
           );
         }
       }
@@ -325,14 +361,20 @@
     box-shadow:
       inset 0 0 0 var(--sky-border-width-action-base)
         var(--sky-color-border-action-danger-base),
-      var(--sky-elevation-action-danger-base);
+      var(
+        --sky-comp-override-toolbar-button-elevation-base,
+        var(--sky-elevation-action-danger-base)
+      );
 
     &:hover {
       background-color: var(--sky-color-background-action-danger-hover);
       box-shadow:
         inset 0 0 0 var(--sky-border-width-action-hover)
           var(--sky-color-border-action-danger-hover),
-        var(--sky-elevation-action-danger-hover);
+        var(
+          --sky-comp-override-toolbar-button-elevation-hover,
+          var(--sky-elevation-action-danger-hover)
+        );
     }
 
     &:active,
@@ -341,7 +383,10 @@
       box-shadow:
         inset 0 0 0 var(--sky-border-width-action-active)
           var(--sky-color-border-action-danger-active),
-        var(--sky-elevation-action-danger-active);
+        var(
+          --sky-comp-override-toolbar-button-elevation-active,
+          var(--sky-elevation-action-danger-active)
+        );
       transition: var(--sky-override-button-box-shadow-hover-transition, none);
     }
 
@@ -351,7 +396,10 @@
         --sky-override-button-danger-box-shadow-focus,
         inset 0 0 0 var(--sky-border-width-action-focus)
           var(--sky-color-border-action-danger-focus),
-        var(--sky-elevation-action-danger-focus)
+        var(
+          --sky-comp-override-toolbar-button-elevation-focus,
+          var(--sky-elevation-action-danger-focus)
+        )
       );
     }
 
@@ -366,7 +414,10 @@
         box-shadow:
           inset 0 0 0 var(--sky-border-width-action-disabled)
             var(--sky-color-border-action-danger-disabled),
-          var(--sky-elevation-action-danger-disabled);
+          var(
+            --sky-comp-override-toolbar-button-elevation-disabled,
+            var(--sky-elevation-action-danger-disabled)
+          );
         background-color: var(--sky-color-background-action-danger-disabled);
 
         &:is(:focus-visible, .sky-btn-focus) {
@@ -374,7 +425,10 @@
             --sky-override-button-danger-disabled-box-shadow,
             inset 0 0 0 var(--sky-border-width-action-disabled)
               var(--sky-color-border-action-danger-disabled),
-            var(--sky-elevation-action-danger-disabled)
+            var(
+              --sky-comp-override-toolbar-button-elevation-disabled,
+              var(--sky-elevation-action-danger-disabled)
+            )
           );
         }
       }
@@ -410,14 +464,20 @@
     box-shadow:
       inset 0 0 0 var(--sky-border-width-action-base)
         var(--sky-color-border-action-tertiary-base),
-      var(--sky-elevation-action-tertiary-base);
+      var(
+        --sky-comp-override-toolbar-button-elevation-base,
+        var(--sky-elevation-action-tertiary-base)
+      );
 
     &:hover {
       background-color: var(--sky-color-background-action-tertiary-hover);
       box-shadow:
         inset 0 0 0 var(--sky-border-width-action-hover)
           var(--sky-color-border-action-tertiary-hover),
-        var(--sky-elevation-action-tertiary-hover);
+        var(
+          --sky-comp-override-toolbar-button-elevation-hover,
+          var(--sky-elevation-action-tertiary-hover)
+        );
     }
 
     &:active,
@@ -426,7 +486,10 @@
       box-shadow:
         inset 0 0 0 var(--sky-border-width-action-active)
           var(--sky-color-border-action-tertiary-active),
-        var(--sky-elevation-action-tertiary-active);
+        var(
+          --sky-comp-override-toolbar-button-elevation-active,
+          var(--sky-elevation-action-tertiary-active)
+        );
       transition: var(--sky-override-button-box-shadow-hover-transition, none);
     }
 
@@ -436,7 +499,10 @@
         --sky-override-button-tertiary-box-shadow-focus,
         inset 0 0 0 var(--sky-border-width-action-focus)
           var(--sky-color-border-action-tertiary-focus),
-        var(--sky-elevation-action-tertiary-focus)
+        var(
+          --sky-comp-override-toolbar-button-elevation-focus,
+          var(--sky-elevation-action-tertiary-focus)
+        )
       );
     }
 
@@ -451,7 +517,10 @@
         box-shadow:
           inset 0 0 0 var(--sky-border-width-action-disabled)
             var(--sky-color-border-action-tertiary-disabled),
-          var(--sky-elevation-action-tertiary-disabled);
+          var(
+            --sky-comp-override-toolbar-button-elevation-disabled,
+            var(--sky-elevation-action-tertiary-disabled)
+          );
         background-color: var(--sky-color-background-action-tertiary-disabled);
 
         &:is(:focus-visible, .sky-btn-focus) {
@@ -459,7 +528,10 @@
             --sky-override-button-tertiary-disabled-box-shadow,
             inset 0 0 0 var(--sky-border-width-action-disabled)
               var(--sky-color-border-action-tertiary-disabled),
-            var(--sky-elevation-action-tertiary-disabled)
+            var(
+              --sky-comp-override-toolbar-button-elevation-disabled,
+              var(--sky-elevation-action-tertiary-disabled)
+            )
           );
         }
       }


### PR DESCRIPTION
:cherries: Cherry picked from #3664 [fix: buttons in toolbars use specific elevation tokens in v2 modern](https://github.com/blackbaud/skyux/pull/3664)

[AB#3429100](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3429100) 