### PR TITLE
fix(components/lookup): search uses secondary border and background color tokens in v2 modern (#3759)

### DIFF
--- a/libs/components/ag-grid/src/lib/styles/_modern.scss
+++ b/libs/components/ag-grid/src/lib/styles/_modern.scss
@@ -176,7 +176,9 @@
       background-color: transparent;
 
       sky-input-box {
-        --sky-background-color-input-box-group: var(--ag-background-color);
+        --sky-comp-override-input-box-group-background-color: var(
+          --ag-background-color
+        );
       }
     }
 

--- a/libs/components/forms/src/lib/modules/file-attachment/file-drop/file-drop.component.scss
+++ b/libs/components/forms/src/lib/modules/file-attachment/file-drop/file-drop.component.scss
@@ -329,11 +329,11 @@ button.sky-file-drop {
   cursor: default;
 
   sky-input-box {
-    --sky-background-color-input-box-group: var(
+    --sky-comp-override-input-box-group-background-color: var(
       --sky-override-file-drop-link-input-background-color,
       var(--bb-color-white)
     );
-    --sky-background-color-input-box-group-focused: var(
+    --sky-comp-override-input-box-group-background-color-focused: var(
       --sky-override-file-drop-link-input-background-color,
       var(--bb-color-white)
     );

--- a/libs/components/forms/src/lib/modules/input-box/input-box.component.scss
+++ b/libs/components/forms/src/lib/modules/input-box/input-box.component.scss
@@ -44,8 +44,10 @@
 
 // default theme initial input box background colors (also set by ag-grid and search)
 sky-input-box {
-  --sky-background-color-input-box-group: transparent;
-  --sky-background-color-input-box-group-focused: transparent;
+  --sky-comp-override-input-box-group-background-color: transparent;
+  --sky-comp-override-input-box-group-background-color-active: transparent;
+  --sky-comp-override-input-box-group-background-color-hover: transparent;
+  --sky-comp-override-input-box-group-background-color-focused: transparent;
 }
 
 .sky-input-box {
@@ -58,11 +60,22 @@ sky-input-box {
 // modern theme initial input box background colors with overrides (also set by ag-grid and search)
 .sky-theme-modern {
   sky-input-box {
-    --sky-background-color-input-box-group: var(
+    --sky-comp-override-input-box-group-background-color: var(
       --sky-override-background-color-input-box,
       var(--sky-color-background-input-base)
     );
-    --sky-background-color-input-box-group-focused: var(
+    --sky-comp-override-input-box-group-background-color-active: var(
+      --sky-override-background-color-input-box,
+      var(--sky-color-background-input-base)
+    );
+    --sky-comp-override-input-box-group-background-color-disabled: var(
+      --sky-color-background-input-disabled
+    );
+    --sky-comp-override-input-box-group-background-color-hover: var(
+      --sky-override-background-color-input-box,
+      var(--sky-color-background-input-base)
+    );
+    --sky-comp-override-input-box-group-background-color-focused: var(
       --sky-override-background-color-input-box,
       var(--sky-color-background-input-base)
     );
@@ -94,10 +107,24 @@ sky-input-box {
   .sky-form-group {
     display: flex;
     flex-wrap: wrap;
-    background-color: var(--sky-background-color-input-box-group);
+    background-color: var(--sky-comp-override-input-box-group-background-color);
 
-    &:focus-within {
-      background-color: var(--sky-background-color-input-box-group-focused);
+    &:has(:active) {
+      background-color: var(
+        --sky-comp-override-input-box-group-background-color-active
+      );
+    }
+
+    &:hover:not(:has(:active)) {
+      background-color: var(
+        --sky-comp-override-input-box-group-background-color-hover
+      );
+    }
+
+    &:focus-within:not(:has(:active)) {
+      background-color: var(
+        --sky-comp-override-input-box-group-background-color-focused
+      );
     }
 
     .sky-input-box-label-wrapper {
@@ -595,17 +622,30 @@ sky-input-box {
         width: initial;
       }
     }
+
+    // apply input border
+    .sky-input-box-group-form-control .sky-form-group {
+      border: none;
+      box-shadow: var(
+        --sky-input-box-box-shadow-with-elevation,
+        inset 0 0 0 var(--sky-input-box-input-border-width)
+          var(--sky-comp-override-input-box-input-border-color),
+        var(--sky-comp-override-input-box-input-elevation-shadow)
+      );
+    }
   }
 
   // border styling for enabled inputs
   .sky-input-box:not(.sky-input-box-disabled) {
     // default border and background values for inputs and buttons
-    --sky-input-box-input-border-color: var(
+    --sky-comp-override-input-box-input-border-color: var(
       --sky-override-input-box-color-border-base,
       var(--sky-color-border-input-base)
     );
     --sky-input-box-input-border-width: var(--sky-border-width-input-base);
-    --sky-input-box-input-elevation-shadow: var(--sky-elevation-input-base);
+    --sky-comp-override-input-box-input-elevation-shadow: var(
+      --sky-elevation-input-base
+    );
     --sky-input-box-button-border-color: var(
       --sky-override-input-box-color-border-base,
       var(--sky-color-border-action-input-base)
@@ -618,17 +658,6 @@ sky-input-box {
     --sky-input-box-button-elevation-shadow: var(
       --sky-elevation-action-input-base
     );
-
-    // apply input border
-    .sky-input-box-group-form-control .sky-form-group {
-      border: none;
-      box-shadow: var(
-        --sky-input-box-box-shadow-with-elevation,
-        inset 0 0 0 var(--sky-input-box-input-border-width)
-          var(--sky-input-box-input-border-color),
-        var(--sky-input-box-input-elevation-shadow)
-      );
-    }
 
     // apply button border and background color
     .sky-input-group-btn .sky-btn {
@@ -645,14 +674,16 @@ sky-input-box {
     // input border states
     .sky-input-box-group-form-control {
       &:hover {
-        --sky-input-box-input-border-color: var(--sky-color-border-input-hover);
+        --sky-comp-override-input-box-input-border-color: var(
+          --sky-color-border-input-hover
+        );
         --sky-input-box-input-border-width: var(--sky-border-width-input-hover);
 
         z-index: 1;
       }
 
       &:active {
-        --sky-input-box-input-border-color: var(
+        --sky-comp-override-input-box-input-border-color: var(
           --sky-color-border-input-active
         );
         --sky-input-box-input-border-width: var(
@@ -670,12 +701,14 @@ sky-input-box {
     .sky-input-box-group-form-control-focus:not(
         :active
       ).sky-input-box-group-form-control-invalid {
-      --sky-input-box-input-border-color: var(--sky-color-border-input-focus);
+      --sky-comp-override-input-box-input-border-color: var(
+        --sky-color-border-input-focus
+      );
       --sky-input-box-input-border-width: var(--sky-border-width-input-focus);
       --sky-input-box-box-shadow-with-elevation: var(
         --sky-override-input-box-shadow-focus,
         inset 0 0 0 var(--sky-input-box-input-border-width)
-          var(--sky-input-box-input-border-color),
+          var(--sky-comp-override-input-box-input-border-color),
         var(--sky-elevation-input-base)
       );
 
@@ -686,7 +719,9 @@ sky-input-box {
     }
 
     .sky-input-box-group-form-control-invalid {
-      --sky-input-box-input-border-color: var(--sky-color-border-input-error);
+      --sky-comp-override-input-box-input-border-color: var(
+        --sky-color-border-input-error
+      );
       --sky-input-box-input-border-width: var(--sky-border-width-input-error);
 
       .sky-form-group {
@@ -773,13 +808,16 @@ sky-input-box {
   .sky-input-box.sky-input-box-disabled {
     .sky-form-group {
       border: none;
-      box-shadow:
-        inset 0 0 0 var(--sky-border-width-input-disabled)
-          var(
-            --sky-override-input-box-color-border-base,
-            var(--sky-color-border-input-disabled)
-          ),
-        var(--sky-elevation-input-disabled);
+      --sky-comp-override-input-box-input-border-color: var(
+        --sky-override-input-box-color-border-base,
+        var(--sky-color-border-input-disabled)
+      );
+      --sky-input-box-input-border-width: var(
+        --sky-border-width-input-disabled
+      );
+      --sky-comp-override-input-box-input-elevation-shadow: var(
+        --sky-elevation-input-disabled
+      );
     }
 
     .sky-input-group-btn .sky-btn {
@@ -791,7 +829,9 @@ sky-input-box {
             var(--sky-color-border-action-input-disabled)
           ),
         var(--sky-elevation-action-input-disabled);
-      background-color: var(--sky-color-background-action-input-disabled);
+      background-color: var(
+        --sky-comp-override-input-box-group-background-color-disabled
+      );
     }
 
     .sky-form-control,
@@ -807,7 +847,9 @@ sky-input-box {
 
     .sky-form-group,
     .sky-input-group-btn .sky-btn {
-      background-color: var(--sky-color-background-input-disabled);
+      background-color: var(
+        --sky-comp-override-input-box-group-background-color-disabled
+      );
     }
   }
 }

--- a/libs/components/lookup/src/lib/modules/search/search.component.scss
+++ b/libs/components/lookup/src/lib/modules/search/search.component.scss
@@ -28,10 +28,49 @@
   --sky-override-search-applied-mobile-button-vertical-padding: 9px;
   --sky-override-search-applied-border-width: 2px;
   --sky-override-search-background-color: var(--modern-color-transparent);
+  --sky-override-search-background-color-disabled: var(
+    --sky-color-background-input-disabled
+  );
   --sky-override-search-button-height-width: 40px;
+  --sky-override-search-container-border-color-active: var(
+    --sky-color-border-input-active
+  );
+  --sky-override-search-container-border-color-disabled: none;
+  --sky-override-search-container-border-color-focus: var(
+    --sky-color-border-input-focus
+  );
+  --sky-override-search-container-border-color-hover: var(
+    --sky-color-border-input-hover
+  );
+  --sky-override-search-container-box-shadow: none;
+  --sky-override-search-container-box-shadow-searched: inset 0 -1px 0 0
+    var(--sky-color-border-selected);
+  --sky-override-search-container-text-color-searched: var(
+    --sky-color-text-default
+  );
   --sky-override-search-placeholder-color: var(--sky-color-text-default);
   --sky-override-search-mobile-button-horizontal-padding: 15px;
   --sky-override-search-mobile-button-vertical-padding: 9px;
+
+  .sky-search-input-container {
+    &.sky-search-input-container-has-value {
+      .sky-input-box-group-form-control:not(
+          .sky-input-box-group-form-control-focus,
+          :hover
+        )
+        .sky-form-group {
+        border: none;
+        border-radius: var(--sky-border-radius-0);
+      }
+    }
+  }
+}
+
+@include compatMixins.sky-modern-overrides('.sky-toolbar-item', false) {
+  sky-search .sky-search-container .sky-search-input-container sky-input-box {
+    --sky-comp-override-input-box-group-background-color: transparent;
+    --sky-comp-override-input-box-group-background-color-focused: transparent;
+  }
 }
 
 sky-search {
@@ -189,13 +228,25 @@ sky-search {
 .sky-theme-modern {
   sky-search {
     sky-input-box {
-      --sky-background-color-input-box-group: var(
+      --sky-comp-override-input-box-group-background-color: var(
         --sky-override-search-background-color,
         var(--sky-color-background-action-secondary-base)
       );
-      --sky-background-color-input-box-group-focused: var(
+      --sky-comp-override-input-box-group-background-color-active: var(
         --sky-override-search-background-color,
-        var(--sky-color-background-action-secondary-base)
+        var(--sky-color-background-action-secondary-active)
+      );
+      --sky-comp-override-input-box-group-background-color-disabled: var(
+        --sky-override-search-background-color-disabled,
+        var(--sky-color-background-action-secondary-disabled)
+      );
+      --sky-comp-override-input-box-group-background-color-focused: var(
+        --sky-override-search-background-color,
+        var(--sky-color-background-action-secondary-focus)
+      );
+      --sky-comp-override-input-box-group-background-color-hover: var(
+        --sky-override-search-background-color,
+        var(--sky-color-background-action-secondary-hover)
       );
     }
 
@@ -265,24 +316,92 @@ sky-search {
     }
 
     .sky-search-container .sky-search-input-container {
-      .sky-input-box-group
-        .sky-input-box-group-form-control:not(
-          .sky-input-box-group-form-control-focus,
-          :hover
-        )
-        .sky-form-group {
-        box-shadow: none;
+      .sky-input-box-disabled {
+        .sky-input-box-group .sky-input-box-group-form-control .sky-form-group {
+          --sky-comp-override-input-box-input-border-color: var(
+            --sky-override-search-container-border-color-disabled,
+            var(--sky-color-border-action-secondary-disabled)
+          );
+        }
       }
 
-      &.sky-search-input-container-has-value {
-        .sky-input-box-group-form-control:not(
+      .sky-input-box:not(.sky-input-box-disabled) {
+        .sky-input-box-group
+          .sky-input-box-group-form-control:not(
             .sky-input-box-group-form-control-focus,
             :hover
           )
           .sky-form-group {
-          border: none;
-          border-radius: var(--sky-border-radius-0);
-          box-shadow: inset 0 -1px 0 0 var(--sky-color-border-selected);
+          --sky-comp-override-input-box-input-border-color: var(
+            --sky-override-search-container-box-shadow,
+            var(--sky-color-border-action-secondary-base)
+          );
+          --sky-comp-override-input-box-input-elevation-shadow: var(
+            --sky-elevation-action-toolbar-base
+          );
+        }
+
+        .sky-input-box-group-form-control:hover:not(
+            .sky-input-box-group-form-control-focus,
+            :has(:active)
+          )
+          .sky-form-group {
+          --sky-comp-override-input-box-input-border-color: var(
+            --sky-override-search-container-border-color-hover,
+            var(--sky-color-border-action-secondary-hover)
+          );
+          --sky-comp-override-input-box-input-elevation-shadow: var(
+            --sky-elevation-action-toolbar-hover
+          );
+        }
+
+        .sky-input-box-group-form-control.sky-input-box-group-form-control-focus:not(
+            :has(:active)
+          )
+          .sky-form-group {
+          --sky-comp-override-input-box-input-border-color: var(
+            --sky-override-search-container-border-color-focus,
+            var(--sky-color-border-action-secondary-focus)
+          );
+          --sky-comp-override-input-box-input-elevation-shadow: var(
+            --sky-elevation-action-toolbar-focus
+          );
+        }
+
+        .sky-input-box-group-form-control:has(:active) .sky-form-group {
+          --sky-comp-override-input-box-input-border-color: var(
+            --sky-override-search-container-border-color-active,
+            var(--sky-color-border-action-secondary-active)
+          );
+          --sky-comp-override-input-box-input-elevation-shadow: var(
+            --sky-elevation-action-toolbar-active
+          );
+        }
+      }
+
+      &.sky-search-input-container-has-value {
+        .sky-input-box-group-form-control {
+          &:not(.sky-input-box-group-form-control-focus, :hover)
+            .sky-form-group {
+            // NOTE: Have to do full box shadow override instead of variable due to only the bottom having the box shadow
+            box-shadow: var(
+              --sky-override-search-container-box-shadow-searched,
+              inset 0 0 0 var(--sky-border-width-input-base)
+                var(--sky-color-border-selected),
+              var(--sky-elevation-action-toolbar-base)
+            );
+            --sky-comp-override-input-box-group-background-color: var(
+              --sky-override-search-background-color,
+              var(--sky-color-background-selected-soft)
+            );
+          }
+
+          &:not(:focus-within:not(:active)) .sky-form-group input {
+            color: var(
+              --sky-override-search-container-text-color-searched,
+              var(--sky-color-text-selected)
+            );
+          }
         }
       }
 
@@ -323,14 +442,5 @@ sky-search {
         }
       }
     }
-  }
-
-  .sky-toolbar-item
-    sky-search
-    .sky-search-container
-    .sky-search-input-container
-    sky-input-box {
-    --sky-background-color-input-box-group: transparent;
-    --sky-background-color-input-box-group-focused: transparent;
   }
 }

--- a/libs/components/lookup/src/lib/modules/search/search.component.ts
+++ b/libs/components/lookup/src/lib/modules/search/search.component.ts
@@ -144,7 +144,7 @@ export class SkySearchComponent implements OnDestroy, OnInit, OnChanges {
   }
 
   /**
-   * Whether to disable the filter button.
+   * Whether to disable the search.
    * @default false
    */
   @Input()


### PR DESCRIPTION
:cherries: Cherry picked from #3759 [fix(components/lookup): search uses secondary border and background color tokens in v2 modern](https://github.com/blackbaud/skyux/pull/3759)

[AB#3429802](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3429802) 