### PR TITLE
chore: release 13.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 # Changelog
 
 
+# [13.3.0](https://github.com/blackbaud/skyux/compare/13.2.0...13.3.0) (2025-10-02)
+
+
+### Features
+
+* add support for split view in a data manager docked in a page ([#3991](https://github.com/blackbaud/skyux/issues/3991)) ([eab5b50](https://github.com/blackbaud/skyux/commit/eab5b5089f4a609085c7dc1a59701de24fea3d40)), closes [AB#3418840](https://github.com/AB/issues/3418840)
+
+
+
 # [13.2.0](https://github.com/blackbaud/skyux/compare/13.1.0...13.2.0) (2025-10-01)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 
-# [13.3.0](https://github.com/blackbaud/skyux/compare/13.2.0...13.3.0) (2025-10-02)
+# [13.3.0](https://github.com/blackbaud/skyux/compare/13.2.0...13.3.0) (2025-10-03)
 
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Features
 
 * add support for split view in a data manager docked in a page ([#3991](https://github.com/blackbaud/skyux/issues/3991)) ([eab5b50](https://github.com/blackbaud/skyux/commit/eab5b5089f4a609085c7dc1a59701de24fea3d40)), closes [AB#3418840](https://github.com/AB/issues/3418840)
+* **components/lists:** add updated testing support for repeater ([#3978](https://github.com/blackbaud/skyux/issues/3978)) ([#4010](https://github.com/blackbaud/skyux/issues/4010)) ([75805bc](https://github.com/blackbaud/skyux/commit/75805bca4f5f455d4acb269f338cad101ef24e62)), closes [AB#3554647](https://github.com/AB/issues/3554647)
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Features
 
 * add support for split view in a data manager docked in a page ([#3991](https://github.com/blackbaud/skyux/issues/3991)) ([eab5b50](https://github.com/blackbaud/skyux/commit/eab5b5089f4a609085c7dc1a59701de24fea3d40)), closes [AB#3418840](https://github.com/AB/issues/3418840)
+* **components/indicators:** add help popover methods to key info harness ([#4017](https://github.com/blackbaud/skyux/issues/4017)) ([66337b4](https://github.com/blackbaud/skyux/commit/66337b4c8f87cb1cd48908d45b4e50c15ae4167b))
 * **components/lists:** add updated testing support for repeater ([#3978](https://github.com/blackbaud/skyux/issues/3978)) ([#4010](https://github.com/blackbaud/skyux/issues/4010)) ([75805bc](https://github.com/blackbaud/skyux/commit/75805bca4f5f455d4acb269f338cad101ef24e62)), closes [AB#3554647](https://github.com/AB/issues/3554647)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 # [13.3.0](https://github.com/blackbaud/skyux/compare/13.2.0...13.3.0) (2025-10-02)
 
 
+### Bug Fixes
+
+* **components/filter-bar:** filter bar respects empty appliedFilters array ([#4014](https://github.com/blackbaud/skyux/issues/4014)) ([3688d5a](https://github.com/blackbaud/skyux/commit/3688d5a41ebe622aa2a5144b9214e0bcd5cb85fa))
+
+
 ### Features
 
 * add support for split view in a data manager docked in a page ([#3991](https://github.com/blackbaud/skyux/issues/3991)) ([eab5b50](https://github.com/blackbaud/skyux/commit/eab5b5089f4a609085c7dc1a59701de24fea3d40)), closes [AB#3418840](https://github.com/AB/issues/3418840)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "skyux",
-  "version": "13.2.0",
+  "version": "13.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "skyux",
-      "version": "13.2.0",
+      "version": "13.3.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skyux",
-  "version": "13.2.0",
+  "version": "13.3.0",
   "license": "MIT",
   "scripts": {
     "ng": "nx",


### PR DESCRIPTION
# [13.3.0](https://github.com/blackbaud/skyux/compare/13.2.0...13.3.0) (2025-10-03)


### Bug Fixes

* **components/filter-bar:** filter bar respects empty appliedFilters array ([#4014](https://github.com/blackbaud/skyux/issues/4014)) ([3688d5a](https://github.com/blackbaud/skyux/commit/3688d5a41ebe622aa2a5144b9214e0bcd5cb85fa))


### Features

* add support for split view in a data manager docked in a page ([#3991](https://github.com/blackbaud/skyux/issues/3991)) ([eab5b50](https://github.com/blackbaud/skyux/commit/eab5b5089f4a609085c7dc1a59701de24fea3d40)), closes [AB#3418840](https://github.com/AB/issues/3418840)
* **components/indicators:** add help popover methods to key info harness ([#4017](https://github.com/blackbaud/skyux/issues/4017)) ([66337b4](https://github.com/blackbaud/skyux/commit/66337b4c8f87cb1cd48908d45b4e50c15ae4167b))
* **components/lists:** add updated testing support for repeater ([#3978](https://github.com/blackbaud/skyux/issues/3978)) ([#4010](https://github.com/blackbaud/skyux/issues/4010)) ([75805bc](https://github.com/blackbaud/skyux/commit/75805bca4f5f455d4acb269f338cad101ef24e62)), closes [AB#3554647](https://github.com/AB/issues/3554647)