### PR TITLE
fix(components/tiles): use same heading size for tile title and summary

### DIFF
--- a/libs/components/tiles/src/lib/modules/tiles/tile/tile.component.html
+++ b/libs/components/tiles/src/lib/modules/tiles/tile/tile.component.html
@@ -22,7 +22,7 @@
           </span>
         }
       </div>
-      <div class="sky-tile-summary sky-font-display-3">
+      <div class="sky-tile-summary sky-font-heading-2">
         <ng-content select="sky-tile-summary" />
       </div>
     </div>


### PR DESCRIPTION
[AB#3593714](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3593714)