### PR TITLE
fix(components/text-editor): remove `background-color` to show border and change spacing token from `xl` to `m` (#3729)

### DIFF
--- a/libs/components/text-editor/src/lib/modules/text-editor/text-editor.component.scss
+++ b/libs/components/text-editor/src/lib/modules/text-editor/text-editor.component.scss
@@ -56,6 +56,8 @@
   --sky-override-text-editor-label-padding: 10px 10px 0 10px;
   --sky-override-text-editor-toolbar-section-padding: #{$sky-theme-modern-space-sm};
   --sky-override-text-editor-top-toolbar-bottom-padding: 0;
+  --sky-override-text-editor-toolbar-item-spacing: 0
+    var(--sky-space-gap-action_group-xl) 0 0;
 }
 
 sky-text-editor.sky-form-field-stacked {
@@ -76,6 +78,7 @@ sky-text-editor.sky-form-field-stacked {
         var(--sky-color-border-input-base)
       )
   );
+  background-color: var(--sky-color-background-input-base);
 
   &.sky-text-editor-disabled {
     background-color: var(--sky-color-background-input-disabled);
@@ -91,10 +94,7 @@ sky-text-editor.sky-form-field-stacked {
   }
 
   .sky-text-editor-label-wrapper:not(:empty) {
-    background-color: var(
-      --sky-override-text-editor-label-background-color,
-      var(--sky-color-background-input-base)
-    );
+    background-color: var(--sky-override-text-editor-label-background-color);
     display: var(--sky-override-text-editor-label-display, inline-block);
     padding: var(
       --sky-override-text-editor-label-padding,
@@ -131,10 +131,7 @@ sky-text-editor.sky-form-field-stacked {
   .sky-text-editor-wrapper {
     display: flex;
     flex-wrap: wrap;
-    background-color: var(
-      --sky-override-text-editor-background-color,
-      var(--sky-color-background-input-base)
-    );
+    background-color: var(--sky-override-text-editor-background-color);
     width: 100%;
     height: 300px;
     padding: var(
@@ -234,8 +231,7 @@ sky-text-editor.sky-form-field-stacked {
   .sky-text-editor-toolbar {
     .sky-toolbar-container {
       background-color: var(
-        --sky-override-text-editor-toolbar-background-color,
-        var(--sky-color-background-input-base)
+        --sky-override-text-editor-toolbar-background-color
       ) !important;
     }
 
@@ -269,7 +265,7 @@ sky-text-editor.sky-form-field-stacked {
     .sky-toolbar-item {
       margin: var(
         --sky-override-text-editor-toolbar-item-spacing,
-        0 var(--sky-space-gap-action_group-xl) 0 0
+        0 var(--sky-space-gap-action_group-m) 0 0
       ) !important;
     }
 


### PR DESCRIPTION
:cherries: Cherry picked from #3729 [fix(components/text-editor): remove `background-color` to show border and change spacing token from `xl` to `m`](https://github.com/blackbaud/skyux/pull/3729)

[AB#3493604](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3493604) 
[AB#3436412](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3436412) 