### PR TITLE
chore: release 13.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 
-## [13.6.3](https://github.com/blackbaud/skyux/compare/13.6.2...13.6.3) (2025-10-23)
+## [13.6.3](https://github.com/blackbaud/skyux/compare/13.6.2...13.6.3) (2025-10-24)
 
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 # Changelog
 
 
+## [13.6.3](https://github.com/blackbaud/skyux/compare/13.6.2...13.6.3) (2025-10-23)
+
+
+### Bug Fixes
+
+* **components/indicators:** align key info value line-height with font class ([#4046](https://github.com/blackbaud/skyux/issues/4046)) ([a25b524](https://github.com/blackbaud/skyux/commit/a25b524e3abc8067dfb1d3710b9043a45ecc81b3)), closes [AB#3591446](https://github.com/AB/issues/3591446)
+
+
+
 ## [13.6.2](https://github.com/blackbaud/skyux/compare/13.6.1...13.6.2) (2025-10-22)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,17 @@
 # Changelog
 
 
-## [13.6.3](https://github.com/blackbaud/skyux/compare/13.6.2...13.6.3) (2025-10-24)
+# [13.7.0](https://github.com/blackbaud/skyux/compare/13.6.2...13.7.0) (2025-10-24)
 
 
 ### Bug Fixes
 
 * **components/indicators:** align key info value line-height with font class ([#4046](https://github.com/blackbaud/skyux/issues/4046)) ([a25b524](https://github.com/blackbaud/skyux/commit/a25b524e3abc8067dfb1d3710b9043a45ecc81b3)), closes [AB#3591446](https://github.com/AB/issues/3591446)
+
+
+### Features
+
+* update design tokens to 3.2.0 ([#4059](https://github.com/blackbaud/skyux/issues/4059)) ([852b7a0](https://github.com/blackbaud/skyux/commit/852b7a09c4d25c7d7c83156d76949042d115b972))
 
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "skyux",
-  "version": "13.6.2",
+  "version": "13.6.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "skyux",
-      "version": "13.6.2",
+      "version": "13.6.3",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "skyux",
-  "version": "13.6.3",
+  "version": "13.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "skyux",
-      "version": "13.6.3",
+      "version": "13.7.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skyux",
-  "version": "13.6.2",
+  "version": "13.6.3",
   "license": "MIT",
   "scripts": {
     "ng": "nx",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skyux",
-  "version": "13.6.3",
+  "version": "13.7.0",
   "license": "MIT",
   "scripts": {
     "ng": "nx",


### PR DESCRIPTION
# [13.7.0](https://github.com/blackbaud/skyux/compare/13.6.2...13.7.0) (2025-10-24)


### Bug Fixes

* **components/indicators:** align key info value line-height with font class ([#4046](https://github.com/blackbaud/skyux/issues/4046)) ([a25b524](https://github.com/blackbaud/skyux/commit/a25b524e3abc8067dfb1d3710b9043a45ecc81b3)), closes [AB#3591446](https://github.com/AB/issues/3591446)


### Features

* update design tokens to 3.2.0 ([#4059](https://github.com/blackbaud/skyux/issues/4059)) ([852b7a0](https://github.com/blackbaud/skyux/commit/852b7a09c4d25c7d7c83156d76949042d115b972))