### PR TITLE
fix: selected tabs use new text and background color tokens, disabled toggle switches use updated tokens, and typography tokens are updated in v2 modern (#3688)

### DIFF
--- a/libs/components/popovers/src/lib/modules/dropdown/dropdown.component.scss
+++ b/libs/components/popovers/src/lib/modules/dropdown/dropdown.component.scss
@@ -35,6 +35,7 @@
     --sky-elevation-focus
   );
   --sky-override-tab-button-radius: 0;
+  --sky-override-tab-dropdown-color: var(--sky-color-text-default);
   --sky-override-tab-line-height: 1.8;
   --sky-override-tab-selected-background-color: var(--modern-color-transparent);
   --sky-override-tab-selected-border-bottom-size: var(--modern-size-3);
@@ -44,7 +45,7 @@
   .sky-dropdown-button-type-tab {
     background-color: var(
       --sky-override-tab-selected-background-color,
-      var(--sky-color-background-selected-soft)
+      var(--sky-color-background-tab-selected)
     );
     border: none;
     box-shadow: none;
@@ -55,7 +56,7 @@
       var(--sky-override-tab-button-radius, var(--sky-border-radius-s)) 0 0;
     color: var(
       --sky-override-tab-dropdown-color,
-      var(--sky-color-text-default)
+      var(--sky-color-text-selected)
     );
     border-bottom: var(
       --sky-override-tab-border-bottom,

--- a/libs/components/theme/package.json
+++ b/libs/components/theme/package.json
@@ -20,7 +20,7 @@
     "@angular/core": "^20.0.5"
   },
   "dependencies": {
-    "@blackbaud/skyux-design-tokens": "2.0.0-alpha.4",
+    "@blackbaud/skyux-design-tokens": "2.0.0-alpha.5",
     "@skyux/icons": "9.0.0",
     "fontfaceobserver": "2.3.0",
     "tslib": "^2.8.1"

--- a/libs/components/theme/src/lib/styles/themes/modern/_buttons.scss
+++ b/libs/components/theme/src/lib/styles/themes/modern/_buttons.scss
@@ -99,6 +99,7 @@
         --sky-border-width-selected-s
       )
   );
+  --sky-override-tab-selected-color: var(--sky-color-text-default);
   --sky-override-tab-selected-focus-color: var(--sky-color-text-default);
   --sky-override-tab-selected-focus-background-color: var(
     --sky-color-background-tab-focus
@@ -715,8 +716,11 @@
 
     &:focus-visible {
       background-color: var(--sky-color-background-tab-focus);
-      color: var(--sky-color-text-default);
       outline: none;
+
+      &:not(.sky-btn-tab-selected) {
+        color: var(--sky-color-text-default);
+      }
 
       &.sky-btn-tab-selected {
         background-color: var(
@@ -727,7 +731,9 @@
     }
 
     &:focus-visible:not(:active) {
-      color: var(--sky-color-text-default);
+      &:not(.sky-btn-tab-selected) {
+        color: var(--sky-color-text-default);
+      }
       outline: solid var(--sky-border-width-selected-m)
         var(--sky-color-border-tab-focus);
       outline-offset: calc(var(--sky-border-width-selected-m) * -1);
@@ -802,9 +808,12 @@
   .sky-btn-tab-selected:not(.sky-btn-tab-disabled) {
     background-color: var(
       --sky-override-tab-selected-background-color,
-      var(--sky-color-background-selected-soft)
+      var(--sky-color-background-tab-selected)
     );
-    color: var(--sky-color-text-default);
+    color: var(
+      --sky-override-tab-selected-color,
+      var(--sky-color-text-selected)
+    );
     box-shadow: none;
 
     &:not(:active) {
@@ -824,9 +833,12 @@
     &:hover:not(.sky-btn-tab-disabled) {
       background-color: var(
         --sky-override-tab-selected-background-color,
-        var(--sky-color-background-selected-soft)
+        var(--sky-color-background-tab-selected)
       );
-      color: var(--sky-color-text-default);
+      color: var(
+        --sky-override-tab-selected-color,
+        var(--sky-color-text-selected)
+      );
     }
 
     .sky-btn-tab-close,

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@angular/platform-browser-dynamic": "20.0.5",
         "@angular/router": "20.0.5",
         "@blackbaud/angular-tree-component": "1.0.0",
-        "@blackbaud/skyux-design-tokens": "2.0.0-alpha.4",
+        "@blackbaud/skyux-design-tokens": "2.0.0-alpha.5",
         "@eslint/js": "9.30.1",
         "@nx/angular": "21.2.1",
         "@skyux/icons": "9.0.0",
@@ -3009,9 +3009,9 @@
       }
     },
     "node_modules/@blackbaud/skyux-design-tokens": {
-      "version": "2.0.0-alpha.4",
-      "resolved": "https://registry.npmjs.org/@blackbaud/skyux-design-tokens/-/skyux-design-tokens-2.0.0-alpha.4.tgz",
-      "integrity": "sha512-7hX5FECQ6pxcwUtS+z0aVv152OoVS8507gzlS2FRN3uxJ3tsYQghB2B/+lKTpQirf4i8jae/vtv34M9JnC7VQA==",
+      "version": "2.0.0-alpha.5",
+      "resolved": "https://registry.npmjs.org/@blackbaud/skyux-design-tokens/-/skyux-design-tokens-2.0.0-alpha.5.tgz",
+      "integrity": "sha512-DSmIr12VcnjZcSnB2VAgUpdBtJW8nypuSQmJweyDxOVwqm5RdOZRy1+jNPV7JuO/PcST8dnjgX2hKkvsyI8tNA==",
       "license": "MIT",
       "engines": {
         "node": ">= 4.2.1",

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "@angular/platform-browser-dynamic": "20.0.5",
     "@angular/router": "20.0.5",
     "@blackbaud/angular-tree-component": "1.0.0",
-    "@blackbaud/skyux-design-tokens": "2.0.0-alpha.4",
+    "@blackbaud/skyux-design-tokens": "2.0.0-alpha.5",
     "@eslint/js": "9.30.1",
     "@nx/angular": "21.2.1",
     "@skyux/icons": "9.0.0",


### PR DESCRIPTION
[AB#3493825](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3493825)

[AB#3495082](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3495082)

[AB#3493637](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3493637)