### PR TITLE
feat(sdk/eslint-config)!: add prompt to `ng add` schematic to install `eslint-config-skyux` instead

### DIFF
--- a/libs/sdk/eslint-config/src/schematics/ng-add/ng-add.schematic.ts
+++ b/libs/sdk/eslint-config/src/schematics/ng-add/ng-add.schematic.ts
@@ -1,4 +1,9 @@
-import { Rule, Tree, chain } from '@angular-devkit/schematics';
+import {
+  Rule,
+  Tree,
+  chain,
+  externalSchematic,
+} from '@angular-devkit/schematics';
 
 import { readJson } from 'fs-extra';
 import { resolve } from 'path';
@@ -7,6 +12,8 @@ import { modifyEsLintConfig } from '../shared/rules/modify-eslint-config';
 import { modifyTsConfig } from '../shared/rules/modify-tsconfig';
 import { PackageJson } from '../shared/types/package-json';
 import { readRequiredFile } from '../shared/utility/tree';
+
+import { NgAddSchema } from './schema';
 
 function getPackageJson(tree: Tree): PackageJson {
   return JSON.parse(readRequiredFile(tree, '/package.json')) as PackageJson;
@@ -26,8 +33,12 @@ function hardenPackageVersion(): Rule {
   };
 }
 
-export default function ngAdd(): Rule {
+export default function ngAdd(options: NgAddSchema): Rule {
   return (tree) => {
+    if (options.useRecommendedPackage) {
+      return externalSchematic('eslint-config-skyux', 'ng-add', {});
+    }
+
     const packageJson = getPackageJson(tree);
 
     if (

--- a/libs/sdk/eslint-config/src/schematics/ng-add/schema.json
+++ b/libs/sdk/eslint-config/src/schematics/ng-add/schema.json
@@ -1,5 +1,12 @@
 {
-  "$schema": "http://json-schema.org/schema",
+  "$schema": "http://json-schema.org/draft-07/schema",
   "type": "object",
-  "properties": {}
+  "properties": {
+    "useRecommendedPackage": {
+      "type": "boolean",
+      "description": "Install eslint-config-skyux instead of the deprecated @skyux-sdk/eslint-config",
+      "default": true,
+      "x-prompt": "The @skyux-sdk/eslint-config package is deprecated. Would you like to install eslint-config-skyux instead? (recommended)"
+    }
+  }
 }

--- a/libs/sdk/eslint-config/src/schematics/ng-add/schema.ts
+++ b/libs/sdk/eslint-config/src/schematics/ng-add/schema.ts
@@ -1,0 +1,6 @@
+export interface NgAddSchema {
+  /**
+   * Install eslint-config-skyux instead of the deprecated @skyux-sdk/eslint-config.
+   */
+  useRecommendedPackage?: boolean;
+}


### PR DESCRIPTION
BREAKING CHANGE

The `ng add` schematic adds a prompt to install `eslint-config-skyux` which may disrupt processes making calls to the schematic programmatically.

[AB#3381661](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3381661)