### PR TITLE
feat(components/split-view): add responsive padding around repeater in split view drawer (#3747)

### DIFF
--- a/apps/e2e/split-view-storybook-e2e/src/e2e/split-view.component.cy.ts
+++ b/apps/e2e/split-view-storybook-e2e/src/e2e/split-view.component.cy.ts
@@ -3,20 +3,18 @@ import { E2eVariations } from '@skyux-sdk/e2e-schematics';
 describe('split-view-storybook', () => {
   E2eVariations.forEachTheme((theme) => {
     describe(`in ${theme} theme`, () => {
-      // TODO: make new array with Lg and Xs widths
+      beforeEach(() => {
+        cy.visit(
+          `/iframe.html?globals=theme:${theme}&id=splitviewcomponent-splitview--split-view`,
+        );
+        cy.skyReady().end();
+      });
       E2eVariations.DISPLAY_WIDTHS.concat(E2eVariations.MOBILE_WIDTHS).forEach(
         (width) => {
           describe(`at ${width}px`, () => {
-            beforeEach(() => {
+            it(`should render the split view component`, () => {
               cy.viewport(width, 960);
-              cy.visit(
-                `/iframe.html?globals=theme:${theme}&id=splitviewcomponent-splitview--split-view`,
-              );
-            });
-            it(`should fill the page when dock is set to fill at width ${width}`, () => {
-              cy.skyReady()
-                .end()
-                .get('.screenshot-area')
+              cy.get('.screenshot-area')
                 .should('exist')
                 .should('be.visible')
                 .screenshot(
@@ -32,6 +30,27 @@ describe('split-view-storybook', () => {
           });
         },
       );
+      it(`should render the drawer when dock is set to mobile width`, () => {
+        E2eVariations.MOBILE_WIDTHS.forEach((width) => {
+          cy.viewport(width, 960);
+          cy.get('.sky-split-view-workspace-header-content > .sky-btn-link')
+            .should('exist')
+            .should('be.visible')
+            .click();
+          cy.get('.screenshot-area')
+            .should('exist')
+            .should('be.visible')
+            .screenshot(
+              `splitviewcomponent-splitview--split-view-drawer-mobile-view-${theme}`,
+            );
+          cy.get('.screenshot-area').percySnapshot(
+            `splitviewcomponent-splitview--split-view-drawer-mobile-view-${theme}`,
+            {
+              widths: [width],
+            },
+          );
+        });
+      });
     });
   });
 });

--- a/apps/e2e/split-view-storybook/src/app/split-view/split-view.component.html
+++ b/apps/e2e/split-view-storybook/src/app/split-view/split-view.component.html
@@ -1,8 +1,81 @@
 <div class="screenshot-area"></div>
-<sky-split-view dock="fill" backButtonText="Responsive button text">
-  <sky-split-view-drawer>Drawer</sky-split-view-drawer>
-  <sky-split-view-workspace>
-    <sky-split-view-workspace-content>Content</sky-split-view-workspace-content>
-    <sky-split-view-workspace-footer>Footer</sky-split-view-workspace-footer>
+<sky-split-view [messageStream]="splitViewStream">
+  <sky-split-view-drawer [ariaLabel]="'Transaction list'">
+    <sky-repeater [activeIndex]="activeIndex">
+      @for (item of items; track item; let i = $index) {
+        <sky-repeater-item>
+          <sky-repeater-item-content>
+            {{ item.amount }} <br />
+            {{ item.date }} <br />
+            {{ item.vendor }}
+          </sky-repeater-item-content>
+        </sky-repeater-item>
+      }
+    </sky-repeater>
+  </sky-split-view-drawer>
+
+  <sky-split-view-workspace ariaLabel="Transaction form">
+    <sky-split-view-workspace-content class="sky-padding-even-xl">
+      <form>
+        <sky-description-list class="sky-margin-stacked-xl">
+          <sky-description-list-content>
+            <sky-description-list-term>
+              Receipt amount
+            </sky-description-list-term>
+            <sky-description-list-description>
+              {{ activeRecord.amount }}
+            </sky-description-list-description>
+          </sky-description-list-content>
+          <sky-description-list-content>
+            <sky-description-list-term> Date </sky-description-list-term>
+            <sky-description-list-description>
+              {{ activeRecord.date }}
+            </sky-description-list-description>
+          </sky-description-list-content>
+          <sky-description-list-content>
+            <sky-description-list-term> Vendor </sky-description-list-term>
+            <sky-description-list-description>
+              {{ activeRecord.vendor }}
+            </sky-description-list-description>
+          </sky-description-list-content>
+        </sky-description-list>
+        <div class="sky-form-group">
+          <sky-input-box labelText="Approved amount" stacked="true">
+            <input
+              class="sky-form-control"
+              formControlName="approvedAmount"
+              name="approvedAmount"
+              type="text"
+              skyId
+            />
+          </sky-input-box>
+        </div>
+
+        <div class="sky-form-group">
+          <sky-input-box labelText="Comments">
+            <textarea
+              class="sky-form-control"
+              formControlName="comments"
+              name="comments"
+              skyId
+            ></textarea>
+          </sky-input-box>
+        </div>
+      </form>
+    </sky-split-view-workspace-content>
+    <sky-split-view-workspace-footer>
+      <sky-summary-action-bar id="summary-action-bar">
+        <sky-summary-action-bar-actions>
+          <sky-summary-action-bar-primary-action>
+            Approve expense
+          </sky-summary-action-bar-primary-action>
+          <sky-summary-action-bar-secondary-actions>
+            <sky-summary-action-bar-secondary-action>
+              Deny expense
+            </sky-summary-action-bar-secondary-action>
+          </sky-summary-action-bar-secondary-actions>
+        </sky-summary-action-bar-actions>
+      </sky-summary-action-bar>
+    </sky-split-view-workspace-footer>
   </sky-split-view-workspace>
 </sky-split-view>

--- a/apps/e2e/split-view-storybook/src/app/split-view/split-view.component.stories.ts
+++ b/apps/e2e/split-view-storybook/src/app/split-view/split-view.component.stories.ts
@@ -1,19 +1,19 @@
 import { moduleMetadata } from '@storybook/angular';
 import type { Meta, StoryObj } from '@storybook/angular';
 
-import { SplitViewDockFillComponent } from './split-view.component';
+import { SplitViewComponent } from './split-view.component';
 import { SplitViewModule } from './split-view.module';
 
 export default {
   id: 'splitviewcomponent-splitview',
   title: 'Components/Split View',
-  component: SplitViewDockFillComponent,
+  component: SplitViewComponent,
   decorators: [
     moduleMetadata({
       imports: [SplitViewModule],
     }),
   ],
-} as Meta<SplitViewDockFillComponent>;
-type Story = StoryObj<SplitViewDockFillComponent>;
+} as Meta<SplitViewComponent>;
+type Story = StoryObj<SplitViewComponent>;
 export const SplitView: Story = {};
 SplitView.args = {};

--- a/apps/e2e/split-view-storybook/src/app/split-view/split-view.component.ts
+++ b/apps/e2e/split-view-storybook/src/app/split-view/split-view.component.ts
@@ -1,4 +1,8 @@
-import { Component } from '@angular/core';
+import { ChangeDetectorRef, Component } from '@angular/core';
+import { SkyConfirmService } from '@skyux/modals';
+import { SkySplitViewMessage } from '@skyux/split-view';
+
+import { Subject } from 'rxjs';
 
 @Component({
   selector: 'app-split-view',
@@ -6,4 +10,66 @@ import { Component } from '@angular/core';
   styleUrls: ['./split-view.component.scss'],
   standalone: false,
 })
-export class SplitViewDockFillComponent {}
+export class SplitViewComponent {
+  public set activeIndex(value: number) {
+    this._activeIndex = value;
+    this.activeRecord = this.items[this._activeIndex];
+  }
+
+  public get activeIndex(): number {
+    return this._activeIndex;
+  }
+
+  public activeRecord: any;
+
+  public items = [
+    {
+      id: 1,
+      amount: 73.19,
+      date: '5/13/2020',
+      vendor: 'amazon.com',
+      receiptImage: 'amzn-office-supply-order-5-13-19.png',
+      approvedAmount: 73.19,
+      comments: '',
+    },
+    {
+      id: 2,
+      amount: 214.12,
+      date: '5/14/2020',
+      vendor: 'Office Max',
+      receiptImage: 'office-max-order.png',
+      approvedAmount: 214.12,
+      comments: '',
+    },
+    {
+      id: 3,
+      amount: 29.99,
+      date: '5/14/2020',
+      vendor: 'amazon.com',
+      receiptImage: 'amzn-office-supply-order-5-14-19.png',
+      approvedAmount: 29.99,
+      comments: '',
+    },
+    {
+      id: 4,
+      amount: 1500,
+      date: '5/15/2020',
+      vendor: 'Fresh Catering, LLC',
+      receiptImage: 'fresh-catering-llc-order.png',
+      approvedAmount: 1500,
+      comments: '',
+    },
+  ];
+
+  public splitViewStream = new Subject<SkySplitViewMessage>();
+
+  private _activeIndex = 0;
+
+  constructor(
+    public changeRef: ChangeDetectorRef,
+    public confirmService: SkyConfirmService,
+  ) {
+    // Start with the first item selected.
+    this.activeIndex = 0;
+  }
+}

--- a/apps/e2e/split-view-storybook/src/app/split-view/split-view.module.ts
+++ b/apps/e2e/split-view-storybook/src/app/split-view/split-view.module.ts
@@ -1,14 +1,26 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
+import { SkySummaryActionBarModule } from '@skyux/action-bars';
+import { SkyInputBoxModule } from '@skyux/forms';
+import { SkyDescriptionListModule } from '@skyux/layout';
+import { SkyRepeaterModule } from '@skyux/lists';
 import { SkySplitViewModule } from '@skyux/split-view';
 
-import { SplitViewDockFillComponent } from './split-view.component';
+import { SplitViewComponent } from './split-view.component';
 
-const routes: Routes = [{ path: '', component: SplitViewDockFillComponent }];
+const routes: Routes = [{ path: '', component: SplitViewComponent }];
 @NgModule({
-  declarations: [SplitViewDockFillComponent],
-  imports: [RouterModule.forChild(routes), SkySplitViewModule, CommonModule],
-  exports: [SplitViewDockFillComponent],
+  declarations: [SplitViewComponent],
+  imports: [
+    RouterModule.forChild(routes),
+    SkySplitViewModule,
+    CommonModule,
+    SkyRepeaterModule,
+    SkyDescriptionListModule,
+    SkyInputBoxModule,
+    SkySummaryActionBarModule,
+  ],
+  exports: [SplitViewComponent],
 })
 export class SplitViewModule {}

--- a/libs/components/split-view/src/lib/modules/split-view/split-view-drawer.component.scss
+++ b/libs/components/split-view/src/lib/modules/split-view/split-view-drawer.component.scss
@@ -28,12 +28,45 @@
   width: 100%;
 }
 
+@include mixins.sky-host-responsive-container-xs-min() {
+  .sky-split-view-drawer {
+    &:has(sky-repeater) {
+      padding-top: var(
+        --sky-comp-split_view-drawer-repeater-space-offset-xs-top
+      );
+      padding-right: var(
+        --sky-comp-split_view-drawer-repeater-space-offset-xs-right
+      );
+      padding-bottom: var(
+        --sky-comp-split_view-drawer-repeater-space-offset-xs-bottom
+      );
+      padding-left: var(
+        --sky-comp-split_view-drawer-repeater-space-offset-xs-left
+      );
+    }
+  }
+}
+
 @include mixins.sky-host-responsive-container-sm-min() {
   .sky-split-view-drawer {
     border-right: var(
       --sky-override-split-view-drawer-border-right,
       var(--sky-border-width-divider) solid var(--sky-color-border-divider)
     );
+    &:has(sky-repeater) {
+      padding-top: var(
+        --sky-comp-split_view-drawer-repeater-space-offset-sm-top
+      );
+      padding-right: var(
+        --sky-comp-split_view-drawer-repeater-space-offset-sm-right
+      );
+      padding-bottom: var(
+        --sky-comp-split_view-drawer-repeater-space-offset-sm-bottom
+      );
+      padding-left: var(
+        --sky-comp-split_view-drawer-repeater-space-offset-sm-left
+      );
+    }
   }
 }
 


### PR DESCRIPTION
:cherries: Cherry picked from #3747 [feat(components/split-view): add responsive padding around repeater in split view drawer](https://github.com/blackbaud/skyux/pull/3747)

[AB#3427197](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3427197) 