### PR TITLE
fix(components/pages): page content has correct top space when no header actions or details are specified and links are present (#3921)

### DIFF
--- a/apps/e2e/pages-storybook-e2e/src/e2e/page-layout-blocks.component.cy.ts
+++ b/apps/e2e/pages-storybook-e2e/src/e2e/page-layout-blocks.component.cy.ts
@@ -27,6 +27,8 @@ describe(`pages-storybook`, () => {
           'block-layout-with-description-list-no-avatar',
           `${ID}-with-description-list-no-avatar`,
         ],
+        ['block-layout-all-hidden', `${ID}-all-hidden`],
+        ['block-layout-all-hidden-with-links', `${ID}-all-hidden-with-links`],
       ].forEach(([_, ID]) => {
         describe(`${_}`, () => {
           beforeEach(() =>

--- a/apps/e2e/pages-storybook/src/app/page/layouts/blocks-page/blocks-page.component.html
+++ b/apps/e2e/pages-storybook/src/app/page/layouts/blocks-page/blocks-page.component.html
@@ -17,35 +17,37 @@
         </sky-alert>
       </sky-page-header-alerts>
     }
-    <sky-page-header-details>
-      <div [class.sky-margin-stacked-sm]="showDescriptionList()">
-        <sky-label labelType="info" descriptionType="important-info">
-          Important information
-        </sky-label>
-      </div>
-      @if (showDescriptionList()) {
-        <sky-description-list mode="horizontal">
-          <sky-description-list-content>
-            <sky-description-list-term> Status </sky-description-list-term>
-            <sky-description-list-description>
-              Requested
-            </sky-description-list-description>
-          </sky-description-list-content>
-          <sky-description-list-content>
-            <sky-description-list-term> Requested </sky-description-list-term>
-            <sky-description-list-description>
-              {{ date | skyDate: 'shortDate' }}
-            </sky-description-list-description>
-          </sky-description-list-content>
-          <sky-description-list-content>
-            <sky-description-list-term> Requester </sky-description-list-term>
-            <sky-description-list-description>
-              First.Last{{ '@' }}blackbaud.com
-            </sky-description-list-description>
-          </sky-description-list-content>
-        </sky-description-list>
-      }
-    </sky-page-header-details>
+    @if (!hideDetails()) {
+      <sky-page-header-details>
+        <div [class.sky-margin-stacked-sm]="showDescriptionList()">
+          <sky-label labelType="info" descriptionType="important-info">
+            Important information
+          </sky-label>
+        </div>
+        @if (showDescriptionList()) {
+          <sky-description-list mode="horizontal">
+            <sky-description-list-content>
+              <sky-description-list-term> Status </sky-description-list-term>
+              <sky-description-list-description>
+                Requested
+              </sky-description-list-description>
+            </sky-description-list-content>
+            <sky-description-list-content>
+              <sky-description-list-term> Requested </sky-description-list-term>
+              <sky-description-list-description>
+                {{ date | skyDate: 'shortDate' }}
+              </sky-description-list-description>
+            </sky-description-list-content>
+            <sky-description-list-content>
+              <sky-description-list-term> Requester </sky-description-list-term>
+              <sky-description-list-description>
+                First.Last{{ '@' }}blackbaud.com
+              </sky-description-list-description>
+            </sky-description-list-content>
+          </sky-description-list>
+        }
+      </sky-page-header-details>
+    }
     @if (!hideActions()) {
       <sky-page-header-actions>
         <button class="sky-btn sky-btn-default" type="button">

--- a/apps/e2e/pages-storybook/src/app/page/layouts/blocks-page/blocks-page.component.stories.ts
+++ b/apps/e2e/pages-storybook/src/app/page/layouts/blocks-page/blocks-page.component.stories.ts
@@ -51,3 +51,20 @@ BlocksPageWithLinksNoAvatarNoAlert.args = {
   hideAvatar: true,
   showLinks: true,
 };
+
+export const BlocksPageAllHidden: Story = {};
+BlocksPageAllHidden.args = {
+  hideAlert: true,
+  hideActions: true,
+  hideAvatar: true,
+  hideDetails: true,
+};
+
+export const BlocksPageAllHiddenWithLinks: Story = {};
+BlocksPageAllHiddenWithLinks.args = {
+  hideAlert: true,
+  hideActions: true,
+  hideAvatar: true,
+  hideDetails: true,
+  showLinks: true,
+};

--- a/apps/e2e/pages-storybook/src/app/page/layouts/blocks-page/blocks-page.component.ts
+++ b/apps/e2e/pages-storybook/src/app/page/layouts/blocks-page/blocks-page.component.ts
@@ -33,6 +33,7 @@ export default class BlocksPageComponent {
   public readonly hideActions = input<boolean>(false);
   public readonly hideAlert = input<boolean>(false);
   public readonly hideAvatar = input<boolean>(false);
+  public readonly hideDetails = input<boolean>(false);
   public readonly showLinks = input<boolean>(false);
   public readonly showDescriptionList = input<boolean>(false);
 

--- a/libs/components/indicators/src/lib/modules/illustration/illustration.component.ts
+++ b/libs/components/indicators/src/lib/modules/illustration/illustration.component.ts
@@ -1,4 +1,3 @@
-import { CommonModule } from '@angular/common';
 import {
   ChangeDetectionStrategy,
   Component,
@@ -18,7 +17,7 @@ import { SkyIllustrationSize } from './illustration-size';
  */
 @Component({
   selector: 'sky-illustration',
-  imports: [CommonModule],
+  imports: [],
   templateUrl: './illustration.component.html',
   styleUrls: ['./illustration.component.scss'],
   hostDirectives: [SkyThemeComponentClassDirective],

--- a/libs/components/theme/src/lib/styles/_layout-host.scss
+++ b/libs/components/theme/src/lib/styles/_layout-host.scss
@@ -255,13 +255,7 @@
             ),
             min-content
           )
-          minmax(
-            var(
-              --sky-override-page-header-link-rows-space,
-              var(--sky-space-stacked-xl)
-            ),
-            min-content
-          )
+          minmax(0, min-content)
           auto;
         grid-template-columns: 0 75% 25%;
 


### PR DESCRIPTION
:cherries: Cherry picked from #3921 [fix(components/pages): page content has correct top space when no header actions or details are specified and links are present](https://github.com/blackbaud/skyux/pull/3921)

[AB#3543596](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3543596) 