### PR TITLE
feat(components/theme): add title and favicon support to brand (#3815)

### DIFF
--- a/libs/components/theme/src/lib/theming/theme-brand.service.spec.ts
+++ b/libs/components/theme/src/lib/theming/theme-brand.service.spec.ts
@@ -1,0 +1,881 @@
+import { DOCUMENT, Renderer2 } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+
+import { SkyThemeBrand } from './theme-brand';
+import { SkyThemeBrandService } from './theme-brand.service';
+
+describe('SkyThemeBrandService', () => {
+  let service: SkyThemeBrandService;
+  let mockHostEl: Element;
+  let mockRenderer: jasmine.SpyObj<Renderer2>;
+  let mockDocument: {
+    head: HTMLHeadElement | null;
+  };
+  let mockHead: jasmine.SpyObj<HTMLHeadElement>;
+  let createdLinkElements: jasmine.SpyObj<HTMLLinkElement>[];
+
+  beforeEach(() => {
+    createdLinkElements = [];
+    mockHead = jasmine.createSpyObj('HTMLHeadElement', ['append']);
+    mockDocument = {
+      head: mockHead,
+    };
+
+    TestBed.configureTestingModule({
+      providers: [{ provide: DOCUMENT, useValue: mockDocument }],
+    });
+
+    service = TestBed.inject(SkyThemeBrandService);
+
+    mockHostEl = document.createElement('div');
+
+    mockRenderer = jasmine.createSpyObj('Renderer2', [
+      'createElement',
+      'setAttribute',
+      'addClass',
+      'removeClass',
+      'appendChild',
+    ]);
+
+    // Return a new mock link element each time createElement is called and track them
+    mockRenderer.createElement.and.callFake(() => {
+      const newMockLinkElement = jasmine.createSpyObj('HTMLLinkElement', [
+        'remove',
+      ]);
+      createdLinkElements.push(newMockLinkElement);
+      return newMockLinkElement;
+    });
+  });
+
+  describe('registerBrand()', () => {
+    it('should register a brand', () => {
+      const brand = new SkyThemeBrand('test', '1.0.0');
+
+      expect(() => service.registerBrand(brand)).not.toThrow();
+    });
+  });
+
+  describe('unregisterBrand()', () => {
+    it('should unregister a brand', () => {
+      const brand = new SkyThemeBrand('test', '1.0.0');
+      service.registerBrand(brand);
+
+      expect(() => service.unregisterBrand('test')).not.toThrow();
+    });
+  });
+
+  describe('updateBrand()', () => {
+    it('should resolve registered brand and update DOM when brand changes', () => {
+      const originalBrand = new SkyThemeBrand('test', '1.0.0');
+      const registeredBrand = new SkyThemeBrand('test', '2.0.0');
+
+      service.registerBrand(registeredBrand);
+
+      service.updateBrand(mockHostEl, mockRenderer, originalBrand, undefined);
+
+      // Should use the registered brand for DOM operations
+      expect(mockRenderer.addClass).toHaveBeenCalledWith(
+        mockHostEl,
+        'sky-theme-brand-base',
+      );
+      expect(mockRenderer.addClass).toHaveBeenCalledWith(
+        mockHostEl,
+        registeredBrand.hostClass,
+      );
+      expect(mockRenderer.createElement).toHaveBeenCalledWith('link');
+      expect(mockRenderer.appendChild).toHaveBeenCalledWith(
+        mockHead,
+        jasmine.any(Object),
+      );
+    });
+
+    it('should use original brand when no registered brand exists', () => {
+      const brand = new SkyThemeBrand('test', '1.0.0');
+
+      service.updateBrand(mockHostEl, mockRenderer, brand, undefined);
+
+      expect(mockRenderer.addClass).toHaveBeenCalledWith(
+        mockHostEl,
+        brand.hostClass,
+      );
+    });
+
+    it('should update both host class and stylesheet when brand changes', () => {
+      const previousBrand = new SkyThemeBrand('old-brand', '1.0.0');
+      const currentBrand = new SkyThemeBrand('new-brand', '2.0.0');
+
+      // First set up the previous brand to establish a stylesheet
+      service.updateBrand(mockHostEl, mockRenderer, previousBrand, undefined);
+
+      // Reset mocks to focus on the brand change
+      mockRenderer.removeClass.calls.reset();
+      mockRenderer.addClass.calls.reset();
+      mockRenderer.createElement.calls.reset();
+      mockRenderer.appendChild.calls.reset();
+      createdLinkElements.forEach((el) => el.remove.calls.reset());
+
+      // Now change to the new brand
+      service.updateBrand(
+        mockHostEl,
+        mockRenderer,
+        currentBrand,
+        previousBrand,
+      );
+
+      // Verify host class changes
+      expect(mockRenderer.removeClass).toHaveBeenCalledWith(
+        mockHostEl,
+        previousBrand.hostClass,
+      );
+      expect(mockRenderer.addClass).toHaveBeenCalledWith(
+        mockHostEl,
+        currentBrand.hostClass,
+      );
+
+      // Verify stylesheet creation and removal
+      expect(createdLinkElements[0].remove).toHaveBeenCalled();
+      expect(mockRenderer.createElement).toHaveBeenCalledWith('link');
+      expect(mockRenderer.appendChild).toHaveBeenCalledWith(
+        mockHead,
+        jasmine.any(Object),
+      );
+    });
+
+    it('should not update when host classes are the same', () => {
+      const brand1 = new SkyThemeBrand('same-brand', '1.0.0');
+      const brand2 = new SkyThemeBrand('same-brand', '1.0.0');
+
+      service.updateBrand(mockHostEl, mockRenderer, brand2, brand1);
+
+      // Should not perform any DOM operations
+      expect(mockRenderer.removeClass).not.toHaveBeenCalled();
+      expect(mockRenderer.addClass).not.toHaveBeenCalled();
+      expect(mockRenderer.createElement).not.toHaveBeenCalled();
+      expect(mockRenderer.appendChild).not.toHaveBeenCalled();
+    });
+
+    it('should update when no previous brand exists', () => {
+      const currentBrand = new SkyThemeBrand('new-brand', '1.0.0');
+
+      service.updateBrand(mockHostEl, mockRenderer, currentBrand, undefined);
+
+      // Verify host class changes - should add base class and brand class
+      expect(mockRenderer.addClass).toHaveBeenCalledWith(
+        mockHostEl,
+        'sky-theme-brand-base',
+      );
+      expect(mockRenderer.addClass).toHaveBeenCalledWith(
+        mockHostEl,
+        currentBrand.hostClass,
+      );
+
+      // Verify stylesheet creation
+      expect(mockRenderer.createElement).toHaveBeenCalledWith('link');
+      expect(mockRenderer.appendChild).toHaveBeenCalledWith(
+        mockHead,
+        jasmine.any(Object),
+      );
+    });
+
+    it('should handle switching to blackbaud brand (no stylesheet)', () => {
+      const previousBrand = new SkyThemeBrand('custom', '1.0.0');
+      const blackbaudBrand = new SkyThemeBrand('blackbaud', '1.0.0');
+
+      // First establish a custom brand
+      service.updateBrand(mockHostEl, mockRenderer, previousBrand, undefined);
+
+      // Reset spies to focus on the switch
+      createdLinkElements.forEach((el) => el.remove.calls.reset());
+      mockRenderer.createElement.calls.reset();
+      mockRenderer.appendChild.calls.reset();
+      mockRenderer.addClass.calls.reset();
+      mockRenderer.removeClass.calls.reset();
+
+      // Switch to blackbaud brand
+      service.updateBrand(
+        mockHostEl,
+        mockRenderer,
+        blackbaudBrand,
+        previousBrand,
+      );
+
+      // Should remove previous brand class and add blackbaud class
+      expect(mockRenderer.removeClass).toHaveBeenCalledWith(
+        mockHostEl,
+        previousBrand.hostClass,
+      );
+      expect(mockRenderer.addClass).toHaveBeenCalledWith(
+        mockHostEl,
+        blackbaudBrand.hostClass,
+      );
+
+      // Should remove stylesheet but not create a new one for blackbaud
+      expect(createdLinkElements[0].remove).toHaveBeenCalled();
+      expect(mockRenderer.createElement).not.toHaveBeenCalled();
+      expect(mockRenderer.appendChild).not.toHaveBeenCalled();
+    });
+
+    it('should handle removing brand (switching to undefined)', () => {
+      const previousBrand = new SkyThemeBrand('custom', '1.0.0');
+
+      // First establish a brand
+      service.updateBrand(mockHostEl, mockRenderer, previousBrand, undefined);
+
+      // Reset spies to focus on the removal
+      createdLinkElements.forEach((el) => el.remove.calls.reset());
+      mockRenderer.removeClass.calls.reset();
+
+      // Remove the brand
+      service.updateBrand(mockHostEl, mockRenderer, undefined, previousBrand);
+
+      // Should remove both the brand class and the base class
+      expect(mockRenderer.removeClass).toHaveBeenCalledWith(
+        mockHostEl,
+        previousBrand.hostClass,
+      );
+      expect(mockRenderer.removeClass).toHaveBeenCalledWith(
+        mockHostEl,
+        'sky-theme-brand-base',
+      );
+
+      // Should remove stylesheet
+      expect(createdLinkElements[0].remove).toHaveBeenCalled();
+    });
+  });
+
+  describe('destroy()', () => {
+    it('should remove brand stylesheet if one exists', () => {
+      const brand = new SkyThemeBrand('custom', '1.0.0');
+
+      // Establish a brand with stylesheet first
+      service.updateBrand(mockHostEl, mockRenderer, brand, undefined);
+
+      createdLinkElements.forEach((el) => el.remove.calls.reset());
+
+      service.destroy();
+
+      expect(createdLinkElements[0].remove).toHaveBeenCalled();
+    });
+
+    it('should not throw if no stylesheet exists', () => {
+      expect(() => service.destroy()).not.toThrow();
+    });
+  });
+
+  describe('favicon handling', () => {
+    it('should add favicon when brand has faviconUrl', () => {
+      const brand = new SkyThemeBrand(
+        'test',
+        '1.0.0',
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        'https://example.com/favicon.ico',
+      );
+
+      service.updateBrand(mockHostEl, mockRenderer, brand, undefined);
+
+      // Should create 3 favicon elements and 1 stylesheet element
+      expect(mockRenderer.createElement).toHaveBeenCalledTimes(4);
+      expect(mockRenderer.createElement).toHaveBeenCalledWith('link');
+
+      // Verify apple-touch-icon attributes
+      expect(mockRenderer.setAttribute).toHaveBeenCalledWith(
+        jasmine.any(Object),
+        'rel',
+        'apple-touch-icon',
+      );
+      expect(mockRenderer.setAttribute).toHaveBeenCalledWith(
+        jasmine.any(Object),
+        'sizes',
+        '180x180',
+      );
+
+      // Verify icon elements
+      expect(mockRenderer.setAttribute).toHaveBeenCalledWith(
+        jasmine.any(Object),
+        'rel',
+        'icon',
+      );
+      expect(mockRenderer.setAttribute).toHaveBeenCalledWith(
+        jasmine.any(Object),
+        'sizes',
+        '32x32',
+      );
+      expect(mockRenderer.setAttribute).toHaveBeenCalledWith(
+        jasmine.any(Object),
+        'sizes',
+        '16x16',
+      );
+
+      // Verify all have the same href
+      expect(mockRenderer.setAttribute).toHaveBeenCalledWith(
+        jasmine.any(Object),
+        'href',
+        'https://example.com/favicon.ico',
+      );
+
+      // Should append all elements to head (3 favicon icons + 1 stylesheet)
+      expect(mockRenderer.appendChild).toHaveBeenCalledTimes(4);
+    });
+
+    it('should update existing favicon when brand changes', () => {
+      // Use the same brand instance but update the favicon URL
+      const brand = new SkyThemeBrand(
+        'test',
+        '1.0.0',
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        'https://example.com/favicon1.ico',
+      );
+
+      // Set first brand with favicon
+      service.updateBrand(mockHostEl, mockRenderer, brand, undefined);
+
+      // Reset spies to focus on the update
+      mockRenderer.createElement.calls.reset();
+      mockRenderer.setAttribute.calls.reset();
+      mockRenderer.appendChild.calls.reset();
+
+      // Create a new brand instance with different favicon but same name
+      const updatedBrand = new SkyThemeBrand(
+        'test',
+        '1.0.0',
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        'https://example.com/favicon2.ico',
+      );
+
+      // Update to brand with different favicon URL
+      service.updateBrand(mockHostEl, mockRenderer, updatedBrand, brand);
+
+      // Should update all 3 favicon href attributes to the new URL
+      expect(mockRenderer.setAttribute).toHaveBeenCalledWith(
+        jasmine.any(Object),
+        'href',
+        'https://example.com/favicon2.ico',
+      );
+      // Should not create new elements since favicon icons already exist
+      expect(mockRenderer.createElement).not.toHaveBeenCalled();
+      // Should not append again since favicon icons already exist
+      expect(mockRenderer.appendChild).not.toHaveBeenCalled();
+    });
+
+    it('should remove favicon when switching to brand without faviconUrl', () => {
+      const brandWithFavicon = new SkyThemeBrand(
+        'test',
+        '1.0.0',
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        'https://example.com/favicon.ico',
+      );
+      const brandWithoutFavicon = new SkyThemeBrand('test2', '1.0.0');
+
+      // Set brand with favicon
+      service.updateBrand(
+        mockHostEl,
+        mockRenderer,
+        brandWithFavicon,
+        undefined,
+      );
+
+      // Verify favicon was created (should have 4 elements: 1 stylesheet + 3 favicon icons)
+      expect(createdLinkElements.length).toBe(4);
+      expect(mockRenderer.setAttribute).toHaveBeenCalledWith(
+        jasmine.any(Object),
+        'rel',
+        'apple-touch-icon',
+      );
+      expect(mockRenderer.setAttribute).toHaveBeenCalledWith(
+        jasmine.any(Object),
+        'rel',
+        'icon',
+      );
+
+      // Switch to brand without favicon
+      service.updateBrand(
+        mockHostEl,
+        mockRenderer,
+        brandWithoutFavicon,
+        brandWithFavicon,
+      );
+
+      // Verify all 3 favicon elements were removed (only stylesheet elements remain)
+      expect(createdLinkElements[1].remove).toHaveBeenCalled(); // First favicon
+      expect(createdLinkElements[2].remove).toHaveBeenCalled(); // Second favicon
+      expect(createdLinkElements[3].remove).toHaveBeenCalled(); // Third favicon
+    });
+
+    it('should handle switching between different brands with favicon icons', () => {
+      const brand1 = new SkyThemeBrand(
+        'brand1',
+        '1.0.0',
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        'https://example.com/favicon1.ico',
+      );
+      const brand2 = new SkyThemeBrand(
+        'brand2',
+        '1.0.0',
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        'https://example.com/favicon2.ico',
+      );
+
+      // Set first brand
+      service.updateBrand(mockHostEl, mockRenderer, brand1, undefined);
+      const initialElementCount = createdLinkElements.length;
+
+      // Switch to second brand
+      service.updateBrand(mockHostEl, mockRenderer, brand2, brand1);
+
+      // Verify new stylesheet element was created but favicon elements were reused
+      expect(createdLinkElements.length).toBeGreaterThan(initialElementCount);
+      expect(mockRenderer.setAttribute).toHaveBeenCalledWith(
+        jasmine.any(Object),
+        'href',
+        'https://example.com/favicon2.ico',
+      );
+    });
+
+    it('should remove favicon when switching to undefined brand', () => {
+      const brandWithFavicon = new SkyThemeBrand(
+        'test',
+        '1.0.0',
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        'https://example.com/favicon.ico',
+      );
+
+      // Set brand with favicon
+      service.updateBrand(
+        mockHostEl,
+        mockRenderer,
+        brandWithFavicon,
+        undefined,
+      );
+
+      // Track the created favicon elements (indices 1, 2, 3 - stylesheet is index 0)
+      const faviconElements = createdLinkElements.slice(1, 4);
+
+      // Switch to undefined brand
+      service.updateBrand(
+        mockHostEl,
+        mockRenderer,
+        undefined,
+        brandWithFavicon,
+      );
+
+      // Verify all favicon elements were removed
+      faviconElements.forEach((faviconElement) => {
+        expect(faviconElement.remove).toHaveBeenCalled();
+      });
+    });
+
+    it('should create three favicon elements with correct attributes', () => {
+      const brand = new SkyThemeBrand(
+        'test',
+        '1.0.0',
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        'https://example.com/favicon.ico',
+      );
+
+      service.updateBrand(mockHostEl, mockRenderer, brand, undefined);
+
+      // Verify correct number of elements created (1 stylesheet + 3 favicon icons)
+      expect(mockRenderer.createElement).toHaveBeenCalledTimes(4);
+
+      // Verify apple-touch-icon attributes
+      expect(mockRenderer.setAttribute).toHaveBeenCalledWith(
+        jasmine.any(Object),
+        'rel',
+        'apple-touch-icon',
+      );
+      expect(mockRenderer.setAttribute).toHaveBeenCalledWith(
+        jasmine.any(Object),
+        'sizes',
+        '180x180',
+      );
+
+      // Verify first icon element attributes
+      expect(mockRenderer.setAttribute).toHaveBeenCalledWith(
+        jasmine.any(Object),
+        'rel',
+        'icon',
+      );
+      expect(mockRenderer.setAttribute).toHaveBeenCalledWith(
+        jasmine.any(Object),
+        'sizes',
+        '32x32',
+      );
+
+      // Verify second icon element attributes
+      expect(mockRenderer.setAttribute).toHaveBeenCalledWith(
+        jasmine.any(Object),
+        'sizes',
+        '16x16',
+      );
+
+      // Verify all elements have the same href
+      const hrefCalls = mockRenderer.setAttribute.calls
+        .all()
+        .filter((call) => call.args[1] === 'href');
+      expect(hrefCalls.length).toBe(4); // 3 favicon + 1 stylesheet
+      hrefCalls.slice(1).forEach((call) => {
+        // Skip stylesheet href
+        expect(call.args[2]).toBe('https://example.com/favicon.ico');
+      });
+    });
+  });
+
+  describe('stylesheet SRI hash', () => {
+    it('should add integrity and crossorigin attributes when brand has sriHash', () => {
+      const brandWithSriHash = new SkyThemeBrand(
+        'test',
+        '1.0.0',
+        undefined,
+        'https://example.com/brand.css',
+        'sha384-test-hash-value',
+      );
+
+      service.updateBrand(
+        mockHostEl,
+        mockRenderer,
+        brandWithSriHash,
+        undefined,
+      );
+
+      expect(mockRenderer.setAttribute).toHaveBeenCalledWith(
+        jasmine.any(Object),
+        'integrity',
+        'sha384-test-hash-value',
+      );
+      expect(mockRenderer.setAttribute).toHaveBeenCalledWith(
+        jasmine.any(Object),
+        'crossorigin',
+        'anonymous',
+      );
+    });
+
+    it('should not add integrity attributes when brand has no sriHash', () => {
+      const brandWithoutSriHash = new SkyThemeBrand('test', '1.0.0');
+
+      service.updateBrand(
+        mockHostEl,
+        mockRenderer,
+        brandWithoutSriHash,
+        undefined,
+      );
+
+      expect(mockRenderer.setAttribute).not.toHaveBeenCalledWith(
+        jasmine.any(Object),
+        'integrity',
+        jasmine.any(String),
+      );
+      expect(mockRenderer.setAttribute).not.toHaveBeenCalledWith(
+        jasmine.any(Object),
+        'crossorigin',
+        jasmine.any(String),
+      );
+    });
+  });
+
+  describe('custom style URLs', () => {
+    it('should use custom styleUrl when provided', () => {
+      const brandWithCustomUrl = new SkyThemeBrand(
+        'test',
+        '1.0.0',
+        undefined,
+        'https://custom.example.com/my-brand.css',
+      );
+
+      service.updateBrand(
+        mockHostEl,
+        mockRenderer,
+        brandWithCustomUrl,
+        undefined,
+      );
+
+      expect(mockRenderer.setAttribute).toHaveBeenCalledWith(
+        jasmine.any(Object),
+        'href',
+        'https://custom.example.com/my-brand.css',
+      );
+    });
+
+    it('should build default URL when no custom styleUrl provided', () => {
+      const brandWithoutCustomUrl = new SkyThemeBrand('my-brand', '2.1.0');
+
+      service.updateBrand(
+        mockHostEl,
+        mockRenderer,
+        brandWithoutCustomUrl,
+        undefined,
+      );
+
+      expect(mockRenderer.setAttribute).toHaveBeenCalledWith(
+        jasmine.any(Object),
+        'href',
+        'https://sky.blackbaudcdn.net/static/skyux-brand-my-brand/2.1.0/assets/scss/my-brand.css',
+      );
+    });
+  });
+
+  describe('mask icon handling', () => {
+    it('should add mask icon when brand has maskIcon', () => {
+      const brand = new SkyThemeBrand(
+        'test',
+        '1.0.0',
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        { url: 'https://example.com/mask-icon.svg', color: '#000000' },
+      );
+
+      service.updateBrand(mockHostEl, mockRenderer, brand, undefined);
+
+      expect(mockRenderer.createElement).toHaveBeenCalledWith('link');
+      expect(mockRenderer.setAttribute).toHaveBeenCalledWith(
+        jasmine.any(Object),
+        'rel',
+        'mask-icon',
+      );
+      expect(mockRenderer.setAttribute).toHaveBeenCalledWith(
+        jasmine.any(Object),
+        'href',
+        'https://example.com/mask-icon.svg',
+      );
+      expect(mockRenderer.setAttribute).toHaveBeenCalledWith(
+        jasmine.any(Object),
+        'color',
+        '#000000',
+      );
+      expect(mockRenderer.appendChild).toHaveBeenCalled();
+    });
+
+    it('should update existing mask icon when brand changes', () => {
+      const brand1 = new SkyThemeBrand(
+        'test',
+        '1.0.0',
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        { url: 'https://example.com/mask-icon1.svg', color: '#000000' },
+      );
+
+      // Set first brand with mask icon
+      service.updateBrand(mockHostEl, mockRenderer, brand1, undefined);
+
+      // Reset spies to focus on the update
+      mockRenderer.createElement.calls.reset();
+      mockRenderer.setAttribute.calls.reset();
+      mockRenderer.appendChild.calls.reset();
+
+      const brand2 = new SkyThemeBrand(
+        'test',
+        '1.0.0',
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        { url: 'https://example.com/mask-icon2.svg', color: '#ff0000' },
+      );
+
+      // Update to brand with different mask icon
+      service.updateBrand(mockHostEl, mockRenderer, brand2, brand1);
+
+      // Should update the mask icon attributes
+      expect(mockRenderer.setAttribute).toHaveBeenCalledWith(
+        jasmine.any(Object),
+        'href',
+        'https://example.com/mask-icon2.svg',
+      );
+      expect(mockRenderer.setAttribute).toHaveBeenCalledWith(
+        jasmine.any(Object),
+        'color',
+        '#ff0000',
+      );
+      // Should not create new element since mask icon already exists
+      expect(mockRenderer.createElement).not.toHaveBeenCalled();
+      // Should not append again since mask icon already exists
+      expect(mockRenderer.appendChild).not.toHaveBeenCalled();
+    });
+
+    it('should remove mask icon when switching to brand without maskIcon', () => {
+      const brandWithMaskIcon = new SkyThemeBrand(
+        'test',
+        '1.0.0',
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        { url: 'https://example.com/mask-icon.svg', color: '#000000' },
+      );
+      const brandWithoutMaskIcon = new SkyThemeBrand('test2', '1.0.0');
+
+      // Set brand with mask icon
+      service.updateBrand(
+        mockHostEl,
+        mockRenderer,
+        brandWithMaskIcon,
+        undefined,
+      );
+
+      // Verify mask icon was created
+      const maskIconElement =
+        createdLinkElements[createdLinkElements.length - 1];
+
+      // Switch to brand without mask icon
+      service.updateBrand(
+        mockHostEl,
+        mockRenderer,
+        brandWithoutMaskIcon,
+        brandWithMaskIcon,
+      );
+
+      // Verify mask icon was removed
+      expect(maskIconElement.remove).toHaveBeenCalled();
+    });
+
+    it('should remove mask icon when switching to undefined brand', () => {
+      const brandWithMaskIcon = new SkyThemeBrand(
+        'test',
+        '1.0.0',
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        { url: 'https://example.com/mask-icon.svg', color: '#000000' },
+      );
+
+      // Set brand with mask icon
+      service.updateBrand(
+        mockHostEl,
+        mockRenderer,
+        brandWithMaskIcon,
+        undefined,
+      );
+
+      // Track the created mask icon element
+      const maskIconElement =
+        createdLinkElements[createdLinkElements.length - 1];
+
+      // Switch to undefined brand
+      service.updateBrand(
+        mockHostEl,
+        mockRenderer,
+        undefined,
+        brandWithMaskIcon,
+      );
+
+      expect(maskIconElement.remove).toHaveBeenCalled();
+    });
+
+    it('should handle brand with both favicon and mask icon', () => {
+      const brand = new SkyThemeBrand(
+        'test',
+        '1.0.0',
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        'https://example.com/favicon.ico',
+        { url: 'https://example.com/mask-icon.svg', color: '#000000' },
+      );
+
+      service.updateBrand(mockHostEl, mockRenderer, brand, undefined);
+
+      // Should create elements: 1 stylesheet + 3 favicon icons + 1 mask icon = 5 total
+      expect(mockRenderer.createElement).toHaveBeenCalledTimes(5);
+
+      // Verify favicon attributes
+      expect(mockRenderer.setAttribute).toHaveBeenCalledWith(
+        jasmine.any(Object),
+        'rel',
+        'apple-touch-icon',
+      );
+      expect(mockRenderer.setAttribute).toHaveBeenCalledWith(
+        jasmine.any(Object),
+        'rel',
+        'icon',
+      );
+
+      // Verify mask icon attributes
+      expect(mockRenderer.setAttribute).toHaveBeenCalledWith(
+        jasmine.any(Object),
+        'rel',
+        'mask-icon',
+      );
+      expect(mockRenderer.setAttribute).toHaveBeenCalledWith(
+        jasmine.any(Object),
+        'href',
+        'https://example.com/mask-icon.svg',
+      );
+      expect(mockRenderer.setAttribute).toHaveBeenCalledWith(
+        jasmine.any(Object),
+        'color',
+        '#000000',
+      );
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should handle when document head is not found', () => {
+      // Mock querySelector to return null (no head element)
+      mockDocument.head = null;
+
+      const brand = new SkyThemeBrand('test', '1.0.0');
+
+      // Should not throw when head is null
+      expect(() =>
+        service.updateBrand(mockHostEl, mockRenderer, brand, undefined),
+      ).not.toThrow();
+    });
+
+    it('should handle brand host class updates correctly when switching from brand to no brand', () => {
+      const brandWithClass = new SkyThemeBrand('test-brand', '1.0.0');
+
+      // First set a brand
+      service.updateBrand(mockHostEl, mockRenderer, brandWithClass, undefined);
+
+      // Reset to focus on the removal
+      mockRenderer.removeClass.calls.reset();
+
+      // Remove brand (set to undefined)
+      service.updateBrand(mockHostEl, mockRenderer, undefined, brandWithClass);
+
+      // Should remove both the brand class and the base class
+      expect(mockRenderer.removeClass).toHaveBeenCalledWith(
+        mockHostEl,
+        brandWithClass.hostClass,
+      );
+      expect(mockRenderer.removeClass).toHaveBeenCalledWith(
+        mockHostEl,
+        'sky-theme-brand-base',
+      );
+    });
+  });
+});

--- a/libs/components/theme/src/lib/theming/theme-brand.service.ts
+++ b/libs/components/theme/src/lib/theming/theme-brand.service.ts
@@ -1,0 +1,199 @@
+import { DOCUMENT, Injectable, Renderer2, inject } from '@angular/core';
+
+import { SkyThemeBrand } from './theme-brand';
+
+const BRAND_BLACKBAUD = 'blackbaud';
+
+// Commonly-used icon configurations. Appending these to the head element will
+// override any existing link elements with the same attribute values. When
+// they are removed, the previous favicon link elements will take effect again.
+const FAVICON_CONFIGS = [
+  { rel: 'apple-touch-icon', sizes: '180x180' },
+  { rel: 'icon', sizes: '32x32' },
+  { rel: 'icon', sizes: '16x16' },
+];
+
+/**
+ * @internal
+ * Provides methods for managing theme branding including brand registration,
+ * stylesheet management, and host class updates.
+ */
+@Injectable({
+  providedIn: 'root',
+})
+export class SkyThemeBrandService {
+  #document = inject(DOCUMENT);
+
+  #stylesheetEl: HTMLLinkElement | undefined;
+  #faviconEls: HTMLLinkElement[] = [];
+  #maskIconEl: HTMLLinkElement | undefined;
+
+  #registeredBrands = new Map<string, SkyThemeBrand>();
+
+  /**
+   * Registers a brand for use in themes.
+   * @param brand The brand to register.
+   */
+  public registerBrand(brand: SkyThemeBrand): void {
+    this.#registeredBrands.set(brand.name, brand);
+  }
+
+  /**
+   * Unregisters a brand.
+   * @param name The name of the brand to unregister.
+   */
+  public unregisterBrand(name: string): void {
+    this.#registeredBrands.delete(name);
+  }
+
+  /**
+   * Updates all brand-related styling and classes for the host element.
+   * This consolidates brand stylesheet updates and host class management,
+   * and automatically resolves registered brands.
+   * @param hostEl The host element to update.
+   * @param renderer The renderer to use for DOM manipulation.
+   * @param brand The brand to apply (will be resolved if registered version exists).
+   * @param previousBrand The previous brand to clean up.
+   */
+  public updateBrand(
+    hostEl: Element,
+    renderer: Renderer2,
+    brand: SkyThemeBrand | undefined,
+    previousBrand: SkyThemeBrand | undefined,
+  ): void {
+    // Resolve to registered brand if available
+    if (brand) {
+      brand = this.#registeredBrands.get(brand.name) ?? brand;
+    }
+
+    const previousClass = previousBrand?.hostClass;
+    const currentClass = brand?.hostClass;
+
+    // Update host classes if they've changed
+    if (!previousClass || previousClass !== currentClass) {
+      this.#updateBrandHostClass(hostEl, renderer, previousClass, currentClass);
+      this.#updateBrandStylesheet(renderer, brand, previousBrand);
+    }
+
+    this.#updateFavicon(renderer, brand);
+  }
+
+  /**
+   * Destroys the brand service, cleaning up any brand stylesheets.
+   */
+  public destroy(): void {
+    this.#removeBrandStylesheet();
+  }
+
+  #updateBrandStylesheet(
+    renderer: Renderer2,
+    currentBrand: SkyThemeBrand | undefined,
+    previousBrand: SkyThemeBrand | undefined,
+  ): void {
+    if (previousBrand && previousBrand.name !== BRAND_BLACKBAUD) {
+      this.#removeBrandStylesheet();
+    }
+
+    if (currentBrand && currentBrand.name !== BRAND_BLACKBAUD) {
+      this.#addBrandStylesheet(renderer, currentBrand);
+    }
+  }
+
+  #updateBrandHostClass(
+    hostEl: Element,
+    renderer: Renderer2,
+    previousClass: string | undefined,
+    currentClass: string | undefined,
+  ): void {
+    if (previousClass) {
+      renderer.removeClass(hostEl, previousClass);
+    }
+
+    if (currentClass && !previousClass) {
+      renderer.addClass(hostEl, 'sky-theme-brand-base');
+    } else if (!currentClass && previousClass) {
+      renderer.removeClass(hostEl, 'sky-theme-brand-base');
+    }
+
+    if (currentClass) {
+      renderer.addClass(hostEl, currentClass);
+    }
+  }
+
+  #addBrandStylesheet(renderer: Renderer2, brand: SkyThemeBrand): void {
+    if (brand.name !== BRAND_BLACKBAUD) {
+      // Use styleUrl if provided, otherwise build the default URL
+      const styleUrl =
+        brand.styleUrl ||
+        `https://sky.blackbaudcdn.net/static/skyux-brand-${brand.name}/${brand.version}/assets/scss/${brand.name}.css`;
+
+      this.#stylesheetEl = renderer.createElement('link') as HTMLLinkElement;
+
+      renderer.setAttribute(this.#stylesheetEl, 'rel', 'stylesheet');
+      renderer.setAttribute(this.#stylesheetEl, 'href', styleUrl);
+
+      if (brand.sriHash) {
+        renderer.setAttribute(this.#stylesheetEl, 'integrity', brand.sriHash);
+        renderer.setAttribute(this.#stylesheetEl, 'crossorigin', 'anonymous');
+      }
+
+      this.#appendToHead(renderer, this.#stylesheetEl);
+    }
+  }
+
+  #removeBrandStylesheet(): void {
+    if (this.#stylesheetEl) {
+      this.#stylesheetEl.remove();
+      this.#stylesheetEl = undefined;
+    }
+  }
+
+  #updateFavicon(renderer: Renderer2, brand: SkyThemeBrand | undefined): void {
+    if (brand?.faviconUrl) {
+      const faviconUrl = brand.faviconUrl;
+
+      // Create favicon elements if they don't exist, or reuse existing ones
+      while (this.#faviconEls.length < FAVICON_CONFIGS.length) {
+        const faviconEl = renderer.createElement('link') as HTMLLinkElement;
+        this.#faviconEls.push(faviconEl);
+        this.#appendToHead(renderer, faviconEl);
+      }
+
+      // Update each favicon element with its configuration
+      for (let i = 0; i < FAVICON_CONFIGS.length; i++) {
+        const config = FAVICON_CONFIGS[i];
+        const faviconEl = this.#faviconEls[i];
+
+        renderer.setAttribute(faviconEl, 'rel', config.rel);
+        renderer.setAttribute(faviconEl, 'sizes', config.sizes);
+        renderer.setAttribute(faviconEl, 'href', faviconUrl);
+      }
+    } else {
+      // Remove all favicon elements when no favicon URL is provided
+      for (const faviconEl of this.#faviconEls) {
+        faviconEl.remove();
+      }
+
+      this.#faviconEls = [];
+    }
+
+    // Handle mask icon
+    if (brand?.maskIcon) {
+      if (!this.#maskIconEl) {
+        this.#maskIconEl = renderer.createElement('link') as HTMLLinkElement;
+        this.#appendToHead(renderer, this.#maskIconEl);
+      }
+
+      renderer.setAttribute(this.#maskIconEl, 'rel', 'mask-icon');
+      renderer.setAttribute(this.#maskIconEl, 'href', brand.maskIcon.url);
+      renderer.setAttribute(this.#maskIconEl, 'color', brand.maskIcon.color);
+    } else if (this.#maskIconEl) {
+      this.#maskIconEl.remove();
+      this.#maskIconEl = undefined;
+    }
+  }
+
+  #appendToHead(renderer: Renderer2, el: HTMLElement): void {
+    renderer.appendChild(this.#document.head, el);
+  }
+}

--- a/libs/components/theme/src/lib/theming/theme-brand.spec.ts
+++ b/libs/components/theme/src/lib/theming/theme-brand.spec.ts
@@ -53,6 +53,52 @@ describe('Theme brand', () => {
     expect(brand.sriHash).toBe(sriHash);
   });
 
+  it('should set title correctly when provided', () => {
+    const title = 'Custom Brand Title';
+    const brand = new SkyThemeBrand(
+      'custom-brand',
+      '1.0.0',
+      undefined,
+      undefined,
+      undefined,
+      title,
+    );
+
+    expect(brand.title).toBe(title);
+  });
+
+  it('should set faviconUrl correctly when provided', () => {
+    const faviconUrl = 'https://example.com/favicon.ico';
+    const brand = new SkyThemeBrand(
+      'custom-brand',
+      '1.0.0',
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      faviconUrl,
+    );
+
+    expect(brand.faviconUrl).toBe(faviconUrl);
+  });
+
+  it('should set both title and faviconUrl when provided', () => {
+    const title = 'Custom Brand Title';
+    const faviconUrl = 'https://example.com/favicon.ico';
+    const brand = new SkyThemeBrand(
+      'custom-brand',
+      '1.0.0',
+      undefined,
+      undefined,
+      undefined,
+      title,
+      faviconUrl,
+    );
+
+    expect(brand.title).toBe(title);
+    expect(brand.faviconUrl).toBe(faviconUrl);
+  });
+
   it('should set both styleUrl and sriHash when provided', () => {
     const styleUrl = 'https://example.com/styles.css';
     const sriHash = 'sha384-abc123def456';
@@ -72,12 +118,16 @@ describe('Theme brand', () => {
     const styleUrl = 'https://example.com/styles.css';
     const sriHash = 'sha384-abc123def456';
     const hostClass = 'custom-host-class';
+    const title = 'Custom Brand Title';
+    const faviconUrl = 'https://example.com/favicon.ico';
     const brand = new SkyThemeBrand(
       'custom-brand',
       '1.0.0',
       hostClass,
       styleUrl,
       sriHash,
+      title,
+      faviconUrl,
     );
 
     expect(brand.name).toBe('custom-brand');
@@ -85,6 +135,8 @@ describe('Theme brand', () => {
     expect(brand.hostClass).toBe(hostClass);
     expect(brand.styleUrl).toBe(styleUrl);
     expect(brand.sriHash).toBe(sriHash);
+    expect(brand.title).toBe(title);
+    expect(brand.faviconUrl).toBe(faviconUrl);
   });
 
   it('should set the version correctly when a version with an appropriate suffix is given', () => {
@@ -180,15 +232,88 @@ describe('Theme brand', () => {
       });
     });
 
+    it('should serialize brand with title correctly', () => {
+      const title = 'Custom Brand Title';
+      const brand = new SkyThemeBrand(
+        'custom',
+        '2.0.0',
+        undefined,
+        undefined,
+        undefined,
+        title,
+      );
+      const serialized = brand.serialize();
+
+      expect(serialized).toEqual({
+        name: 'custom',
+        version: '2.0.0',
+        title,
+      });
+    });
+
+    it('should serialize brand with faviconUrl correctly', () => {
+      const faviconUrl = 'https://example.com/favicon.ico';
+      const brand = new SkyThemeBrand(
+        'custom',
+        '2.0.0',
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        faviconUrl,
+      );
+      const serialized = brand.serialize();
+
+      expect(serialized).toEqual({
+        name: 'custom',
+        version: '2.0.0',
+        faviconUrl,
+      });
+    });
+
+    it('should serialize brand with maskIcon correctly', () => {
+      const brand = new SkyThemeBrand(
+        'custom',
+        '2.0.0',
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        {
+          color: '#fff',
+          url: 'https://example.com/mask-icon.ico',
+        },
+      );
+      const serialized = brand.serialize();
+
+      expect(serialized).toEqual({
+        name: 'custom',
+        version: '2.0.0',
+        maskIcon: {
+          color: '#fff',
+          url: 'https://example.com/mask-icon.ico',
+        },
+      });
+    });
+
     it('should serialize brand with all properties correctly', () => {
       const styleUrl = 'https://example.com/styles.css';
       const sriHash = 'sha384-abc123def456';
+      const title = 'Custom Brand Title';
+      const faviconUrl = 'https://example.com/favicon.ico';
       const brand = new SkyThemeBrand(
         'custom',
         '2.0.0',
         'custom-host-class',
         styleUrl,
         sriHash,
+        title,
+        faviconUrl,
+        {
+          color: '#fff',
+          url: 'https://example.com/mask-icon.ico',
+        },
       );
       const serialized = brand.serialize();
 
@@ -198,6 +323,12 @@ describe('Theme brand', () => {
         hostClass: 'custom-host-class',
         styleUrl,
         sriHash,
+        title,
+        faviconUrl,
+        maskIcon: {
+          color: '#fff',
+          url: 'https://example.com/mask-icon.ico',
+        },
       });
     });
 
@@ -252,15 +383,70 @@ describe('Theme brand', () => {
       expect(brand.sriHash).toBe(sriHash);
     });
 
+    it('should deserialize brand with title correctly', () => {
+      const title = 'Custom Brand Title';
+      const brand = SkyThemeBrand.deserialize({
+        name: 'custom',
+        version: '2.0.0',
+        title,
+      });
+
+      expect(brand.name).toBe('custom');
+      expect(brand.version).toBe('2.0.0');
+      expect(brand.hostClass).toBe('sky-theme-brand-custom');
+      expect(brand.title).toBe(title);
+    });
+
+    it('should deserialize brand with faviconUrl correctly', () => {
+      const faviconUrl = 'https://example.com/favicon.ico';
+      const brand = SkyThemeBrand.deserialize({
+        name: 'custom',
+        version: '2.0.0',
+        faviconUrl,
+      });
+
+      expect(brand.name).toBe('custom');
+      expect(brand.version).toBe('2.0.0');
+      expect(brand.hostClass).toBe('sky-theme-brand-custom');
+      expect(brand.faviconUrl).toBe(faviconUrl);
+    });
+
+    it('should deserialize brand with maskIcon correctly', () => {
+      const brand = SkyThemeBrand.deserialize({
+        name: 'custom',
+        version: '2.0.0',
+        maskIcon: {
+          color: '#fff',
+          url: 'https://example.com/mask-icon.ico',
+        },
+      });
+
+      expect(brand.name).toBe('custom');
+      expect(brand.version).toBe('2.0.0');
+      expect(brand.hostClass).toBe('sky-theme-brand-custom');
+      expect(brand.maskIcon).toEqual({
+        color: '#fff',
+        url: 'https://example.com/mask-icon.ico',
+      });
+    });
+
     it('should deserialize brand with all properties correctly', () => {
       const styleUrl = 'https://example.com/styles.css';
       const sriHash = 'sha384-abc123def456';
+      const title = 'Custom Brand Title';
+      const faviconUrl = 'https://example.com/favicon.ico';
       const brand = SkyThemeBrand.deserialize({
         name: 'custom',
         version: '2.0.0',
         hostClass: 'custom-host-class',
         styleUrl,
         sriHash,
+        title,
+        faviconUrl,
+        maskIcon: {
+          color: '#fff',
+          url: 'https://example.com/mask-icon.ico',
+        },
       });
 
       expect(brand.name).toBe('custom');
@@ -268,6 +454,12 @@ describe('Theme brand', () => {
       expect(brand.hostClass).toBe('custom-host-class');
       expect(brand.styleUrl).toBe(styleUrl);
       expect(brand.sriHash).toBe(sriHash);
+      expect(brand.title).toBe(title);
+      expect(brand.faviconUrl).toBe(faviconUrl);
+      expect(brand.maskIcon).toEqual({
+        color: '#fff',
+        url: 'https://example.com/mask-icon.ico',
+      });
     });
   });
 });

--- a/libs/components/theme/src/lib/theming/theme-brand.ts
+++ b/libs/components/theme/src/lib/theming/theme-brand.ts
@@ -2,6 +2,21 @@ import { SkyThemeBrandData } from './theme-serialization-types';
 
 /**
  * @internal
+ * Defines properties for a mask icon.
+ */
+export interface SkyThemeBrandMaskIcon {
+  /**
+   * The URL of the mask icon.
+   */
+  url: string;
+  /**
+   * The color of the mask icon.
+   */
+  color: string;
+}
+
+/**
+ * @internal
  * Defines properties of SKY UX theme branding.
  */
 export class SkyThemeBrand {
@@ -22,6 +37,9 @@ export class SkyThemeBrand {
    * adjusting for a specified theme brand. This defaults to `sky-theme-brand-<name>`
    * @param styleUrl The URL of the stylesheet to load for this brand
    * @param sriHash The subresource integrity hash for the stylesheet
+   * @param title The title to display for this brand
+   * @param faviconUrl The URL of the favicon to use for this brand
+   * @param maskIcon The mask icon configuration for this brand
    */
   constructor(
     public readonly name: string,
@@ -29,6 +47,9 @@ export class SkyThemeBrand {
     hostClass?: string,
     public readonly styleUrl?: string,
     public readonly sriHash?: string,
+    public readonly title?: string,
+    public readonly faviconUrl?: string,
+    public readonly maskIcon?: SkyThemeBrandMaskIcon,
   ) {
     this.hostClass = hostClass;
 
@@ -56,13 +77,24 @@ export class SkyThemeBrand {
       result.hostClass = this.hostClass;
     }
 
-    // Include styleUrl and sriHash if they are provided
     if (this.styleUrl) {
       result.styleUrl = this.styleUrl;
     }
 
     if (this.sriHash) {
       result.sriHash = this.sriHash;
+    }
+
+    if (this.title) {
+      result.title = this.title;
+    }
+
+    if (this.faviconUrl) {
+      result.faviconUrl = this.faviconUrl;
+    }
+
+    if (this.maskIcon) {
+      result.maskIcon = this.maskIcon;
     }
 
     return result;
@@ -79,6 +111,9 @@ export class SkyThemeBrand {
       data.hostClass,
       data.styleUrl,
       data.sriHash,
+      data.title,
+      data.faviconUrl,
+      data.maskIcon,
     );
   }
 

--- a/libs/components/theme/src/lib/theming/theme-class.directive.spec.ts
+++ b/libs/components/theme/src/lib/theming/theme-class.directive.spec.ts
@@ -198,12 +198,7 @@ describe('ThemeClass directive', () => {
       TestBed.configureTestingModule({
         declarations: [SkyThemeClassTestComponent],
         imports: [SkyThemeModule],
-        providers: [
-          {
-            provide: SkyThemeService,
-            useValue: new SkyThemeService(),
-          },
-        ],
+        providers: [SkyThemeService],
       });
       const fixture = TestBed.createComponent(SkyThemeClassTestComponent);
       fixture.detectChanges();

--- a/libs/components/theme/src/lib/theming/theme-if.directive.spec.ts
+++ b/libs/components/theme/src/lib/theming/theme-if.directive.spec.ts
@@ -223,12 +223,7 @@ describe('ThemeIf directive', () => {
       TestBed.configureTestingModule({
         declarations: [SkyThemeIfTestComponent, TestProjectionComponent],
         imports: [SkyThemeModule],
-        providers: [
-          {
-            provide: SkyThemeService,
-            useValue: new SkyThemeService(),
-          },
-        ],
+        providers: [SkyThemeService],
       });
       const fixture = TestBed.createComponent(SkyThemeIfTestComponent);
       fixture.detectChanges();

--- a/libs/components/theme/src/lib/theming/theme-serialization-types.ts
+++ b/libs/components/theme/src/lib/theming/theme-serialization-types.ts
@@ -1,6 +1,7 @@
 /**
  * Type definitions for theme serialization and deserialization.
  */
+import { SkyThemeBrandMaskIcon } from './theme-brand';
 
 /**
  * Serialized representation of a SkyThemeMode.
@@ -29,6 +30,9 @@ export interface SkyThemeBrandData {
   hostClass?: string;
   styleUrl?: string;
   sriHash?: string;
+  title?: string;
+  faviconUrl?: string;
+  maskIcon?: SkyThemeBrandMaskIcon;
 }
 
 /**

--- a/libs/components/theme/src/lib/theming/theme.service.spec.ts
+++ b/libs/components/theme/src/lib/theming/theme.service.spec.ts
@@ -1,7 +1,9 @@
 import { Renderer2 } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
 
 import { SkyTheme } from './theme';
 import { SkyThemeBrand } from './theme-brand';
+import { SkyThemeBrandService } from './theme-brand.service';
 import { SkyThemeMode } from './theme-mode';
 import { SkyThemeSettings } from './theme-settings';
 import { SkyThemeSpacing } from './theme-spacing';
@@ -11,17 +13,12 @@ describe('Theme service', () => {
   let mockHostEl: {
     foo: string;
   };
-  let mockLinkElement: {
-    href: string;
-  };
   let mockRenderer: {
     addClass: jasmine.Spy;
-    appendChild: jasmine.Spy;
-    createElement: jasmine.Spy;
     removeClass: jasmine.Spy;
-    removeChild: jasmine.Spy;
-    setAttribute: jasmine.Spy;
   };
+  let mockBrandService: jasmine.SpyObj<SkyThemeBrandService>;
+  let themeSvc: SkyThemeService;
 
   function validateSettingsApplied(
     current: SkyThemeSettings,
@@ -78,80 +75,17 @@ describe('Theme service', () => {
     }
   }
 
-  // eslint-disable-next-line complexity
   function validateBrand(
     current: SkyThemeSettings,
     previous?: SkyThemeSettings,
   ): void {
-    if (current.brand?.name) {
-      expect(mockRenderer.addClass).toHaveBeenCalledWith(
-        mockHostEl,
-        current.brand.hostClass,
-      );
-
-      if (!previous?.brand?.name) {
-        expect(mockRenderer.addClass).toHaveBeenCalledWith(
-          mockHostEl,
-          `sky-theme-brand-base`,
-        );
-
-        if (current.brand.name !== 'blackbaud') {
-          expect(mockRenderer.createElement).toHaveBeenCalledWith('link');
-          expect(mockRenderer.setAttribute).toHaveBeenCalledWith(
-            mockLinkElement,
-            'rel',
-            'stylesheet',
-          );
-
-          // Use styleUrl if provided, otherwise fallback to default CDN URL
-          const expectedHref =
-            current.brand.styleUrl ||
-            `https://sky.blackbaudcdn.net/static/skyux-brand-${current.brand.name}/${current.brand.version}/assets/scss/${current.brand.name}.css`;
-
-          expect(mockRenderer.setAttribute).toHaveBeenCalledWith(
-            mockLinkElement,
-            'href',
-            expectedHref,
-          );
-          expect(mockRenderer.appendChild).toHaveBeenCalledWith(
-            mockHostEl,
-            mockLinkElement,
-          );
-        } else {
-          expect(mockRenderer.createElement).not.toHaveBeenCalled();
-          expect(mockRenderer.setAttribute).not.toHaveBeenCalled();
-          expect(mockRenderer.appendChild).not.toHaveBeenCalled();
-        }
-      }
-    } else {
-      expect(mockRenderer.addClass).not.toHaveBeenCalledWith(
-        mockHostEl,
-        current.brand?.hostClass,
-      );
-      expect(mockRenderer.addClass).not.toHaveBeenCalledWith(
-        mockHostEl,
-        `sky-theme-brand-base`,
-      );
-
-      if (previous?.brand?.name) {
-        expect(mockRenderer.removeClass).toHaveBeenCalledWith(
-          mockHostEl,
-          previous.brand.hostClass,
-        );
-        expect(mockRenderer.removeClass).toHaveBeenCalledWith(
-          mockHostEl,
-          'sky-theme-brand-base',
-        );
-        if (previous.brand.name !== 'blackbaud') {
-          expect(mockRenderer.removeChild).toHaveBeenCalledWith(
-            mockHostEl,
-            mockLinkElement,
-          );
-        } else {
-          expect(mockRenderer.removeChild).not.toHaveBeenCalled();
-        }
-      }
-    }
+    // Validate that the brand service updateBrand method was called with correct parameters
+    expect(mockBrandService.updateBrand).toHaveBeenCalledWith(
+      jasmine.any(Object),
+      mockRenderer as unknown as Renderer2,
+      current.brand,
+      previous?.brand,
+    );
   }
 
   function validateInitError(fn: () => unknown): void {
@@ -161,29 +95,33 @@ describe('Theme service', () => {
   }
 
   beforeEach(() => {
-    mockRenderer = jasmine.createSpyObj('mockRenderer', [
+    mockRenderer = jasmine.createSpyObj('Renderer2', [
       'addClass',
-      'appendChild',
-      'createElement',
       'removeClass',
-      'removeChild',
-      'setAttribute',
     ]);
 
+    mockBrandService = jasmine.createSpyObj('SkyThemeBrandService', [
+      'updateBrand',
+      'registerBrand',
+      'unregisterBrand',
+      'destroy',
+    ]);
     mockHostEl = {
       foo: 'bar',
     };
-    mockLinkElement = {
-      href: 'moo',
-    };
 
-    mockRenderer.createElement.and.returnValue(mockLinkElement);
+    TestBed.configureTestingModule({
+      providers: [
+        SkyThemeService,
+        { provide: SkyThemeBrandService, useValue: mockBrandService },
+      ],
+    });
+
+    themeSvc = TestBed.inject(SkyThemeService);
   });
 
   describe('init()', () => {
     it('should not apply an unsupported mode', () => {
-      const themeSvc = new SkyThemeService();
-
       const settings = new SkyThemeSettings(
         SkyTheme.presets.default,
         SkyThemeMode.presets.dark,
@@ -195,8 +133,6 @@ describe('Theme service', () => {
     });
 
     it('should apply supported spacing', () => {
-      const themeSvc = new SkyThemeService();
-
       const settings = new SkyThemeSettings(
         SkyTheme.presets.modern,
         SkyThemeMode.presets.light,
@@ -209,8 +145,6 @@ describe('Theme service', () => {
     });
 
     it('should apply the initial theme', () => {
-      const themeSvc = new SkyThemeService();
-
       const settings = new SkyThemeSettings(
         SkyTheme.presets.modern,
         SkyThemeMode.presets.dark,
@@ -221,14 +155,12 @@ describe('Theme service', () => {
       validateSettingsApplied(settings);
 
       themeSvc.settingsChange.subscribe((settingsChange) => {
-        expect(settingsChange.currentSettings).toBe(settings);
+        expect(settingsChange.currentSettings).toEqual(settings);
         expect(settingsChange.previousSettings).toBeUndefined();
       });
     });
 
     it('should not apply unsupported spacing', () => {
-      const themeSvc = new SkyThemeService();
-
       const settings = new SkyThemeSettings(
         SkyTheme.presets.default,
         SkyThemeMode.presets.light,
@@ -241,8 +173,6 @@ describe('Theme service', () => {
     });
 
     it('should throw an error if branding is requested for a theme which does not support branding', () => {
-      const themeSvc = new SkyThemeService();
-
       const settingsWithBranding = new SkyThemeSettings(
         SkyTheme.presets.default,
         SkyThemeMode.presets.light,
@@ -258,13 +188,32 @@ describe('Theme service', () => {
         );
       }).toThrowError('Branding is not supported for the given theme.');
     });
+
+    it('should register initial brands when provided', () => {
+      const brand1 = new SkyThemeBrand('brand1', '1.0.0');
+      const brand2 = new SkyThemeBrand('brand2', '1.0.0');
+      const registeredBrands = [brand1, brand2];
+
+      const settings = new SkyThemeSettings(
+        SkyTheme.presets.modern,
+        SkyThemeMode.presets.light,
+      );
+
+      themeSvc.init(
+        mockHostEl,
+        mockRenderer as unknown as Renderer2,
+        settings,
+        registeredBrands,
+      );
+
+      expect(mockBrandService.registerBrand).toHaveBeenCalledWith(brand1);
+      expect(mockBrandService.registerBrand).toHaveBeenCalledWith(brand2);
+    });
   });
 
   describe('setTheme()', () => {
     describe('with SkyThemeSettings parameter', () => {
       function testBrandingWithSri(sriHash?: string): void {
-        const themeSvc = new SkyThemeService();
-
         const settingsWithBranding = new SkyThemeSettings(
           SkyTheme.presets.modern,
           SkyThemeMode.presets.light,
@@ -280,37 +229,9 @@ describe('Theme service', () => {
 
         // Validate basic branding is applied
         validateSettingsApplied(settingsWithBranding);
-
-        if (sriHash) {
-          // Validate SRI-specific attributes are set
-          expect(mockRenderer.setAttribute).toHaveBeenCalledWith(
-            mockLinkElement,
-            'integrity',
-            sriHash,
-          );
-          expect(mockRenderer.setAttribute).toHaveBeenCalledWith(
-            mockLinkElement,
-            'crossorigin',
-            'anonymous',
-          );
-        } else {
-          // Validate SRI-specific attributes are NOT set
-          expect(mockRenderer.setAttribute).not.toHaveBeenCalledWith(
-            mockLinkElement,
-            'integrity',
-            jasmine.any(String),
-          );
-          expect(mockRenderer.setAttribute).not.toHaveBeenCalledWith(
-            mockLinkElement,
-            'crossorigin',
-            'anonymous',
-          );
-        }
       }
 
       it('should error if settings are attempted to be changed prior to initialization', () => {
-        const themeSvc = new SkyThemeService();
-
         const settings = new SkyThemeSettings(
           SkyTheme.presets.modern,
           SkyThemeMode.presets.dark,
@@ -324,8 +245,6 @@ describe('Theme service', () => {
       });
 
       it('should fire the settings change event as settings are applied', () => {
-        const themeSvc = new SkyThemeService();
-
         let settings = new SkyThemeSettings(
           SkyTheme.presets.modern,
           SkyThemeMode.presets.dark,
@@ -341,8 +260,10 @@ describe('Theme service', () => {
         let expectedPreviousSettings: SkyThemeSettings | undefined = undefined;
 
         themeSvc.settingsChange.subscribe((settingsChange) => {
-          expect(settingsChange.currentSettings).toBe(expectedCurrentSettings);
-          expect(settingsChange.previousSettings).toBe(
+          expect(settingsChange.currentSettings).toEqual(
+            expectedCurrentSettings,
+          );
+          expect(settingsChange.previousSettings).toEqual(
             expectedPreviousSettings,
           );
 
@@ -377,8 +298,6 @@ describe('Theme service', () => {
       });
 
       it('should not remove the host class if the theme settings have not changed', () => {
-        const themeSvc = new SkyThemeService();
-
         const settings = new SkyThemeSettings(
           SkyTheme.presets.default,
           SkyThemeMode.presets.dark,
@@ -396,8 +315,6 @@ describe('Theme service', () => {
       });
 
       it('should apply branding', () => {
-        const themeSvc = new SkyThemeService();
-
         const settingsWithBranding = new SkyThemeSettings(
           SkyTheme.presets.modern,
           SkyThemeMode.presets.light,
@@ -426,8 +343,6 @@ describe('Theme service', () => {
       });
 
       it('should apply branding (blackbaud brand)', () => {
-        const themeSvc = new SkyThemeService();
-
         const settingsWithBranding = new SkyThemeSettings(
           SkyTheme.presets.modern,
           SkyThemeMode.presets.light,
@@ -468,47 +383,10 @@ describe('Theme service', () => {
       it('should apply branding without SRI attributes when empty SRI hash is provided', () => {
         testBrandingWithSri('');
       });
-
-      it('should use a registered brand with the same name instead of the specified brand when it exists', () => {
-        const registeredBrand = new SkyThemeBrand(
-          'rainbow',
-          '2.0.0',
-          undefined,
-          'https://example.com/rainbow/registered/rainbow.css',
-          'abc123',
-        );
-
-        const themeSvc = new SkyThemeService();
-
-        const settingsWithBranding = new SkyThemeSettings(
-          SkyTheme.presets.modern,
-          SkyThemeMode.presets.light,
-          SkyThemeSpacing.presets.compact,
-          new SkyThemeBrand('rainbow', '1.0.1'),
-        );
-
-        themeSvc.init(
-          mockHostEl,
-          mockRenderer as unknown as Renderer2,
-          settingsWithBranding,
-          [registeredBrand],
-        );
-
-        validateSettingsApplied(
-          new SkyThemeSettings(
-            settingsWithBranding.theme,
-            settingsWithBranding.mode,
-            settingsWithBranding.spacing,
-            registeredBrand,
-          ),
-        );
-      });
     });
 
     describe('with SkyTheme parameter', () => {
       it('should update only the theme while preserving other settings', () => {
-        const themeSvc = new SkyThemeService();
-
         const initialSettings = new SkyThemeSettings(
           SkyTheme.presets.modern,
           SkyThemeMode.presets.light,
@@ -552,14 +430,10 @@ describe('Theme service', () => {
       });
 
       it('should throw error if called before initialization', () => {
-        validateInitError(() =>
-          new SkyThemeService().setTheme(SkyTheme.presets.modern),
-        );
+        validateInitError(() => themeSvc.setTheme(SkyTheme.presets.modern));
       });
 
       it('should remove brand when switching to a theme that does not support branding', () => {
-        const themeSvc = new SkyThemeService();
-
         const initialSettings = new SkyThemeSettings(
           SkyTheme.presets.modern,
           SkyThemeMode.presets.light,
@@ -573,9 +447,7 @@ describe('Theme service', () => {
           initialSettings,
         );
 
-        mockRenderer.addClass.calls.reset();
-        mockRenderer.removeClass.calls.reset();
-        mockRenderer.removeChild.calls.reset();
+        mockBrandService.updateBrand.calls.reset();
 
         let capturedSettings: SkyThemeSettings | undefined;
         themeSvc.settingsChange.subscribe((settingsChange) => {
@@ -593,23 +465,16 @@ describe('Theme service', () => {
           }),
         );
 
-        expect(mockRenderer.removeClass).toHaveBeenCalledWith(
-          mockHostEl,
-          initialSettings.brand?.hostClass,
-        );
-        expect(mockRenderer.removeClass).toHaveBeenCalledWith(
-          mockHostEl,
-          'sky-theme-brand-base',
-        );
-        expect(mockRenderer.removeChild).toHaveBeenCalledWith(
-          mockHostEl,
-          mockLinkElement,
+        // Should call updateBrand to remove branding since new theme doesn't support it
+        expect(mockBrandService.updateBrand).toHaveBeenCalledWith(
+          jasmine.any(Object),
+          mockRenderer as unknown as Renderer2,
+          undefined,
+          initialSettings.brand,
         );
       });
 
       it('should maintain brand when switching to a theme that supports branding', () => {
-        const themeSvc = new SkyThemeService();
-
         const initialSettings = new SkyThemeSettings(
           SkyTheme.presets.modern,
           SkyThemeMode.presets.light,
@@ -650,8 +515,6 @@ describe('Theme service', () => {
 
   describe('destroy()', () => {
     it('should complete the settings change event when destroyed.', () => {
-      const themeSvc = new SkyThemeService();
-
       const settings = new SkyThemeSettings(
         SkyTheme.presets.default,
         SkyThemeMode.presets.dark,
@@ -667,12 +530,23 @@ describe('Theme service', () => {
 
       expect(sub.closed).toBe(true);
     });
+
+    it('should call brand service destroy when destroyed', () => {
+      const settings = new SkyThemeSettings(
+        SkyTheme.presets.default,
+        SkyThemeMode.presets.dark,
+      );
+
+      themeSvc.init(mockHostEl, mockRenderer as unknown as Renderer2, settings);
+
+      themeSvc.destroy();
+
+      expect(mockBrandService.destroy).toHaveBeenCalled();
+    });
   });
 
   describe('setThemeMode()', () => {
     it('should update only the theme mode while preserving other settings', () => {
-      const themeSvc = new SkyThemeService();
-
       const initialSettings = new SkyThemeSettings(
         SkyTheme.presets.modern,
         SkyThemeMode.presets.light,
@@ -715,14 +589,10 @@ describe('Theme service', () => {
     });
 
     it('should throw error if called before initialization', () => {
-      validateInitError(() =>
-        new SkyThemeService().setThemeMode(SkyThemeMode.presets.dark),
-      );
+      validateInitError(() => themeSvc.setThemeMode(SkyThemeMode.presets.dark));
     });
 
     it('should throw error when mode is not supported by current theme', () => {
-      const themeSvc = new SkyThemeService();
-
       const settings = new SkyThemeSettings(
         SkyTheme.presets.default,
         SkyThemeMode.presets.light,
@@ -738,8 +608,6 @@ describe('Theme service', () => {
 
   describe('setThemeSpacing()', () => {
     it('should update only the theme spacing while preserving other settings', () => {
-      const themeSvc = new SkyThemeService();
-
       const initialSettings = new SkyThemeSettings(
         SkyTheme.presets.modern,
         SkyThemeMode.presets.light,
@@ -771,13 +639,11 @@ describe('Theme service', () => {
 
     it('should throw error if called before initialization', () => {
       validateInitError(() =>
-        new SkyThemeService().setThemeSpacing(SkyThemeSpacing.presets.compact),
+        themeSvc.setThemeSpacing(SkyThemeSpacing.presets.compact),
       );
     });
 
     it('should throw error when spacing is not supported by current theme', () => {
-      const themeSvc = new SkyThemeService();
-
       const settings = new SkyThemeSettings(
         SkyTheme.presets.default,
         SkyThemeMode.presets.light,
@@ -794,12 +660,7 @@ describe('Theme service', () => {
   });
 
   describe('setThemeBrand()', () => {
-    function testClearBrand(
-      brandName: string,
-      shouldRemoveStylesheet: boolean,
-    ): void {
-      const themeSvc = new SkyThemeService();
-
+    function testClearBrand(brandName: string): void {
       const brand = new SkyThemeBrand(brandName, '1.0.0');
 
       const initialSettingsWithBrand = new SkyThemeSettings(
@@ -816,23 +677,15 @@ describe('Theme service', () => {
       );
 
       // Verify brand was applied initially
-      expect(mockRenderer.addClass).toHaveBeenCalledWith(
-        mockHostEl,
-        'sky-theme-brand-base',
+      expect(mockBrandService.updateBrand).toHaveBeenCalledWith(
+        jasmine.any(Object),
+        mockRenderer as unknown as Renderer2,
+        brand,
+        undefined,
       );
-      expect(mockRenderer.addClass).toHaveBeenCalledWith(
-        mockHostEl,
-        brand.hostClass,
-      );
-
-      if (!shouldRemoveStylesheet) {
-        // Blackbaud brand shouldn't create a stylesheet
-        expect(mockRenderer.createElement).not.toHaveBeenCalled();
-      }
 
       // Reset calls to focus on clearing the brand
-      mockRenderer.removeClass.calls.reset();
-      mockRenderer.removeChild.calls.reset();
+      mockBrandService.updateBrand.calls.reset();
 
       let capturedSettings: SkyThemeSettings | undefined;
       themeSvc.settingsChange.subscribe((settingsChange) => {
@@ -845,30 +698,16 @@ describe('Theme service', () => {
       // Verify that the brand was cleared
       expect(capturedSettings?.brand).toBeUndefined();
 
-      // Verify that brand classes were removed
-      expect(mockRenderer.removeClass).toHaveBeenCalledWith(
-        mockHostEl,
-        brand.hostClass,
+      // Verify that the brand service was called to update brand from existing to undefined
+      expect(mockBrandService.updateBrand).toHaveBeenCalledWith(
+        jasmine.any(Object),
+        mockRenderer as unknown as Renderer2,
+        undefined,
+        brand,
       );
-      expect(mockRenderer.removeClass).toHaveBeenCalledWith(
-        mockHostEl,
-        'sky-theme-brand-base',
-      );
-
-      // Verify stylesheet removal behavior based on brand type
-      if (shouldRemoveStylesheet) {
-        expect(mockRenderer.removeChild).toHaveBeenCalledWith(
-          mockHostEl,
-          mockLinkElement,
-        );
-      } else {
-        expect(mockRenderer.removeChild).not.toHaveBeenCalled();
-      }
     }
 
     it('should update only the theme brand while preserving other settings', () => {
-      const themeSvc = new SkyThemeService();
-
       const initialSettings = new SkyThemeSettings(
         SkyTheme.presets.modern,
         SkyThemeMode.presets.light,
@@ -881,34 +720,27 @@ describe('Theme service', () => {
         initialSettings,
       );
 
-      mockRenderer.addClass.calls.reset();
-      mockRenderer.removeClass.calls.reset();
-      mockRenderer.createElement.calls.reset();
+      mockBrandService.updateBrand.calls.reset();
 
       const newBrand = new SkyThemeBrand('rainbow', '1.0.1');
       themeSvc.setThemeBrand(newBrand);
 
-      expect(mockRenderer.addClass).toHaveBeenCalledWith(
-        mockHostEl,
-        'sky-theme-brand-base',
-      );
-      expect(mockRenderer.addClass).toHaveBeenCalledWith(
-        mockHostEl,
-        newBrand.hostClass,
+      // Verify the brand service was called with the new brand
+      expect(mockBrandService.updateBrand).toHaveBeenCalledWith(
+        jasmine.any(Object),
+        mockRenderer as unknown as Renderer2,
+        newBrand,
+        undefined,
       );
     });
 
     it('should throw error if called before initialization', () => {
       validateInitError(() =>
-        new SkyThemeService().setThemeBrand(
-          new SkyThemeBrand('rainbow', '1.0.1'),
-        ),
+        themeSvc.setThemeBrand(new SkyThemeBrand('rainbow', '1.0.1')),
       );
     });
 
     it('should throw error if branding is not supported by the current theme', () => {
-      const themeSvc = new SkyThemeService();
-
       const initialSettings = new SkyThemeSettings(
         SkyTheme.presets.default,
         SkyThemeMode.presets.light,
@@ -926,7 +758,6 @@ describe('Theme service', () => {
     });
 
     it('should apply brand with SRI hash using setThemeBrand', () => {
-      const themeSvc = new SkyThemeService();
       const sriHash =
         'sha384-abc123def456ghi789jkl012mno345pqr678stu901vwx234yz567890abcdef';
 
@@ -942,10 +773,7 @@ describe('Theme service', () => {
         initialSettings,
       );
 
-      mockRenderer.addClass.calls.reset();
-      mockRenderer.removeClass.calls.reset();
-      mockRenderer.createElement.calls.reset();
-      mockRenderer.setAttribute.calls.reset();
+      mockBrandService.updateBrand.calls.reset();
 
       const newBrandWithSri = new SkyThemeBrand(
         'rainbow',
@@ -956,30 +784,16 @@ describe('Theme service', () => {
       );
       themeSvc.setThemeBrand(newBrandWithSri);
 
-      expect(mockRenderer.addClass).toHaveBeenCalledWith(
-        mockHostEl,
-        'sky-theme-brand-base',
-      );
-      expect(mockRenderer.addClass).toHaveBeenCalledWith(
-        mockHostEl,
-        newBrandWithSri.hostClass,
-      );
-
-      // Validate SRI-specific attributes are set
-      expect(mockRenderer.setAttribute).toHaveBeenCalledWith(
-        mockLinkElement,
-        'integrity',
-        sriHash,
-      );
-      expect(mockRenderer.setAttribute).toHaveBeenCalledWith(
-        mockLinkElement,
-        'crossorigin',
-        'anonymous',
+      // Verify the brand service was called with the new brand (including SRI)
+      expect(mockBrandService.updateBrand).toHaveBeenCalledWith(
+        jasmine.any(Object),
+        mockRenderer as unknown as Renderer2,
+        newBrandWithSri,
+        undefined,
       );
     });
 
     it('should use styleUrl when provided for brand stylesheet', () => {
-      const themeSvc = new SkyThemeService();
       const customStyleUrl = 'https://custom.example.com/theme.css';
 
       const settingsWithCustomStyleUrl = new SkyThemeSettings(
@@ -995,19 +809,16 @@ describe('Theme service', () => {
         settingsWithCustomStyleUrl,
       );
 
-      // Validate that the custom styleUrl is used
-      expect(mockRenderer.setAttribute).toHaveBeenCalledWith(
-        mockLinkElement,
-        'href',
-        customStyleUrl,
+      // Validate that the brand service was called with the custom styleUrl brand
+      expect(mockBrandService.updateBrand).toHaveBeenCalledWith(
+        jasmine.any(Object),
+        mockRenderer as unknown as Renderer2,
+        settingsWithCustomStyleUrl.brand,
+        undefined,
       );
-
-      // Validate other branding is applied correctly
-      validateSettingsApplied(settingsWithCustomStyleUrl);
     });
 
     it('should use styleUrl with SRI when both are provided', () => {
-      const themeSvc = new SkyThemeService();
       const customStyleUrl = 'https://custom.example.com/theme.css';
       const sriHash = 'sha384-abc123';
 
@@ -1030,85 +841,16 @@ describe('Theme service', () => {
         settingsWithCustomStyleUrlAndSri,
       );
 
-      // Validate that the custom styleUrl is used
-      expect(mockRenderer.setAttribute).toHaveBeenCalledWith(
-        mockLinkElement,
-        'href',
-        customStyleUrl,
-      );
-
-      // Validate SRI attributes are set
-      expect(mockRenderer.setAttribute).toHaveBeenCalledWith(
-        mockLinkElement,
-        'integrity',
-        sriHash,
-      );
-      expect(mockRenderer.setAttribute).toHaveBeenCalledWith(
-        mockLinkElement,
-        'crossorigin',
-        'anonymous',
-      );
-
-      // Validate other branding is applied correctly
-      validateSettingsApplied(settingsWithCustomStyleUrlAndSri);
-    });
-
-    it('should use a registered brand with the same name instead of the specified brand when it exists', () => {
-      const registeredBrand = new SkyThemeBrand(
-        'rainbow',
-        '2.0.0',
-        undefined,
-        'https://example.com/rainbow/registered/rainbow.css',
-        'abc123',
-      );
-
-      const specifiedBrand = new SkyThemeBrand('rainbow', '1.0.1');
-
-      const themeSvc = new SkyThemeService();
-
-      themeSvc.registerBrand(registeredBrand);
-
-      const initialSettings = new SkyThemeSettings(
-        SkyTheme.presets.modern,
-        SkyThemeMode.presets.light,
-        SkyThemeSpacing.presets.compact,
-      );
-
-      themeSvc.init(
-        mockHostEl,
+      // Validate that the brand service was called with the combined custom styleUrl + SRI brand
+      expect(mockBrandService.updateBrand).toHaveBeenCalledWith(
+        jasmine.any(Object),
         mockRenderer as unknown as Renderer2,
-        initialSettings,
-      );
-
-      themeSvc.setThemeBrand(specifiedBrand);
-
-      const settingsWithRegisteredBrand = new SkyThemeSettings(
-        initialSettings.theme,
-        initialSettings.mode,
-        initialSettings.spacing,
-        registeredBrand,
-      );
-
-      validateSettingsApplied(settingsWithRegisteredBrand, initialSettings);
-
-      themeSvc.unregisterBrand('rainbow');
-
-      themeSvc.setThemeBrand(specifiedBrand);
-
-      validateSettingsApplied(
-        new SkyThemeSettings(
-          initialSettings.theme,
-          initialSettings.mode,
-          initialSettings.spacing,
-          specifiedBrand,
-        ),
-        settingsWithRegisteredBrand,
+        settingsWithCustomStyleUrlAndSri.brand,
+        undefined,
       );
     });
 
-    it('should remove old stylesheet when switching from one brand to another brand', () => {
-      const themeSvc = new SkyThemeService();
-
+    it('should handle switching between brands', () => {
       const brand1 = new SkyThemeBrand('brand1', '1.0.0');
       const brand2 = new SkyThemeBrand('brand2', '1.0.0');
 
@@ -1126,181 +868,29 @@ describe('Theme service', () => {
       );
 
       // Reset calls to focus on the brand switching
-      mockRenderer.removeChild.calls.reset();
-      mockRenderer.createElement.calls.reset();
-      mockRenderer.appendChild.calls.reset();
+      mockBrandService.updateBrand.calls.reset();
 
       // Switch to brand2
       themeSvc.setThemeBrand(brand2);
 
-      // Verify that the old stylesheet was removed first
-      expect(mockRenderer.removeChild).toHaveBeenCalledWith(
-        mockHostEl,
-        mockLinkElement,
-      );
-
-      // Verify that a new stylesheet was created and added
-      expect(mockRenderer.createElement).toHaveBeenCalledWith('link');
-      expect(mockRenderer.appendChild).toHaveBeenCalledWith(
-        mockHostEl,
-        mockLinkElement,
-      );
-    });
-
-    it('should remove old stylesheet when switching from brand to blackbaud brand', () => {
-      const themeSvc = new SkyThemeService();
-
-      const customBrand = new SkyThemeBrand('custom', '1.0.0');
-      const blackbaudBrand = new SkyThemeBrand('blackbaud', '1.0.0');
-
-      const initialSettingsWithCustomBrand = new SkyThemeSettings(
-        SkyTheme.presets.modern,
-        SkyThemeMode.presets.light,
-        SkyThemeSpacing.presets.compact,
-        customBrand,
-      );
-
-      themeSvc.init(
-        mockHostEl,
+      // Verify the brand service was called to switch from brand1 to brand2
+      expect(mockBrandService.updateBrand).toHaveBeenCalledWith(
+        jasmine.any(Object),
         mockRenderer as unknown as Renderer2,
-        initialSettingsWithCustomBrand,
-      );
-
-      // Reset calls to focus on the brand switching
-      mockRenderer.removeChild.calls.reset();
-      mockRenderer.createElement.calls.reset();
-      mockRenderer.appendChild.calls.reset();
-
-      // Switch to blackbaud brand
-      themeSvc.setThemeBrand(blackbaudBrand);
-
-      // Verify that the old stylesheet was removed
-      expect(mockRenderer.removeChild).toHaveBeenCalledWith(
-        mockHostEl,
-        mockLinkElement,
-      );
-
-      // Verify that no new stylesheet was created (blackbaud doesn't need one)
-      expect(mockRenderer.createElement).not.toHaveBeenCalled();
-      expect(mockRenderer.appendChild).not.toHaveBeenCalled();
-    });
-
-    it('should remove old stylesheet when switching from blackbaud to custom brand', () => {
-      const themeSvc = new SkyThemeService();
-
-      const blackbaudBrand = new SkyThemeBrand('blackbaud', '1.0.0');
-      const customBrand = new SkyThemeBrand('custom', '1.0.0');
-
-      const initialSettingsWithBlackbaud = new SkyThemeSettings(
-        SkyTheme.presets.modern,
-        SkyThemeMode.presets.light,
-        SkyThemeSpacing.presets.compact,
-        blackbaudBrand,
-      );
-
-      themeSvc.init(
-        mockHostEl,
-        mockRenderer as unknown as Renderer2,
-        initialSettingsWithBlackbaud,
-      );
-
-      // Blackbaud brand shouldn't create a stylesheet initially
-      expect(mockRenderer.createElement).not.toHaveBeenCalled();
-
-      // Reset calls to focus on the brand switching
-      mockRenderer.removeChild.calls.reset();
-      mockRenderer.createElement.calls.reset();
-      mockRenderer.appendChild.calls.reset();
-
-      // Switch to custom brand
-      themeSvc.setThemeBrand(customBrand);
-
-      // Verify that no old stylesheet was removed (blackbaud doesn't have one)
-      expect(mockRenderer.removeChild).not.toHaveBeenCalled();
-
-      // Verify that a new stylesheet was created and added
-      expect(mockRenderer.createElement).toHaveBeenCalledWith('link');
-      expect(mockRenderer.appendChild).toHaveBeenCalledWith(
-        mockHostEl,
-        mockLinkElement,
-      );
-    });
-
-    it('should properly handle switching between brands with custom styleUrls', () => {
-      const themeSvc = new SkyThemeService();
-
-      const brand1 = new SkyThemeBrand(
-        'brand1',
-        '1.0.0',
-        undefined,
-        'https://example.com/brand1.css',
-      );
-      const brand2 = new SkyThemeBrand(
-        'brand2',
-        '1.0.0',
-        undefined,
-        'https://example.com/brand2.css',
-      );
-
-      const initialSettingsWithBrand1 = new SkyThemeSettings(
-        SkyTheme.presets.modern,
-        SkyThemeMode.presets.light,
-        SkyThemeSpacing.presets.compact,
+        brand2,
         brand1,
-      );
-
-      themeSvc.init(
-        mockHostEl,
-        mockRenderer as unknown as Renderer2,
-        initialSettingsWithBrand1,
-      );
-
-      // Verify brand1 stylesheet was set
-      expect(mockRenderer.setAttribute).toHaveBeenCalledWith(
-        mockLinkElement,
-        'href',
-        'https://example.com/brand1.css',
-      );
-
-      // Reset calls to focus on the brand switching
-      mockRenderer.removeChild.calls.reset();
-      mockRenderer.createElement.calls.reset();
-      mockRenderer.appendChild.calls.reset();
-      mockRenderer.setAttribute.calls.reset();
-
-      // Switch to brand2
-      themeSvc.setThemeBrand(brand2);
-
-      // Verify that the old stylesheet was removed first
-      expect(mockRenderer.removeChild).toHaveBeenCalledWith(
-        mockHostEl,
-        mockLinkElement,
-      );
-
-      // Verify that a new stylesheet was created and added with the correct URL
-      expect(mockRenderer.createElement).toHaveBeenCalledWith('link');
-      expect(mockRenderer.appendChild).toHaveBeenCalledWith(
-        mockHostEl,
-        mockLinkElement,
-      );
-      expect(mockRenderer.setAttribute).toHaveBeenCalledWith(
-        mockLinkElement,
-        'href',
-        'https://example.com/brand2.css',
       );
     });
 
     it('should clear custom brand when setThemeBrand() is called with undefined', () => {
-      testClearBrand('rainbow', true);
+      testClearBrand('rainbow');
     });
 
     it('should clear blackbaud brand when setThemeBrand() is called with undefined', () => {
-      testClearBrand('blackbaud', false);
+      testClearBrand('blackbaud');
     });
 
     it('should allow setting a brand after clearing it with undefined', () => {
-      const themeSvc = new SkyThemeService();
-
       const brand1 = new SkyThemeBrand('brand1', '1.0.0');
       const brand2 = new SkyThemeBrand('brand2', '1.0.0');
 
@@ -1312,7 +902,7 @@ describe('Theme service', () => {
       );
 
       themeSvc.init(
-        mockHostEl,
+        jasmine.any(Object),
         mockRenderer as unknown as Renderer2,
         initialSettingsWithBrand,
       );
@@ -1321,10 +911,7 @@ describe('Theme service', () => {
       themeSvc.setThemeBrand(undefined);
 
       // Reset calls to focus on setting the new brand
-      mockRenderer.addClass.calls.reset();
-      mockRenderer.removeClass.calls.reset();
-      mockRenderer.createElement.calls.reset();
-      mockRenderer.appendChild.calls.reset();
+      mockBrandService.updateBrand.calls.reset();
 
       let capturedSettings: SkyThemeSettings | undefined;
       themeSvc.settingsChange.subscribe((settingsChange) => {
@@ -1337,22 +924,33 @@ describe('Theme service', () => {
       // Verify that the new brand was applied
       expect(capturedSettings?.brand).toBe(brand2);
 
-      // Verify that brand classes were added
-      expect(mockRenderer.addClass).toHaveBeenCalledWith(
-        mockHostEl,
-        'sky-theme-brand-base',
+      // Verify the brand service was called with the new brand
+      expect(mockBrandService.updateBrand).toHaveBeenCalledWith(
+        jasmine.any(Object),
+        mockRenderer as unknown as Renderer2,
+        brand2,
+        undefined,
       );
-      expect(mockRenderer.addClass).toHaveBeenCalledWith(
-        mockHostEl,
-        brand2.hostClass,
-      );
+    });
+  });
 
-      // Verify that a new stylesheet was created
-      expect(mockRenderer.createElement).toHaveBeenCalledWith('link');
-      expect(mockRenderer.appendChild).toHaveBeenCalledWith(
-        mockHostEl,
-        mockLinkElement,
-      );
+  describe('registerBrand()', () => {
+    it('should call brand service registerBrand method', () => {
+      const brand = new SkyThemeBrand('test-brand', '1.0.0');
+
+      themeSvc.registerBrand(brand);
+
+      expect(mockBrandService.registerBrand).toHaveBeenCalledWith(brand);
+    });
+  });
+
+  describe('unregisterBrand()', () => {
+    it('should call brand service unregisterBrand method', () => {
+      const brandName = 'test-brand';
+
+      themeSvc.unregisterBrand(brandName);
+
+      expect(mockBrandService.unregisterBrand).toHaveBeenCalledWith(brandName);
     });
   });
 });

--- a/libs/components/theme/src/lib/theming/theme.service.ts
+++ b/libs/components/theme/src/lib/theming/theme.service.ts
@@ -1,15 +1,14 @@
-import { Injectable, Renderer2 } from '@angular/core';
+import { Injectable, Renderer2, inject } from '@angular/core';
 
 import { Observable, ReplaySubject } from 'rxjs';
 
 import { SkyTheme } from './theme';
 import { SkyThemeBrand } from './theme-brand';
+import { SkyThemeBrandService } from './theme-brand.service';
 import { SkyThemeMode } from './theme-mode';
 import { SkyThemeSettings } from './theme-settings';
 import { SkyThemeSettingsChange } from './theme-settings-change';
 import { SkyThemeSpacing } from './theme-spacing';
-
-const BRAND_BLACKBAUD = 'blackbaud';
 
 function assertCurrentSettings(
   currentSettings: SkyThemeSettings | undefined,
@@ -24,6 +23,8 @@ function assertCurrentSettings(
  */
 @Injectable()
 export class SkyThemeService {
+  #brandSvc = inject(SkyThemeBrandService);
+
   /**
    * Notifies consumers when the current theme settings have changed.
    */
@@ -33,15 +34,11 @@ export class SkyThemeService {
 
   #current: SkyThemeSettings | undefined;
 
-  #brandLinkElement: HTMLLinkElement | undefined;
-
   #hostEl: any | undefined;
 
   #renderer: Renderer2 | undefined;
 
   #settings: ReplaySubject<SkyThemeSettingsChange>;
-
-  #registeredBrands = new Map<string, SkyThemeBrand>();
 
   #_settingsObs: Observable<SkyThemeSettingsChange>;
 
@@ -70,7 +67,7 @@ export class SkyThemeService {
 
     if (registeredBrands) {
       for (const brand of registeredBrands) {
-        this.#registeredBrands.set(brand.name, brand);
+        this.#brandSvc.registerBrand(brand);
       }
     }
 
@@ -83,6 +80,7 @@ export class SkyThemeService {
    */
   public destroy(): void {
     this.#settings.complete();
+    this.#brandSvc.destroy();
 
     this.#hostEl = this.#renderer = undefined;
   }
@@ -127,7 +125,7 @@ export class SkyThemeService {
     let settings: SkyThemeSettings;
 
     if (settingsOrTheme instanceof SkyThemeSettings) {
-      settings = this.#applyRegisteredBrand(settingsOrTheme);
+      settings = settingsOrTheme;
     } else {
       const current = this.#current;
 
@@ -146,7 +144,20 @@ export class SkyThemeService {
     this.#applyThemeClass(previous, settings, 'theme');
     this.#applyThemeClass(previous, settings, 'mode', 'supportedModes');
     this.#applyThemeClass(previous, settings, 'spacing', 'supportedSpacing');
-    this.#applyThemeClass(previous, settings, 'brand');
+
+    if (this.#hostEl) {
+      // Validate branding support
+      if (settings.brand && !settings.theme.supportsBranding) {
+        throw new Error('Branding is not supported for the given theme.');
+      }
+
+      this.#brandSvc.updateBrand(
+        this.#hostEl,
+        this.#getRenderer(),
+        settings.brand,
+        previous?.brand,
+      );
+    }
 
     this.#settings.next({
       currentSettings: settings,
@@ -157,30 +168,11 @@ export class SkyThemeService {
   }
 
   public registerBrand(brand: SkyThemeBrand): void {
-    this.#registeredBrands.set(brand.name, brand);
+    this.#brandSvc.registerBrand(brand);
   }
 
   public unregisterBrand(name: string): void {
-    this.#registeredBrands.delete(name);
-  }
-
-  #applyRegisteredBrand(settings: SkyThemeSettings): SkyThemeSettings {
-    const brandName = settings.brand?.name;
-
-    if (brandName) {
-      const registeredBrand = this.#registeredBrands.get(brandName);
-
-      if (registeredBrand) {
-        settings = new SkyThemeSettings(
-          settings.theme,
-          settings.mode,
-          settings.spacing,
-          registeredBrand,
-        );
-      }
-    }
-
-    return settings;
+    this.#brandSvc.unregisterBrand(name);
   }
 
   #updateThemeProperty(
@@ -233,7 +225,7 @@ export class SkyThemeService {
   #applyThemeClass(
     previous: SkyThemeSettings | undefined,
     current: SkyThemeSettings,
-    prop: 'theme' | 'mode' | 'spacing' | 'brand',
+    prop: 'theme' | 'mode' | 'spacing',
     supportedProp?: 'supportedModes' | 'supportedSpacing',
   ): void {
     const currentSetting = current[prop];
@@ -242,39 +234,16 @@ export class SkyThemeService {
 
     if (!previousClass || previousClass !== currentClass) {
       this.#updateHostClass(
-        prop,
         previousClass,
         currentClass,
         currentSetting,
         current,
         supportedProp,
       );
-
-      if (prop === 'brand') {
-        if (!current.theme.supportsBranding && currentSetting) {
-          throw new Error('Branding is not supported for the given theme.');
-        }
-
-        this.#updateBrandStylesheet(current.brand, previous?.brand);
-      }
-    }
-  }
-
-  #updateBrandStylesheet(
-    currentBrand: SkyThemeBrand | undefined,
-    previousBrand: SkyThemeBrand | undefined,
-  ): void {
-    if (previousBrand && previousBrand.name !== BRAND_BLACKBAUD) {
-      this.#removeBrandStylesheet();
-    }
-
-    if (currentBrand && currentBrand.name !== BRAND_BLACKBAUD) {
-      this.#addBrandStylesheet(currentBrand);
     }
   }
 
   #updateHostClass(
-    prop: 'theme' | 'mode' | 'spacing' | 'brand',
     previousClass: string | undefined,
     currentClass: string | undefined,
     currentSetting:
@@ -290,60 +259,11 @@ export class SkyThemeService {
       this.#removeHostClass(previousClass);
     }
 
-    if (prop === 'brand') {
-      if (currentClass && !previousClass) {
-        this.#addHostClass('sky-theme-brand-base');
-      } else if (!currentClass && previousClass) {
-        this.#removeHostClass('sky-theme-brand-base');
-      }
-    }
-
     if (
       currentClass &&
       this.#isSupportedProperty(currentSetting, current, supportedProp)
     ) {
       this.#addHostClass(currentClass);
-    }
-  }
-
-  #addBrandStylesheet(brand: SkyThemeBrand): void {
-    if (brand.name !== BRAND_BLACKBAUD) {
-      // Use styleUrl if provided, otherwise build the default URL
-      const styleUrl =
-        brand.styleUrl ||
-        `https://sky.blackbaudcdn.net/static/skyux-brand-${brand.name}/${brand.version}/assets/scss/${brand.name}.css`;
-
-      const renderer = this.#getRenderer();
-
-      this.#brandLinkElement = renderer.createElement(
-        'link',
-      ) as HTMLLinkElement;
-
-      renderer.appendChild(this.#hostEl, this.#brandLinkElement);
-
-      renderer.setAttribute(this.#brandLinkElement, 'rel', 'stylesheet');
-      renderer.setAttribute(this.#brandLinkElement, 'href', styleUrl);
-
-      if (brand.sriHash) {
-        renderer.setAttribute(
-          this.#brandLinkElement,
-          'integrity',
-          brand.sriHash,
-        );
-
-        renderer.setAttribute(
-          this.#brandLinkElement,
-          'crossorigin',
-          'anonymous',
-        );
-      }
-    }
-  }
-
-  #removeBrandStylesheet(): void {
-    if (this.#brandLinkElement) {
-      this.#getRenderer().removeChild(this.#hostEl, this.#brandLinkElement);
-      this.#brandLinkElement = undefined;
     }
   }
 


### PR DESCRIPTION
:cherries: Cherry picked from #3815 [feat(components/theme): add title and favicon support to brand](https://github.com/blackbaud/skyux/pull/3815)

[AB#3403328](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3403328) 