### PR TITLE
docs(components/ag-grid): lookup properties call out `wrapperClass` requirements for `addClick`

### DIFF
--- a/libs/components/ag-grid/src/lib/modules/ag-grid/types/lookup-properties.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/types/lookup-properties.ts
@@ -10,7 +10,10 @@ import {
 
 export interface SkyAgGridLookupProperties {
   /**
-   * Fires when users select the button to add options to the list.
+   * Fires when users select the button to add options to the list. If opening a modal, include
+   * `wrapperClass: 'ag-custom-component-popup'` in the
+   * [modal configuration](https://developer.blackbaud.com/skyux/components/modal?docs-active-tab=development#interface_sky-modal-configuration-interface)
+   * to ensure proper focus behavior.
    */
   addClick?: (args: SkyLookupAddClickEventArgs) => void;
   /**

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/types/lookup-properties.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/types/lookup-properties.ts
@@ -10,7 +10,7 @@ import {
 
 export interface SkyAgGridLookupProperties {
   /**
-   * Fires when users select the button to add options to the list. If the button opens a modal, include
+   * Fires when users select the button to add options to the list. When the button opens a modal, include
    * `wrapperClass: 'ag-custom-component-popup'` in the
    * [modal configuration](https://developer.blackbaud.com/skyux/components/modal?docs-active-tab=development#interface_sky-modal-configuration-interface)
    * to ensure proper focus behavior.

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/types/lookup-properties.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/types/lookup-properties.ts
@@ -10,7 +10,7 @@ import {
 
 export interface SkyAgGridLookupProperties {
   /**
-   * Fires when users select the button to add options to the list. If opening a modal, include
+   * Fires when users select the button to add options to the list. If the button opens a modal, include
    * `wrapperClass: 'ag-custom-component-popup'` in the
    * [modal configuration](https://developer.blackbaud.com/skyux/components/modal?docs-active-tab=development#interface_sky-modal-configuration-interface)
    * to ensure proper focus behavior.


### PR DESCRIPTION
[AB#3619682](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3619682)