### PR TITLE
fix(sdk/skyux-eslint): do not fix `prefer-label-text` rule if label element includes double quotes (#3922)

### DIFF
--- a/libs/components/indicators/src/lib/modules/illustration/illustration.component.ts
+++ b/libs/components/indicators/src/lib/modules/illustration/illustration.component.ts
@@ -1,4 +1,3 @@
-import { CommonModule } from '@angular/common';
 import {
   ChangeDetectionStrategy,
   Component,
@@ -18,7 +17,7 @@ import { SkyIllustrationSize } from './illustration-size';
  */
 @Component({
   selector: 'sky-illustration',
-  imports: [CommonModule],
+  imports: [],
   templateUrl: './illustration.component.html',
   styleUrls: ['./illustration.component.scss'],
   hostDirectives: [SkyThemeComponentClassDirective],

--- a/libs/sdk/skyux-eslint/src/rules/template/prefer-label-text.spec.ts
+++ b/libs/sdk/skyux-eslint/src/rules/template/prefer-label-text.spec.ts
@@ -329,5 +329,27 @@ ruleTester.run(RULE_NAME, rule, {
         labelSelector: 'sky-checkbox-label',
       },
     }),
+    convertAnnotatedSourceToFailureCase({
+      description:
+        'should fail if labelText not set and has label element with double quotes',
+      annotatedSource: `
+        <sky-checkbox>
+        ~~~~~~~~~~~~~~
+          <sky-checkbox-label>
+          ~~~~~~~~~~~~~~~~~~~~
+            {{ foo ?? "my_message" | skyAppResources }}
+            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+          </sky-checkbox-label>
+          ~~~~~~~~~~~~~~~~~~~~~
+        </sky-checkbox>
+        ~~~~~~~~~~~~~~~
+      `,
+      messageId,
+      data: {
+        selector: 'sky-checkbox',
+        labelInputName: 'labelText',
+        labelSelector: 'sky-checkbox-label',
+      },
+    }),
   ],
 });


### PR DESCRIPTION
:cherries: Cherry picked from #3922 [fix(sdk/skyux-eslint): do not fix `prefer-label-text` rule if label element includes double quotes](https://github.com/blackbaud/skyux/pull/3922)