### PR TITLE
fix(components/manifest): include `ModelSignal` in directive properties metadata

### DIFF
--- a/libs/components/manifest-generator/src/lib/__snapshots__/generate-manifest.test.ts.snap
+++ b/libs/components/manifest-generator/src/lib/__snapshots__/generate-manifest.test.ts.snap
@@ -361,7 +361,7 @@ exports[`generate-manifest > should generate manifest 1`] = `
         "filePath": "libs/components/manifest-generator/src/testing/fixtures/example-packages/foo/src/lib/foo.component.ts",
         "kind": "component",
         "name": "SkyFooNonStandaloneComponent",
-        "repoUrl": "https://github.com/blackbaud/skyux/blob/CURRENT_BRANCH/libs/components/manifest-generator/src/testing/fixtures/example-packages/foo/src/lib/foo.component.ts#L84",
+        "repoUrl": "https://github.com/blackbaud/skyux/blob/CURRENT_BRANCH/libs/components/manifest-generator/src/testing/fixtures/example-packages/foo/src/lib/foo.component.ts#L95",
         "selector": "sky-foo-non-standalone"
       },
       {
@@ -371,7 +371,7 @@ exports[`generate-manifest > should generate manifest 1`] = `
         "filePath": "libs/components/manifest-generator/src/testing/fixtures/example-packages/foo/src/lib/foo.component.ts",
         "kind": "component",
         "name": "SkyFooStandaloneComponent",
-        "repoUrl": "https://github.com/blackbaud/skyux/blob/CURRENT_BRANCH/libs/components/manifest-generator/src/testing/fixtures/example-packages/foo/src/lib/foo.component.ts#L94",
+        "repoUrl": "https://github.com/blackbaud/skyux/blob/CURRENT_BRANCH/libs/components/manifest-generator/src/testing/fixtures/example-packages/foo/src/lib/foo.component.ts#L105",
         "selector": "sky-foo-standalone"
       },
       {
@@ -404,6 +404,18 @@ exports[`generate-manifest > should generate manifest 1`] = `
             "type": "InputSignalWithTransform<boolean, unknown>"
           },
           {
+            "description": "This describes the items model.",
+            "kind": "directive-input",
+            "name": "items",
+            "type": "ModelSignal<undefined | string[]>"
+          },
+          {
+            "description": "This describes the requiredItems model.",
+            "kind": "directive-input",
+            "name": "requiredItems",
+            "type": "ModelSignal<string[]>"
+          },
+          {
             "description": "This describes an input with only a setter.",
             "defaultValue": "false",
             "kind": "directive-input",
@@ -427,7 +439,7 @@ exports[`generate-manifest > should generate manifest 1`] = `
         "filePath": "libs/components/manifest-generator/src/testing/fixtures/example-packages/foo/src/lib/foo.component.ts",
         "kind": "component",
         "name": "FooComponent",
-        "repoUrl": "https://github.com/blackbaud/skyux/blob/CURRENT_BRANCH/libs/components/manifest-generator/src/testing/fixtures/example-packages/foo/src/lib/foo.component.ts#L20",
+        "repoUrl": "https://github.com/blackbaud/skyux/blob/CURRENT_BRANCH/libs/components/manifest-generator/src/testing/fixtures/example-packages/foo/src/lib/foo.component.ts#L21",
         "selector": "lib-foo"
       },
       {

--- a/libs/components/manifest-generator/src/lib/utility/get-directive.ts
+++ b/libs/components/manifest-generator/src/lib/utility/get-directive.ts
@@ -27,7 +27,8 @@ function isInputSignal(
   return (
     reflection.type instanceof ReferenceType &&
     (reflection.type?.name === 'InputSignal' ||
-      reflection.type?.name === 'InputSignalWithTransform')
+      reflection.type?.name === 'InputSignalWithTransform' ||
+      reflection.type?.name === 'ModelSignal')
   );
 }
 

--- a/libs/components/manifest-generator/src/testing/fixtures/example-packages/foo/src/lib/foo.component.ts
+++ b/libs/components/manifest-generator/src/testing/fixtures/example-packages/foo/src/lib/foo.component.ts
@@ -8,6 +8,7 @@ import {
   ViewChild,
   booleanAttribute,
   input,
+  model,
   output,
 } from '@angular/core';
 
@@ -60,6 +61,16 @@ export class FooComponent implements OnDestroy {
    */
   @Output()
   public onTouch = new EventEmitter<void>();
+
+  /**
+   * This describes the items model.
+   */
+  public items = model<string[]>();
+
+  /**
+   * This describes the requiredItems model.
+   */
+  public requiredItems = model.required<string[]>();
 
   /**
    * This describes a public query property.


### PR DESCRIPTION
[AB#3547496](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3547496)

I noticed we're tracking metrics for inputs and outputs in the Metrics CLI. I think for the sake of existing systems, we'll just consider the `ModelSignal` an "input" type.