### PR TITLE
fix(components/datetime): datepicker callendar header uses standard button styles in v2 modern (#3707)

### DIFF
--- a/libs/components/datetime/src/lib/modules/datepicker/calendar/datepicker-calendar-inner.component.html
+++ b/libs/components/datetime/src/lib/modules/datepicker/calendar/datepicker-calendar-inner.component.html
@@ -4,8 +4,12 @@
       <span class="sky-datepicker-header-left">
         <button
           type="button"
-          class="sky-btn sky-btn-default sky-btn-sm sky-datepicker-btn-previous"
+          class="sky-btn sky-datepicker-btn-previous"
           [attr.aria-label]="previousLabel"
+          [skyThemeClass]="{
+            'sky-btn-default sky-btn-sm': 'default',
+            'sky-btn-icon-borderless': 'modern'
+          }"
           (click)="moveCalendar($event, -1)"
         >
           <sky-icon class="sky-datepicker-chevron" iconName="chevron-left" />
@@ -15,11 +19,15 @@
         <!-- display: inline -->
         <button
           type="button"
-          class="sky-btn sky-btn-default sky-btn-sm sky-datepicker-calendar-title"
+          class="sky-btn sky-datepicker-calendar-title"
           [id]="datepickerId + '-title'"
           [disabled]="datepickerMode === maxMode"
           [ngClass]="{
             'sky-btn-disabled': datepickerMode === maxMode
+          }"
+          [skyThemeClass]="{
+            'sky-btn-default sky-btn-sm': 'default',
+            'sky-btn-link': 'modern'
           }"
           (click)="toggleModeCalendar($event)"
           >{{ title }}</button
@@ -28,8 +36,12 @@
       <span class="sky-datepicker-header-right">
         <button
           type="button"
-          class="sky-btn sky-btn-default sky-btn-sm sky-datepicker-btn-next"
+          class="sky-btn sky-datepicker-btn-next"
           [attr.aria-label]="nextLabel"
+          [skyThemeClass]="{
+            'sky-btn-default sky-btn-sm': 'default',
+            'sky-btn-icon-borderless': 'modern'
+          }"
           (click)="moveCalendar($event, 1)"
         >
           <sky-icon class="sky-datepicker-chevron" iconName="chevron-right" />

--- a/libs/components/datetime/src/lib/modules/datepicker/calendar/datepicker-calendar-inner.component.scss
+++ b/libs/components/datetime/src/lib/modules/datepicker/calendar/datepicker-calendar-inner.component.scss
@@ -33,6 +33,7 @@
   --sky-override-datepicker-table-border-spacing: 2px;
   --sky-override-datepicker-td-padding: 1px;
   --sky-override-datepicker-title-font-style: 700;
+  --sky-override-datepicker-title-font-weight: 12px;
   --sky-override-datepicker-vertical-padding: 0;
   --sky-override-datepicker-weekday-font-size: 12px;
   --sky-override-datepicker-weekday-font-weight: 900;
@@ -72,6 +73,7 @@
   --sky-override-datepicker-table-border-spacing: 2px;
   --sky-override-datepicker-td-padding: 1px;
   --sky-override-datepicker-title-font-style: 700;
+  --sky-override-datepicker-title-font-weight: 12px;
   --sky-override-datepicker-vertical-padding: 5px;
   --sky-override-datepicker-weekday-font-size: 12.8px;
   --sky-override-datepicker-weekday-font-weight: 900;
@@ -154,6 +156,72 @@
     }
   }
 
+  .sky-datepicker-btn-previous {
+    margin-right: var(
+      --sky-override-datepicker-nav-space,
+      var(--sky-space-gap-action_group-s)
+    );
+
+    // Rules can be removed when default and modern v1 are removed. Classes will handle this.
+    padding: var(
+      --sky-override-datepicker-nav-button-padding,
+      var(--sky-comp-button-borderless-space-inset-top)
+        var(--sky-comp-button-borderless-space-inset-right)
+        var(--sky-comp-button-borderless-space-inset-bottom)
+        var(--sky-comp-button-borderless-space-inset-left)
+    );
+    height: auto;
+    width: auto;
+  }
+
+  .sky-datepicker-btn-next {
+    margin-left: var(
+      --sky-override-datepicker-nav-space,
+      var(--sky-space-gap-action_group-s)
+    );
+
+    // Rules can be removed when default and modern v1 are removed. Classes will handle this.
+    padding: var(
+      --sky-override-datepicker-nav-button-padding,
+      var(--sky-comp-button-borderless-space-inset-top)
+        var(--sky-comp-button-borderless-space-inset-right)
+        var(--sky-comp-button-borderless-space-inset-bottom)
+        var(--sky-comp-button-borderless-space-inset-left)
+    );
+    height: auto;
+    width: auto;
+  }
+
+  // Rules can be removed when default and modern v1 are removed. Classes will handle this.
+  .sky-datepicker-calendar-title {
+    font-size: var(
+      --sky-override-datepicker-title-font-weight,
+      var(--sky-font-size-body-m)
+    );
+    font-weight: var(
+      --sky-override-datepicker-title-font-style,
+      var(--sky-font-style-default)
+    );
+    padding: var(
+      --sky-override-datepicker-nav-button-padding,
+      var(--sky-comp-button-borderless-space-inset-top)
+        var(--sky-comp-button-borderless-space-inset-right)
+        var(--sky-comp-button-borderless-space-inset-bottom)
+        var(--sky-comp-button-borderless-space-inset-left)
+    );
+  }
+
+  .sky-btn-link {
+    color: var(--sky-color-text-default);
+    padding: var(
+      --sky-override-datepicker-nav-button-padding,
+      var(--sky-comp-button-borderless-space-inset-top)
+        var(--sky-comp-button-borderless-space-inset-right)
+        var(--sky-comp-button-borderless-space-inset-bottom)
+        var(--sky-comp-button-borderless-space-inset-left)
+    );
+  }
+
   .sky-btn-default {
     background-color: var(
       --sky-override-datepicker-button-background-color,
@@ -216,43 +284,6 @@
             var(--sky-border-width-action-disabled)
           )
           var(--sky-color-border-action-tertiary-disabled)
-      );
-    }
-
-    &.sky-datepicker-btn-next,
-    &.sky-datepicker-btn-previous {
-      padding: var(
-        --sky-override-datepicker-nav-button-padding,
-        var(--sky-comp-button-borderless-space-inset-top)
-          var(--sky-comp-button-borderless-space-inset-right)
-          var(--sky-comp-button-borderless-space-inset-bottom)
-          var(--sky-comp-button-borderless-space-inset-left)
-      );
-    }
-
-    &.sky-datepicker-btn-previous {
-      margin-right: var(
-        --sky-override-datepicker-nav-space,
-        var(--sky-space-gap-action_group-s)
-      );
-    }
-
-    &.sky-datepicker-btn-next {
-      margin-left: var(
-        --sky-override-datepicker-nav-space,
-        var(--sky-space-gap-action_group-s)
-      );
-    }
-
-    &.sky-datepicker-calendar-title {
-      font-weight: var(
-        --sky-override-datepicker-title-font-style,
-        var(--sky-font-style-emphasized)
-      );
-      padding: var(
-        --sky-override-datepicker-nav-button-padding,
-        var(--sky-comp-button-borderless-space-inset-top) auto
-          var(--sky-comp-button-borderless-space-inset-bottom)
       );
     }
   }

--- a/libs/components/datetime/src/lib/modules/datepicker/calendar/datepicker-calendar-inner.component.ts
+++ b/libs/components/datetime/src/lib/modules/datepicker/calendar/datepicker-calendar-inner.component.ts
@@ -14,6 +14,7 @@ import {
 import { SkyLiveAnnouncerService } from '@skyux/core';
 import { SkyLibResourcesService } from '@skyux/i18n';
 import { SkyIconModule } from '@skyux/icon';
+import { SkyThemeModule } from '@skyux/theme';
 
 import { Subject, takeUntil } from 'rxjs';
 
@@ -32,7 +33,7 @@ let nextDatepickerId = 0;
  */
 @Component({
   encapsulation: ViewEncapsulation.None,
-  imports: [CommonModule, SkyIconModule],
+  imports: [CommonModule, SkyIconModule, SkyThemeModule],
   selector: 'sky-datepicker-inner',
   templateUrl: './datepicker-calendar-inner.component.html',
   styleUrl: './datepicker-calendar-inner.component.scss',


### PR DESCRIPTION
:cherries: Cherry picked from #3707 [fix(components/datetime): datepicker callendar header uses standard button styles in v2 modern](https://github.com/blackbaud/skyux/pull/3707)

[AB#3485780](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3485780) 