### PR TITLE
fix(components/forms): toggle switch uses active border width token in v2 modern (#3717)

### DIFF
--- a/libs/components/forms/src/lib/modules/toggle-switch/toggle-switch.component.scss
+++ b/libs/components/forms/src/lib/modules/toggle-switch/toggle-switch.component.scss
@@ -8,14 +8,14 @@
   --sky-override-toggle-switch-background-color-selected: #{$sky-background-color-info-light};
   --sky-override-toggle-switch-border: 1px solid
     #{$sky-border-color-neutral-medium};
-  --sky-override-toggle-switch-border-color-active: #{$sky-border-color-neutral-medium};
+  --sky-override-toggle-switch-border-color-active: #{$sky-highlight-color-info};
   --sky-override-toggle-switch-border-color-disabled: transparent;
   --sky-override-toggle-switch-border-color-focus: #{$sky-theme-modern-background-color-primary-dark};
   --sky-override-toggle-switch-border-color-hover: #{$sky-highlight-color-info};
   --sky-override-toggle-switch-border-color-selected: #{$sky-highlight-color-info};
   --sky-override-toggle-switch-border-radius: 24px;
   --sky-override-toggle-switch-border-width: 1px;
-  --sky-override-toggle-switch-border-width-active: 1px;
+  --sky-override-toggle-switch-border-width-active: 2px;
   --sky-override-toggle-switch-border-width-disabled: 2px;
   --sky-override-toggle-switch-border-width-focus: 2px;
   --sky-override-toggle-switch-border-width-hover: 2px;
@@ -36,7 +36,7 @@
   --sky-override-toggle-switch-label-gap: #{$sky-margin};
   --sky-override-toggle-switch-line-height: calc(20 / 14);
   --sky-override-toggle-switch-padding: 1px;
-  --sky-override-toggle-switch-padding-active: 1px;
+  --sky-override-toggle-switch-padding-active: 0;
   --sky-override-toggle-switch-padding-disabled: 0;
   --sky-override-toggle-switch-padding-focus: 0;
   --sky-override-toggle-switch-padding-hover: 0;
@@ -48,8 +48,14 @@
 
 @include compatMixins.sky-modern-overrides('.sky-toggle-switch') {
   --sky-override-toggle-switch-background-color: var(--modern-color-white);
+  --sky-override-toggle-switch-border-color-active: var(
+    --sky-color-border-switch-hover
+  );
   --sky-override-toggle-switch-border-color-selected: var(
     --sky-color-border-selected
+  );
+  --sky-override-toggle-switch-border-width-active: var(
+    --sky-border-width-input-hover
   );
   --sky-override-toggle-switch-box-shadow-focus: var(--sky-elevation-focus);
   --sky-override-toggle-switch-indicator-box-shadow: 0px 1px 2px 0px
@@ -58,6 +64,9 @@
     --sky-color-text-default
   );
   --sky-override-toggle-switch-line-height: calc(20 / 14);
+  --sky-override-toggle-switch-padding-active: calc(
+    calc(var(--sky-space-inset-thumb) * 2) - var(--sky-border-width-input-base)
+  );
   --sky-override-toggle-switch-width: var(--modern-size-48);
 }
 
@@ -174,7 +183,7 @@
     &:hover:not(.sky-toggle-switch-disabled) {
       cursor: pointer;
 
-      &:not(:focus-visible) .sky-toggle-switch-switch {
+      &:not(:focus-visible):not(:active) .sky-toggle-switch-switch {
         border-width: var(
           --sky-override-toggle-switch-border-width-hover,
           var(--sky-border-width-input-hover)


### PR DESCRIPTION
:cherries: Cherry picked from #3717 [fix(components/forms): toggle switch uses active border width token in v2 modern](https://github.com/blackbaud/skyux/pull/3717)

[AB#3493645](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3493645) 