### PR TITLE
feat(components/indicators): use correct label line height (#3710)

### DIFF
--- a/libs/components/indicators/src/lib/modules/label/label.component.scss
+++ b/libs/components/indicators/src/lib/modules/label/label.component.scss
@@ -97,8 +97,11 @@
     --sky-override-label-border-radius-pill,
     var(--sky-border-radius-pill)
   );
-  line-height: var(--sky-override-label-line-height, unset);
-  margin: var(--sky-override-label-margin, unset);
+  line-height: var(
+    --sky-override-label-line-height,
+    var(--sky-font-line_height-body-m)
+  );
+  margin: var(--sky-override-label-margin, 0);
   white-space: nowrap;
   padding: var(
     --sky-override-label-padding,


### PR DESCRIPTION
:cherries: Cherry picked from #3710 [feat(components/indicators): use correct label line height](https://github.com/blackbaud/skyux/pull/3710)