### PR TITLE
fix(components/datetime): timepicker buttons use a set size in v2 modern

### DIFF
--- a/apps/playground/src/app/components/datetime/timepicker/timepicker.component.html
+++ b/apps/playground/src/app/components/datetime/timepicker/timepicker.component.html
@@ -1,8 +1,23 @@
 <sky-page layout="blocks">
   <sky-page-content>
-    <sky-input-box hintText="Here's some hint text." labelText="Pick a time">
+    <sky-input-box
+      hintText="Here's some hint text."
+      labelText="Pick a time - 12hr format"
+    >
       <sky-timepicker #timepicker>
         <input type="text" [skyTimepickerInput]="timepicker" />
+      </sky-timepicker>
+    </sky-input-box>
+    <sky-input-box
+      hintText="Here's some hint text."
+      labelText="Pick a time - 24hr format"
+    >
+      <sky-timepicker #timepicker24>
+        <input
+          type="text"
+          [skyTimepickerInput]="timepicker24"
+          [timeFormat]="'HH'"
+        />
       </sky-timepicker>
     </sky-input-box>
   </sky-page-content>

--- a/libs/components/datetime/src/lib/modules/timepicker/timepicker.component.html
+++ b/libs/components/datetime/src/lib/modules/timepicker/timepicker.component.html
@@ -53,7 +53,7 @@
     <div class="sky-timepicker-content">
       <section
         class="sky-timepicker-column sky-timepicker-column-hours"
-        [ngClass]="{ 'sky-timepicker-24hour': is8601 }"
+        [ngClass]="{ 'sky-timepicker-24hour-hours': is8601 }"
       >
         <ol>
           @for (hour of hours; track hour) {
@@ -70,7 +70,10 @@
           }
         </ol>
       </section>
-      <section class="sky-timepicker-column sky-timepicker-column-minutes">
+      <section
+        class="sky-timepicker-column sky-timepicker-column-minutes"
+        [ngClass]="{ 'sky-timepicker-24hour-minutes': is8601 }"
+      >
         <ol>
           @for (minute of minutes; track minute) {
             <li>

--- a/libs/components/datetime/src/lib/modules/timepicker/timepicker.component.scss
+++ b/libs/components/datetime/src/lib/modules/timepicker/timepicker.component.scss
@@ -140,7 +140,7 @@
         );
       }
 
-      &:hover:not(.sky-btn-active) {
+      &:hover:not(.sky-btn-active):not(:active) {
         border-radius: var(
           --sky-override-timepicker-button-hover-active-focus-border-radius,
           var(--sky-border-radius-s)

--- a/libs/components/datetime/src/lib/modules/timepicker/timepicker.component.scss
+++ b/libs/components/datetime/src/lib/modules/timepicker/timepicker.component.scss
@@ -12,6 +12,7 @@
   --sky-override-timepicker-button-focus-outline-offset: -2px;
   --sky-override-timepicker-button-focus-outline: -webkit-focus-ring-color auto
     5px;
+  --sky-override-timepicker-button-height: 100%;
   --sky-override-timepicker-button-hover-active-focus-border-radius: 0;
   --sky-override-timepicker-button-hover-active-box-shadow: none;
   --sky-override-timepicker-button-hover-background-color: #{$sky-color-gray-05};
@@ -20,6 +21,7 @@
   --sky-override-timepicker-button-selected-background-color: #{$sky-background-color-info-light};
   --sky-override-timepicker-button-selected-box-shadow: #{inset 0 0 0 2px
     $sky-highlight-color-info};
+  --sky-override-timepicker-button-width: 100%;
   --sky-override-timepicker-column-border: #{1px solid
     $sky-border-color-neutral-light};
   --sky-override-timepicker-column-gap: 10px;
@@ -41,10 +43,13 @@
     inset 0 0 0 var(--sky-border-width-action-focus)
       var(--sky-color-border-action-tertiary-focus),
     var(--sky-elevation-focus);
+  --sky-override-timepicker-button-height: 100%;
+  --sky-override-timepicker-button-padding-horizontal: var(--modern-size-15);
   --sky-override-timepicker-button-padding-vertical: var(--modern-size-5);
   --sky-override-timepicker-button-selected-hover-border-color: var(
     --modern-color-blue-50
   );
+  --sky-override-timepicker-button-width: 100%;
   --sky-override-timepicker-column-border: #{1px solid
     var(--modern-color-gray-10)};
   --sky-override-timepicker-content-space: var(--modern-space-s)
@@ -108,24 +113,16 @@
         var(--sky-color-text-default)
       );
       cursor: pointer;
-      padding: var(
-          --sky-override-timepicker-button-padding-vertical,
-          var(--sky-comp-timepicker-footer-space-inset-top)
-        )
-        var(
-          --sky-override-timepicker-button-padding-horizontal,
-          var(--sky-comp-timepicker-footer-space-inset-right)
-        )
-        var(
-          --sky-override-timepicker-button-padding-vertical,
-          var(--sky-comp-timepicker-footer-space-inset-bottom)
-        )
-        var(
-          --sky-override-timepicker-button-padding-horizontal,
-          var(--sky-comp-timepicker-footer-space-inset-left)
-        );
-      width: 100%;
-      height: 100%;
+      padding: var(--sky-override-timepicker-button-padding-vertical, auto)
+        var(--sky-override-timepicker-button-padding-horizontal, auto);
+      width: var(
+        --sky-override-timepicker-button-width,
+        var(--sky-size-picker_btn)
+      );
+      height: var(
+        --sky-override-timepicker-button-height,
+        var(--sky-size-picker_btn)
+      );
 
       &:focus-visible:not(:active) {
         outline: var(--sky-override-timepicker-button-focus-outline);
@@ -200,11 +197,20 @@
   }
 }
 
-.sky-timepicker-column.sky-timepicker-24hour ol {
+.sky-timepicker-column.sky-timepicker-column-meridies ol,
+.sky-timepicker-column.sky-timepicker-24hour-minutes ol {
+  li {
+    button {
+      height: 100%;
+    }
+  }
+}
+
+.sky-timepicker-column.sky-timepicker-24hour-hours ol {
   columns: 4;
 }
 
-.sky-timepicker-column.sky-timepicker-24hour ol li {
+.sky-timepicker-column.sky-timepicker-24hour-hours ol li {
   border-bottom-width: 0;
 }
 


### PR DESCRIPTION
[AB#3493611](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3493611)

NOTE: Timepicker buttons are now square with 2 exceptions

1. The AM/PM buttons on 12 hour format
2. The minute buttons on 24 hour format

Cleared with design that these can use the standard width but then grow vertically to fill their column