### PR TITLE
chore: bump design token library to `alpha.7` (#3698)

### DIFF
--- a/libs/components/theme/package.json
+++ b/libs/components/theme/package.json
@@ -20,7 +20,7 @@
     "@angular/core": "^20.0.5"
   },
   "dependencies": {
-    "@blackbaud/skyux-design-tokens": "2.0.0-alpha.5",
+    "@blackbaud/skyux-design-tokens": "2.0.0-alpha.7",
     "@skyux/icons": "9.0.0",
     "fontfaceobserver": "2.3.0",
     "tslib": "^2.8.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@angular/platform-browser-dynamic": "20.0.5",
         "@angular/router": "20.0.5",
         "@blackbaud/angular-tree-component": "1.0.0",
-        "@blackbaud/skyux-design-tokens": "2.0.0-alpha.5",
+        "@blackbaud/skyux-design-tokens": "2.0.0-alpha.7",
         "@eslint/js": "9.30.1",
         "@nx/angular": "21.2.1",
         "@skyux/icons": "9.0.0",
@@ -3009,10 +3009,9 @@
       }
     },
     "node_modules/@blackbaud/skyux-design-tokens": {
-      "version": "2.0.0-alpha.5",
-      "resolved": "https://registry.npmjs.org/@blackbaud/skyux-design-tokens/-/skyux-design-tokens-2.0.0-alpha.5.tgz",
-      "integrity": "sha512-DSmIr12VcnjZcSnB2VAgUpdBtJW8nypuSQmJweyDxOVwqm5RdOZRy1+jNPV7JuO/PcST8dnjgX2hKkvsyI8tNA==",
-      "license": "MIT",
+      "version": "2.0.0-alpha.7",
+      "resolved": "https://registry.npmjs.org/@blackbaud/skyux-design-tokens/-/skyux-design-tokens-2.0.0-alpha.7.tgz",
+      "integrity": "sha512-hu+oo0p7iFCPzfwc9zGyCvQKheanzcGqHTPruDBGGVU4yfGNpZ8RrIbGcSgAw8W3MH2fVr+5O65o3+Z+dwhaHA==",
       "engines": {
         "node": ">= 4.2.1",
         "npm": ">= 3"

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "@angular/platform-browser-dynamic": "20.0.5",
     "@angular/router": "20.0.5",
     "@blackbaud/angular-tree-component": "1.0.0",
-    "@blackbaud/skyux-design-tokens": "2.0.0-alpha.5",
+    "@blackbaud/skyux-design-tokens": "2.0.0-alpha.7",
     "@eslint/js": "9.30.1",
     "@nx/angular": "21.2.1",
     "@skyux/icons": "9.0.0",


### PR DESCRIPTION
:cherries: Cherry picked from #3698 [chore: bump design token library to alpha.7](https://github.com/blackbaud/skyux/pull/3698)

[AB#3429118](https://dev.azure.com/blackbaud/Products/_boards/board/t/SKY%20UX%20Program/Stories?System.AssignedTo=%40me&workitem=3429118) 