### PR TITLE
fix(components/forms): validate file attachment on cancel and on blur when not opening file dialog

### DIFF
--- a/libs/components/forms/src/lib/modules/file-attachment/file-attachment/file-attachment.component.html
+++ b/libs/components/forms/src/lib/modules/file-attachment/file-attachment/file-attachment.component.html
@@ -65,6 +65,7 @@
       [disabled]="disabled"
       [required]="isRequired"
       (change)="fileChangeEvent($event)"
+      (cancel)="onFileCancel()"
     />
     @if (showFileAttachmentButton) {
       <button
@@ -87,7 +88,6 @@
         "
         [disabled]="disabled"
         (click)="onDropClicked()"
-        (blur)="onButtonBlur()"
       >
         <sky-icon iconName="folder-open" />
         {{

--- a/libs/components/forms/src/lib/modules/file-attachment/file-attachment/file-attachment.component.html
+++ b/libs/components/forms/src/lib/modules/file-attachment/file-attachment/file-attachment.component.html
@@ -88,6 +88,7 @@
         "
         [disabled]="disabled"
         (click)="onDropClicked()"
+        (blur)="onButtonBlur()"
       >
         <sky-icon iconName="folder-open" />
         {{

--- a/libs/components/forms/src/lib/modules/file-attachment/file-attachment/file-attachment.component.spec.ts
+++ b/libs/components/forms/src/lib/modules/file-attachment/file-attachment/file-attachment.component.spec.ts
@@ -1764,10 +1764,10 @@ describe('File attachment', () => {
     expect(fileAttachment).not.toHaveClass('sky-form-field-stacked');
   });
 
-  it('should mark file attachment as touched when blurred', () => {
+  it('should mark file attachment as touched when canceled', () => {
     expect(fixture.componentInstance.attachment.touched).toBeFalse();
-    const button = getButtonEl(el);
-    SkyAppTestUtility.fireDomEvent(button, 'blur');
+    const input = getInputDebugEl(fixture).nativeElement;
+    SkyAppTestUtility.fireDomEvent(input, 'cancel');
     fixture.detectChanges();
 
     expect(fixture.componentInstance.attachment.touched).toBeTrue();

--- a/libs/components/forms/src/lib/modules/file-attachment/file-attachment/file-attachment.component.spec.ts
+++ b/libs/components/forms/src/lib/modules/file-attachment/file-attachment/file-attachment.component.spec.ts
@@ -1,4 +1,4 @@
-import { DebugElement } from '@angular/core';
+import { DOCUMENT, DebugElement } from '@angular/core';
 import {
   ComponentFixture,
   TestBed,
@@ -1762,6 +1762,27 @@ describe('File attachment', () => {
     );
 
     expect(fileAttachment).not.toHaveClass('sky-form-field-stacked');
+  });
+
+  it('should mark file attachment as touched when blurred and focus is still on the document', () => {
+    const document = fixture.debugElement.injector.get(DOCUMENT);
+
+    const hasFocusSpy = spyOn(document, 'hasFocus').and.returnValue(false);
+
+    expect(fixture.componentInstance.attachment.touched).toBeFalse();
+
+    const button = getButtonEl(el);
+    SkyAppTestUtility.fireDomEvent(button, 'blur');
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.attachment.touched).toBeFalse();
+
+    hasFocusSpy.and.returnValue(true);
+
+    SkyAppTestUtility.fireDomEvent(button, 'blur');
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.attachment.touched).toBeTrue();
   });
 
   it('should mark file attachment as touched when canceled', () => {

--- a/libs/components/forms/src/lib/modules/file-attachment/file-attachment/file-attachment.component.ts
+++ b/libs/components/forms/src/lib/modules/file-attachment/file-attachment/file-attachment.component.ts
@@ -383,12 +383,12 @@ export class SkyFileAttachmentComponent
     }
   }
 
-  public onButtonBlur(): void {
+  public onFileCancel(): void {
     this.#onTouched();
   }
 
   public onDropClicked(): void {
-    this.#onTouched();
+    // this.#onTouched();
     /* istanbul ignore else */
     if (this.inputEl) {
       this.inputEl.nativeElement.click();
@@ -450,7 +450,6 @@ export class SkyFileAttachmentComponent
   }
 
   public fileDrop(dropEvent: DragEvent): void {
-    this.#onTouched();
     dropEvent.stopPropagation();
     dropEvent.preventDefault();
 
@@ -594,6 +593,8 @@ export class SkyFileAttachmentComponent
   }
 
   #handleFiles(fileList?: FileList | null): void {
+    this.#onTouched();
+
     if (fileList) {
       const files: SkyFileItem[] = [];
 

--- a/libs/components/forms/src/lib/modules/file-attachment/file-attachment/file-attachment.component.ts
+++ b/libs/components/forms/src/lib/modules/file-attachment/file-attachment/file-attachment.component.ts
@@ -6,6 +6,7 @@ import {
   ChangeDetectorRef,
   Component,
   ContentChildren,
+  DOCUMENT,
   ElementRef,
   EventEmitter,
   HostBinding,
@@ -99,6 +100,8 @@ export class SkyFileAttachmentComponent
     OnInit,
     OnDestroy
 {
+  readonly #document = inject(DOCUMENT);
+
   readonly #fileReaderSvc = inject(SkyFileReaderService);
 
   /**
@@ -380,6 +383,16 @@ export class SkyFileAttachmentComponent
             this.#changeDetector.markForCheck();
           },
         );
+    }
+  }
+
+  public onButtonBlur(): void {
+    // Only mark the field as touched on blur when the document still has focus. This
+    // prevents validation from occurring while the user has the file dialog open,
+    // since focus moves away from the document and onto the file dialog before this
+    // event fires.
+    if (this.#document.hasFocus()) {
+      this.#onTouched();
     }
   }
 

--- a/libs/components/forms/src/lib/modules/file-attachment/file-attachment/file-attachment.component.ts
+++ b/libs/components/forms/src/lib/modules/file-attachment/file-attachment/file-attachment.component.ts
@@ -388,7 +388,6 @@ export class SkyFileAttachmentComponent
   }
 
   public onDropClicked(): void {
-    // this.#onTouched();
     /* istanbul ignore else */
     if (this.inputEl) {
       this.inputEl.nativeElement.click();


### PR DESCRIPTION
[AB#3579535](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3579535)