### PR TITLE
chore: release 13.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [13.1.0](https://github.com/blackbaud/skyux/compare/13.0.1...13.1.0) (2025-09-26)
+
+
+### Features
+
+* **components/icon:** use v10 of icons ([#3994](https://github.com/blackbaud/skyux/issues/3994)) ([87a862a](https://github.com/blackbaud/skyux/commit/87a862a7ff05929c13dbc7b164a2a3061ecf737b))
+
+
+### Bug Fixes
+
+* downgrade required version of ag-grid ([#3997](https://github.com/blackbaud/skyux/issues/3997)) ([90d436f](https://github.com/blackbaud/skyux/commit/90d436f2ab69faa212876c416571dc87ef37fae4))
+
 ## [13.0.1](https://github.com/blackbaud/skyux/compare/13.0.0...13.0.1) (2025-09-24)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
-## [13.1.0](https://github.com/blackbaud/skyux/compare/13.0.1...13.1.0) (2025-09-26)
+
+# [13.1.0](https://github.com/blackbaud/skyux/compare/13.0.1...13.1.0) (2025-09-26)
+
+
+### Bug Fixes
+
+* downgrade required version of ag-grid ([#3997](https://github.com/blackbaud/skyux/issues/3997)) ([90d436f](https://github.com/blackbaud/skyux/commit/90d436f2ab69faa212876c416571dc87ef37fae4))
 
 
 ### Features
@@ -8,9 +14,6 @@
 * **components/icon:** use v10 of icons ([#3994](https://github.com/blackbaud/skyux/issues/3994)) ([87a862a](https://github.com/blackbaud/skyux/commit/87a862a7ff05929c13dbc7b164a2a3061ecf737b))
 
 
-### Bug Fixes
-
-* downgrade required version of ag-grid ([#3997](https://github.com/blackbaud/skyux/issues/3997)) ([90d436f](https://github.com/blackbaud/skyux/commit/90d436f2ab69faa212876c416571dc87ef37fae4))
 
 ## [13.0.1](https://github.com/blackbaud/skyux/compare/13.0.0...13.0.1) (2025-09-24)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "skyux",
-  "version": "13.0.1",
+  "version": "13.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "skyux",
-      "version": "13.0.1",
+      "version": "13.1.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skyux",
-  "version": "13.0.1",
+  "version": "13.1.0",
   "license": "MIT",
   "scripts": {
     "ng": "nx",


### PR DESCRIPTION
# [13.1.0](https://github.com/blackbaud/skyux/compare/13.0.1...13.1.0) (2025-09-26)


### Bug Fixes

* downgrade required version of ag-grid ([#3997](https://github.com/blackbaud/skyux/issues/3997)) ([90d436f](https://github.com/blackbaud/skyux/commit/90d436f2ab69faa212876c416571dc87ef37fae4))


### Features

* **components/icon:** use v10 of icons ([#3994](https://github.com/blackbaud/skyux/issues/3994)) ([87a862a](https://github.com/blackbaud/skyux/commit/87a862a7ff05929c13dbc7b164a2a3061ecf737b))