### PR TITLE
feat: replace `font-weight` tokens with `font-style` (#3687)

### DIFF
--- a/libs/components/colorpicker/src/lib/modules/colorpicker/colorpicker.component.scss
+++ b/libs/components/colorpicker/src/lib/modules/colorpicker/colorpicker.component.scss
@@ -802,7 +802,7 @@ sky-colorpicker.sky-form-field-stacked {
     font-style: var(--sky-font-style-input-label);
     font-weight: var(
       --sky-override-colorpicker-label-font-weight,
-      var(--sky-font-weight-input-label)
+      var(--sky-font-style-input-label)
     );
     letter-spacing: var(--sky-font-letter_spacing-input-label);
     line-height: var(

--- a/libs/components/forms/src/lib/modules/file-attachment/file-drop/file-drop.component.scss
+++ b/libs/components/forms/src/lib/modules/file-attachment/file-drop/file-drop.component.scss
@@ -70,10 +70,10 @@
     --sky-font-size-display-3
   );
   --sky-override-file-drop-text-header-font-weight: var(
-    --sky-font-weight-display-3
+    --sky-font-style-display-3
   );
   --sky-override-file-drop-text-font-size: #{$sky-font-size-base};
-  --sky-override-file-drop-text-font-weight: var(--sky-font-weight-body-m);
+  --sky-override-file-drop-text-font-weight: var(--sky-font-style-body-m);
   --sky-override-file-drop-text-header-line-height: var(
     --modern-line_height-110
   );
@@ -354,7 +354,7 @@ button.sky-file-drop {
   font-style: var(--sky-font-style-body-m);
   font-weight: var(
     --sky-override-file-drop-text-header-font-weight,
-    var(--sky-font-weight-body-m)
+    var(--sky-font-style-body-m)
   );
   line-height: var(
     --sky-override-file-drop-text-header-line-height,
@@ -375,7 +375,7 @@ button.sky-file-drop {
   font-style: var(--sky-font-style-body-s);
   font-weight: var(
     --sky-override-file-drop-text-font-weight,
-    var(--sky-font-weight-body-s)
+    var(--sky-font-style-body-s)
   );
   line-height: var(
     --sky-override-file-drop-text-line-height,
@@ -411,7 +411,7 @@ button.sky-file-drop {
     var(--sky-font-size-input-label)
   );
   font-style: var(--sky-font-style-input-label);
-  font-weight: var(--sky-font-weight-input-label);
+  font-weight: var(--sky-font-style-input-label);
   letter-spacing: var(--sky-font-letter_spacing-input-label);
   line-height: var(--sky-font-line_height-input-label);
 }

--- a/libs/components/forms/src/lib/modules/file-attachment/file-drop/file-item.component.scss
+++ b/libs/components/forms/src/lib/modules/file-attachment/file-drop/file-item.component.scss
@@ -35,7 +35,7 @@
   --sky-override-file-item-preview-other-font-size: 100px;
   --sky-override-file-item-size-line-height: normal;
   --sky-override-file-item-size-font-size: var(--sky-font-size-body-m);
-  --sky-override-file-item-size-font-weight: var(--sky-font-weight-body-m);
+  --sky-override-file-item-size-font-weight: var(--sky-font-style-body-m);
 }
 
 :host:not(:last-of-type) {
@@ -102,7 +102,7 @@
   text-overflow: ellipsis;
   font-weight: var(
     --sky-override-file-item-name-font-weight,
-    var(--sky-font-weight-body-m)
+    var(--sky-font-style-body-m)
   );
   font-size: var(
     --sky-override-file-item-name-font-size,
@@ -118,7 +118,7 @@
 .sky-file-item-size {
   font-weight: var(
     --sky-override-file-item-size-font-weight,
-    var(--sky-font-weight-body-s)
+    var(--sky-font-style-body-s)
   );
   font-size: var(
     --sky-override-file-item-size-font-size,

--- a/libs/components/forms/src/lib/modules/input-box/input-box.component.scss
+++ b/libs/components/forms/src/lib/modules/input-box/input-box.component.scss
@@ -403,7 +403,7 @@ sky-input-box {
             var(--sky-comp-input-label-space-inset-bottom)
           );
           font-style: var(--sky-font-style-input-label);
-          font-weight: var(--sky-font-weight-input-label);
+          font-weight: var(--sky-font-style-input-label);
 
           &:has(+ sky-character-counter-indicator) {
             margin-right: var(--sky-comp-input-label-space-inset-right);

--- a/libs/components/forms/src/lib/modules/selection-box/selection-box-grid.component.scss
+++ b/libs/components/forms/src/lib/modules/selection-box/selection-box-grid.component.scss
@@ -107,7 +107,7 @@
         );
         font-weight: var(
           --sky-override-selection-box-header-heading-3-font-weight,
-          var(--sky-font-weight-display-2)
+          var(--sky-font-style-display-2)
         );
         line-height: var(
           --sky-override-selection-box-header-heading-3-line-height,
@@ -132,7 +132,7 @@
         );
         font-weight: var(
           --sky-override-selection-box-header-heading-3-font-weight-no-icon-sm,
-          var(--sky-font-weight-display-2)
+          var(--sky-font-style-display-2)
         );
         line-height: var(
           --sky-override-selection-box-header-heading-3-line-height,
@@ -173,7 +173,7 @@
         );
         font-weight: var(
           --sky-override-selection-box-header-heading-3-font-weight,
-          var(--sky-font-weight-display-2)
+          var(--sky-font-style-display-2)
         );
         line-height: var(
           --sky-override-selection-box-header-heading-3-line-height,
@@ -198,7 +198,7 @@
         );
         font-weight: var(
           --sky-override-selection-box-header-heading-3-font-weight-no-icon-sm,
-          var(--sky-font-weight-display-2)
+          var(--sky-font-style-display-2)
         );
         line-height: var(
           --sky-override-selection-box-header-heading-3-line-height,
@@ -223,7 +223,7 @@
         );
         font-weight: var(
           --sky-override-selection-box-header-heading-2-font-weight,
-          var(--sky-font-weight-display-2)
+          var(--sky-font-style-display-2)
         );
         line-height: var(
           --sky-override-selection-box-header-heading-2-line-height,
@@ -248,7 +248,7 @@
         );
         font-weight: var(
           --sky-override-selection-box-header-heading-3-font-weight-no-icon,
-          var(--sky-font-weight-display-2)
+          var(--sky-font-style-display-2)
         );
         line-height: var(
           --sky-override-selection-box-header-heading-3-line-height,
@@ -273,7 +273,7 @@
         );
         font-weight: var(
           --sky-override-selection-box-header-heading-2-font-weight,
-          var(--sky-font-weight-display-2)
+          var(--sky-font-style-display-2)
         );
         line-height: var(
           --sky-override-selection-box-header-heading-2-line-height,
@@ -298,7 +298,7 @@
         );
         font-weight: var(
           --sky-override-selection-box-header-heading-3-font-weight-no-icon,
-          var(--sky-font-weight-display-2)
+          var(--sky-font-style-display-2)
         );
         line-height: var(
           --sky-override-selection-box-header-heading-3-line-height,

--- a/libs/components/layout/src/lib/modules/description-list/description-list.component.scss
+++ b/libs/components/layout/src/lib/modules/description-list/description-list.component.scss
@@ -138,7 +138,7 @@
         );
         font-weight: var(
           --sky-override-description-list-long-term-font-weight,
-          var(--sky-font-weight-emphasized)
+          var(--sky-font-style-emphasized)
         );
         margin: 0
           var(

--- a/libs/components/lists/src/lib/modules/filter/filter-summary.component.scss
+++ b/libs/components/lists/src/lib/modules/filter/filter-summary.component.scss
@@ -22,7 +22,7 @@
   );
   font-weight: var(
     --sky-override-filter-summary-font-weight,
-    var(--sky-font-weight-emphasized)
+    var(--sky-font-style-emphasized)
   );
 }
 

--- a/libs/components/lists/src/lib/modules/sort/sort-item.component.scss
+++ b/libs/components/lists/src/lib/modules/sort/sort-item.component.scss
@@ -177,7 +177,7 @@
     );
     font-weight: var(
       --sky-override-sort-item-font-weight-selected,
-      var(--sky-font-weight-body-m)
+      var(--sky-font-style-body-m)
     );
     color: var(
       --sky-override-sort-item-color-text,

--- a/libs/components/modals/src/lib/modules/modal/modal-header.component.scss
+++ b/libs/components/modals/src/lib/modules/modal/modal-header.component.scss
@@ -10,7 +10,7 @@
 
 @include compatMixins.sky-modern-overrides('.sky-modal-heading') {
   --sky-override-modal-h2-font-size: var(--sky-font-size-display-3);
-  --sky-override-modal-h2-font-weight: var(--sky-font-weight-display-3);
+  --sky-override-modal-h2-font-weight: var(--sky-font-style-display-3);
   --sky-override-modal-h2-line-height: 1.2;
 }
 
@@ -28,6 +28,6 @@ h2.sky-modal-heading {
   );
   font-weight: var(
     --sky-override-modal-h2-font-weight,
-    var(--sky-font-weight-heading-2)
+    var(--sky-font-style-heading-2)
   );
 }

--- a/libs/components/navbar/src/lib/modules/navbar/navbar-item.component.scss
+++ b/libs/components/navbar/src/lib/modules/navbar/navbar-item.component.scss
@@ -84,7 +84,7 @@
   display: block;
   font-weight: var(
     --sky-override-navbar-item-font-weight,
-    var(--sky-font-weight-body-m)
+    var(--sky-font-style-body-m)
   );
   margin-right: var(
     --sky-override-navbar-item-margin-right,

--- a/libs/components/popovers/src/lib/modules/dropdown/dropdown.component.scss
+++ b/libs/components/popovers/src/lib/modules/dropdown/dropdown.component.scss
@@ -71,7 +71,7 @@
     font-size: var(--sky-override-tab-font-size, var(--sky-font-size-body-m));
     font-weight: var(
       --sky-override-tab-font-weight,
-      var(--sky-font-weight-body-m)
+      var(--sky-font-style-body-m)
     );
     line-height: var(
       --sky-override-tab-line-height,

--- a/libs/components/text-editor/src/lib/modules/text-editor/text-editor.component.scss
+++ b/libs/components/text-editor/src/lib/modules/text-editor/text-editor.component.scss
@@ -116,7 +116,7 @@ sky-text-editor.sky-form-field-stacked {
       font-style: var(--sky-font-style-input-label);
       font-weight: var(
         --sky-override-text-editor-label-font-weight,
-        var(--sky-font-weight-input-label)
+        var(--sky-font-style-input-label)
       );
       letter-spacing: var(--sky-font-letter_spacing-input-label);
       line-height: var(

--- a/libs/components/theme/src/lib/styles/themes/modern/_buttons.scss
+++ b/libs/components/theme/src/lib/styles/themes/modern/_buttons.scss
@@ -685,7 +685,7 @@
     );
     color: var(--sky-color-text-deemphasized);
     font-size: var(--sky-font-size-body-m);
-    font-weight: var(--sky-font-weight-body-m);
+    font-weight: var(--sky-font-style-body-m);
     line-height: var(
       --sky-override-tab-line-height,
       var(--sky-font-line_height-body-m)

--- a/libs/components/theme/src/lib/styles/themes/modern/_theme.scss
+++ b/libs/components/theme/src/lib/styles/themes/modern/_theme.scss
@@ -10,7 +10,7 @@
   --sky-override-a-color-hover-active: var(
     --sky-text-color-action-primary-hover
   );
-  --sky-override-form-font-weight: var(--sky-font-weight-body-m);
+  --sky-override-form-font-weight: var(--sky-font-style-body-m);
   --sky-override-p-line-height: var(--sky-font-line_height-body-m);
   --sky-override-body-line-height: normal;
 }
@@ -21,7 +21,7 @@
 
 .sky-theme-modern {
   font-size: var(--sky-font-size-body-m);
-  font-weight: var(--sky-font-weight-body-m);
+  font-weight: var(--sky-font-style-body-m);
   font-family: var(--sky-font-family-primary);
   color: var(--sky-color-text-default);
   background-color: var(--sky-color-background-page);
@@ -71,7 +71,7 @@ body.sky-theme-modern {
     color: var(--sky-color-text-heading);
     font-family: var(--sky-font-family-primary);
     font-size: var(--sky-font-size-heading-1);
-    font-weight: var(--sky-font-weight-heading-1);
+    font-weight: var(--sky-font-style-heading-1);
   }
 
   h2,
@@ -79,21 +79,21 @@ body.sky-theme-modern {
     color: var(--sky-color-text-heading);
     font-family: var(--sky-font-family-primary);
     font-size: var(--sky-font-size-heading-2);
-    font-weight: var(--sky-font-weight-heading-2);
+    font-weight: var(--sky-font-style-heading-2);
   }
 
   h3,
   .sky-font-heading-3 {
     color: var(--sky-color-text-heading);
     font-size: var(--sky-font-size-heading-3);
-    font-weight: var(--sky-font-weight-heading-3);
+    font-weight: var(--sky-font-style-heading-3);
   }
 
   h4,
   .sky-font-heading-4 {
     color: var(--sky-color-text-heading);
     font-size: var(--sky-font-size-heading-4);
-    font-weight: var(--sky-font-weight-heading-4);
+    font-weight: var(--sky-font-style-heading-4);
     text-transform: none;
   }
 
@@ -101,7 +101,7 @@ body.sky-theme-modern {
   .sky-font-heading-5 {
     color: var(--sky-color-text-heading);
     font-size: var(--sky-font-size-heading-5);
-    font-weight: var(--sky-font-weight-heading-5);
+    font-weight: var(--sky-font-style-heading-5);
     text-transform: none;
   }
 

--- a/libs/components/theme/src/lib/styles/themes/modern/_type.scss
+++ b/libs/components/theme/src/lib/styles/themes/modern/_type.scss
@@ -6,35 +6,35 @@
     color: var(--sky-color-text-default);
     font-family: var(--sky-font-family-primary);
     font-size: var(--sky-font-size-body-m);
-    font-weight: var(--sky-font-weight-body-m);
+    font-weight: var(--sky-font-style-body-m);
   }
 
   .sky-font-body-sm {
     color: var(--sky-color-text-default);
     font-family: var(--sky-font-family-primary);
     font-size: var(--sky-font-size-body-s);
-    font-weight: var(--sky-font-weight-body-s);
+    font-weight: var(--sky-font-style-body-s);
   }
 
   .sky-font-body-lg {
     color: var(--sky-color-text-default);
     font-family: var(--sky-font-family-primary);
     font-size: var(--sky-font-size-body-l);
-    font-weight: var(--sky-font-weight-body-l);
+    font-weight: var(--sky-font-style-body-l);
   }
 
   .sky-font-data-label {
     color: var(--sky-color-text-deemphasized);
     font-family: var(--sky-font-family-primary);
     font-size: var(--sky-font-size-body-m);
-    font-weight: var(--sky-font-weight-body-m);
+    font-weight: var(--sky-font-style-body-m);
   }
 
   .sky-font-field-label {
     color: var(--sky-color-text-deemphasized);
     font-family: var(--sky-font-family-primary);
     font-size: var(--sky-font-size-body-m);
-    font-weight: var(--sky-font-weight-body-m);
+    font-weight: var(--sky-font-style-body-m);
   }
 
   .sky-font-deemphasized {
@@ -48,7 +48,7 @@
   .sky-font-emphasized {
     font-family: var(--sky-font-family-primary);
     font-size: inherit;
-    font-weight: var(--sky-font-weight-emphasized);
+    font-weight: var(--sky-font-style-emphasized);
   }
 
   .sky-font-hint-text-s {
@@ -56,7 +56,7 @@
     font-family: var(--sky-font-family-primary);
     font-size: var(--sky-font-size-hint-s);
     font-style: var(--sky-font-style-hint-s-style);
-    font-weight: var(--sky-font-weight-hint-s);
+    font-weight: var(--sky-font-style-hint-s);
     letter-spacing: var(--sky-font-letter_spacing-hint-s);
     line-height: var(--sky-font-line_height-hint-s);
   }
@@ -66,7 +66,7 @@
     font-family: var(--sky-font-family-primary);
     font-size: var(--sky-font-size-hint-m);
     font-style: var(--sky-font-style-hint-m-style);
-    font-weight: var(--sky-font-weight-hint-m);
+    font-weight: var(--sky-font-style-hint-m);
     line-height: var(--sky-font-line_height-hint-m);
   }
 
@@ -74,14 +74,14 @@
     color: var(--sky-color-text-default);
     font-family: var(--sky-font-family-primary);
     font-size: var(--sky-font-size-display-1);
-    font-weight: var(--sky-font-weight-display-1);
+    font-weight: var(--sky-font-style-display-1);
   }
 
   .sky-font-display-2 {
     color: var(--sky-color-text-default);
     font-family: var(--sky-font-family-primary);
     font-size: var(--sky-font-size-display-2);
-    font-weight: var(--sky-font-weight-display-2);
+    font-weight: var(--sky-font-style-display-2);
   }
 
   .sky-font-display-3,
@@ -89,14 +89,14 @@
     color: var(--sky-color-text-default);
     font-family: var(--sky-font-family-primary);
     font-size: var(--sky-font-size-display-3);
-    font-weight: var(--sky-font-weight-display-3);
+    font-weight: var(--sky-font-style-display-3);
   }
 
   .sky-font-display-4 {
     color: var(--sky-color-text-default);
     font-family: var(--sky-font-family-primary);
     font-size: var(--sky-font-size-display-4);
-    font-weight: var(--sky-font-weight-display-4);
+    font-weight: var(--sky-font-style-display-4);
   }
 }
 


### PR DESCRIPTION
:cherries: Cherry picked from #3687 [feat: replace `font-weight` tokens with `font-style`](https://github.com/blackbaud/skyux/pull/3687)

[AB#3429118](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3429118) 