### PR TITLE
chore: bump design tokens library to `alpha.10` (#3718)

### DIFF
--- a/libs/components/theme/package.json
+++ b/libs/components/theme/package.json
@@ -20,7 +20,7 @@
     "@angular/core": "^20.0.5"
   },
   "dependencies": {
-    "@blackbaud/skyux-design-tokens": "2.0.0-alpha.9",
+    "@blackbaud/skyux-design-tokens": "2.0.0-alpha.10",
     "@skyux/icons": "9.0.0",
     "fontfaceobserver": "2.3.0",
     "tslib": "^2.8.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@angular/platform-browser-dynamic": "20.0.5",
         "@angular/router": "20.0.5",
         "@blackbaud/angular-tree-component": "1.0.0",
-        "@blackbaud/skyux-design-tokens": "2.0.0-alpha.9",
+        "@blackbaud/skyux-design-tokens": "2.0.0-alpha.10",
         "@eslint/js": "9.30.1",
         "@nx/angular": "21.2.1",
         "@skyux/icons": "9.0.0",
@@ -3009,9 +3009,9 @@
       }
     },
     "node_modules/@blackbaud/skyux-design-tokens": {
-      "version": "2.0.0-alpha.9",
-      "resolved": "https://registry.npmjs.org/@blackbaud/skyux-design-tokens/-/skyux-design-tokens-2.0.0-alpha.9.tgz",
-      "integrity": "sha512-N8N6PU1DnSctpR485+ZcYq7CiirqoWeCL2WYeSUCdeo56dKhc1GDPssYI/t/HnNtVn8dfaddCgU4/Hv63SONng==",
+      "version": "2.0.0-alpha.10",
+      "resolved": "https://registry.npmjs.org/@blackbaud/skyux-design-tokens/-/skyux-design-tokens-2.0.0-alpha.10.tgz",
+      "integrity": "sha512-p+tZW752yHZ7KULT8JUgcyxxbhUdbvHoUYJCISEjidNM51xN+d+MWqu7uUE9FWCfSGRqn3vPtsmykLGJHXwjlA==",
       "engines": {
         "node": ">= 4.2.1",
         "npm": ">= 3"

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "@angular/platform-browser-dynamic": "20.0.5",
     "@angular/router": "20.0.5",
     "@blackbaud/angular-tree-component": "1.0.0",
-    "@blackbaud/skyux-design-tokens": "2.0.0-alpha.9",
+    "@blackbaud/skyux-design-tokens": "2.0.0-alpha.10",
     "@eslint/js": "9.30.1",
     "@nx/angular": "21.2.1",
     "@skyux/icons": "9.0.0",


### PR DESCRIPTION
:cherries: Cherry picked from #3718 [chore: bump design tokens library to alpha.10](https://github.com/blackbaud/skyux/pull/3718)