### PR TITLE
fix(sdk/skyux-stylelint): use correct documentation link for rules (#3881)

### DIFF
--- a/libs/sdk/skyux-stylelint/src/utility/meta.ts
+++ b/libs/sdk/skyux-stylelint/src/utility/meta.ts
@@ -8,6 +8,6 @@ export function getRuleMeta(args: {
 
   return {
     fixable,
-    url: `https://github.com/blackbaud/skyux/blob/main/libs/cdk/skyux-stylelint/docs/rules/${ruleId}.md`,
+    url: `https://github.com/blackbaud/skyux/blob/main/libs/sdk/skyux-stylelint/docs/rules/${ruleId}.md`,
   } satisfies stylelint.RuleMeta;
 }


### PR DESCRIPTION
:cherries: Cherry picked from #3881 [fix(sdk/skyux-stylelint): use correct documentation link for rules](https://github.com/blackbaud/skyux/pull/3881)