### PR TITLE
fix(components/tabs): selected vertical tabs do not show the hover and active interactive state in v2 modern (#3728)

### DIFF
--- a/libs/components/tabs/src/lib/modules/vertical-tabset/vertical-tab.component.scss
+++ b/libs/components/tabs/src/lib/modules/vertical-tabset/vertical-tab.component.scss
@@ -120,7 +120,7 @@
   );
   border-radius: var(--sky-border-radius-0);
 
-  &:hover {
+  &:hover:not(.sky-vertical-tab-active) {
     color: var(
       --sky-override-vertical-tab-hover-font-color,
       var(--sky-color-text-default)
@@ -138,7 +138,7 @@
     }
   }
 
-  &:active {
+  &:active:not(.sky-vertical-tab-active) {
     background-color: var(
       --sky-override-vertical-tab-background-color-active,
       var(--sky-color-background-nav-active)


### PR DESCRIPTION
:cherries: Cherry picked from #3728 [fix(components/tabs): selected vertical tabs do not show the hover and active interactive state in v2 modern](https://github.com/blackbaud/skyux/pull/3728)

[AB#3433580](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3433580) 