### PR TITLE
feat: remove `background-color` from inline buttons for all states (#3696)

### DIFF
--- a/libs/components/flyout/src/lib/modules/flyout/flyout.component.scss
+++ b/libs/components/flyout/src/lib/modules/flyout/flyout.component.scss
@@ -253,7 +253,7 @@
     );
     background-color: var(
       --sky-override-flyout-header-permalink-background-color,
-      var(--sky-color-background-action-tertiary-base)
+      transparent
     );
     border-radius: var(--sky-border-radius-s);
     box-shadow: var(--sky-override-flyout-header-permalink-box-shadow, none);
@@ -261,7 +261,7 @@
     &:hover {
       background-color: var(
         --sky-override-flyout-header-permalink-background-color-hover,
-        var(--sky-color-background-action-tertiary-hover)
+        transparent
       );
       box-shadow: var(
         --sky-override-flyout-header-permalink-box-shadow-hover,
@@ -273,7 +273,7 @@
     &.sky-btn-active {
       background-color: var(
         --sky-override-flyout-header-permalink-background-color-active,
-        var(--sky-color-background-action-tertiary-active)
+        transparent
       );
       box-shadow: var(
         --sky-override-flyout-header-permalink-box-shadow-active,
@@ -284,7 +284,7 @@
     &:focus-visible:not(:active) {
       background-color: var(
         --sky-override-flyout-header-permalink-background-color-focus,
-        var(--sky-color-background-action-tertiary-focus)
+        transparent
       );
       box-shadow: var(
         --sky-override-flyout-header-permalink-box-shadow-focus,

--- a/libs/components/theme/src/lib/styles/themes/modern/_buttons.scss
+++ b/libs/components/theme/src/lib/styles/themes/modern/_buttons.scss
@@ -540,7 +540,7 @@
   }
 
   .sky-btn-link-inline {
-    background-color: var(--sky-color-background-action-tertiary-base);
+    background-color: transparent;
     border-radius: var(
       --sky-override-button-link-inline-border-radius,
       var(--sky-border-radius-s)
@@ -550,7 +550,7 @@
     font-size: var(--sky-override-button-link-inline-font-size, inherit);
 
     &:focus-visible:not(:active) {
-      background-color: var(--sky-color-background-action-tertiary-focus);
+      background-color: transparent;
       box-shadow: var(
         --sky-override-button-link-inline-box-shadow-focus,
         0 0 0 var(--sky-border-width-action-focus)
@@ -559,11 +559,11 @@
     }
 
     &:active {
-      background-color: var(--sky-color-background-action-tertiary-active);
+      background-color: transparent;
     }
 
     &:hover {
-      background-color: var(--sky-color-background-action-tertiary-hover);
+      background-color: transparent;
     }
 
     &:hover,


### PR DESCRIPTION
:cherries: Cherry picked from #3696 [feat: remove `background-color` from inline buttons for all states](https://github.com/blackbaud/skyux/pull/3696)

[AB#3493626](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3493626) 