### PR TITLE
chore(sdk/eslint-config-skyux): set tsconfigRootDir to absolute path for ESLint config (#3879)

### DIFF
--- a/libs/sdk/eslint-config-skyux/README.md
+++ b/libs/sdk/eslint-config-skyux/README.md
@@ -26,7 +26,7 @@ export default tseslint.config(
     languageOptions: {
       parserOptions: {
         projectService: true,
-        tsconfigRootDir: '.',
+        tsconfigRootDir: import.meta.dirname,
       },
     },
   },


### PR DESCRIPTION
:cherries: Cherry picked from #3879 [chore(sdk/eslint-config-skyux): set tsconfigRootDir to absolute path for ESLint config](https://github.com/blackbaud/skyux/pull/3879)