### PR TITLE
feat(sdk/stylelint-config-skyux): add `no-static-color-values` rule to prevent usage of static color values in stylesheets (#3851)

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -4,6 +4,7 @@
     "autofit",
     "buttontype",
     "checkmark",
+    "currentcolor",
     "cyclomatic",
     "fetchpriority",
     "gantt",

--- a/libs/sdk/skyux-stylelint/docs/rules/no-static-color-values.md
+++ b/libs/sdk/skyux-stylelint/docs/rules/no-static-color-values.md
@@ -1,0 +1,206 @@
+# skyux-stylelint/no-static-color-values
+
+Prevent consumers from assigning static color values to color-related CSS properties. Use SKY UX approved custom properties instead.
+
+This rule prevents the use of static color values (hex, RGB, RGBA, HSL, HSLA, and named colors) on the following CSS properties:
+
+- `color`
+- `background`
+- `background-color`
+- `border`
+- `border-color`
+- `border-top-color`
+- `border-right-color`
+- `border-bottom-color`
+- `border-left-color`
+
+## Rationale
+
+Static color values can create inconsistency in the user interface and make it difficult to maintain a cohesive design system. SKY UX provides approved custom properties that ensure consistency across all applications and support theming.
+
+## Usage
+
+### stylelint.config.mjs
+
+```js
+export default {
+  plugins: ['skyux-stylelint'],
+  rules: {
+    'skyux-stylelint/no-static-color-values': true,
+  },
+};
+```
+
+## ❌ Failing Examples
+
+### Hex colors
+
+```css
+.my-component {
+  color: #fff;
+  ~~~~~~~~~~~~~~
+}
+```
+
+```css
+.my-component {
+  background-color: #000000;
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+}
+```
+
+### RGB/RGBA colors
+
+```css
+.my-component {
+  color: rgb(255, 255, 255);
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+}
+```
+
+```css
+.my-component {
+  background-color: rgba(0, 0, 0, 0.5);
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+}
+```
+
+### HSL/HSLA colors
+
+```css
+.my-component {
+  border-color: hsl(0, 0%, 100%);
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+}
+```
+
+### Named colors
+
+```css
+.my-component {
+  color: red;
+  ~~~~~~~~~~~
+}
+```
+
+```css
+.my-component {
+  background-color: blue;
+  ~~~~~~~~~~~~~~~~~~~~~~
+}
+```
+
+### Shorthand properties with static colors
+
+```css
+.my-component {
+  border: 1px solid red;
+  ~~~~~~~~~~~~~~~~~~~~~~
+}
+```
+
+```css
+.my-component {
+  background: #fff url(image.png) no-repeat;
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+}
+```
+
+### Specific border colors
+
+```css
+.my-component {
+  border-top-color: #fff;
+  ~~~~~~~~~~~~~~~~~~~~~~~~~
+}
+```
+
+```css
+.my-component {
+  border-right-color: green;
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~
+}
+```
+
+## ✅ Passing Examples
+
+### Using approved SKY UX custom properties
+
+```css
+.my-component {
+  color: var(--sky-color-text-default);
+}
+```
+
+```css
+.my-component {
+  background-color: var(--sky-background-color-page-default);
+}
+```
+
+```css
+.my-component {
+  border-color: var(--sky-border-color-neutral-medium);
+}
+```
+
+```css
+.my-component {
+  border: 1px solid var(--sky-border-color-neutral-medium);
+}
+```
+
+### CSS keywords that are allowed
+
+```css
+.my-component {
+  color: inherit;
+}
+```
+
+```css
+.my-component {
+  background-color: transparent;
+}
+```
+
+```css
+.my-component {
+  color: currentColor;
+}
+```
+
+### Non-color properties (not affected by this rule)
+
+```css
+.my-component {
+  margin: 10px;
+  font-size: 16px;
+  width: 100px;
+}
+```
+
+## Approved SKY UX Custom Properties
+
+Use custom properties that follow these patterns:
+
+- `var(--sky-color-*)`
+- `var(--sky-background-color-*)`
+- `var(--sky-border-color-*)`
+- `var(--sky-text-color-*)`
+- `var(--sky-category-color-*)`
+- `var(--sky-highlight-color-*)`
+
+For a complete list of available custom properties, see the [SKY UX Color documentation](https://developer.blackbaud.com/skyux/design/styles/color).
+
+## Configuration
+
+This rule accepts a boolean value. When set to `true`, the rule is enabled.
+
+```js
+{
+  "rules": {
+    "skyux-stylelint/no-static-color-values": true
+  }
+}
+```

--- a/libs/sdk/skyux-stylelint/src/index.ts
+++ b/libs/sdk/skyux-stylelint/src/index.ts
@@ -1,3 +1,4 @@
 import noSkySelectors from './rules/no-sky-selectors.js';
+import noStaticColorValues from './rules/no-static-color-values.js';
 
-export default [noSkySelectors];
+export default [noSkySelectors, noStaticColorValues];

--- a/libs/sdk/skyux-stylelint/src/rules/no-static-color-values.test.ts
+++ b/libs/sdk/skyux-stylelint/src/rules/no-static-color-values.test.ts
@@ -1,0 +1,309 @@
+import { describe } from 'vitest';
+
+import { testRule } from '../testing/test-rule.js';
+
+import plugin, { ruleName } from './no-static-color-values.js';
+
+describe(ruleName, () => {
+  testRule({
+    plugins: [plugin],
+    ruleName,
+    config: true,
+    accept: [
+      // Approved SKY UX custom properties
+      {
+        code: '.my-class { color: var(--sky-color-text-default); }',
+        description: 'approved sky color custom property should be allowed',
+      },
+      {
+        code: '.my-class { background-color: var(--sky-background-color-page-default); }',
+        description:
+          'approved sky background color custom property should be allowed',
+      },
+      {
+        code: '.my-class { border-color: var(--sky-border-color-neutral-medium); }',
+        description:
+          'approved sky border color custom property should be allowed',
+      },
+      {
+        code: '.my-class { border: 1px solid var(--sky-border-color-neutral-medium); }',
+        description:
+          'shorthand border with approved custom property should be allowed',
+      },
+      {
+        code: '.my-class { background: var(--sky-background-color-info) url(image.png) no-repeat; }',
+        description:
+          'shorthand background with approved custom property should be allowed',
+      },
+      {
+        code: '.my-class { border-top-color: var(--sky-color-text-default); }',
+        description:
+          'specific border color with approved custom property should be allowed',
+      },
+      {
+        code: '.my-class { border-right-color: var(--sky-border-color-neutral-medium); }',
+        description:
+          'border-right-color with approved custom property should be allowed',
+      },
+      {
+        code: '.my-class { border-bottom-color: var(--sky-border-color-neutral-medium); }',
+        description:
+          'border-bottom-color with approved custom property should be allowed',
+      },
+      {
+        code: '.my-class { border-left-color: var(--sky-border-color-neutral-medium); }',
+        description:
+          'border-left-color with approved custom property should be allowed',
+      },
+      {
+        code: '.my-class { color: var(--sky-text-color-action-primary); }',
+        description: 'text color custom property should be allowed',
+      },
+      {
+        code: '.my-class { background-color: var(--sky-category-color-blue); }',
+        description: 'category color custom property should be allowed',
+      },
+      {
+        code: '.my-class { color: var(--sky-highlight-color-info); }',
+        description: 'highlight color custom property should be allowed',
+      },
+      // Non-color properties should be ignored
+      {
+        code: '.my-class { margin: 10px; }',
+        description: 'non-color properties should be ignored',
+      },
+      {
+        code: '.my-class { font-size: 16px; }',
+        description: 'non-color properties should be ignored',
+      },
+      {
+        code: '.my-class { width: 100px; }',
+        description: 'non-color properties should be ignored',
+      },
+      // Other CSS values that contain color words but aren't colors
+      {
+        code: '.my-class { content: "red text here"; }',
+        description: 'content property with color words should be allowed',
+      },
+      // inherit, initial, unset, etc.
+      {
+        code: '.my-class { color: inherit; }',
+        description: 'inherit value should be allowed',
+      },
+      {
+        code: '.my-class { background-color: initial; }',
+        description: 'initial value should be allowed',
+      },
+      {
+        code: '.my-class { border-color: unset; }',
+        description: 'unset value should be allowed',
+      },
+      {
+        code: '.my-class { color: currentColor; }',
+        description: 'currentColor value should be allowed',
+      },
+      {
+        code: '.my-class { background-color: transparent; }',
+        description: 'transparent value should be allowed',
+      },
+      // Approved custom properties with whitespace formatting
+      {
+        code: '.my-class { color: var( --sky-color-text-default); }',
+        description:
+          'approved custom property with space after opening parenthesis should be allowed',
+      },
+      {
+        code: '.my-class { background-color: var(\n  --sky-background-color-page-default\n); }',
+        description: 'approved custom property with newlines should be allowed',
+      },
+      {
+        code: '.my-class { border-color: var(\t--sky-border-color-neutral-medium); }',
+        description:
+          'approved custom property with tab after opening parenthesis should be allowed',
+      },
+      {
+        code: '.my-class { color: var(  --sky-color-text-default  ); }',
+        description:
+          'approved custom property with multiple spaces should be allowed',
+      },
+    ],
+
+    reject: [
+      // Hex colors
+      {
+        code: '.my-class { color: #fff; }',
+        description: 'hex color should be rejected',
+        message:
+          'Unexpected static color value "#fff" for property "color". Use SKY UX approved custom properties instead.',
+        line: 1,
+      },
+      {
+        code: '.my-class { color: #ffffff; }',
+        description: '6-digit hex color should be rejected',
+        message:
+          'Unexpected static color value "#ffffff" for property "color". Use SKY UX approved custom properties instead.',
+        line: 1,
+      },
+      {
+        code: '.my-class { background-color: #000; }',
+        description: 'hex background color should be rejected',
+        message:
+          'Unexpected static color value "#000" for property "background-color". Use SKY UX approved custom properties instead.',
+        line: 1,
+      },
+      {
+        code: '.my-class { border-color: #ff0000; }',
+        description: 'hex border color should be rejected',
+        message:
+          'Unexpected static color value "#ff0000" for property "border-color". Use SKY UX approved custom properties instead.',
+        line: 1,
+      },
+      // RGB/RGBA colors
+      {
+        code: '.my-class { color: rgb(255, 255, 255); }',
+        description: 'RGB color should be rejected',
+        message:
+          'Unexpected static color value "rgb(255, 255, 255)" for property "color". Use SKY UX approved custom properties instead.',
+        line: 1,
+      },
+      {
+        code: '.my-class { background-color: rgba(0, 0, 0, 0.5); }',
+        description: 'RGBA color should be rejected',
+        message:
+          'Unexpected static color value "rgba(0, 0, 0, 0.5)" for property "background-color". Use SKY UX approved custom properties instead.',
+        line: 1,
+      },
+      // HSL/HSLA colors
+      {
+        code: '.my-class { color: hsl(0, 0%, 100%); }',
+        description: 'HSL color should be rejected',
+        message:
+          'Unexpected static color value "hsl(0, 0%, 100%)" for property "color". Use SKY UX approved custom properties instead.',
+        line: 1,
+      },
+      {
+        code: '.my-class { background-color: hsla(0, 0%, 0%, 0.5); }',
+        description: 'HSLA color should be rejected',
+        message:
+          'Unexpected static color value "hsla(0, 0%, 0%, 0.5)" for property "background-color". Use SKY UX approved custom properties instead.',
+        line: 1,
+      },
+      // Named colors
+      {
+        code: '.my-class { color: red; }',
+        description: 'named color should be rejected',
+        message:
+          'Unexpected static color value "red" for property "color". Use SKY UX approved custom properties instead.',
+        line: 1,
+      },
+      {
+        code: '.my-class { background-color: blue; }',
+        description: 'named background color should be rejected',
+        message:
+          'Unexpected static color value "blue" for property "background-color". Use SKY UX approved custom properties instead.',
+        line: 1,
+      },
+      {
+        code: '.my-class { border-color: green; }',
+        description: 'named border color should be rejected',
+        message:
+          'Unexpected static color value "green" for property "border-color". Use SKY UX approved custom properties instead.',
+        line: 1,
+      },
+      // Specific border colors
+      {
+        code: '.my-class { border-top-color: #fff; }',
+        description: 'border-top-color with static value should be rejected',
+        message:
+          'Unexpected static color value "#fff" for property "border-top-color". Use SKY UX approved custom properties instead.',
+        line: 1,
+      },
+      {
+        code: '.my-class { border-right-color: red; }',
+        description: 'border-right-color with static value should be rejected',
+        message:
+          'Unexpected static color value "red" for property "border-right-color". Use SKY UX approved custom properties instead.',
+        line: 1,
+      },
+      {
+        code: '.my-class { border-bottom-color: rgb(0, 0, 0); }',
+        description: 'border-bottom-color with static value should be rejected',
+        message:
+          'Unexpected static color value "rgb(0, 0, 0)" for property "border-bottom-color". Use SKY UX approved custom properties instead.',
+        line: 1,
+      },
+      {
+        code: '.my-class { border-left-color: #000000; }',
+        description: 'border-left-color with static value should be rejected',
+        message:
+          'Unexpected static color value "#000000" for property "border-left-color". Use SKY UX approved custom properties instead.',
+        line: 1,
+      },
+      // Shorthand properties with static colors
+      {
+        code: '.my-class { border: 1px solid red; }',
+        description: 'border shorthand with static color should be rejected',
+        message:
+          'Unexpected static color value "red" for property "border". Use SKY UX approved custom properties instead.',
+        line: 1,
+      },
+      {
+        code: '.my-class { background: #fff url(image.png) no-repeat; }',
+        description:
+          'background shorthand with static color should be rejected',
+        message:
+          'Unexpected static color value "#fff" for property "background". Use SKY UX approved custom properties instead.',
+        line: 1,
+      },
+      {
+        code: '.my-class { border: 2px dashed rgba(255, 0, 0, 0.5); }',
+        description: 'border shorthand with RGBA should be rejected',
+        message:
+          'Unexpected static color value "rgba(255, 0, 0, 0.5)" for property "border". Use SKY UX approved custom properties instead.',
+        line: 1,
+      },
+      // Case variations
+      {
+        code: '.my-class { color: RED; }',
+        description: 'uppercase named color should be rejected',
+        message:
+          'Unexpected static color value "RED" for property "color". Use SKY UX approved custom properties instead.',
+        line: 1,
+      },
+      {
+        code: '.my-class { background-color: Blue; }',
+        description: 'mixed case named color should be rejected',
+        message:
+          'Unexpected static color value "Blue" for property "background-color". Use SKY UX approved custom properties instead.',
+        line: 1,
+      },
+      {
+        code: '.my-class { color: #FFF; }',
+        description: 'uppercase hex color should be rejected',
+        message:
+          'Unexpected static color value "#FFF" for property "color". Use SKY UX approved custom properties instead.',
+        line: 1,
+      },
+      {
+        code: '.my-class { border-color: #AbCdEf; }',
+        description: 'mixed case hex color should be rejected',
+        message:
+          'Unexpected static color value "#AbCdEf" for property "border-color". Use SKY UX approved custom properties instead.',
+        line: 1,
+      },
+    ],
+  });
+
+  testRule({
+    plugins: [plugin],
+    ruleName,
+    config: 'some-invalid-value',
+    reject: [
+      {
+        code: '.my-class { color: #ffffff; }',
+        description: 'should not validate when config invalid',
+        message: `Invalid option value "some-invalid-value" for rule "${ruleName}"`,
+      },
+    ],
+  });
+});

--- a/libs/sdk/skyux-stylelint/src/rules/no-static-color-values.ts
+++ b/libs/sdk/skyux-stylelint/src/rules/no-static-color-values.ts
@@ -1,0 +1,180 @@
+import stylelint, { Rule, RuleBase } from 'stylelint';
+
+import { getRuleMeta } from '../utility/meta.js';
+import { withNamespace } from '../utility/namespace.js';
+
+const ruleId = 'no-static-color-values';
+export const ruleName = withNamespace(ruleId);
+
+const messages = stylelint.utils.ruleMessages(ruleName, {
+  rejected: (property: string, value: string) =>
+    `Unexpected static color value "${value}" for property "${property}". Use SKY UX approved custom properties instead.`,
+});
+
+// Properties that only assign color values (non-shorthand)
+const DIRECT_COLOR_PROPERTIES = new Set([
+  'color',
+  'background-color',
+  'border-color',
+  'border-top-color',
+  'border-right-color',
+  'border-bottom-color',
+  'border-left-color',
+]);
+
+// Shorthand properties that can assign color values.
+const SHORTHAND_COLOR_PROPERTIES = new Set(['background', 'border']);
+
+// Properties that should not have static color values
+const COLOR_PROPERTIES = new Set([
+  ...DIRECT_COLOR_PROPERTIES,
+  ...SHORTHAND_COLOR_PROPERTIES,
+]);
+
+// Allowed CSS keywords that should not be flagged
+const ALLOWED_KEYWORDS = new Set([
+  'inherit',
+  'initial',
+  'unset',
+  'revert',
+  'currentcolor', // normalized to lowercase for consistent comparison
+  'transparent',
+]);
+
+// Regular expressions to detect static color values
+const COLOR_VALUE_PATTERNS = [
+  // Hex colors: #fff, #ffffff, #FFF, #FFFFFF
+  /^#[0-9a-fA-F]{3}(?:[0-9a-fA-F]{3})?$/,
+  // RGB/RGBA: rgb(255, 255, 255), rgba(255, 255, 255, 0.5)
+  /^rgba?\([^)]+\)$/,
+  // HSL/HSLA: hsl(0, 0%, 100%), hsla(0, 0%, 100%, 0.5)
+  /^hsla?\([^)]+\)$/,
+];
+
+/**
+ * Check if a value is a CSS named color.
+ * Note: CSS named colors are standardized and stable since CSS 2.1/3.0 (2011).
+ * This list is complete and unlikely to change.
+ */
+function isNamedColor(value: string): boolean {
+  const namedColorPattern =
+    /^(?:aliceblue|antiquewhite|aqua|aquamarine|azure|beige|bisque|black|blanchedalmond|blue|blueviolet|brown|burlywood|cadetblue|chartreuse|chocolate|coral|cornflowerblue|cornsilk|crimson|cyan|darkblue|darkcyan|darkgoldenrod|darkgray|darkgrey|darkgreen|darkkhaki|darkmagenta|darkolivegreen|darkorange|darkorchid|darkred|darksalmon|darkseagreen|darkslateblue|darkslategray|darkslategrey|darkturquoise|darkviolet|deeppink|deepskyblue|dimgray|dimgrey|dodgerblue|firebrick|floralwhite|forestgreen|fuchsia|gainsboro|ghostwhite|gold|goldenrod|gray|grey|green|greenyellow|honeydew|hotpink|indianred|indigo|ivory|khaki|lavender|lavenderblush|lawngreen|lemonchiffon|lightblue|lightcoral|lightcyan|lightgoldenrodyellow|lightgray|lightgrey|lightgreen|lightpink|lightsalmon|lightseagreen|lightskyblue|lightslategray|lightslategrey|lightsteelblue|lightyellow|lime|limegreen|linen|magenta|maroon|mediumaquamarine|mediumblue|mediumorchid|mediumpurple|mediumseagreen|mediumslateblue|mediumspringgreen|mediumturquoise|mediumvioletred|midnightblue|mintcream|mistyrose|moccasin|navajowhite|navy|oldlace|olive|olivedrab|orange|orangered|orchid|palegoldenrod|palegreen|paleturquoise|palevioletred|papayawhip|peachpuff|peru|pink|plum|powderblue|purple|red|rosybrown|royalblue|saddlebrown|salmon|sandybrown|seagreen|seashell|sienna|silver|skyblue|slateblue|slategray|slategrey|snow|springgreen|steelblue|tan|teal|thistle|tomato|turquoise|violet|wheat|white|whitesmoke|yellow|yellowgreen)$/i;
+
+  return namedColorPattern.test(value.toLowerCase());
+}
+
+const APPROVED_CUSTOM_PROPERTIES = [
+  /^var\(\s*--sky-category-color-/,
+  /^var\(\s*--sky-color-/,
+  /^var\(\s*--sky-background-color-/,
+  /^var\(\s*--sky-border-color-/,
+  /^var\(\s*--sky-highlight-color-/,
+  /^var\(\s*--sky-text-color-/,
+];
+
+function isStaticColorValue(value: string): boolean {
+  const trimmedValue = value.trim();
+
+  if (COLOR_VALUE_PATTERNS.some((pattern) => pattern.test(trimmedValue))) {
+    return true;
+  }
+
+  return isNamedColor(trimmedValue);
+}
+
+function isApprovedCustomProperty(value: string): boolean {
+  // Normalize whitespace: remove newlines and extra spaces, but preserve single spaces
+  const normalizedValue = value.replace(/\s+/g, ' ').trim();
+
+  return APPROVED_CUSTOM_PROPERTIES.some((pattern) =>
+    pattern.test(normalizedValue),
+  );
+}
+
+function extractColorValues(value: string): string[] {
+  const colorValues: string[] = [];
+
+  // First, check for function-based colors like rgb(), rgba(), hsl(), hsla()
+  const functionColorPattern = /(rgba?\([^)]+\)|hsla?\([^)]+\))/gi;
+  let match;
+  while ((match = functionColorPattern.exec(value)) !== null) {
+    const colorValue = match[1];
+    if (isStaticColorValue(colorValue)) {
+      colorValues.push(colorValue);
+    }
+  }
+
+  // Then check for hex colors and named colors by splitting on spaces
+  // but skip parts that are already matched by function patterns
+  const parts = value.split(/\s+/);
+  for (const part of parts) {
+    if (isStaticColorValue(part)) {
+      colorValues.push(part);
+    }
+  }
+
+  return colorValues;
+}
+
+const ruleBase: RuleBase = (options) => {
+  return (root, result) => {
+    const validOptions = stylelint.utils.validateOptions(result, ruleName, {
+      actual: options,
+      possible: [true],
+    });
+
+    if (!validOptions) {
+      return;
+    }
+
+    root.walkDecls((decl) => {
+      const { prop, value } = decl;
+      const lowerProp = prop.toLowerCase();
+
+      if (!COLOR_PROPERTIES.has(lowerProp)) {
+        return;
+      }
+
+      if (isApprovedCustomProperty(value)) {
+        return;
+      }
+
+      const lowerValue = value.toLowerCase();
+      if (ALLOWED_KEYWORDS.has(lowerValue)) {
+        return;
+      }
+
+      if (DIRECT_COLOR_PROPERTIES.has(lowerProp)) {
+        if (isStaticColorValue(value)) {
+          stylelint.utils.report({
+            result,
+            ruleName,
+            message: messages.rejected(prop, value),
+            node: decl,
+          });
+        }
+        return;
+      }
+
+      if (SHORTHAND_COLOR_PROPERTIES.has(lowerProp)) {
+        const colorValues = extractColorValues(value);
+        for (const colorValue of colorValues) {
+          stylelint.utils.report({
+            result,
+            ruleName,
+            message: messages.rejected(prop, colorValue),
+            node: decl,
+          });
+        }
+      }
+    });
+  };
+};
+
+const rule = ruleBase as Rule;
+
+rule.messages = messages;
+rule.meta = getRuleMeta({ ruleId });
+rule.ruleName = ruleName;
+
+export default stylelint.createPlugin(ruleName, rule);

--- a/libs/sdk/stylelint-config-skyux/src/index.ts
+++ b/libs/sdk/stylelint-config-skyux/src/index.ts
@@ -3,5 +3,6 @@ export default {
   plugins: ['skyux-stylelint'],
   rules: {
     'skyux-stylelint/no-sky-selectors': true,
+    'skyux-stylelint/no-static-color-values': true,
   },
 };


### PR DESCRIPTION
:cherries: Cherry picked from #3851 [feat(sdk/stylelint-config-skyux): add `no-static-color-values` rule to prevent usage of static color values in stylesheets](https://github.com/blackbaud/skyux/pull/3851)

[AB#3391761](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3391761) 