### PR TITLE
feat(components/theme)!: remove the `--sky-category-color-light-blue` custom property in favor of `--sky-category-color-green` and add a schematic to convert existing usages

### DIFF
--- a/libs/components/avatar/src/lib/modules/avatar/avatar.inner.component.scss
+++ b/libs/components/avatar/src/lib/modules/avatar/avatar.inner.component.scss
@@ -52,7 +52,7 @@
 
 // begin avatar colors
 $sky-avatar-colors: (
-  var(--sky-category-color-light-blue),
+  var(--sky-category-color-green),
   var(--sky-category-color-teal),
   var(--sky-category-color-purple),
   var(--sky-category-color-orange),

--- a/libs/components/docs-tools/src/lib/modules/category-tag/category-tag.component.scss
+++ b/libs/components/docs-tools/src/lib/modules/category-tag/category-tag.component.scss
@@ -15,10 +15,9 @@
   --sky-docs-category-tag-background-color: var(--sky-category-color-blue);
 }
 
-:host(.sky-docs-category-tag-color-light-blue) {
-  --sky-docs-category-tag-background-color: var(
-    --sky-category-color-light-blue
-  );
+:host(.sky-docs-category-tag-color-light-blue),
+:host(.sky-docs-category-tag-color-green) {
+  --sky-docs-category-tag-background-color: var(--sky-category-color-green);
 }
 
 :host(.sky-docs-category-tag-color-orange) {

--- a/libs/components/packages/migrations.json
+++ b/libs/components/packages/migrations.json
@@ -19,6 +19,11 @@
       "version": "0.0.0-PLACEHOLDER",
       "factory": "./src/schematics/migrations/update-13/workspace-check/workspace-check.schematic",
       "description": "Log warnings if the workspace is not configured correctly."
+    },
+    "replace-light-blue-custom-property": {
+      "version": "0.0.0-PLACEHOLDER",
+      "factory": "./src/schematics/migrations/update-13/replace-light-blue-custom-property/replace-light-blue-custom-property.schematic",
+      "description": "Replace --sky-category-color-light-blue custom property with --sky-category-color-green."
     }
   }
 }

--- a/libs/components/packages/src/schematics/migrations/update-13/replace-light-blue-custom-property/replace-light-blue-custom-property.schematic.spec.ts
+++ b/libs/components/packages/src/schematics/migrations/update-13/replace-light-blue-custom-property/replace-light-blue-custom-property.schematic.spec.ts
@@ -1,0 +1,132 @@
+import {
+  SchematicTestRunner,
+  UnitTestTree,
+} from '@angular-devkit/schematics/testing';
+
+import path from 'node:path';
+
+import { createTestApp } from '../../../testing/scaffold';
+
+describe('Migrations > Replace light blue custom property', () => {
+  const runner = new SchematicTestRunner(
+    'migrations',
+    path.join(__dirname, '../../../../../migrations.json'),
+  );
+
+  async function setup(): Promise<{
+    runSchematic: () => Promise<UnitTestTree>;
+    tree: UnitTestTree;
+  }> {
+    const tree = await createTestApp(runner, {
+      projectName: 'test-app',
+    });
+
+    return {
+      runSchematic: (): Promise<UnitTestTree> =>
+        runner.runSchematic('replace-light-blue-custom-property', {}, tree),
+      tree,
+    };
+  }
+
+  afterEach(() => {
+    jest.resetAllMocks();
+    jest.resetModules();
+  });
+
+  it('should replace --sky-category-color-light-blue with --sky-category-color-green in TypeScript files', async () => {
+    const { tree, runSchematic } = await setup();
+
+    const tsContent = `
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-test',
+  template: \`
+    <div [style.color]="'var(--sky-category-color-light-blue)'">
+      Test content
+    </div>
+  \`,
+  styleUrls: ['./test.component.scss']
+})
+export class TestComponent {
+  customProperty = '--sky-category-color-light-blue';
+}
+    `;
+
+    tree.create('/src/app/test.component.ts', tsContent);
+
+    const updatedTree = await runSchematic();
+
+    const updatedContent = updatedTree.readText('/src/app/test.component.ts');
+
+    expect(updatedContent).toContain('--sky-category-color-green');
+    expect(updatedContent).not.toContain('--sky-category-color-light-blue');
+  });
+
+  it('should replace --sky-category-color-light-blue with --sky-category-color-green in SCSS files', async () => {
+    const { tree, runSchematic } = await setup();
+
+    const scssContent = `
+.test-class {
+  color: var(--sky-category-color-light-blue);
+  background-color: var(--sky-category-color-light-blue);
+}
+
+:host {
+  --custom-prop: var(--sky-category-color-light-blue);
+}
+    `;
+
+    tree.create('/src/app/test.component.scss', scssContent);
+
+    const updatedTree = await runSchematic();
+
+    const updatedContent = updatedTree.readText('/src/app/test.component.scss');
+
+    expect(updatedContent).toContain('--sky-category-color-green');
+    expect(updatedContent).not.toContain('--sky-category-color-light-blue');
+  });
+
+  it('should not modify files that do not contain the old custom property', async () => {
+    const { tree, runSchematic } = await setup();
+
+    const originalContent = `
+.test-class {
+  color: var(--sky-category-color-red);
+  background-color: var(--other-custom-property);
+}
+    `;
+
+    tree.create('/src/app/clean.component.scss', originalContent);
+
+    const updatedTree = await runSchematic();
+
+    const updatedContent = updatedTree.readText(
+      '/src/app/clean.component.scss',
+    );
+
+    expect(updatedContent).toBe(originalContent);
+  });
+
+  it('should handle multiple occurrences in the same file', async () => {
+    const { tree, runSchematic } = await setup();
+
+    const content = `
+.class1 { color: var(--sky-category-color-light-blue); }
+.class2 { background: var(--sky-category-color-light-blue); }
+.class3 { border-color: var(--sky-category-color-light-blue); }
+    `;
+
+    tree.create('/src/app/multiple.component.scss', content);
+
+    const updatedTree = await runSchematic();
+
+    const updatedContent = updatedTree.readText(
+      '/src/app/multiple.component.scss',
+    );
+
+    const matches = updatedContent.match(/--sky-category-color-green/g);
+    expect(matches).toHaveLength(3);
+    expect(updatedContent).not.toContain('--sky-category-color-light-blue');
+  });
+});

--- a/libs/components/packages/src/schematics/migrations/update-13/replace-light-blue-custom-property/replace-light-blue-custom-property.schematic.ts
+++ b/libs/components/packages/src/schematics/migrations/update-13/replace-light-blue-custom-property/replace-light-blue-custom-property.schematic.ts
@@ -1,0 +1,10 @@
+import { Rule } from '@angular-devkit/schematics';
+
+import { replaceCustomProperty } from '../../../rules/replace-custom-property/replace-custom-property';
+
+export default function (): Rule {
+  return replaceCustomProperty(
+    '--sky-category-color-light-blue',
+    '--sky-category-color-green',
+  );
+}

--- a/libs/components/packages/src/schematics/rules/replace-custom-property/replace-custom-property.spec.ts
+++ b/libs/components/packages/src/schematics/rules/replace-custom-property/replace-custom-property.spec.ts
@@ -1,8 +1,9 @@
-import { SchematicContext, Tree } from '@angular-devkit/schematics';
 import {
   SchematicTestRunner,
   UnitTestTree,
 } from '@angular-devkit/schematics/testing';
+
+import { firstValueFrom } from 'rxjs';
 
 import { createTestApp } from '../../testing/scaffold';
 
@@ -13,24 +14,12 @@ const collectionPath = require.resolve('../../../../collection.json');
 describe('replaceCustomProperty rule', () => {
   const runner = new SchematicTestRunner('schematics', collectionPath);
 
-  async function setup(): Promise<{
-    tree: UnitTestTree;
-    context: SchematicContext;
-  }> {
+  async function setup(): Promise<UnitTestTree> {
     const tree = await createTestApp(runner, {
       projectName: 'test-app',
     });
 
-    const context = {
-      logger: {
-        info: jest.fn(),
-        warn: jest.fn(),
-        error: jest.fn(),
-        debug: jest.fn(),
-      },
-    } as unknown as SchematicContext;
-
-    return { tree, context };
+    return tree;
   }
 
   afterEach(() => {
@@ -39,7 +28,7 @@ describe('replaceCustomProperty rule', () => {
   });
 
   it('should replace custom property in TypeScript files', async () => {
-    const { tree, context } = await setup();
+    const tree = await setup();
 
     const tsContent = `
 export class TestComponent {
@@ -50,16 +39,20 @@ export class TestComponent {
 
     tree.create('/src/app/test-file.ts', tsContent);
 
-    const rule = replaceCustomProperty('--old-property', '--new-property');
-    const result = await rule(tree, context);
+    await firstValueFrom(
+      runner.callRule(
+        replaceCustomProperty('--old-property', '--new-property'),
+        tree,
+      ),
+    );
 
-    const updatedContent = (result as Tree).readText('/src/app/test-file.ts');
+    const updatedContent = tree.readText('/src/app/test-file.ts');
     expect(updatedContent).toContain('--new-property');
     expect(updatedContent).not.toContain('--old-property');
   });
 
   it('should replace custom property in SCSS files', async () => {
-    const { tree, context } = await setup();
+    const tree = await setup();
 
     const scssContent = `
 .test-class {
@@ -70,16 +63,20 @@ export class TestComponent {
 
     tree.create('/src/app/test-file.scss', scssContent);
 
-    const rule = replaceCustomProperty('--old-property', '--new-property');
-    const result = await rule(tree, context);
+    await firstValueFrom(
+      runner.callRule(
+        replaceCustomProperty('--old-property', '--new-property'),
+        tree,
+      ),
+    );
 
-    const updatedContent = (result as Tree).readText('/src/app/test-file.scss');
+    const updatedContent = tree.readText('/src/app/test-file.scss');
     expect(updatedContent).toContain('--new-property');
     expect(updatedContent).not.toContain('--old-property');
   });
 
   it('should not modify files without the old custom property', async () => {
-    const { tree, context } = await setup();
+    const tree = await setup();
 
     const originalContent = `
 .test-class {
@@ -89,17 +86,19 @@ export class TestComponent {
 
     tree.create('/src/app/clean-file.scss', originalContent);
 
-    const rule = replaceCustomProperty('--old-property', '--new-property');
-    const result = await rule(tree, context);
-
-    const updatedContent = (result as Tree).readText(
-      '/src/app/clean-file.scss',
+    await firstValueFrom(
+      runner.callRule(
+        replaceCustomProperty('--old-property', '--new-property'),
+        tree,
+      ),
     );
+
+    const updatedContent = tree.readText('/src/app/clean-file.scss');
     expect(updatedContent).toBe(originalContent);
   });
 
   it('should handle multiple different custom properties', async () => {
-    const { tree, context } = await setup();
+    const tree = await setup();
 
     const tsContent = `
 export class TestComponent {
@@ -110,17 +109,59 @@ export class TestComponent {
 
     tree.create('/src/app/test-multiple.ts', tsContent);
 
-    const rule = replaceCustomProperty(
-      '--sky-category-color-light-blue',
-      '--sky-category-color-green',
+    await firstValueFrom(
+      runner.callRule(
+        replaceCustomProperty(
+          '--sky-category-color-light-blue',
+          '--sky-category-color-green',
+        ),
+        tree,
+      ),
     );
-    const result = await rule(tree, context);
 
-    const updatedContent = (result as Tree).readText(
-      '/src/app/test-multiple.ts',
-    );
+    const updatedContent = tree.readText('/src/app/test-multiple.ts');
     expect(updatedContent).toContain('--sky-category-color-green');
     expect(updatedContent).toContain('--sky-category-color-dark-blue'); // Should remain unchanged
     expect(updatedContent).not.toContain('--sky-category-color-light-blue');
+  });
+
+  it('should preserve var() function around custom properties', async () => {
+    const tree = await setup();
+
+    const content = `
+.test-class {
+  color: var(--old-property);
+  background: var(--old-property, blue);
+  border-color: var(--old-property, var(--fallback));
+}
+
+export class TestComponent {
+  styles = {
+    color: 'var(--old-property)',
+    background: 'var(--old-property, red)'
+  };
+}
+    `;
+
+    tree.create('/src/app/var-test.scss', content);
+
+    await firstValueFrom(
+      runner.callRule(
+        replaceCustomProperty('--old-property', '--new-property'),
+        tree,
+      ),
+    );
+
+    const updatedContent = tree.readText('/src/app/var-test.scss');
+
+    // Verify var() function is preserved with new property
+    expect(updatedContent).toContain('var(--new-property)');
+    expect(updatedContent).toContain('var(--new-property, blue)');
+    expect(updatedContent).toContain('var(--new-property, var(--fallback))');
+    expect(updatedContent).toContain("'var(--new-property)'");
+    expect(updatedContent).toContain("'var(--new-property, red)'");
+
+    // Verify old property is completely replaced
+    expect(updatedContent).not.toContain('--old-property');
   });
 });

--- a/libs/components/packages/src/schematics/rules/replace-custom-property/replace-custom-property.spec.ts
+++ b/libs/components/packages/src/schematics/rules/replace-custom-property/replace-custom-property.spec.ts
@@ -1,0 +1,126 @@
+import { SchematicContext, Tree } from '@angular-devkit/schematics';
+import {
+  SchematicTestRunner,
+  UnitTestTree,
+} from '@angular-devkit/schematics/testing';
+
+import { createTestApp } from '../../testing/scaffold';
+
+import { replaceCustomProperty } from './replace-custom-property';
+
+const collectionPath = require.resolve('../../../../collection.json');
+
+describe('replaceCustomProperty rule', () => {
+  const runner = new SchematicTestRunner('schematics', collectionPath);
+
+  async function setup(): Promise<{
+    tree: UnitTestTree;
+    context: SchematicContext;
+  }> {
+    const tree = await createTestApp(runner, {
+      projectName: 'test-app',
+    });
+
+    const context = {
+      logger: {
+        info: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn(),
+        debug: jest.fn(),
+      },
+    } as unknown as SchematicContext;
+
+    return { tree, context };
+  }
+
+  afterEach(() => {
+    jest.resetAllMocks();
+    jest.resetModules();
+  });
+
+  it('should replace custom property in TypeScript files', async () => {
+    const { tree, context } = await setup();
+
+    const tsContent = `
+export class TestComponent {
+  color = 'var(--old-property)';
+  property = '--old-property';
+}
+    `;
+
+    tree.create('/src/app/test-file.ts', tsContent);
+
+    const rule = replaceCustomProperty('--old-property', '--new-property');
+    const result = await rule(tree, context);
+
+    const updatedContent = (result as Tree).readText('/src/app/test-file.ts');
+    expect(updatedContent).toContain('--new-property');
+    expect(updatedContent).not.toContain('--old-property');
+  });
+
+  it('should replace custom property in SCSS files', async () => {
+    const { tree, context } = await setup();
+
+    const scssContent = `
+.test-class {
+  color: var(--old-property);
+  --custom-var: var(--old-property);
+}
+    `;
+
+    tree.create('/src/app/test-file.scss', scssContent);
+
+    const rule = replaceCustomProperty('--old-property', '--new-property');
+    const result = await rule(tree, context);
+
+    const updatedContent = (result as Tree).readText('/src/app/test-file.scss');
+    expect(updatedContent).toContain('--new-property');
+    expect(updatedContent).not.toContain('--old-property');
+  });
+
+  it('should not modify files without the old custom property', async () => {
+    const { tree, context } = await setup();
+
+    const originalContent = `
+.test-class {
+  color: var(--different-property);
+}
+    `;
+
+    tree.create('/src/app/clean-file.scss', originalContent);
+
+    const rule = replaceCustomProperty('--old-property', '--new-property');
+    const result = await rule(tree, context);
+
+    const updatedContent = (result as Tree).readText(
+      '/src/app/clean-file.scss',
+    );
+    expect(updatedContent).toBe(originalContent);
+  });
+
+  it('should handle multiple different custom properties', async () => {
+    const { tree, context } = await setup();
+
+    const tsContent = `
+export class TestComponent {
+  lightBlue = 'var(--sky-category-color-light-blue)';
+  darkBlue = 'var(--sky-category-color-dark-blue)';
+}
+    `;
+
+    tree.create('/src/app/test-multiple.ts', tsContent);
+
+    const rule = replaceCustomProperty(
+      '--sky-category-color-light-blue',
+      '--sky-category-color-green',
+    );
+    const result = await rule(tree, context);
+
+    const updatedContent = (result as Tree).readText(
+      '/src/app/test-multiple.ts',
+    );
+    expect(updatedContent).toContain('--sky-category-color-green');
+    expect(updatedContent).toContain('--sky-category-color-dark-blue'); // Should remain unchanged
+    expect(updatedContent).not.toContain('--sky-category-color-light-blue');
+  });
+});

--- a/libs/components/packages/src/schematics/rules/replace-custom-property/replace-custom-property.spec.ts
+++ b/libs/components/packages/src/schematics/rules/replace-custom-property/replace-custom-property.spec.ts
@@ -164,4 +164,108 @@ export class TestComponent {
     // Verify old property is completely replaced
     expect(updatedContent).not.toContain('--old-property');
   });
+
+  it('should not process files with unsupported extensions', async () => {
+    const tree = await setup();
+
+    const htmlContent = `
+<div style="color: var(--old-property);">Content</div>
+    `;
+
+    tree.create('/src/app/test.component.html', htmlContent);
+
+    await firstValueFrom(
+      runner.callRule(
+        replaceCustomProperty('--old-property', '--new-property'),
+        tree,
+      ),
+    );
+
+    const updatedContent = tree.readText('/src/app/test.component.html');
+    // HTML files should not be processed, so content should remain unchanged
+    expect(updatedContent).toBe(htmlContent);
+    expect(updatedContent).toContain('--old-property');
+  });
+
+  it('should handle regex special characters in custom property names', async () => {
+    const tree = await setup();
+
+    const content = `
+.test-class {
+  color: var(--my-prop.with[special](chars));
+  background: var(--my-prop.with[special](chars), blue);
+}
+    `;
+
+    tree.create('/src/app/special-chars.scss', content);
+
+    await firstValueFrom(
+      runner.callRule(
+        replaceCustomProperty(
+          '--my-prop.with[special](chars)',
+          '--escaped-prop',
+        ),
+        tree,
+      ),
+    );
+
+    const updatedContent = tree.readText('/src/app/special-chars.scss');
+    expect(updatedContent).toContain('--escaped-prop');
+    expect(updatedContent).toContain('var(--escaped-prop)');
+    expect(updatedContent).toContain('var(--escaped-prop, blue)');
+    expect(updatedContent).not.toContain('--my-prop.with[special](chars)');
+  });
+
+  it('should handle case where regex replace does not change content', async () => {
+    const tree = await setup();
+
+    const content = `
+.test-class {
+  /* This comment mentions --different-property that won't be replaced in comments by our simple replace */
+}
+    `;
+
+    tree.create('/src/app/edge-case.scss', content);
+
+    await firstValueFrom(
+      runner.callRule(
+        replaceCustomProperty('--non-existent-property', '--new-property'),
+        tree,
+      ),
+    );
+
+    const updatedContent = tree.readText('/src/app/edge-case.scss');
+    expect(updatedContent).toBe(content); // Content should be unchanged
+  });
+
+  it('should process files in project root when no sourceRoot is defined', async () => {
+    const tree = await setup();
+
+    // Modify angular.json to remove sourceRoot
+    const angularJson = tree.readJson('angular.json') as {
+      projects: Record<string, { sourceRoot?: string }>;
+    };
+    delete angularJson.projects['test-app'].sourceRoot;
+    tree.overwrite('angular.json', JSON.stringify(angularJson, null, 2));
+
+    const content = `
+export class TestComponent {
+  color = 'var(--old-property)';
+}
+    `;
+
+    // Place file in project root since no sourceRoot is defined
+    tree.create('/test-root.ts', content);
+
+    await firstValueFrom(
+      runner.callRule(
+        replaceCustomProperty('--old-property', '--new-property'),
+        tree,
+      ),
+    );
+
+    const updatedContent = tree.readText('/test-root.ts');
+    expect(updatedContent).toContain('--new-property');
+    expect(updatedContent).not.toContain('--old-property');
+  });
 });

--- a/libs/components/packages/src/schematics/rules/replace-custom-property/replace-custom-property.ts
+++ b/libs/components/packages/src/schematics/rules/replace-custom-property/replace-custom-property.ts
@@ -1,0 +1,75 @@
+import { Rule, SchematicContext, Tree } from '@angular-devkit/schematics';
+import { getWorkspace } from '@schematics/angular/utility/workspace';
+
+import { visitProjectFiles } from '../../utility/visit-project-files';
+
+function replaceCustomPropertyInFile(
+  tree: Tree,
+  filePath: string,
+  context: SchematicContext,
+  oldCustomProperty: string,
+  newCustomProperty: string,
+): void {
+  const content = tree.readText(filePath);
+
+  // Check if the old custom property exists in the file
+  if (content.includes(oldCustomProperty)) {
+    const recorder = tree.beginUpdate(filePath);
+
+    // Replace all occurrences of the old custom property with the new one
+    const updatedContent = content.replace(
+      new RegExp(
+        oldCustomProperty.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&'),
+        'g',
+      ),
+      newCustomProperty,
+    );
+
+    // Only update if there were actual changes
+    if (updatedContent !== content) {
+      recorder.remove(0, content.length);
+      recorder.insertLeft(0, updatedContent);
+      tree.commitUpdate(recorder);
+
+      context.logger.info(
+        `Replaced ${oldCustomProperty} with ${newCustomProperty} in ${filePath}`,
+      );
+    }
+  }
+}
+
+export function replaceCustomProperty(
+  oldCustomProperty: string,
+  newCustomProperty: string,
+): Rule {
+  return async (tree, context) => {
+    context.logger.info(
+      `Replacing ${oldCustomProperty} with ${newCustomProperty} in all workspace files...`,
+    );
+
+    const workspace = await getWorkspace(tree);
+
+    workspace.projects.forEach((project) => {
+      visitProjectFiles(
+        tree,
+        project.sourceRoot || project.root,
+        (filePath) => {
+          // Process TypeScript and SCSS files
+          if (filePath.endsWith('.ts') || filePath.endsWith('.scss')) {
+            replaceCustomPropertyInFile(
+              tree,
+              filePath,
+              context,
+              oldCustomProperty,
+              newCustomProperty,
+            );
+          }
+        },
+      );
+    });
+
+    context.logger.info(
+      `Finished replacing ${oldCustomProperty} with ${newCustomProperty}`,
+    );
+  };
+}

--- a/libs/components/theme/src/lib/styles/_custom-properties.scss
+++ b/libs/components/theme/src/lib/styles/_custom-properties.scss
@@ -17,7 +17,7 @@
 
   --sky-border-color-neutral-medium: #{$sky-border-color-neutral-medium};
 
-  --sky-category-color-light-blue: #{$sky-category-color-light-blue};
+  --sky-category-color-green: #{$sky-category-color-light-blue};
   --sky-category-color-teal: #{$sky-category-color-teal};
   --sky-category-color-purple: #{$sky-category-color-purple};
   --sky-category-color-orange: #{$sky-category-color-orange};

--- a/libs/components/theme/src/lib/styles/themes/modern/_custom-properties.scss
+++ b/libs/components/theme/src/lib/styles/themes/modern/_custom-properties.scss
@@ -17,7 +17,7 @@
   --sky-border-color-neutral-medium: var(--sky-color-border-container-base);
   --sky-border-color-neutral-medium-dark: var(--sky-color-border-switch-base);
 
-  --sky-category-color-light-blue: var(--sky-color-category-green);
+  --sky-category-color-green: var(--sky-color-category-green);
   --sky-category-color-teal: var(--sky-color-category-teal);
   --sky-category-color-purple: var(--sky-color-category-purple);
   --sky-category-color-orange: var(--sky-color-category-orange);


### PR DESCRIPTION
[AB#3387362](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3387362)