### PR TITLE
fix(sdk/skyux-eslint): do not apply fix for `prefer-label-text` rule when label element uses control flow syntax (#3904)

### DIFF
--- a/libs/sdk/skyux-eslint/src/rules/template/prefer-label-text.spec.ts
+++ b/libs/sdk/skyux-eslint/src/rules/template/prefer-label-text.spec.ts
@@ -209,5 +209,125 @@ ruleTester.run(RULE_NAME, rule, {
         labelSelector: 'sky-checkbox-label',
       },
     }),
+    convertAnnotatedSourceToFailureCase({
+      description:
+        'should fail but not fix if label contains control flow syntax',
+      annotatedSource: `
+        <sky-checkbox>
+        ~~~~~~~~~~~~~~
+          <sky-checkbox-label>
+          ~~~~~~~~~~~~~~~~~~~~
+            @if (showPrefix) {
+            ~~~~~~~~~~~~~~~~~~
+              Prefix:
+              ~~~~~~~
+            }
+            ~
+            Label text
+            ~~~~~~~~~~
+          </sky-checkbox-label>
+          ~~~~~~~~~~~~~~~~~~~~~
+        </sky-checkbox>
+        ~~~~~~~~~~~~~~~
+      `,
+      messageId,
+      data: {
+        selector: 'sky-checkbox',
+        labelInputName: 'labelText',
+        labelSelector: 'sky-checkbox-label',
+      },
+    }),
+    convertAnnotatedSourceToFailureCase({
+      description:
+        'should fail but not fix if label contains @for control flow',
+      annotatedSource: `
+        <sky-toggle-switch>
+        ~~~~~~~~~~~~~~~~~~~
+          <sky-toggle-switch-label>
+          ~~~~~~~~~~~~~~~~~~~~~~~~~
+            @for (item of items; track item.id) {
+            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+              {{ item.name }}
+              ~~~~~~~~~~~~~~~
+            }
+            ~
+          </sky-toggle-switch-label>
+          ~~~~~~~~~~~~~~~~~~~~~~~~~~
+        </sky-toggle-switch>
+        ~~~~~~~~~~~~~~~~~~~~
+      `,
+      messageId,
+      data: {
+        selector: 'sky-toggle-switch',
+        labelInputName: 'labelText',
+        labelSelector: 'sky-toggle-switch-label',
+      },
+    }),
+    convertAnnotatedSourceToFailureCase({
+      description:
+        'should fail but not fix if label contains @switch control flow',
+      annotatedSource: `
+        <sky-input-box>
+        ~~~~~~~~~~~~~~~
+          <label>
+          ~~~~~~~
+            @switch (labelType) {
+            ~~~~~~~~~~~~~~~~~~~~~
+              @case ('short') {
+              ~~~~~~~~~~~~~~~~~
+                Short Label
+                ~~~~~~~~~~~
+              }
+              ~
+              @default {
+              ~~~~~~~~~~
+                Default Label
+                ~~~~~~~~~~~~~
+              }
+              ~
+            }
+            ~
+          </label>
+          ~~~~~~~~
+        </sky-input-box>
+        ~~~~~~~~~~~~~~~~
+      `,
+      messageId,
+      data: {
+        selector: 'sky-input-box',
+        labelInputName: 'labelText',
+        labelSelector: 'label',
+      },
+    }),
+    convertAnnotatedSourceToFailureCase({
+      description:
+        'should fail and fix if labelText not set and has label element with escaped "@" character',
+      annotatedSource: `
+        <sky-checkbox>
+        ~~~~~~~~~~~~~~
+          <sky-checkbox-label>
+          ~~~~~~~~~~~~~~~~~~~~
+            foo&#64;email.com
+            ~~~~~~~~~~~~~
+          </sky-checkbox-label>
+          ~~~~~~~~~~~~~~~~~~~~~
+        </sky-checkbox>
+        ~~~~~~~~~~~~~~~
+      `,
+      annotatedOutput: `
+        <sky-checkbox labelText="foo&#64;email.com">
+        ~
+          ~
+          ~
+        </sky-checkbox>
+        ~
+      `,
+      messageId,
+      data: {
+        selector: 'sky-checkbox',
+        labelInputName: 'labelText',
+        labelSelector: 'sky-checkbox-label',
+      },
+    }),
   ],
 });

--- a/libs/sdk/skyux-eslint/src/rules/utils/ast-utils.ts
+++ b/libs/sdk/skyux-eslint/src/rules/utils/ast-utils.ts
@@ -72,14 +72,15 @@ export function getNgFor(el: TmplAstTemplate): string {
 }
 
 /**
- * Gets the text content of the provided element.
+ * Gets the text content of the provided element, preserving HTML entities.
  */
 export function getTextContent(el: TmplAstElement): string {
   let text = '';
 
   el.children.forEach((child) => {
     if (child instanceof TmplAstText) {
-      text += child.value.trim();
+      // Use sourceSpan to get original source text with entities preserved (e.g. `&#64;`).
+      text += child.sourceSpan.toString().trim();
     } else if (child instanceof TmplAstBoundText) {
       text += child.sourceSpan.toString().trim();
     }


### PR DESCRIPTION
:cherries: Cherry picked from #3904 [fix(sdk/skyux-eslint): do not apply fix for `prefer-label-text` rule when label element uses control flow syntax](https://github.com/blackbaud/skyux/pull/3904)

[AB#3543394](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3543394) 