### PR TITLE
fix: remove non-component cell renderer templates from page examples

### DIFF
--- a/libs/components/code-examples/src/lib/modules/pages/page/list-page-list-layout-demo/dashboard-link-cell-renderer.component.ts
+++ b/libs/components/code-examples/src/lib/modules/pages/page/list-page-list-layout-demo/dashboard-link-cell-renderer.component.ts
@@ -1,0 +1,31 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+
+import { ICellRendererAngularComp } from 'ag-grid-angular';
+import { ICellRendererParams } from 'ag-grid-community';
+
+/**
+ * Cell renderer for dashboard name links.
+ */
+@Component({
+  selector: 'app-dashboard-link-cell-renderer',
+  template: `<a
+    href="/"
+    [attr.aria-label]="'View dashboard details for ' + value"
+    >{{ value }}</a
+  >`,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class DashboardLinkCellRendererComponent
+  implements ICellRendererAngularComp
+{
+  protected value = '';
+
+  public agInit(params: ICellRendererParams): void {
+    this.value = params.value || '';
+  }
+
+  public refresh(params: ICellRendererParams): boolean {
+    this.value = params.value || '';
+    return true;
+  }
+}

--- a/libs/components/code-examples/src/lib/modules/pages/page/list-page-list-layout-demo/dashboard-link-cell-renderer.component.ts
+++ b/libs/components/code-examples/src/lib/modules/pages/page/list-page-list-layout-demo/dashboard-link-cell-renderer.component.ts
@@ -3,6 +3,8 @@ import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { ICellRendererAngularComp } from 'ag-grid-angular';
 import { ICellRendererParams } from 'ag-grid-community';
 
+import { Item } from './item';
+
 /**
  * Cell renderer for dashboard name links.
  */
@@ -20,11 +22,11 @@ export class DashboardLinkCellRendererComponent
 {
   protected value = '';
 
-  public agInit(params: ICellRendererParams): void {
+  public agInit(params: ICellRendererParams<Item, string>): void {
     this.value = params.value || '';
   }
 
-  public refresh(params: ICellRendererParams): boolean {
+  public refresh(params: ICellRendererParams<Item, string>): boolean {
     this.value = params.value || '';
     return true;
   }

--- a/libs/components/code-examples/src/lib/modules/pages/page/list-page-list-layout-demo/list-page-content.component.ts
+++ b/libs/components/code-examples/src/lib/modules/pages/page/list-page-list-layout-demo/list-page-content.component.ts
@@ -14,10 +14,10 @@ import {
   AllCommunityModule,
   ColDef,
   GridOptions,
-  ICellRendererParams,
   ModuleRegistry,
 } from 'ag-grid-community';
 
+import { DashboardLinkCellRendererComponent } from './dashboard-link-cell-renderer.component';
 import { DashboardGridContextMenuComponent } from './dashboards-grid-context-menu.component';
 import { Item } from './item';
 
@@ -84,9 +84,7 @@ export class ListPageContentComponent implements OnInit {
       field: 'dashboard',
       headerName: 'Name',
       width: 150,
-      cellRenderer: (params: ICellRendererParams): string => {
-        return `<a href="/">${params.value}</a>`;
-      },
+      cellRenderer: DashboardLinkCellRendererComponent,
     },
     {
       colId: 'name',

--- a/libs/components/code-examples/src/lib/modules/pages/page/list-page-tabs-layout-demo/contact-link-cell-renderer.component.ts
+++ b/libs/components/code-examples/src/lib/modules/pages/page/list-page-tabs-layout-demo/contact-link-cell-renderer.component.ts
@@ -1,0 +1,31 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+
+import { ICellRendererAngularComp } from 'ag-grid-angular';
+import { ICellRendererParams } from 'ag-grid-community';
+
+/**
+ * Cell renderer for contact name links.
+ */
+@Component({
+  selector: 'app-contact-link-cell-renderer',
+  template: `<a
+    href="/"
+    [attr.aria-label]="'View contact details for ' + value"
+    >{{ value }}</a
+  >`,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ContactLinkCellRendererComponent
+  implements ICellRendererAngularComp
+{
+  protected value = '';
+
+  public agInit(params: ICellRendererParams): void {
+    this.value = params.value || '';
+  }
+
+  public refresh(params: ICellRendererParams): boolean {
+    this.value = params.value || '';
+    return true;
+  }
+}

--- a/libs/components/code-examples/src/lib/modules/pages/page/list-page-tabs-layout-demo/contact-link-cell-renderer.component.ts
+++ b/libs/components/code-examples/src/lib/modules/pages/page/list-page-tabs-layout-demo/contact-link-cell-renderer.component.ts
@@ -3,6 +3,8 @@ import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { ICellRendererAngularComp } from 'ag-grid-angular';
 import { ICellRendererParams } from 'ag-grid-community';
 
+import { Contact } from './contact';
+
 /**
  * Cell renderer for contact name links.
  */
@@ -20,11 +22,11 @@ export class ContactLinkCellRendererComponent
 {
   protected value = '';
 
-  public agInit(params: ICellRendererParams): void {
+  public agInit(params: ICellRendererParams<Contact, string>): void {
     this.value = params.value || '';
   }
 
-  public refresh(params: ICellRendererParams): boolean {
+  public refresh(params: ICellRendererParams<Contact, string>): boolean {
     this.value = params.value || '';
     return true;
   }

--- a/libs/components/code-examples/src/lib/modules/pages/page/list-page-tabs-layout-demo/list-page-contacts-grid.component.ts
+++ b/libs/components/code-examples/src/lib/modules/pages/page/list-page-tabs-layout-demo/list-page-contacts-grid.component.ts
@@ -14,11 +14,11 @@ import {
   AllCommunityModule,
   ColDef,
   GridOptions,
-  ICellRendererParams,
   ModuleRegistry,
 } from 'ag-grid-community';
 
 import { ContactContextMenuComponent } from './contact-context-menu.component';
+import { ContactLinkCellRendererComponent } from './contact-link-cell-renderer.component';
 
 ModuleRegistry.registerModules([AllCommunityModule]);
 
@@ -62,9 +62,7 @@ export class ListPageContactsGridComponent implements OnInit {
       field: 'name',
       headerName: 'Name',
       width: 150,
-      cellRenderer: (params: ICellRendererParams): string => {
-        return `<a href="/">${params.value}</a>`;
-      },
+      cellRenderer: ContactLinkCellRendererComponent,
     },
     {
       colId: 'organization',

--- a/libs/components/code-examples/src/lib/modules/pages/page/record-page-tabs-layout-demo/attachment-link-cell-renderer.component.ts
+++ b/libs/components/code-examples/src/lib/modules/pages/page/record-page-tabs-layout-demo/attachment-link-cell-renderer.component.ts
@@ -3,6 +3,8 @@ import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { ICellRendererAngularComp } from 'ag-grid-angular';
 import { ICellRendererParams } from 'ag-grid-community';
 
+import { Attachment } from './attachment';
+
 /**
  * Cell renderer for attachment name links.
  */
@@ -20,11 +22,11 @@ export class AttachmentLinkCellRendererComponent
 {
   protected value = '';
 
-  public agInit(params: ICellRendererParams): void {
+  public agInit(params: ICellRendererParams<Attachment, string>): void {
     this.value = params.value || '';
   }
 
-  public refresh(params: ICellRendererParams): boolean {
+  public refresh(params: ICellRendererParams<Attachment, string>): boolean {
     this.value = params.value || '';
     return true;
   }

--- a/libs/components/code-examples/src/lib/modules/pages/page/record-page-tabs-layout-demo/attachment-link-cell-renderer.component.ts
+++ b/libs/components/code-examples/src/lib/modules/pages/page/record-page-tabs-layout-demo/attachment-link-cell-renderer.component.ts
@@ -1,0 +1,31 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+
+import { ICellRendererAngularComp } from 'ag-grid-angular';
+import { ICellRendererParams } from 'ag-grid-community';
+
+/**
+ * Cell renderer for attachment name links.
+ */
+@Component({
+  selector: 'app-attachment-link-cell-renderer',
+  template: `<a
+    href="/"
+    [attr.aria-label]="'View attachment details for ' + value"
+    >{{ value }}</a
+  >`,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class AttachmentLinkCellRendererComponent
+  implements ICellRendererAngularComp
+{
+  protected value = '';
+
+  public agInit(params: ICellRendererParams): void {
+    this.value = params.value || '';
+  }
+
+  public refresh(params: ICellRendererParams): boolean {
+    this.value = params.value || '';
+    return true;
+  }
+}

--- a/libs/components/code-examples/src/lib/modules/pages/page/record-page-tabs-layout-demo/record-page-attachments-tab.component.ts
+++ b/libs/components/code-examples/src/lib/modules/pages/page/record-page-tabs-layout-demo/record-page-attachments-tab.component.ts
@@ -14,11 +14,11 @@ import {
   AllCommunityModule,
   ColDef,
   GridOptions,
-  ICellRendererParams,
   ModuleRegistry,
 } from 'ag-grid-community';
 
 import { Attachment } from './attachment';
+import { AttachmentLinkCellRendererComponent } from './attachment-link-cell-renderer.component';
 import { AttachmentsGridContextMenuComponent } from './attachments-grid-context-menu.component';
 
 ModuleRegistry.registerModules([AllCommunityModule]);
@@ -68,9 +68,7 @@ export class RecordPageAttachmentsTabComponent implements OnInit {
       field: 'name',
       headerName: 'Name',
       width: 150,
-      cellRenderer: (params: ICellRendererParams): string => {
-        return `<a href="/">${params.value}</a>`;
-      },
+      cellRenderer: AttachmentLinkCellRendererComponent,
     },
     {
       colId: 'description',


### PR DESCRIPTION
[AB#3613689](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3613689)