### PR TITLE
feat(sdk/stylelint-config-skyux): add `no-ng-deep` rule to prevent usage of `::ng-deep` in stylesheets

### DIFF
--- a/libs/sdk/skyux-stylelint/docs/rules/no-ng-deep.md
+++ b/libs/sdk/skyux-stylelint/docs/rules/no-ng-deep.md
@@ -63,25 +63,6 @@ export default {
 }
 ```
 
-### Case variations
-
-```css
-::NG-DEEP .uppercase {
-~~~~~~~~
-  font-weight: bold;
-}
-
-:: ng-deep .with-space {
-~~~~~~~~
-  text-decoration: underline;
-}
-
-: ng-deep .single-colon {
-~~~~~~~~
-  border: 1px solid black;
-}
-```
-
 ### `::ng-deep` in media queries
 
 ```css

--- a/libs/sdk/skyux-stylelint/docs/rules/no-ng-deep.md
+++ b/libs/sdk/skyux-stylelint/docs/rules/no-ng-deep.md
@@ -1,0 +1,171 @@
+# skyux-stylelint/no-ng-deep
+
+Disallow the usage of `::ng-deep` in CSS selectors. According to [Angular's official documentation](https://angular.dev/guide/components/styling#ng-deep), the Angular team strongly discourages new use of `::ng-deep` as it breaks component encapsulation and exists only for backwards compatibility.
+
+## Why this rule exists
+
+The `::ng-deep` pseudo-element was introduced as a shadow-piercing combinator to allow styles to penetrate component boundaries in Angular's emulated view encapsulation. However, it has several significant drawbacks:
+
+1. **Breaks component encapsulation**: Defeats the purpose of scoped component styles
+2. **Creates global styles**: Styles leak out and can affect other components unintentionally  
+3. **Difficult to maintain**: Makes it hard to understand which styles apply where
+4. **Deprecated by Angular team**: Strongly discouraged and may be removed in future versions
+
+## Better alternatives
+
+Instead of using `::ng-deep`, consider these approaches:
+
+- **Use `:host` selectors** for styling the component's host element
+- **Use `:host-context()`** for conditional styling based on ancestor classes
+- **Use component communication** (inputs, outputs, services) to coordinate styling
+- **Use global styles** in `styles.css` for truly global styles
+- **Use CSS custom properties (variables)** to pass styling data down to child components
+
+## Usage
+
+### stylelint.config.mjs
+
+```js
+export default {
+  plugins: ['skyux-stylelint'],
+  rules: {
+    'skyux-stylelint/no-ng-deep': true,
+  },
+};
+```
+
+## ❌ Failing Examples
+
+### Basic `::ng-deep` usage
+
+```css
+::ng-deep .global-style {
+~~~~~~~~
+  color: red;
+}
+```
+
+### `::ng-deep` with `:host`
+
+```css
+:host ::ng-deep .child-component {
+      ~~~~~~~~
+  background: blue;
+}
+```
+
+### `::ng-deep` in complex selectors
+
+```css
+.parent ::ng-deep .child .nested {
+       ~~~~~~~~
+  margin: 10px;
+}
+```
+
+### Case variations
+
+```css
+::NG-DEEP .uppercase {
+~~~~~~~~
+  font-weight: bold;
+}
+
+:: ng-deep .with-space {
+~~~~~~~~
+  text-decoration: underline;
+}
+
+: ng-deep .single-colon {
+~~~~~~~~
+  border: 1px solid black;
+}
+```
+
+### `::ng-deep` in media queries
+
+```css
+@media (min-width: 768px) {
+  ::ng-deep .responsive {
+  ~~~~~~~~
+    font-size: 18px;
+  }
+}
+```
+
+## ✅ Passing Examples
+
+### Using `:host` selectors
+
+```css
+:host {
+  display: block;
+  background: white;
+}
+
+:host(.theme-dark) {
+  background: black;
+}
+```
+
+### Using `:host-context()`
+
+```css
+:host-context(.mobile) {
+  font-size: 14px;
+}
+
+:host-context(.desktop) {
+  font-size: 16px;
+}
+```
+
+### Regular component styles
+
+```css
+.my-component {
+  color: blue;
+}
+
+.my-component .nested-element {
+  margin: 10px;
+}
+```
+
+### Global styles (in global stylesheet)
+
+```css
+/* In styles.css or global stylesheet */
+.global-utility-class {
+  text-align: center;
+}
+```
+
+### Using CSS custom properties
+
+```css
+/* Parent component */
+:host {
+  --child-background: #f0f0f0;
+  --child-text-color: #333;
+}
+
+/* Child component can use these variables */
+.child-content {
+  background: var(--child-background, white);
+  color: var(--child-text-color, black);
+}
+```
+
+## Configuration
+
+This rule accepts a boolean value:
+
+- `true` (default): Disallows all usage of `::ng-deep`
+- `false`: Disables the rule
+
+## Related Links
+
+- [Angular Documentation - Style Scoping](https://angular.dev/guide/components/styling#style-scoping)
+- [Angular Documentation - ::ng-deep](https://angular.dev/guide/components/styling#ng-deep)
+- [Angular Style Guide - Component Styles](https://angular.dev/style-guide#component-styles)

--- a/libs/sdk/skyux-stylelint/docs/rules/no-ng-deep.md
+++ b/libs/sdk/skyux-stylelint/docs/rules/no-ng-deep.md
@@ -7,7 +7,7 @@ Disallow the usage of `::ng-deep` in CSS selectors. According to [Angular's offi
 The `::ng-deep` pseudo-element was introduced as a shadow-piercing combinator to allow styles to penetrate component boundaries in Angular's emulated view encapsulation. However, it has several significant drawbacks:
 
 1. **Breaks component encapsulation**: Defeats the purpose of scoped component styles
-2. **Creates global styles**: Styles leak out and can affect other components unintentionally  
+2. **Creates global styles**: Styles leak out and can affect other components unintentionally
 3. **Difficult to maintain**: Makes it hard to understand which styles apply where
 4. **Deprecated by Angular team**: Strongly discouraged and may be removed in future versions
 
@@ -162,7 +162,7 @@ export default {
 This rule accepts a boolean value:
 
 - `true` (default): Disallows all usage of `::ng-deep`
-- `false`: Disables the rule
+- `null`: Disables the rule
 
 ## Related Links
 

--- a/libs/sdk/skyux-stylelint/src/index.ts
+++ b/libs/sdk/skyux-stylelint/src/index.ts
@@ -1,4 +1,5 @@
+import noNgDeep from './rules/no-ng-deep.js';
 import noSkySelectors from './rules/no-sky-selectors.js';
 import noStaticColorValues from './rules/no-static-color-values.js';
 
-export default [noSkySelectors, noStaticColorValues];
+export default [noNgDeep, noSkySelectors, noStaticColorValues];

--- a/libs/sdk/skyux-stylelint/src/rules/no-ng-deep.test.ts
+++ b/libs/sdk/skyux-stylelint/src/rules/no-ng-deep.test.ts
@@ -70,6 +70,11 @@ describe(ruleName, () => {
         code: '.ng-container { display: contents; }',
         description: 'other ng- prefixed classes should be allowed',
       },
+      {
+        code: '::NG-DEEP .uppercase { color: green; }',
+        description:
+          'uppercase ::NG-DEEP should be allowed (Angular does not recognize it)',
+      },
     ],
 
     reject: [
@@ -90,27 +95,6 @@ describe(ruleName, () => {
       {
         code: ':host ::ng-deep .global { color: blue; }',
         description: '::ng-deep with :host should be rejected',
-        message:
-          'Unexpected usage of "::ng-deep". The Angular team strongly discourages new use of ::ng-deep as it breaks component encapsulation. Consider using :host or component communication patterns instead.',
-        line: 1,
-      },
-      {
-        code: '::NG-DEEP .uppercase { color: green; }',
-        description: 'uppercase ::NG-DEEP should be rejected',
-        message:
-          'Unexpected usage of "::ng-deep". The Angular team strongly discourages new use of ::ng-deep as it breaks component encapsulation. Consider using :host or component communication patterns instead.',
-        line: 1,
-      },
-      {
-        code: ':: ng-deep .with-space { color: purple; }',
-        description: ':: ng-deep with space should be rejected',
-        message:
-          'Unexpected usage of "::ng-deep". The Angular team strongly discourages new use of ::ng-deep as it breaks component encapsulation. Consider using :host or component communication patterns instead.',
-        line: 1,
-      },
-      {
-        code: ': ng-deep .single-colon { color: orange; }',
-        description: ': ng-deep (single colon) should be rejected',
         message:
           'Unexpected usage of "::ng-deep". The Angular team strongly discourages new use of ::ng-deep as it breaks component encapsulation. Consider using :host or component communication patterns instead.',
         line: 1,

--- a/libs/sdk/skyux-stylelint/src/rules/no-ng-deep.test.ts
+++ b/libs/sdk/skyux-stylelint/src/rules/no-ng-deep.test.ts
@@ -1,0 +1,240 @@
+import { describe } from 'vitest';
+
+import { testRule } from '../testing/test-rule.js';
+
+import plugin, { ruleName } from './no-ng-deep.js';
+
+describe(ruleName, () => {
+  testRule({
+    plugins: [plugin],
+    ruleName,
+    config: true,
+    accept: [
+      {
+        code: '.my-class { color: red; }',
+        description: 'regular selectors should be allowed',
+      },
+      {
+        code: ':host { display: block; }',
+        description: ':host selector should be allowed',
+      },
+      {
+        code: ':host-context(.theme-dark) { background: black; }',
+        description: ':host-context selector should be allowed',
+      },
+      {
+        code: '.parent .child { margin: 10px; }',
+        description: 'descendant selectors should be allowed',
+      },
+      {
+        code: '.parent > .child { margin: 10px; }',
+        description: 'child selectors should be allowed',
+      },
+      {
+        code: '.parent + .sibling { margin: 10px; }',
+        description: 'adjacent sibling selectors should be allowed',
+      },
+      {
+        code: '.parent ~ .sibling { margin: 10px; }',
+        description: 'general sibling selectors should be allowed',
+      },
+      {
+        code: 'div:hover { color: blue; }',
+        description: 'pseudo-class selectors should be allowed',
+      },
+      {
+        code: 'p::before { content: ""; }',
+        description: 'other pseudo-element selectors should be allowed',
+      },
+      {
+        code: '.ng-deep-like-class { color: red; }',
+        description: 'classes containing "ng-deep" should be allowed',
+      },
+      {
+        code: '[data-ng-deep] { color: red; }',
+        description: 'attribute selectors with ng-deep should be allowed',
+      },
+      {
+        code: '/* ::ng-deep would be invalid */',
+        description: 'comments containing ::ng-deep should be allowed',
+      },
+      {
+        code: '@media (min-width: 768px) { .my-class { color: red; } }',
+        description: 'media queries without ng-deep should be allowed',
+      },
+      {
+        code: '.deep { color: blue; }',
+        description: 'classes with "deep" should be allowed',
+      },
+      {
+        code: '.ng-container { display: contents; }',
+        description: 'other ng- prefixed classes should be allowed',
+      },
+    ],
+
+    reject: [
+      {
+        code: '::ng-deep .my-class { color: red; }',
+        description: 'standard ::ng-deep usage should be rejected',
+        message:
+          'Unexpected usage of "::ng-deep". The Angular team strongly discourages new use of ::ng-deep as it breaks component encapsulation. Consider using :host or component communication patterns instead.',
+        line: 1,
+      },
+      {
+        code: '.parent ::ng-deep .child { margin: 10px; }',
+        description: '::ng-deep in descendant selectors should be rejected',
+        message:
+          'Unexpected usage of "::ng-deep". The Angular team strongly discourages new use of ::ng-deep as it breaks component encapsulation. Consider using :host or component communication patterns instead.',
+        line: 1,
+      },
+      {
+        code: ':host ::ng-deep .global { color: blue; }',
+        description: '::ng-deep with :host should be rejected',
+        message:
+          'Unexpected usage of "::ng-deep". The Angular team strongly discourages new use of ::ng-deep as it breaks component encapsulation. Consider using :host or component communication patterns instead.',
+        line: 1,
+      },
+      {
+        code: '::NG-DEEP .uppercase { color: green; }',
+        description: 'uppercase ::NG-DEEP should be rejected',
+        message:
+          'Unexpected usage of "::ng-deep". The Angular team strongly discourages new use of ::ng-deep as it breaks component encapsulation. Consider using :host or component communication patterns instead.',
+        line: 1,
+      },
+      {
+        code: ':: ng-deep .with-space { color: purple; }',
+        description: ':: ng-deep with space should be rejected',
+        message:
+          'Unexpected usage of "::ng-deep". The Angular team strongly discourages new use of ::ng-deep as it breaks component encapsulation. Consider using :host or component communication patterns instead.',
+        line: 1,
+      },
+      {
+        code: ': ng-deep .single-colon { color: orange; }',
+        description: ': ng-deep (single colon) should be rejected',
+        message:
+          'Unexpected usage of "::ng-deep". The Angular team strongly discourages new use of ::ng-deep as it breaks component encapsulation. Consider using :host or component communication patterns instead.',
+        line: 1,
+      },
+      {
+        code: '.component ::ng-deep .nested .deep { padding: 5px; }',
+        description: 'complex selectors with ::ng-deep should be rejected',
+        message:
+          'Unexpected usage of "::ng-deep". The Angular team strongly discourages new use of ::ng-deep as it breaks component encapsulation. Consider using :host or component communication patterns instead.',
+        line: 1,
+      },
+      {
+        code: '::ng-deep { display: block; }',
+        description: '::ng-deep without following selector should be rejected',
+        message:
+          'Unexpected usage of "::ng-deep". The Angular team strongly discourages new use of ::ng-deep as it breaks component encapsulation. Consider using :host or component communication patterns instead.',
+        line: 1,
+      },
+      {
+        code: '@media (min-width: 768px) { ::ng-deep .responsive { font-size: 16px; } }',
+        description: '::ng-deep within media queries should be rejected',
+        message:
+          'Unexpected usage of "::ng-deep". The Angular team strongly discourages new use of ::ng-deep as it breaks component encapsulation. Consider using :host or component communication patterns instead.',
+        line: 1,
+      },
+      {
+        code: '.parent ::ng-deep .child, .other-selector { margin: 0; }',
+        description: '::ng-deep in selector groups should be rejected',
+        message:
+          'Unexpected usage of "::ng-deep". The Angular team strongly discourages new use of ::ng-deep as it breaks component encapsulation. Consider using :host or component communication patterns instead.',
+        line: 1,
+      },
+      {
+        code: '::ng-deep .mat-dialog-container { background: white; }',
+        description:
+          '::ng-deep targeting third-party components should be rejected',
+        message:
+          'Unexpected usage of "::ng-deep". The Angular team strongly discourages new use of ::ng-deep as it breaks component encapsulation. Consider using :host or component communication patterns instead.',
+        line: 1,
+      },
+    ],
+  });
+
+  // Test with a more complex CSS structure
+  testRule({
+    plugins: [plugin],
+    ruleName,
+    config: true,
+    accept: [
+      {
+        code: `
+          .component {
+            color: blue;
+
+            .nested {
+              margin: 10px;
+            }
+          }
+
+          :host(.theme-dark) {
+            background: black;
+          }
+        `,
+        description: 'complex CSS without ng-deep should be allowed',
+      },
+    ],
+
+    reject: [
+      {
+        code: `
+          .component {
+            color: blue;
+
+            ::ng-deep .global-override {
+              font-weight: bold;
+            }
+          }
+        `,
+        description: '::ng-deep in nested CSS should be rejected',
+        message:
+          'Unexpected usage of "::ng-deep". The Angular team strongly discourages new use of ::ng-deep as it breaks component encapsulation. Consider using :host or component communication patterns instead.',
+        line: 5,
+      },
+      {
+        code: `
+          :host {
+            display: block;
+          }
+
+          :host ::ng-deep .global {
+            color: red;
+          }
+        `,
+        description:
+          '::ng-deep after :host in separate rules should be rejected',
+        message:
+          'Unexpected usage of "::ng-deep". The Angular team strongly discourages new use of ::ng-deep as it breaks component encapsulation. Consider using :host or component communication patterns instead.',
+        line: 6,
+      },
+    ],
+  });
+
+  testRule({
+    plugins: [plugin],
+    ruleName,
+    config: null,
+    accept: [
+      {
+        code: '::ng-deep .should-be-allowed { color: red; }',
+        description: 'should allow ng-deep when rule is disabled',
+      },
+    ],
+  });
+
+  testRule({
+    plugins: [plugin],
+    ruleName,
+    config: 'invalid',
+    reject: [
+      {
+        code: '::ng-deep .should-not-be-checked { color: red; }',
+        description: 'should not validate when config invalid',
+        message: `Invalid option value "invalid" for rule "${ruleName}"`,
+      },
+    ],
+  });
+});

--- a/libs/sdk/skyux-stylelint/src/rules/no-ng-deep.ts
+++ b/libs/sdk/skyux-stylelint/src/rules/no-ng-deep.ts
@@ -1,0 +1,50 @@
+import stylelint, { Rule, RuleBase } from 'stylelint';
+
+import { getRuleMeta } from '../utility/meta.js';
+import { withNamespace } from '../utility/namespace.js';
+
+const ruleId = 'no-ng-deep';
+export const ruleName = withNamespace(ruleId);
+
+const messages = stylelint.utils.ruleMessages(ruleName, {
+  rejected: () =>
+    'Unexpected usage of "::ng-deep". The Angular team strongly discourages ' +
+    'new use of ::ng-deep as it breaks component encapsulation. Consider ' +
+    'using :host or component communication patterns instead.',
+});
+
+const ruleBase: RuleBase = (options) => {
+  return (root, result) => {
+    const validOptions = stylelint.utils.validateOptions(result, ruleName, {
+      actual: options,
+      possible: [true],
+    });
+
+    if (!validOptions) {
+      return;
+    }
+
+    root.walkRules((ruleNode) => {
+      const { selector } = ruleNode;
+
+      // Check for ::ng-deep in selectors (case-insensitive)
+      // Matches ::ng-deep, : :ng-deep (with space), and variations
+      if (/::?\s*ng-deep/i.test(selector)) {
+        stylelint.utils.report({
+          result,
+          ruleName,
+          message: messages.rejected(),
+          node: ruleNode,
+        });
+      }
+    });
+  };
+};
+
+const rule = ruleBase as Rule;
+
+rule.messages = messages;
+rule.meta = getRuleMeta({ ruleId });
+rule.ruleName = ruleName;
+
+export default stylelint.createPlugin(ruleName, rule);

--- a/libs/sdk/skyux-stylelint/src/rules/no-ng-deep.ts
+++ b/libs/sdk/skyux-stylelint/src/rules/no-ng-deep.ts
@@ -27,9 +27,7 @@ const ruleBase: RuleBase = (options) => {
     root.walkRules((ruleNode) => {
       const { selector } = ruleNode;
 
-      // Check for ::ng-deep in selectors (case-insensitive)
-      // Matches ::ng-deep, : :ng-deep (with space), and variations
-      if (/::?\s*ng-deep/i.test(selector)) {
+      if (/::ng-deep/.test(selector)) {
         stylelint.utils.report({
           result,
           ruleName,

--- a/libs/sdk/stylelint-config-skyux/src/index.ts
+++ b/libs/sdk/stylelint-config-skyux/src/index.ts
@@ -2,6 +2,7 @@ export default {
   extends: ['stylelint-config-recommended-scss'],
   plugins: ['skyux-stylelint'],
   rules: {
+    'skyux-stylelint/no-ng-deep': true,
     'skyux-stylelint/no-sky-selectors': true,
     'skyux-stylelint/no-static-color-values': true,
   },


### PR DESCRIPTION
[AB#3391820](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3391820)