### PR TITLE
chore: release 13.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 
-## [13.7.1](https://github.com/blackbaud/skyux/compare/13.7.0...13.7.1) (2025-10-29)
+## [13.7.1](https://github.com/blackbaud/skyux/compare/13.7.0...13.7.1) (2025-10-30)
 
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 # Changelog
 
 
+## [13.7.1](https://github.com/blackbaud/skyux/compare/13.7.0...13.7.1) (2025-10-29)
+
+
+### Bug Fixes
+
+* **components/lists:** remove non-selectable repeater item from tab order and update role of repeater item with only context-menu to `grid` ([#4057](https://github.com/blackbaud/skyux/issues/4057)) ([b426ba3](https://github.com/blackbaud/skyux/commit/b426ba351b71c73d5b825b859d961d51a022b720)), closes [AB#3430131](https://github.com/AB/issues/3430131)
+
+
+
 # [13.7.0](https://github.com/blackbaud/skyux/compare/13.6.2...13.7.0) (2025-10-24)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Bug Fixes
 
+* **components/lists:** add background color styles to list summary when scrolled ([#4062](https://github.com/blackbaud/skyux/issues/4062)) ([1cd5912](https://github.com/blackbaud/skyux/commit/1cd5912f3956ef47f4026997c93a91f9a1a615b4))
 * **components/lists:** remove non-selectable repeater item from tab order and update role of repeater item with only context-menu to `grid` ([#4057](https://github.com/blackbaud/skyux/issues/4057)) ([b426ba3](https://github.com/blackbaud/skyux/commit/b426ba351b71c73d5b825b859d961d51a022b720)), closes [AB#3430131](https://github.com/AB/issues/3430131)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 
-## [13.7.1](https://github.com/blackbaud/skyux/compare/13.7.0...13.7.1) (2025-10-30)
+## [13.7.1](https://github.com/blackbaud/skyux/compare/13.7.0...13.7.1) (2025-10-31)
 
 
 ### Bug Fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "skyux",
-  "version": "13.7.0",
+  "version": "13.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "skyux",
-      "version": "13.7.0",
+      "version": "13.7.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skyux",
-  "version": "13.7.0",
+  "version": "13.7.1",
   "license": "MIT",
   "scripts": {
     "ng": "nx",


### PR DESCRIPTION
## [13.7.1](https://github.com/blackbaud/skyux/compare/13.7.0...13.7.1) (2025-10-31)


### Bug Fixes

* **components/lists:** add background color styles to list summary when scrolled ([#4062](https://github.com/blackbaud/skyux/issues/4062)) ([1cd5912](https://github.com/blackbaud/skyux/commit/1cd5912f3956ef47f4026997c93a91f9a1a615b4))
* **components/lists:** remove non-selectable repeater item from tab order and update role of repeater item with only context-menu to `grid` ([#4057](https://github.com/blackbaud/skyux/issues/4057)) ([b426ba3](https://github.com/blackbaud/skyux/commit/b426ba351b71c73d5b825b859d961d51a022b720)), closes [AB#3430131](https://github.com/AB/issues/3430131)