### PR TITLE
fix(components/docs-tools): scroll to header on page load (#3869)

### DIFF
--- a/libs/components/docs-tools/src/lib/modules/table-of-contents/table-of-contents-page.component.ts
+++ b/libs/components/docs-tools/src/lib/modules/table-of-contents/table-of-contents-page.component.ts
@@ -2,14 +2,17 @@ import {
   AfterViewInit,
   ChangeDetectionStrategy,
   Component,
+  DOCUMENT,
   DestroyRef,
   ElementRef,
   computed,
+  effect,
   inject,
   input,
   signal,
 } from '@angular/core';
 import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
+import { ActivatedRoute } from '@angular/router';
 import { SkyMediaQueryService, SkyScrollableHostService } from '@skyux/core';
 
 import { debounceTime, distinctUntilChanged, fromEvent, map } from 'rxjs';
@@ -66,6 +69,22 @@ export class SkyDocsTableOfContentsPageComponent implements AfterViewInit {
       }) ?? []
     );
   });
+
+  readonly #routeFragment = toSignal(inject(ActivatedRoute).fragment);
+  readonly #doc = inject(DOCUMENT);
+
+  constructor() {
+    effect(() => {
+      const fragment = this.#routeFragment();
+      const links = this.links();
+      if (
+        fragment &&
+        links.some((link) => link.anchorId === fragment && !link.active)
+      ) {
+        setTimeout(() => this.#doc.getElementById(fragment)?.scrollIntoView());
+      }
+    });
+  }
 
   public ngAfterViewInit(): void {
     const scrollEl = this.#scrollableHostSvc.getScrollableHost(


### PR DESCRIPTION
:cherries: Cherry picked from #3869 [fix(components/docs-tools): scroll to header on page load](https://github.com/blackbaud/skyux/pull/3869)

[AB#3533198](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3533198) 