### PR TITLE
chore: release 13.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,18 @@
 # Changelog
 
 
-## [13.7.3](https://github.com/blackbaud/skyux/compare/13.7.2...13.7.3) (2025-11-06)
+# [13.8.0](https://github.com/blackbaud/skyux/compare/13.7.2...13.8.0) (2025-11-06)
 
 
 ### Bug Fixes
 
 * add missed links to global help docs ([#4064](https://github.com/blackbaud/skyux/issues/4064)) ([2c45bce](https://github.com/blackbaud/skyux/commit/2c45bce4f389afebf218803a91bb963e233b03e7)), closes [AB#3612167](https://github.com/AB/issues/3612167)
 * **components/ag-grid:** maintain column types when using service grid options ([#4078](https://github.com/blackbaud/skyux/issues/4078)) ([bcabffc](https://github.com/blackbaud/skyux/commit/bcabffc731160f08949fcdca0b9a9739b2db7051))
+
+
+### Features
+
+* add helper functions to get custom form errors and add SkyFormErrorHarness to docs ([#4070](https://github.com/blackbaud/skyux/issues/4070)) ([99d83b9](https://github.com/blackbaud/skyux/commit/99d83b908916b70ad10861aeaf74bf56b49720e2)), closes [AB#3609292](https://github.com/AB/issues/3609292)
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 # Changelog
 
 
+## [13.7.3](https://github.com/blackbaud/skyux/compare/13.7.2...13.7.3) (2025-11-06)
+
+
+### Bug Fixes
+
+* add missed links to global help docs ([#4064](https://github.com/blackbaud/skyux/issues/4064)) ([2c45bce](https://github.com/blackbaud/skyux/commit/2c45bce4f389afebf218803a91bb963e233b03e7)), closes [AB#3612167](https://github.com/AB/issues/3612167)
+
+
+
 ## [13.7.2](https://github.com/blackbaud/skyux/compare/13.7.1...13.7.2) (2025-11-05)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 
-# [13.8.0](https://github.com/blackbaud/skyux/compare/13.7.2...13.8.0) (2025-11-09)
+# [13.8.0](https://github.com/blackbaud/skyux/compare/13.7.2...13.8.0) (2025-11-10)
 
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 
-# [13.8.0](https://github.com/blackbaud/skyux/compare/13.7.2...13.8.0) (2025-11-07)
+# [13.8.0](https://github.com/blackbaud/skyux/compare/13.7.2...13.8.0) (2025-11-08)
 
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 
-# [13.8.0](https://github.com/blackbaud/skyux/compare/13.7.2...13.8.0) (2025-11-06)
+# [13.8.0](https://github.com/blackbaud/skyux/compare/13.7.2...13.8.0) (2025-11-07)
 
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 
-# [13.8.0](https://github.com/blackbaud/skyux/compare/13.7.2...13.8.0) (2025-11-08)
+# [13.8.0](https://github.com/blackbaud/skyux/compare/13.7.2...13.8.0) (2025-11-09)
 
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Bug Fixes
 
 * add missed links to global help docs ([#4064](https://github.com/blackbaud/skyux/issues/4064)) ([2c45bce](https://github.com/blackbaud/skyux/commit/2c45bce4f389afebf218803a91bb963e233b03e7)), closes [AB#3612167](https://github.com/AB/issues/3612167)
+* **components/ag-grid:** maintain column types when using service grid options ([#4078](https://github.com/blackbaud/skyux/issues/4078)) ([bcabffc](https://github.com/blackbaud/skyux/commit/bcabffc731160f08949fcdca0b9a9739b2db7051))
 
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "skyux",
-  "version": "13.7.3",
+  "version": "13.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "skyux",
-      "version": "13.7.3",
+      "version": "13.8.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "skyux",
-  "version": "13.7.2",
+  "version": "13.7.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "skyux",
-      "version": "13.7.2",
+      "version": "13.7.3",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skyux",
-  "version": "13.7.3",
+  "version": "13.8.0",
   "license": "MIT",
   "scripts": {
     "ng": "nx",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skyux",
-  "version": "13.7.2",
+  "version": "13.7.3",
   "license": "MIT",
   "scripts": {
     "ng": "nx",


### PR DESCRIPTION
# [13.8.0](https://github.com/blackbaud/skyux/compare/13.7.2...13.8.0) (2025-11-10)


### Bug Fixes

* add missed links to global help docs ([#4064](https://github.com/blackbaud/skyux/issues/4064)) ([2c45bce](https://github.com/blackbaud/skyux/commit/2c45bce4f389afebf218803a91bb963e233b03e7)), closes [AB#3612167](https://github.com/AB/issues/3612167)
* **components/ag-grid:** maintain column types when using service grid options ([#4078](https://github.com/blackbaud/skyux/issues/4078)) ([bcabffc](https://github.com/blackbaud/skyux/commit/bcabffc731160f08949fcdca0b9a9739b2db7051))


### Features

* add helper functions to get custom form errors and add SkyFormErrorHarness to docs ([#4070](https://github.com/blackbaud/skyux/issues/4070)) ([99d83b9](https://github.com/blackbaud/skyux/commit/99d83b908916b70ad10861aeaf74bf56b49720e2)), closes [AB#3609292](https://github.com/AB/issues/3609292)