### PR TITLE
chore: release 13.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 # Changelog
 
 
+## [13.5.1](https://github.com/blackbaud/skyux/compare/13.5.0...13.5.1) (2025-10-15)
+
+
+### Bug Fixes
+
+* **components/theme:** properly default brand when setting theme to modern ([#4038](https://github.com/blackbaud/skyux/issues/4038)) ([730e54f](https://github.com/blackbaud/skyux/commit/730e54f167da7aab9d22a53fdb82e29fe133ef31))
+
+
+
 # [13.5.0](https://github.com/blackbaud/skyux/compare/13.4.1...13.5.0) (2025-10-14)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "skyux",
-  "version": "13.5.0",
+  "version": "13.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "skyux",
-      "version": "13.5.0",
+      "version": "13.5.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skyux",
-  "version": "13.5.0",
+  "version": "13.5.1",
   "license": "MIT",
   "scripts": {
     "ng": "nx",


### PR DESCRIPTION
## [13.5.1](https://github.com/blackbaud/skyux/compare/13.5.0...13.5.1) (2025-10-15)


### Bug Fixes

* **components/theme:** properly default brand when setting theme to modern ([#4038](https://github.com/blackbaud/skyux/issues/4038)) ([730e54f](https://github.com/blackbaud/skyux/commit/730e54f167da7aab9d22a53fdb82e29fe133ef31))