### PR TITLE
fix(components/tiles): tile tools items are center aligned (#3677)

### DIFF
--- a/apps/playground/src/app/components/tiles/tile-dashboard/tile1.component.html
+++ b/apps/playground/src/app/components/tiles/tile-dashboard/tile1.component.html
@@ -2,6 +2,8 @@
   helpPopoverContent="Sample help information for tile 1."
   helpPopoverTitle="Sample help content"
   tileName="Tile 1"
+  [showSettings]="true"
+  (settingsClick)="settingsClick()"
 >
   <sky-tile-title> Tile 1 w/ easy help inline</sky-tile-title>
   <sky-tile-summary> Tile summary</sky-tile-summary>

--- a/apps/playground/src/app/components/tiles/tile-dashboard/tile1.component.ts
+++ b/apps/playground/src/app/components/tiles/tile-dashboard/tile1.component.ts
@@ -18,4 +18,8 @@ export class Tile1Component {
   public get greeting(): string {
     return this.#greetingSvc.sayHello();
   }
+
+  protected settingsClick(): void {
+    alert('Settings clicked!');
+  }
 }

--- a/apps/playground/src/app/components/tiles/tile-dashboard/tile2.component.html
+++ b/apps/playground/src/app/components/tiles/tile-dashboard/tile2.component.html
@@ -1,4 +1,4 @@
-<sky-tile>
+<sky-tile [showSettings]="true" (settingsClick)="settingsClick()">
   <sky-tile-title>
     Tile 2 w/ legacy inline help
     <sky-help-inline

--- a/apps/playground/src/app/components/tiles/tile-dashboard/tile2.component.ts
+++ b/apps/playground/src/app/components/tiles/tile-dashboard/tile2.component.ts
@@ -16,4 +16,8 @@ export class Tile2Component {
   protected onHelpClick($event: MouseEvent): void {
     $event.stopPropagation();
   }
+
+  protected settingsClick(): void {
+    alert('Settings clicked!');
+  }
 }

--- a/apps/playground/src/app/components/tiles/tile-dashboard/tile3.component.ts
+++ b/apps/playground/src/app/components/tiles/tile-dashboard/tile3.component.ts
@@ -7,7 +7,12 @@ import { SkyTilesModule } from '@skyux/tiles';
   // eslint-disable-next-line @angular-eslint/component-selector
   selector: 'div.tile2',
   template: `
-    <sky-tile [showHelp]="true" (helpClick)="onHelpClick()">
+    <sky-tile
+      [showHelp]="true"
+      [showSettings]="true"
+      (helpClick)="onHelpClick()"
+      (settingsClick)="settingsClick()"
+    >
       <sky-tile-title> Tile 3 w/ legacy help click </sky-tile-title>
       <sky-tile-content>
         <sky-tile-content-section> Content here. </sky-tile-content-section>
@@ -18,5 +23,9 @@ import { SkyTilesModule } from '@skyux/tiles';
 export class Tile3Component {
   public onHelpClick(): void {
     console.log('help clicked');
+  }
+
+  protected settingsClick(): void {
+    alert('Settings clicked!');
   }
 }

--- a/libs/components/tiles/src/lib/modules/tiles/tile/tile.component.scss
+++ b/libs/components/tiles/src/lib/modules/tiles/tile/tile.component.scss
@@ -137,6 +137,7 @@
 }
 
 .sky-tile-tools {
+  align-items: center;
   display: flex;
   padding: 0 var(--sky-override-tile-tools-padding-right, 0) 0 0;
 }


### PR DESCRIPTION
:cherries: Cherry picked from #3677 [fix(components/tiles): tile tools items are center aligned](https://github.com/blackbaud/skyux/pull/3677)

[AB#3436345](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3436345) 