### PR TITLE
fix(components/forms): toggle has a base background color in v2 modern (#3694)

### DIFF
--- a/libs/components/forms/src/lib/modules/toggle-switch/toggle-switch.component.scss
+++ b/libs/components/forms/src/lib/modules/toggle-switch/toggle-switch.component.scss
@@ -87,7 +87,7 @@
       );
       background-color: var(
         --sky-override-toggle-switch-background-color,
-        var(--sky-background-input-base)
+        var(--sky-color-background-input-base)
       );
       padding: var(
         --sky-override-toggle-switch-padding,


### PR DESCRIPTION
:cherries: Cherry picked from #3694 [fix(components/forms): toggle has a base background color in v2 modern](https://github.com/blackbaud/skyux/pull/3694)

[AB#3493629](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3493629) 