### PR TITLE
fix: viewkeeper and summary action bar use correct fallback values for css calculations using a fallback for a custom property (#3888)

### DIFF
--- a/apps/playground/src/app/components/popovers/dropdown/dropdown.component.ts
+++ b/apps/playground/src/app/components/popovers/dropdown/dropdown.component.ts
@@ -22,7 +22,7 @@ import { DropdownExampleComponent } from './dropdown-example.component';
       }
 
       .space {
-        height: calc(100vh - 200px - var(--sky-viewport-top, 0));
+        height: calc(100vh - 200px - var(--sky-viewport-top, 0px));
         min-height: 200px;
         background-color: var(--sky-background-color-info-light);
         padding: var(--sky-padding-even-xl);

--- a/libs/components/action-bars/src/lib/modules/summary-action-bar/summary-action-bar-adapter.service.ts
+++ b/libs/components/action-bars/src/lib/modules/summary-action-bar/summary-action-bar-adapter.service.ts
@@ -36,7 +36,7 @@ export class SkySummaryActionBarAdapterService {
       this.#renderer.setStyle(
         body,
         'margin-bottom',
-        `calc(${actionBarEl.offsetHeight}px + var(--sky-dock-height, 0))`,
+        `calc(${actionBarEl.offsetHeight}px + var(--sky-dock-height, 0px))`,
       );
     }
   }

--- a/libs/components/action-bars/src/lib/modules/summary-action-bar/summary-action-bar.component.spec.ts
+++ b/libs/components/action-bars/src/lib/modules/summary-action-bar/summary-action-bar.component.spec.ts
@@ -102,6 +102,23 @@ describe('Summary Action Bar component', () => {
     );
   }
 
+  function validateBodyMargin(
+    debugElement: DebugElement,
+    dockHeight = 0,
+  ): void {
+    const actionBarHeight = getActionBarHeight(debugElement);
+
+    // Verify the CSS calc() expression is set correctly
+    expect(document.body.style.marginBottom).toBe(
+      `calc(${actionBarHeight}px + var(--sky-dock-height, 0px))`,
+    );
+
+    // Verify computed style is calculated correctly
+    const computedStyle = window.getComputedStyle(document.body);
+    const expectedMargin = `${parseInt(actionBarHeight) + dockHeight}px`;
+    expect(computedStyle.marginBottom).toBe(expectedMargin);
+  }
+
   let mediaQueryController: SkyMediaQueryTestingController;
 
   beforeEach(() => {
@@ -132,25 +149,28 @@ describe('Summary Action Bar component', () => {
     describe('body stylings', () => {
       it('should set a margin on the body if the action bar is not in a modal footer', () => {
         fixture.detectChanges();
-        const actionBarHeight = getActionBarHeight(debugElement);
-        expect(document.body.style.marginBottom).toBe(
-          `calc(${actionBarHeight}px + var(--sky-dock-height, 0))`,
-        );
+        validateBodyMargin(debugElement);
       });
 
       it('should set a new margin when the summary area changes collapsed state', fakeAsync(() => {
         mediaQueryController.setBreakpoint('xs');
         fixture.detectChanges();
-        let actionBarHeight = getActionBarHeight(debugElement);
-        expect(document.body.style.marginBottom).toBe(
-          `calc(${actionBarHeight}px + var(--sky-dock-height, 0))`,
-        );
+        validateBodyMargin(debugElement);
+
         clickCollapseButton(debugElement);
-        actionBarHeight = getActionBarHeight(debugElement);
-        expect(document.body.style.marginBottom).toBe(
-          `calc(${actionBarHeight}px + var(--sky-dock-height, 0))`,
-        );
+        validateBodyMargin(debugElement);
       }));
+
+      it('should compute correct margin when sky-dock-height is set', () => {
+        // Set a dock height value
+        document.documentElement.style.setProperty('--sky-dock-height', '50px');
+
+        fixture.detectChanges();
+        validateBodyMargin(debugElement, 50);
+
+        // Clean up
+        document.documentElement.style.removeProperty('--sky-dock-height');
+      });
 
       it('should set a new margin on the body if the window is resized', () => {
         const initialBottomMargin = document.body.style.marginBottom;
@@ -448,10 +468,7 @@ describe('Summary Action Bar component', () => {
         cmp.hideMainActionBar = true;
         cmp.showSecondaryActionBar = true;
         fixture.detectChanges();
-        const actionBarHeight = getActionBarHeight(debugElement);
-        expect(document.body.style.marginBottom).toBe(
-          `calc(${actionBarHeight}px + var(--sky-dock-height, 0))`,
-        );
+        validateBodyMargin(debugElement);
       });
 
       it('should set isSummaryCollapsible to true when on a xs screen on a replaced action bar', () => {
@@ -626,10 +643,7 @@ describe('Summary Action Bar component', () => {
           setTimeout(() => {
             fixture.detectChanges();
             void fixture.whenStable().then(() => {
-              const actionBarHeight = getActionBarHeight(debugElement);
-              expect(document.body.style.marginBottom).toBe(
-                `calc(${actionBarHeight}px + var(--sky-dock-height, 0))`,
-              );
+              validateBodyMargin(debugElement);
               done();
             });
           });
@@ -658,10 +672,7 @@ describe('Summary Action Bar component', () => {
             setTimeout(() => {
               fixture.detectChanges();
               void fixture.whenStable().then(() => {
-                const actionBarHeight = getActionBarHeight(debugElement);
-                expect(document.body.style.marginBottom).toBe(
-                  `calc(${actionBarHeight}px + var(--sky-dock-height, 0))`,
-                );
+                validateBodyMargin(debugElement);
                 done();
               });
             });
@@ -684,10 +695,7 @@ describe('Summary Action Bar component', () => {
               setTimeout(() => {
                 fixture.detectChanges();
                 void fixture.whenStable().then(() => {
-                  const actionBarHeight = getActionBarHeight(debugElement);
-                  expect(document.body.style.marginBottom).toBe(
-                    `calc(${actionBarHeight}px + var(--sky-dock-height, 0))`,
-                  );
+                  validateBodyMargin(debugElement);
                   done();
                 });
               });

--- a/libs/components/core/src/lib/modules/viewkeeper/viewkeeper.spec.ts
+++ b/libs/components/core/src/lib/modules/viewkeeper/viewkeeper.spec.ts
@@ -34,6 +34,21 @@ describe('Viewkeeper', () => {
     expect(getComputedStyle(elToValidate)[styleProperty]).toBe(expectedValue);
   }
 
+  function validateMarginTopStyles(
+    elToValidate: HTMLElement,
+    expectedComputedMargin: string,
+    viewportMarginProperty: string,
+  ): void {
+    // Verify the CSS calc() expression is set correctly
+    expect(elToValidate.style.marginTop).toContain(
+      `var(${viewportMarginProperty}, 0px)`,
+    );
+
+    // Verify computed style is calculated correctly
+    const computedStyle = window.getComputedStyle(elToValidate);
+    expect(computedStyle.marginTop).toBe(expectedComputedMargin);
+  }
+
   function validatePinned(
     elToValidate: HTMLElement,
     pinned: boolean,
@@ -236,15 +251,37 @@ describe('Viewkeeper', () => {
       document.documentElement.style.setProperty('--test-viewport-top', '2px');
       scrollWindowTo(40, 100);
       validatePinned(el, true, 0, 2);
-      expect(el.style.marginTop).toBe(
-        'calc(0px + var(--test-viewport-top, 0))',
-      );
+      validateMarginTopStyles(el, '2px', '--test-viewport-top');
 
       document.documentElement.style.setProperty('--test-viewport-top', '12px');
       validatePinned(el, true, 0, 12);
 
+      validateMarginTopStyles(el, '12px', '--test-viewport-top');
+
       document.documentElement.style.removeProperty('--test-viewport-top');
       document.body.style.removeProperty('--test-viewport-top');
+    });
+
+    it('should compute correct margin when viewportMarginProperty fallback is used', () => {
+      vks.push(
+        new SkyViewkeeper({
+          el,
+          boundaryEl,
+          viewportMarginTop: 5,
+          viewportMarginProperty: '--test-viewport-fallback',
+          setWidth: true,
+        }),
+      );
+
+      scrollWindowTo(0, 5);
+      validatePinned(el, false);
+
+      // Scroll to trigger pinning (without setting the CSS property, so fallback is used)
+      scrollWindowTo(40, 100);
+      validatePinned(el, true, 0, 5);
+
+      // Verify CSS calc() expression and computed style when property is not set (uses fallback 0px)
+      validateMarginTopStyles(el, '5px', '--test-viewport-fallback');
     });
 
     describe('ResizeObserver', () => {

--- a/libs/components/core/src/lib/modules/viewkeeper/viewkeeper.ts
+++ b/libs/components/core/src/lib/modules/viewkeeper/viewkeeper.ts
@@ -52,7 +52,7 @@ function setElPosition(
   el.style.top = px(top);
   el.style.left = px(left);
   el.style.marginTop = marginTopProperty
-    ? `calc(${px(marginTop)} + var(${marginTopProperty}, 0))`
+    ? `calc(${px(marginTop)} + var(${marginTopProperty}, 0px))`
     : px(marginTop);
   el.style.clipPath =
     clipTop || clipLeft ? `inset(${px(clipTop)} 0 0 ${px(clipLeft)})` : 'none';

--- a/libs/components/docs-tools/src/lib/modules/heading-anchor/heading-anchor.component.scss
+++ b/libs/components/docs-tools/src/lib/modules/heading-anchor/heading-anchor.component.scss
@@ -36,5 +36,5 @@ Use a specific selector so it beats out "stacked" classes added to the host.
 
 .sky-docs-heading-anchor-position {
   position: relative;
-  top: calc(-1 * (var(--sky-viewport-top, 0) + var(--sky-margin-stacked-lg)));
+  top: calc(-1 * (var(--sky-viewport-top, 0px) + var(--sky-margin-stacked-lg)));
 }


### PR DESCRIPTION
:cherries: Cherry picked from #3888 [fix: viewkeeper and summary action bar use correct fallback values for css calculations using a fallback for a custom property](https://github.com/blackbaud/skyux/pull/3888)

[AB#3543662](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3543662) 