### PR TITLE
fix(components/ag-grid): wrapText autoHeight columns resize correctly (#3928)

### DIFF
--- a/apps/playground/src/app/components/ag-grid/data-manager-large/data-set-large.ts
+++ b/apps/playground/src/app/components/ag-grid/data-manager-large/data-set-large.ts
@@ -11,11 +11,13 @@ export const columnDefinitions: ColDef[] = [
   {
     field: 'object_number',
     headerName: 'Object Number',
-    type: [],
+    type: SkyCellType.Text,
     sortable: false,
     headerComponentParams: {
       inlineHelpComponent: InlineHelpComponent,
     },
+    wrapText: true,
+    autoHeight: true,
   },
   {
     field: 'is_highlight',

--- a/libs/components/ag-grid/src/lib/styles/_base.scss
+++ b/libs/components/ag-grid/src/lib/styles/_base.scss
@@ -101,12 +101,6 @@
     }
   }
 
-  // Stretch the cell wrapper to the full height of the row so validator popovers are triggered on the entire cell.
-  .ag-row > .ag-cell.sky-ag-grid-cell-validator > .ag-cell-wrapper {
-    align-items: stretch;
-    height: 100%;
-  }
-
   .ag-cell.sky-ag-grid-cell-invalid:not(
       .ag-cell-inline-editing,
       .ag-cell-popup-editing


### PR DESCRIPTION
:cherries: Cherry picked from #3928 [fix(components/ag-grid): wrapText autoHeight columns resize correctly](https://github.com/blackbaud/skyux/pull/3928)