### PR TITLE
fix: checkboxes, radios, and toggle switches use deemphasized label color when the switch is disabled in v2 modern (#3665)

### DIFF
--- a/libs/components/forms/src/lib/modules/toggle-switch/toggle-switch.component.scss
+++ b/libs/components/forms/src/lib/modules/toggle-switch/toggle-switch.component.scss
@@ -29,6 +29,10 @@
   --sky-override-toggle-switch-indicator-left: 22px;
   --sky-override-toggle-switch-indicator-margin-left: -22px;
   --sky-override-toggle-switch-indicator-width: 22px;
+
+  --sky-override-toggle-switch-label-color-disabled: var(
+    --sky-text-color-default
+  );
   --sky-override-toggle-switch-label-gap: #{$sky-margin};
   --sky-override-toggle-switch-line-height: calc(20 / 14);
   --sky-override-toggle-switch-padding: 1px;
@@ -50,6 +54,9 @@
   --sky-override-toggle-switch-box-shadow-focus: var(--sky-elevation-focus);
   --sky-override-toggle-switch-indicator-box-shadow: 0px 1px 2px 0px
     rgba(0, 0, 0, 0.5);
+  --sky-override-toggle-switch-label-color-disabled: var(
+    --sky-color-text-default
+  );
   --sky-override-toggle-switch-line-height: calc(20 / 14);
   --sky-override-toggle-switch-width: var(--modern-size-48);
 }
@@ -274,6 +281,13 @@
           )
         );
         cursor: var(--sky-override-toggle-switch-pointer-disabled, not-allowed);
+      }
+
+      + span .sky-toggle-switch-label {
+        color: var(
+          --sky-override-toggle-switch-label-color-disabled,
+          var(--sky-color-text-deemphasized)
+        );
       }
 
       .sky-toggle-switch-indicator {

--- a/libs/components/theme/src/lib/styles/themes/modern/_switch.scss
+++ b/libs/components/theme/src/lib/styles/themes/modern/_switch.scss
@@ -31,6 +31,7 @@
   --sky-override-switch-icon-checked-color-no-group: var(
     --sky-color-text-default
   );
+  --sky-override-switch-label-color-disabled: var(--sky-color-text-default);
   --sky-switch-label-margin-right: #{$sky-margin};
 }
 
@@ -45,6 +46,13 @@
 
   &.sky-switch-disabled {
     cursor: not-allowed;
+
+    .sky-switch-label {
+      color: var(
+        --sky-override-switch-label-color-disabled,
+        var(--sky-color-text-deemphasized)
+      );
+    }
   }
 
   &.sky-control-label-required {


### PR DESCRIPTION
:cherries: Cherry picked from #3665 [fix: checkboxes, radios, and toggle switches use deemphasized label color when the switch is disabled in v2 modern](https://github.com/blackbaud/skyux/pull/3665)

[AB#3427457](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3427457) 