### PR TITLE
feat(components/theme): modern v2 styles are now the styles rendered for modern theme when no brand is applied

### DIFF
--- a/apps/code-examples/src/app/shared/theme-selector/theme-selector.component.html
+++ b/apps/code-examples/src/app/shared/theme-selector/theme-selector.component.html
@@ -57,6 +57,7 @@
       [disabled]="brandingValues().length === 0"
       [(ngModel)]="themeBrand"
     >
+      <option [ngValue]="undefined">Blackbaud</option>
       @for (brandingValue of brandingValues(); track brandingValue) {
         <option [ngValue]="brandingValue">
           {{

--- a/apps/code-examples/src/app/shared/theme-selector/theme-selector.component.ts
+++ b/apps/code-examples/src/app/shared/theme-selector/theme-selector.component.ts
@@ -29,10 +29,7 @@ interface LocalStorageSettings {
   themeBrand?: SkyThemeBrand;
 }
 
-const AVAILABLE_BRANDS = [
-  new SkyThemeBrand('blackbaud', '1.0.0'),
-  new SkyThemeBrand('rainbow', '1.0.1'),
-];
+const AVAILABLE_BRANDS = [new SkyThemeBrand('rainbow', '1.0.1')];
 const PREVIOUS_SETTINGS_KEY =
   'skyux-playground-theme-mode-spacing-selector-settings';
 

--- a/apps/integration-e2e/src/e2e/field-heights.cy.ts
+++ b/apps/integration-e2e/src/e2e/field-heights.cy.ts
@@ -32,5 +32,5 @@ describe('field heights', () => {
         cy.skyVisualTest(`field-heights-${theme}`);
       });
     });
-  }, false);
+  });
 });

--- a/apps/integration-e2e/src/e2e/lookup-in-modal.cy.ts
+++ b/apps/integration-e2e/src/e2e/lookup-in-modal.cy.ts
@@ -44,5 +44,5 @@ describe('lookup in modal', () => {
         });
       });
     });
-  }, false);
+  });
 });

--- a/apps/integration-e2e/src/e2e/modal-colorpicker.cy.ts
+++ b/apps/integration-e2e/src/e2e/modal-colorpicker.cy.ts
@@ -110,5 +110,5 @@ describe('Modal Colorpicker', () => {
           .click({ waitForAnimations: true });
       });
     });
-  }, false);
+  });
 });

--- a/apps/integration-e2e/src/e2e/modal-date-range-picker.cy.ts
+++ b/apps/integration-e2e/src/e2e/modal-date-range-picker.cy.ts
@@ -24,5 +24,5 @@ describe('Modal Date range picker', () => {
         .should('have.length', 3);
       cy.skyVisualTest(`modal-date-range-picker-${theme}`);
     });
-  }, false);
+  });
 });

--- a/apps/integration-e2e/src/e2e/modal-footer-dropdown.cy.ts
+++ b/apps/integration-e2e/src/e2e/modal-footer-dropdown.cy.ts
@@ -101,5 +101,5 @@ describe('modal footer dropdown', () => {
         });
       });
     });
-  }, false);
+  });
 });

--- a/apps/integration-e2e/src/e2e/modal-split-view-tile-dashboard.cy.ts
+++ b/apps/integration-e2e/src/e2e/modal-split-view-tile-dashboard.cy.ts
@@ -59,5 +59,5 @@ describe('Modal Split View Tile Dashboard', () => {
       cy.get('.sky-modal').should('have.focus');
       cy.skyVisualTest(`modal-split-view-tile-dashboard-fit-layout-${theme}`);
     });
-  }, false);
+  });
 });

--- a/apps/integration-e2e/src/e2e/modal-viewkept-toolbars.cy.ts
+++ b/apps/integration-e2e/src/e2e/modal-viewkept-toolbars.cy.ts
@@ -59,5 +59,5 @@ describe('modal-viewkept-toolbars', () => {
         cy.skyVisualTest(`modal-viewkept-toolbars-${theme}`);
       });
     });
-  }, false);
+  });
 });

--- a/apps/integration-e2e/src/e2e/vertical-tabset-back-to-top.cy.ts
+++ b/apps/integration-e2e/src/e2e/vertical-tabset-back-to-top.cy.ts
@@ -82,5 +82,5 @@ describe('vertical-tabset-back-to-top', () => {
         },
       );
     });
-  }, false);
+  });
 });

--- a/apps/integration-e2e/src/e2e/viewkeeper-tabset.cy.ts
+++ b/apps/integration-e2e/src/e2e/viewkeeper-tabset.cy.ts
@@ -18,5 +18,5 @@ describe('viewkeeper-tabset', () => {
           .should('have.class', 'sky-viewkeeper-fixed');
       });
     });
-  }, false);
+  });
 });

--- a/apps/integration/src/app/integrations/modal-viewkept-toolbars/modal-viewkept-toolbars.component.spec.ts
+++ b/apps/integration/src/app/integrations/modal-viewkept-toolbars/modal-viewkept-toolbars.component.spec.ts
@@ -126,8 +126,8 @@ describe('Modals with viewkept toolbars', () => {
       toolbarContainers.forEach((toolbar) => {
         const toolbarStyle = window.getComputedStyle(toolbar);
         expect(toolbarStyle.backgroundColor).toBe('rgb(255, 255, 255)');
-        expect(toolbarStyle.paddingLeft).toBe('30px');
-        expect(toolbarStyle.paddingRight).toBe('30px');
+        expect(toolbarStyle.paddingLeft).toBe('24px');
+        expect(toolbarStyle.paddingRight).toBe('24px');
       });
     });
   });

--- a/apps/integration/src/app/shared/theme-selector/theme-selector.component.html
+++ b/apps/integration/src/app/shared/theme-selector/theme-selector.component.html
@@ -57,6 +57,7 @@
       [disabled]="brandingValues().length === 0"
       [(ngModel)]="themeBrand"
     >
+      <option [ngValue]="undefined">Blackbaud</option>
       @for (brandingValue of brandingValues(); track brandingValue) {
         <option [ngValue]="brandingValue">
           {{

--- a/apps/integration/src/app/shared/theme-selector/theme-selector.component.ts
+++ b/apps/integration/src/app/shared/theme-selector/theme-selector.component.ts
@@ -29,10 +29,7 @@ interface LocalStorageSettings {
   themeBrand?: SkyThemeBrand;
 }
 
-const AVAILABLE_BRANDS = [
-  new SkyThemeBrand('blackbaud', '1.0.0'),
-  new SkyThemeBrand('rainbow', '1.0.1'),
-];
+const AVAILABLE_BRANDS = [new SkyThemeBrand('rainbow', '1.0.1')];
 const PREVIOUS_SETTINGS_KEY =
   'skyux-playground-theme-mode-spacing-selector-settings';
 

--- a/apps/playground/src/app/shared/theme-selector/theme-selector.component.html
+++ b/apps/playground/src/app/shared/theme-selector/theme-selector.component.html
@@ -57,6 +57,7 @@
       [disabled]="brandingValues().length === 0"
       [(ngModel)]="themeBrand"
     >
+      <option [ngValue]="undefined">Blackbaud</option>
       @for (brandingValue of brandingValues(); track brandingValue) {
         <option [ngValue]="brandingValue">
           {{

--- a/apps/playground/src/app/shared/theme-selector/theme-selector.component.ts
+++ b/apps/playground/src/app/shared/theme-selector/theme-selector.component.ts
@@ -29,10 +29,7 @@ interface LocalStorageSettings {
   themeBrand?: SkyThemeBrand;
 }
 
-const AVAILABLE_BRANDS = [
-  new SkyThemeBrand('blackbaud', '1.0.0'),
-  new SkyThemeBrand('rainbow', '1.0.1'),
-];
+const AVAILABLE_BRANDS = [new SkyThemeBrand('rainbow', '1.0.1')];
 const PREVIOUS_SETTINGS_KEY =
   'skyux-playground-theme-mode-spacing-selector-settings';
 

--- a/libs/components/storybook/src/lib/preview-wrapper/preview-wrapper.component.spec.ts
+++ b/libs/components/storybook/src/lib/preview-wrapper/preview-wrapper.component.spec.ts
@@ -74,7 +74,6 @@ describe('PreviewWrapperComponent', () => {
     expectedTheme = {
       theme: 'modern',
       mode: 'dark',
-      brand: 'blackbaud',
     };
     expectModernV2Class = true;
     component.theme = 'modern-v2-dark';
@@ -88,7 +87,6 @@ describe('PreviewWrapperComponent', () => {
     expectedTheme = {
       theme: 'modern',
       mode: 'light',
-      brand: 'blackbaud',
     };
     expectModernV2Class = true;
     component.theme = 'modern-v2-light';

--- a/libs/components/storybook/src/lib/preview-wrapper/preview-wrapper.component.ts
+++ b/libs/components/storybook/src/lib/preview-wrapper/preview-wrapper.component.ts
@@ -12,7 +12,6 @@ import {
 import { toSignal } from '@angular/core/rxjs-interop';
 import {
   SkyTheme,
-  SkyThemeBrand,
   SkyThemeMode,
   SkyThemeService,
   SkyThemeSettings,

--- a/libs/components/storybook/src/lib/preview-wrapper/preview-wrapper.component.ts
+++ b/libs/components/storybook/src/lib/preview-wrapper/preview-wrapper.component.ts
@@ -41,14 +41,12 @@ export class PreviewWrapperComponent implements OnInit, OnDestroy {
           SkyTheme.presets.modern,
           SkyThemeMode.presets.dark,
           SkyThemeSpacing.presets.standard,
-          new SkyThemeBrand('blackbaud', '1.0.0'),
         );
       } else {
         this.themeSettings = new SkyThemeSettings(
           SkyTheme.presets.modern,
           SkyThemeMode.presets.light,
           SkyThemeSpacing.presets.standard,
-          new SkyThemeBrand('blackbaud', '1.0.0'),
         );
       }
     } else {

--- a/libs/components/text-editor/src/lib/modules/text-editor/text-editor.component.spec.ts
+++ b/libs/components/text-editor/src/lib/modules/text-editor/text-editor.component.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @angular-eslint/component-class-suffix */
 import { Component, DebugElement, Provider, Type } from '@angular/core';
 import {
   ComponentFixture,
@@ -886,10 +885,10 @@ describe('Text editor', () => {
         value: jasmine.stringContaining('data-fielddisplay="&quot;&gt;&lt;'),
       });
 
-      // The browser converts the escaped angle brackets back to their unescaped
-      // versions since they appear within quotes in an attribute value.
-      expect(testComponent.value).toContain('data-fieldid="&quot;><');
-      expect(testComponent.value).toContain('data-fielddisplay="&quot;><"');
+      expect(testComponent.value).toContain('data-fieldid="&quot;&gt;&lt;');
+      expect(testComponent.value).toContain(
+        'data-fielddisplay="&quot;&gt;&lt;"',
+      );
     }));
 
     it('Toolbar values should update based on selection', fakeAsync(() => {

--- a/libs/components/theme/src/lib/styles/themes/modern/styles.scss
+++ b/libs/components/theme/src/lib/styles/themes/modern/styles.scss
@@ -1,5 +1,4 @@
 @forward '@blackbaud/skyux-design-tokens/assets/scss/blackbaud';
-@forward '@blackbaud/skyux-design-tokens/assets/scss/modern';
 
 @forward 'custom-properties';
 @forward 'box';

--- a/libs/components/theme/src/lib/theming/theme.service.ts
+++ b/libs/components/theme/src/lib/theming/theme.service.ts
@@ -154,7 +154,10 @@ export class SkyThemeService {
       this.#brandSvc.updateBrand(
         this.#hostEl,
         this.#getRenderer(),
-        settings.brand,
+        settings.brand ??
+          (settings.theme === SkyTheme.presets.modern
+            ? new SkyThemeBrand('blackbaud', '1.0.0')
+            : undefined),
         previous?.brand,
       );
     }

--- a/libs/sdk/cypress-commands/src/lib/choose-theme-command.ts
+++ b/libs/sdk/cypress-commands/src/lib/choose-theme-command.ts
@@ -13,7 +13,13 @@ declare namespace Cypress {
  * Choose theme for visual regression testing.
  */
 Cypress.Commands.add('skyChooseTheme', (theme: string) => {
-  const [themeName, themeMode] = theme.split('-');
+  // Normalize modern-v2 themes to modern themes
+  let processedTheme = theme;
+  if (theme.startsWith('modern-v2')) {
+    processedTheme = theme.replace(/^modern-v2/, 'modern');
+  }
+
+  const [themeName, themeMode] = processedTheme.split('-');
   cy.get('select.sky-theme-selector')
     .first()
     .should('be.visible')

--- a/libs/sdk/e2e-schematics/src/lib/e2e-variations/e2e-variations.spec.ts
+++ b/libs/sdk/e2e-schematics/src/lib/e2e-variations/e2e-variations.spec.ts
@@ -11,12 +11,6 @@ describe('e2e variations', function () {
     expect(callback).not.toHaveBeenCalledWith('modern-dark');
     callback.mockReset();
 
-    E2eVariations.forEachTheme(callback, false);
-    expect(callback).toHaveBeenCalledTimes(1);
-    expect(callback).toHaveBeenCalledWith('default');
-    expect(callback).not.toHaveBeenCalledWith('modern-v2-light');
-    callback.mockReset();
-
     expect(E2eVariations.DISPLAY_WIDTHS).toEqual([1280]);
     expect(E2eVariations.RESPONSIVE_WIDTHS).toEqual([375, 800, 1000, 1280]);
     expect(E2eVariations.MOBILE_WIDTHS).toEqual([375]);

--- a/libs/sdk/e2e-schematics/src/lib/e2e-variations/e2e-variations.ts
+++ b/libs/sdk/e2e-schematics/src/lib/e2e-variations/e2e-variations.ts
@@ -5,14 +5,8 @@ export const E2eVariations = {
   RESPONSIVE_WIDTHS: [375, 800, 1000, 1280],
   MOBILE_WIDTHS: [375],
 
-  forEachTheme: (
-    callback: (theme: E2EVariationName) => void,
-    includeModernV2 = true,
-  ): void => {
+  forEachTheme: (callback: (theme: E2EVariationName) => void): void => {
     callback('default');
-
-    if (includeModernV2) {
-      callback('modern-v2-light');
-    }
+    callback('modern-v2-light');
   },
 };


### PR DESCRIPTION
[AB#3519128](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3519128)
Also addresses: [AB#3520028](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3520028)