### PR TITLE
fix(components/tiles): tile box shadows are not clipped on xs breakpoints and block layout host configurations (#3748)

### DIFF
--- a/libs/components/tiles/src/lib/modules/tiles/tile-dashboard-column/tile-dashboard-column.component.scss
+++ b/libs/components/tiles/src/lib/modules/tiles/tile-dashboard-column/tile-dashboard-column.component.scss
@@ -17,12 +17,24 @@
 }
 
 @include mixins.sky-host-responsive-container-xs-min() {
+  // The calculations here ensure that the columns have enough padding that the tiles within them have enough space to display their shadows.
+  // Negative margins at the dashboard level ensure that it has no visual side effect other than the shadow.
+  // This is done on both left and right as the dashboard is single column at that breakpoint.
   padding: var(
     --sky-override-tile-dashboard-column-padding-xs,
     var(--sky-comp-tile-dashboard-column-space-inset-xs-top)
-      var(--sky-comp-tile-dashboard-column-space-inset-xs-right)
-      var(--sky-comp-tile-dashboard-column-space-inset-xs-bottom)
-      var(--sky-comp-tile-dashboard-column-space-inset-xs-left)
+      calc(
+        var(--sky-comp-tile-dashboard-column-space-inset-sm-right) +
+          var(--sky-comp-tile-dashboard-column-space-inset-xs-right)
+      )
+      calc(
+        var(--sky-space-stacked-xl) +
+          var(--sky-comp-tile-dashboard-column-space-inset-xs-bottom)
+      )
+      calc(
+        var(--sky-comp-tile-dashboard-column-space-inset-sm-left) +
+          var(--sky-comp-tile-dashboard-column-space-inset-xs-left)
+      )
   );
 }
 
@@ -34,6 +46,13 @@
       var(--sky-comp-tile-dashboard-column-space-inset-sm-bottom)
       var(--sky-comp-tile-dashboard-column-space-inset-sm-left)
   );
+
+  &.sky-tile-dashboard-layout-single {
+    padding-bottom: calc(
+      var(--sky-space-stacked-xl) +
+        var(--sky-comp-tile-dashboard-column-space-inset-sm-bottom)
+    );
+  }
 }
 
 .sky-tile-dashboard-column {
@@ -41,23 +60,4 @@
   // other column is tall enough to give it a reasonable drop target.
   min-height: 100px;
   width: 100%;
-}
-
-:host-context(.sky-theme-modern .sky-layout-host-blocks) {
-  @include mixins.sky-host-responsive-container-sm-min() {
-    &.sky-tile-dashboard-layout-multi {
-      &-first {
-        padding-left: 0;
-      }
-
-      &-last {
-        padding-right: 0;
-      }
-    }
-
-    &.sky-tile-dashboard-layout-single {
-      padding-left: 0;
-      padding-right: 0;
-    }
-  }
 }

--- a/libs/components/tiles/src/lib/modules/tiles/tile-dashboard/tile-dashboard.component.scss
+++ b/libs/components/tiles/src/lib/modules/tiles/tile-dashboard/tile-dashboard.component.scss
@@ -22,6 +22,8 @@
       var(--sky-comp-tile-dashboard-space-inset-xs-bottom)
       var(--sky-comp-tile-dashboard-space-inset-xs-left)
   );
+  // The negative margins here ensure that it appears that the dashboard has no bottom, left, and right padding - but the box shadows of the tiles still come through.
+  margin-bottom: calc(var(--sky-space-stacked-xl) * -1);
 
   .sky-tile-dashboard-layout-multi {
     display: none;
@@ -40,6 +42,21 @@
   ) !important;
 }
 
+@include mixins.sky-host-responsive-container-xs-min() {
+  // The negative margins here ensure that it appears that the dashboard has no bottom, left, and right padding - but the box shadows of the tiles still come through.
+  margin-left: calc(
+    var(--sky-comp-tile-dashboard-column-space-inset-sm-left) * -1
+  );
+  margin-right: calc(
+    var(--sky-comp-tile-dashboard-column-space-inset-sm-right) * -1
+  );
+}
+
+@include mixins.sky-host-responsive-container-sm-min() {
+  margin-left: 0;
+  margin-right: 0;
+}
+
 :host-context(.sky-tile-dashboard-multi-column) {
   display: flex;
   padding: var(
@@ -49,6 +66,7 @@
       var(--sky-comp-tile-dashboard-space-inset-sm-bottom)
       var(--sky-comp-tile-dashboard-space-inset-sm-left)
   );
+  margin-bottom: 0;
 
   .sky-tile-dashboard-layout-multi {
     display: block;
@@ -67,4 +85,11 @@
 
 :host-context(.sky-theme-modern .sky-layout-host-blocks) {
   padding: 0;
+  // The negative margins here ensure that it appears that the dashboard has no left and right padding - but the box shadows of the tiles still come through.
+  margin-left: calc(
+    var(--sky-comp-tile-dashboard-column-space-inset-sm-left) * -1
+  );
+  margin-right: calc(
+    var(--sky-comp-tile-dashboard-column-space-inset-sm-right) * -1
+  );
 }


### PR DESCRIPTION
:cherries: Cherry picked from #3748 [fix(components/tiles): tile box shadows are not clipped on xs breakpoints and block layout host configurations](https://github.com/blackbaud/skyux/pull/3748)

[AB#3436330](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3436330) 