### PR TITLE
fix(components/theme): icon switch components are sized based on the icon size in v2 modern

### DIFF
--- a/libs/components/theme/src/lib/styles/themes/modern/_switch.scss
+++ b/libs/components/theme/src/lib/styles/themes/modern/_switch.scss
@@ -252,9 +252,7 @@
       width: var(
         --sky-override-icon-switch-size,
         calc(
-          calc(
-              var(--sky-font-line_height-body-m) * var(--sky-font-size-body-m)
-            ) +
+          var(--sky-size-icon-m) +
             calc(
               var(--sky-comp-button-icon-space-inset-left) +
                 var(--sky-comp-button-icon-space-inset-right)
@@ -264,9 +262,7 @@
       height: var(
         --sky-override-icon-switch-size,
         calc(
-          calc(
-              var(--sky-font-line_height-body-m) * var(--sky-font-size-body-m)
-            ) +
+          var(--sky-size-icon-m) +
             calc(
               var(--sky-comp-button-icon-space-inset-top) +
                 var(--sky-comp-button-icon-space-inset-bottom)
@@ -277,9 +273,7 @@
         var(
           --sky-override-icon-switch-size,
           calc(
-            calc(
-                var(--sky-font-line_height-body-m) * var(--sky-font-size-body-m)
-              ) +
+            var(--sky-size-icon-m) +
               calc(
                 var(--sky-comp-button-icon-space-inset-left) +
                   var(--sky-comp-button-icon-space-inset-right)
@@ -380,9 +374,7 @@
       width: var(
         --sky-override-icon-switch-size-group,
         calc(
-          calc(
-              var(--sky-font-line_height-body-m) * var(--sky-font-size-body-m)
-            ) +
+          var(--sky-size-icon-m) +
             calc(
               var(--sky-comp-button-icon-space-inset-left) +
                 var(--sky-comp-button-icon-space-inset-right)
@@ -392,9 +384,7 @@
       height: var(
         --sky-override-icon-switch-size-group,
         calc(
-          calc(
-              var(--sky-font-line_height-body-m) * var(--sky-font-size-body-m)
-            ) +
+          var(--sky-size-icon-m) +
             calc(
               var(--sky-comp-button-icon-space-inset-top) +
                 var(--sky-comp-button-icon-space-inset-bottom)


### PR DESCRIPTION
[AB#3427518](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3427518)