### PR TITLE
fix(components/tabs): dropdown tab menu uses medium left selected border in v2 modern (#3726)

### DIFF
--- a/libs/components/theme/src/lib/styles/themes/modern/_buttons.scss
+++ b/libs/components/theme/src/lib/styles/themes/modern/_buttons.scss
@@ -897,7 +897,7 @@
         border-radius: 0 var(--sky-border-radius-s) var(--sky-border-radius-s) 0;
         border-left: var(
             --sky-override-selected-dropdown-item-border-width,
-            var(--sky-border-width-selected-l)
+            var(--sky-border-width-selected-m)
           )
           var(--sky-border-style-accent) var(--sky-color-border-selected);
         padding: var(--sky-comp-tab-horizontal-space-inset-top)
@@ -906,7 +906,7 @@
           calc(
             var(--sky-comp-tab-horizontal-space-inset-left) - var(
                 --sky-override-selected-dropdown-item-border-width,
-                var(--sky-border-width-selected-l)
+                var(--sky-border-width-selected-m)
               )
           );
       }


### PR DESCRIPTION
:cherries: Cherry picked from #3726 [fix(components/tabs): dropdown tab menu uses medium left selected border in v2 modern](https://github.com/blackbaud/skyux/pull/3726)

[AB#3433566](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3433566) 