### PR TITLE
fix: ag-grid headers are correctly styled when within a page component (#3803)

### DIFF
--- a/libs/components/pages/src/lib/modules/page/page.component.scss
+++ b/libs/components/pages/src/lib/modules/page/page.component.scss
@@ -1,8 +1,9 @@
-:host {
-  &.sky-layout-host-list,
-  &.sky-layout-host-fit {
-    --sky-comp-override-list-header-background-color: var(
-      --sky-color-background-container-dimmed
-    );
-  }
+@use 'libs/components/theme/src/lib/styles/compat-tokens-mixins' as compatMixins;
+
+@include compatMixins.sky-modern-v2(
+  ':host.sky-layout-host-fit, :host.sky-layout-host-list'
+) {
+  --sky-comp-override-list-header-background-color: var(
+    --sky-color-background-container-dimmed
+  );
 }

--- a/libs/components/tabs/src/lib/modules/tabs/tab.component.scss
+++ b/libs/components/tabs/src/lib/modules/tabs/tab.component.scss
@@ -1,3 +1,5 @@
+@use 'libs/components/theme/src/lib/styles/compat-tokens-mixins' as compatMixins;
+
 :host {
   display: block;
 
@@ -12,13 +14,6 @@
         position: relative;
       }
     }
-
-    &-fit,
-    &-list {
-      --sky-comp-override-list-header-background-color: var(
-        --sky-color-background-container-dimmed
-      );
-    }
   }
 }
 
@@ -27,4 +22,12 @@
   overflow: var(--sky-layout-host-content-overflow, visible);
   padding: var(--sky-layout-host-content-spacing, 0);
   position: var(--sky-layout-host-content-position, static);
+}
+
+@include compatMixins.sky-modern-v2(
+  ':host.sky-layout-host-fit, :host.sky-layout-host-list'
+) {
+  --sky-comp-override-list-header-background-color: var(
+    --sky-color-background-container-dimmed
+  );
 }


### PR DESCRIPTION
:cherries: Cherry picked from #3803 [fix: ag-grid headers are correctly styled when within a page component](https://github.com/blackbaud/skyux/pull/3803)

[AB#3518045](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3518045) 