### PR TITLE
fix(sdk/skyux-eslint): do not apply fix for `prefer-label-text` rule when label element uses control flow syntax

### DIFF
--- a/libs/sdk/skyux-eslint/src/rules/template/prefer-label-text.spec.ts
+++ b/libs/sdk/skyux-eslint/src/rules/template/prefer-label-text.spec.ts
@@ -17,6 +17,10 @@ ruleTester.run(RULE_NAME, rule, {
       <label [for]="myInput.id">My label</label>
       <input #myInput="skyId" skyId class="sky-form-control" type="text" />
     </sky-input-box>`,
+    // Should not trigger when there's text that looks like control flow but isn't
+    `<sky-checkbox>
+      <sky-checkbox-label>Email: @if.service.com</sky-checkbox-label>
+    </sky-checkbox>`,
   ],
   invalid: [
     convertAnnotatedSourceToFailureCase({
@@ -207,6 +211,96 @@ ruleTester.run(RULE_NAME, rule, {
         selector: 'sky-checkbox',
         labelInputName: 'labelText',
         labelSelector: 'sky-checkbox-label',
+      },
+    }),
+    convertAnnotatedSourceToFailureCase({
+      description:
+        'should fail but not fix if label contains control flow syntax',
+      annotatedSource: `
+        <sky-checkbox>
+        ~~~~~~~~~~~~~~
+          <sky-checkbox-label>
+          ~~~~~~~~~~~~~~~~~~~~
+            @if (showPrefix) {
+            ~~~~~~~~~~~~~~~~~~
+              Prefix:
+              ~~~~~~~
+            }
+            ~
+            Label text
+            ~~~~~~~~~~
+          </sky-checkbox-label>
+          ~~~~~~~~~~~~~~~~~~~~~
+        </sky-checkbox>
+        ~~~~~~~~~~~~~~~
+      `,
+      messageId,
+      data: {
+        selector: 'sky-checkbox',
+        labelInputName: 'labelText',
+        labelSelector: 'sky-checkbox-label',
+      },
+    }),
+    convertAnnotatedSourceToFailureCase({
+      description:
+        'should fail but not fix if label contains @for control flow',
+      annotatedSource: `
+        <sky-toggle-switch>
+        ~~~~~~~~~~~~~~~~~~~
+          <sky-toggle-switch-label>
+          ~~~~~~~~~~~~~~~~~~~~~~~~~
+            @for (item of items; track item.id) {
+            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+              {{ item.name }}
+              ~~~~~~~~~~~~~~~
+            }
+            ~
+          </sky-toggle-switch-label>
+          ~~~~~~~~~~~~~~~~~~~~~~~~~~
+        </sky-toggle-switch>
+        ~~~~~~~~~~~~~~~~~~~~
+      `,
+      messageId,
+      data: {
+        selector: 'sky-toggle-switch',
+        labelInputName: 'labelText',
+        labelSelector: 'sky-toggle-switch-label',
+      },
+    }),
+    convertAnnotatedSourceToFailureCase({
+      description:
+        'should fail but not fix if label contains @switch control flow',
+      annotatedSource: `
+        <sky-input-box>
+        ~~~~~~~~~~~~~~~
+          <label>
+          ~~~~~~~
+            @switch (labelType) {
+            ~~~~~~~~~~~~~~~~~~~~~
+              @case ('short') {
+              ~~~~~~~~~~~~~~~~~
+                Short Label
+                ~~~~~~~~~~~
+              }
+              ~
+              @default {
+              ~~~~~~~~~~
+                Default Label
+                ~~~~~~~~~~~~~
+              }
+              ~
+            }
+            ~
+          </label>
+          ~~~~~~~~
+        </sky-input-box>
+        ~~~~~~~~~~~~~~~~
+      `,
+      messageId,
+      data: {
+        selector: 'sky-input-box',
+        labelInputName: 'labelText',
+        labelSelector: 'label',
       },
     }),
   ],

--- a/libs/sdk/skyux-eslint/src/rules/template/prefer-label-text.spec.ts
+++ b/libs/sdk/skyux-eslint/src/rules/template/prefer-label-text.spec.ts
@@ -17,10 +17,6 @@ ruleTester.run(RULE_NAME, rule, {
       <label [for]="myInput.id">My label</label>
       <input #myInput="skyId" skyId class="sky-form-control" type="text" />
     </sky-input-box>`,
-    // Should not trigger when there's text that looks like control flow but isn't
-    `<sky-checkbox>
-      <sky-checkbox-label>Email: @if.service.com</sky-checkbox-label>
-    </sky-checkbox>`,
   ],
   invalid: [
     convertAnnotatedSourceToFailureCase({
@@ -301,6 +297,36 @@ ruleTester.run(RULE_NAME, rule, {
         selector: 'sky-input-box',
         labelInputName: 'labelText',
         labelSelector: 'label',
+      },
+    }),
+    convertAnnotatedSourceToFailureCase({
+      description:
+        'should fail and fix if labelText not set and has label element with escaped "@" character',
+      annotatedSource: `
+        <sky-checkbox>
+        ~~~~~~~~~~~~~~
+          <sky-checkbox-label>
+          ~~~~~~~~~~~~~~~~~~~~
+            foo&#64;email.com
+            ~~~~~~~~~~~~~
+          </sky-checkbox-label>
+          ~~~~~~~~~~~~~~~~~~~~~
+        </sky-checkbox>
+        ~~~~~~~~~~~~~~~
+      `,
+      annotatedOutput: `
+        <sky-checkbox labelText="foo&#64;email.com">
+        ~
+          ~
+          ~
+        </sky-checkbox>
+        ~
+      `,
+      messageId,
+      data: {
+        selector: 'sky-checkbox',
+        labelInputName: 'labelText',
+        labelSelector: 'sky-checkbox-label',
       },
     }),
   ],

--- a/libs/sdk/skyux-eslint/src/rules/template/prefer-label-text.ts
+++ b/libs/sdk/skyux-eslint/src/rules/template/prefer-label-text.ts
@@ -76,6 +76,16 @@ function getAttributeByName(
 }
 
 /**
+ * Checks if the provided element contains Angular control flow syntax (@if, @for, @switch, etc.).
+ */
+function hasControlFlowSyntax(el: TmplAstElement): boolean {
+  const sourceText = el.sourceSpan.toString();
+  const controlFlowPatterns =
+    /@(if|for|switch|case|default|else|defer|placeholder|loading|error)\b/;
+  return controlFlowPatterns.test(sourceText);
+}
+
+/**
  * Removes the "sky-form-control" CSS class from <sky-input-box /> input elements
  * to satisfy the input box's input directive selector.
  * See: https://github.com/blackbaud/skyux/blob/040e461a50cb3d08ff8f7332dba350b7e97c5fd8/libs/components/forms/src/lib/modules/input-box/input-box-control.directive.ts#L11
@@ -168,6 +178,8 @@ export const rule = createESLintTemplateRule({
             (child) => child instanceof TmplAstElement,
           );
 
+          const hasControlFlow = hasControlFlowSyntax(labelEl);
+
           context.report({
             loc: parserServices.convertNodeSourceSpanToLoc(el.sourceSpan),
             messageId,
@@ -176,36 +188,37 @@ export const rule = createESLintTemplateRule({
               labelInputName,
               labelSelector,
             },
-            // Don't fix if the label includes child elements.
-            fix: hasElementChildren
-              ? undefined
-              : (fixer): RuleFix[] => {
-                  const textContent = getTextContent(labelEl);
-                  const textReplacement = ` ${labelInputName}="${textContent}"`;
-                  const range = [
-                    el.startSourceSpan.end.offset - 1,
-                    el.startSourceSpan.end.offset,
-                  ] as const;
+            // Don't fix if the label includes child elements or control flow syntax.
+            fix:
+              hasElementChildren || hasControlFlow
+                ? undefined
+                : (fixer): RuleFix[] => {
+                    const textContent = getTextContent(labelEl);
+                    const textReplacement = ` ${labelInputName}="${textContent}"`;
+                    const range = [
+                      el.startSourceSpan.end.offset - 1,
+                      el.startSourceSpan.end.offset,
+                    ] as const;
 
-                  const fixers = [
-                    fixer.removeRange([
-                      labelEl.sourceSpan.start.offset,
-                      labelEl.sourceSpan.end.offset,
-                    ]),
-                  ];
+                    const fixers = [
+                      fixer.removeRange([
+                        labelEl.sourceSpan.start.offset,
+                        labelEl.sourceSpan.end.offset,
+                      ]),
+                    ];
 
-                  if (!hasLabelText) {
-                    fixers.push(
-                      fixer.insertTextBeforeRange(range, textReplacement),
-                    );
-                  }
+                    if (!hasLabelText) {
+                      fixers.push(
+                        fixer.insertTextBeforeRange(range, textReplacement),
+                      );
+                    }
 
-                  if (el.name === 'sky-input-box' && inputEl) {
-                    fixers.push(...removeFormControlClass(fixer, inputEl));
-                  }
+                    if (el.name === 'sky-input-box' && inputEl) {
+                      fixers.push(...removeFormControlClass(fixer, inputEl));
+                    }
 
-                  return fixers;
-                },
+                    return fixers;
+                  },
           });
         }
       },

--- a/libs/sdk/skyux-eslint/src/rules/template/prefer-label-text.ts
+++ b/libs/sdk/skyux-eslint/src/rules/template/prefer-label-text.ts
@@ -80,9 +80,7 @@ function getAttributeByName(
  */
 function hasControlFlowSyntax(el: TmplAstElement): boolean {
   const sourceText = el.sourceSpan.toString();
-  const controlFlowPatterns =
-    /@(if|for|switch|case|default|else|defer|placeholder|loading|error)\b/;
-  return controlFlowPatterns.test(sourceText);
+  return sourceText.includes('@');
 }
 
 /**

--- a/libs/sdk/skyux-eslint/src/rules/utils/ast-utils.ts
+++ b/libs/sdk/skyux-eslint/src/rules/utils/ast-utils.ts
@@ -72,14 +72,15 @@ export function getNgFor(el: TmplAstTemplate): string {
 }
 
 /**
- * Gets the text content of the provided element.
+ * Gets the text content of the provided element, preserving HTML entities.
  */
 export function getTextContent(el: TmplAstElement): string {
   let text = '';
 
   el.children.forEach((child) => {
     if (child instanceof TmplAstText) {
-      text += child.value.trim();
+      // Use sourceSpan to get original source text with entities preserved (e.g. `&#64;`).
+      text += child.sourceSpan.toString().trim();
     } else if (child instanceof TmplAstBoundText) {
       text += child.sourceSpan.toString().trim();
     }


### PR DESCRIPTION
[AB#3543394](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3543394)