### PR TITLE
fix(components/forms): radio buttons do not use interactive styling when checked in v2 modern (#3746)

### DIFF
--- a/libs/components/forms/src/lib/modules/radio/radio.component.scss
+++ b/libs/components/forms/src/lib/modules/radio/radio.component.scss
@@ -3,6 +3,21 @@
 @use 'libs/components/theme/src/lib/styles/compat-tokens-mixins' as compatMixins;
 
 @include compatMixins.sky-default-overrides('.sky-radio-outer-wrapper') {
+  --sky-override-radio-border-color-checked-active: var(
+    --sky-highlight-color-info
+  );
+  --sky-override-radio-border-color-checked-hover: var(
+    --sky-highlight-color-info
+  );
+  --sky-override-radio-border-width-checked-active: 2px;
+  --sky-override-radio-border-width-checked-hover: 2px;
+  --sky-override-radio-border-color-icon-checked-active: var(
+    --sky-highlight-color-info
+  );
+  --sky-override-radio-border-color-icon-checked-hover: var(
+    --sky-highlight-color-info
+  );
+  --sky-override-radio-border-width-icon-checked-active: 2px;
   --sky-override-radio-icon-border-radius: 50%;
   --sky-override-radio-icon-color-disabled: #{$sky-color-black};
   --sky-override-radio-icon-color-selected: #{$sky-color-black};
@@ -17,6 +32,24 @@
 }
 
 @include compatMixins.sky-modern-overrides('.sky-radio-outer-wrapper') {
+  --sky-override-radio-border-color-checked-active: var(
+    --sky-color-border-switch-selected-active
+  );
+  --sky-override-radio-border-color-checked-hover: var(
+    --sky-color-border-switch-selected-hover
+  );
+  --sky-override-radio-border-width-checked-active: var(
+    --sky-border-width-input-active
+  );
+  --sky-override-radio-border-width-checked-hover: var(
+    --sky-border-width-input-hover
+  );
+  --sky-override-radio-border-color-icon-checked-active: var(
+    --sky-color-border-switch-selected-active
+  );
+  --sky-override-radio-border-color-icon-checked-hover: var(
+    --sky-color-border-switch-selected-hover
+  );
   --sky-override-radio-icon-color-selected: var(--sky-color-icon-selected);
   --sky-override-radio-label-margin-right: var(--sky-margin-inline-xs);
 }
@@ -73,6 +106,48 @@
     --sky-override-radio-icon-color-disabled,
     var(--sky-color-text-deemphasized)
   );
+}
+
+.sky-switch-input:checked:not(:disabled) {
+  &.sky-radio-input:active + .sky-switch-control {
+    border-width: var(
+      --sky-override-radio-border-width-checked-active,
+      var(--sky-border-width-selected-s)
+    );
+    border-color: var(
+      --sky-override-radio-border-color-checked-active,
+      var(--sky-color-border-switch-selected-base)
+    );
+
+    &.sky-switch-control-icon {
+      border-width: var(
+        --sky-override-radio-border-width-icon-checked-active,
+        var(--sky-border-width-selected-s)
+      );
+      border-color: var(
+        --sky-override-radio-border-color-icon-checked-active,
+        var(--sky-color-border-selected)
+      );
+    }
+  }
+
+  &.sky-radio-input:hover:not(:active) + .sky-switch-control {
+    border-width: var(
+      --sky-override-radio-border-width-checked-hover,
+      var(--sky-border-width-selected-s)
+    );
+    border-color: var(
+      --sky-override-radio-border-color-checked-hover,
+      var(--sky-color-border-switch-selected-base)
+    );
+
+    &.sky-switch-control-icon {
+      border-color: var(
+        --sky-override-radio-border-color-icon-checked-hover,
+        var(--sky-color-border-selected)
+      );
+    }
+  }
 }
 
 .sky-radio-hint-text {

--- a/libs/components/theme/src/lib/styles/themes/modern/_switch.scss
+++ b/libs/components/theme/src/lib/styles/themes/modern/_switch.scss
@@ -316,7 +316,7 @@
 
   .sky-switch-control {
     background-color: var(--sky-color-background-action-tertiary-base);
-    border-width: var(--sky-width-action-base);
+    border-width: var(--sky-border-width-action-base);
     border-color: var(--sky-color-border-action-tertiary-base);
   }
 


### PR DESCRIPTION
:cherries: Cherry picked from #3746 [fix(components/forms): radio buttons do not use interactive styling when checked in v2 modern](https://github.com/blackbaud/skyux/pull/3746)

[AB#3502817](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3502817) 