### PR TITLE
feat(components/lookup): lookup no longer displays a search icon when `showMore` is not enabled

### DIFF
--- a/libs/components/lookup/src/lib/modules/lookup/lookup.component.html
+++ b/libs/components/lookup/src/lib/modules/lookup/lookup.component.html
@@ -74,9 +74,6 @@
                 (keydown)="inputKeydown($event)"
                 (keyup)="inputKeyup($event)"
               ></textarea>
-              @if (!inputBoxHostSvc && !enableShowMore) {
-                <ng-container *ngTemplateOutlet="searchIconTemplateRef" />
-              }
             </sky-tokens>
           } @else if (selectMode === 'single') {
             <div class="sky-lookup-single-control">
@@ -95,9 +92,6 @@
                 (blur)="onAutocompleteBlur()"
                 (focus)="onFocus($event)"
               ></textarea>
-              @if (!inputBoxHostSvc && !enableShowMore) {
-                <ng-container *ngTemplateOutlet="searchIconTemplateRef" />
-              }
             </div>
           }
         </div>
@@ -123,14 +117,5 @@
     >
       <sky-icon iconName="search" iconSize="l" />
     </button>
-  </div>
-</ng-template>
-
-<ng-template #searchIconTemplateRef>
-  <div
-    class="sky-input-group-icon sky-input-box-icon-inset"
-    [ngClass]="{ 'sky-lookup-disabled': disabled }"
-  >
-    <sky-icon iconName="search" iconSize="l" />
   </div>
 </ng-template>

--- a/libs/components/lookup/src/lib/modules/lookup/lookup.component.ts
+++ b/libs/components/lookup/src/lib/modules/lookup/lookup.component.ts
@@ -315,12 +315,6 @@ export class SkyLookupComponent
   })
   public lookupWrapperRef: ElementRef | undefined;
 
-  @ViewChild('searchIconTemplateRef', {
-    read: TemplateRef,
-    static: true,
-  })
-  public searchIconTemplateRef: TemplateRef<unknown> | undefined;
-
   #idle = new Subject<void>();
   #markForTokenFocusOnKeyUp = false;
   #ngUnsubscribe = new Subject<void>();
@@ -389,9 +383,6 @@ export class SkyLookupComponent
         buttonsTemplate: this.enableShowMore
           ? this.showMoreButtonTemplateRef
           : undefined,
-        iconsInsetTemplate: this.enableShowMore
-          ? undefined
-          : this.searchIconTemplateRef,
       });
 
       this.inputBoxHostSvc?.setRequired(this.required);


### PR DESCRIPTION
[AB#3493586](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3493586)