### PR TITLE
fix(components/forms): file attachment file names are styled with `sky-btn-inline-link`

### DIFF
--- a/libs/components/forms/src/lib/modules/file-attachment/file-attachment/file-attachment.component.html
+++ b/libs/components/forms/src/lib/modules/file-attachment/file-attachment/file-attachment.component.html
@@ -110,7 +110,11 @@
     @if (value || currentThemeName === 'default') {
       <span class="sky-file-attachment-file-link">
         @if (value) {
-          <a [attr.title]="fileName" (click)="emitClick()">
+          <a
+            class="sky-btn sky-btn-link-inline"
+            [attr.title]="fileName"
+            (click)="emitClick()"
+          >
             {{ truncatedFileName }}
           </a>
         } @else {


### PR DESCRIPTION
[AB#3579522](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3579522)