### PR TITLE
fix(sdk/skyux-eslint): do not fix `prefer-label-text` rule if label element includes double quotes

### DIFF
--- a/libs/sdk/skyux-eslint/src/rules/template/prefer-label-text.spec.ts
+++ b/libs/sdk/skyux-eslint/src/rules/template/prefer-label-text.spec.ts
@@ -329,5 +329,27 @@ ruleTester.run(RULE_NAME, rule, {
         labelSelector: 'sky-checkbox-label',
       },
     }),
+    convertAnnotatedSourceToFailureCase({
+      description:
+        'should fail if labelText not set and has label element with double quotes',
+      annotatedSource: `
+        <sky-checkbox>
+        ~~~~~~~~~~~~~~
+          <sky-checkbox-label>
+          ~~~~~~~~~~~~~~~~~~~~
+            {{ foo ?? "my_message" | skyAppResources }}
+            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+          </sky-checkbox-label>
+          ~~~~~~~~~~~~~~~~~~~~~
+        </sky-checkbox>
+        ~~~~~~~~~~~~~~~
+      `,
+      messageId,
+      data: {
+        selector: 'sky-checkbox',
+        labelInputName: 'labelText',
+        labelSelector: 'sky-checkbox-label',
+      },
+    }),
   ],
 });


### PR DESCRIPTION
This resolves the following error:
```
Error: src/app/errors/multiple-matches/multiple-matches.component.html:52:17 - error NG5002: Opening tag "sky-radio" not terminated.

52                 <sky-radio [disabled]="false" [value]="9999" labelText="{{ "multiple_matches_none_option" | skyAppResources }}">
                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

  src/app/errors/multiple-matches/multiple-matches.component.ts:13:16
    13   templateUrl: './multiple-matches.component.html',
                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    Error occurs in the template of component MultipleMatchesComponent.
```