### PR TITLE
chore: release 13.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 # Changelog
 
 
+## [13.5.2](https://github.com/blackbaud/skyux/compare/13.5.1...13.5.2) (2025-10-15)
+
+
+### Bug Fixes
+
+* **components/lists:** sort items use pointer cursor ([#4037](https://github.com/blackbaud/skyux/issues/4037)) ([5c5f617](https://github.com/blackbaud/skyux/commit/5c5f61710f0def590c9334417c281417d087cd9a)), closes [AB#3592292](https://github.com/AB/issues/3592292)
+
+
+
 ## [13.5.1](https://github.com/blackbaud/skyux/compare/13.5.0...13.5.1) (2025-10-15)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 
-## [13.5.2](https://github.com/blackbaud/skyux/compare/13.5.1...13.5.2) (2025-10-15)
+## [13.5.2](https://github.com/blackbaud/skyux/compare/13.5.1...13.5.2) (2025-10-16)
 
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Bug Fixes
 
 * **components/lists:** sort items use pointer cursor ([#4037](https://github.com/blackbaud/skyux/issues/4037)) ([5c5f617](https://github.com/blackbaud/skyux/commit/5c5f61710f0def590c9334417c281417d087cd9a)), closes [AB#3592292](https://github.com/AB/issues/3592292)
+* update design tokens to version `3.1.1` ([#4042](https://github.com/blackbaud/skyux/issues/4042)) ([be25ea9](https://github.com/blackbaud/skyux/commit/be25ea9ad4df7857d54eac4e043e3d1dcb701c2b))
 
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "skyux",
-  "version": "13.5.1",
+  "version": "13.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "skyux",
-      "version": "13.5.1",
+      "version": "13.5.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skyux",
-  "version": "13.5.1",
+  "version": "13.5.2",
   "license": "MIT",
   "scripts": {
     "ng": "nx",


### PR DESCRIPTION
## [13.5.2](https://github.com/blackbaud/skyux/compare/13.5.1...13.5.2) (2025-10-16)


### Bug Fixes

* **components/lists:** sort items use pointer cursor ([#4037](https://github.com/blackbaud/skyux/issues/4037)) ([5c5f617](https://github.com/blackbaud/skyux/commit/5c5f61710f0def590c9334417c281417d087cd9a)), closes [AB#3592292](https://github.com/AB/issues/3592292)
* update design tokens to version `3.1.1` ([#4042](https://github.com/blackbaud/skyux/issues/4042)) ([be25ea9](https://github.com/blackbaud/skyux/commit/be25ea9ad4df7857d54eac4e043e3d1dcb701c2b))