### PR TITLE
chore: release 13.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 
-# [13.9.0](https://github.com/blackbaud/skyux/compare/13.8.2...13.9.0) (2025-11-29)
+# [13.9.0](https://github.com/blackbaud/skyux/compare/13.8.2...13.9.0) (2025-11-30)
 
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 
-# [13.9.0](https://github.com/blackbaud/skyux/compare/13.8.2...13.9.0) (2025-11-27)
+# [13.9.0](https://github.com/blackbaud/skyux/compare/13.8.2...13.9.0) (2025-11-28)
 
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 
-# [13.9.0](https://github.com/blackbaud/skyux/compare/13.8.2...13.9.0) (2025-11-26)
+# [13.9.0](https://github.com/blackbaud/skyux/compare/13.8.2...13.9.0) (2025-11-27)
 
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 * **components/ag-grid:** lookup cell editor should not stop editing when adding a new record ([#4086](https://github.com/blackbaud/skyux/issues/4086)) ([cbd547b](https://github.com/blackbaud/skyux/commit/cbd547be48e28e257c8be69f1628174f9cd35d8b)), closes [AB#3619682](https://github.com/AB/issues/3619682)
 * **components/tabs:** tab dropdown close button is on the right in modern theme ([#4073](https://github.com/blackbaud/skyux/issues/4073)) ([d7deacb](https://github.com/blackbaud/skyux/commit/d7deacbbc06c15b7adac1fff9e1827b6a1d2afc3)), closes [AB#3614210](https://github.com/AB/issues/3614210)
+* **components/theme:** fix default semantic header styling ([#4093](https://github.com/blackbaud/skyux/issues/4093)) ([8591069](https://github.com/blackbaud/skyux/commit/8591069d032b396cc470b0071036934e08a33b34)), closes [AB#3618574](https://github.com/AB/issues/3618574)
 
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 # Changelog
 
 
+## [13.8.3](https://github.com/blackbaud/skyux/compare/13.8.2...13.8.3) (2025-11-17)
+
+
+### Bug Fixes
+
+* **components/ag-grid:** lookup cell editor should not stop editing when adding a new record ([#4086](https://github.com/blackbaud/skyux/issues/4086)) ([cbd547b](https://github.com/blackbaud/skyux/commit/cbd547be48e28e257c8be69f1628174f9cd35d8b)), closes [AB#3619682](https://github.com/AB/issues/3619682)
+
+
+
 ## [13.8.2](https://github.com/blackbaud/skyux/compare/13.8.1...13.8.2) (2025-11-14)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 
-# [13.9.0](https://github.com/blackbaud/skyux/compare/13.8.2...13.9.0) (2025-11-30)
+# [13.9.0](https://github.com/blackbaud/skyux/compare/13.8.2...13.9.0) (2025-12-01)
 
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 
-# [13.9.0](https://github.com/blackbaud/skyux/compare/13.8.2...13.9.0) (2025-11-21)
+# [13.9.0](https://github.com/blackbaud/skyux/compare/13.8.2...13.9.0) (2025-11-22)
 
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,18 @@
 # Changelog
 
 
-## [13.8.3](https://github.com/blackbaud/skyux/compare/13.8.2...13.8.3) (2025-11-18)
+# [13.9.0](https://github.com/blackbaud/skyux/compare/13.8.2...13.9.0) (2025-11-18)
 
 
 ### Bug Fixes
 
 * **components/ag-grid:** lookup cell editor should not stop editing when adding a new record ([#4086](https://github.com/blackbaud/skyux/issues/4086)) ([cbd547b](https://github.com/blackbaud/skyux/commit/cbd547be48e28e257c8be69f1628174f9cd35d8b)), closes [AB#3619682](https://github.com/AB/issues/3619682)
 * **components/tabs:** tab dropdown close button is on the right in modern theme ([#4073](https://github.com/blackbaud/skyux/issues/4073)) ([d7deacb](https://github.com/blackbaud/skyux/commit/d7deacbbc06c15b7adac1fff9e1827b6a1d2afc3)), closes [AB#3614210](https://github.com/AB/issues/3614210)
+
+
+### Features
+
+* **components/packages:** create schematic to convert SKY UX projects to use standalone components ([#4082](https://github.com/blackbaud/skyux/issues/4082)) ([9c1b329](https://github.com/blackbaud/skyux/commit/9c1b32960cb1a796505bef526c3d912d7f167611)), closes [AB#3603880](https://github.com/AB/issues/3603880)
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 
-# [13.9.0](https://github.com/blackbaud/skyux/compare/13.8.2...13.9.0) (2025-11-23)
+# [13.9.0](https://github.com/blackbaud/skyux/compare/13.8.2...13.9.0) (2025-11-24)
 
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Bug Fixes
 
 * **components/ag-grid:** lookup cell editor should not stop editing when adding a new record ([#4086](https://github.com/blackbaud/skyux/issues/4086)) ([cbd547b](https://github.com/blackbaud/skyux/commit/cbd547be48e28e257c8be69f1628174f9cd35d8b)), closes [AB#3619682](https://github.com/AB/issues/3619682)
+* **components/filter-bar:** add top border styling for filter bar in data manager ([#4094](https://github.com/blackbaud/skyux/issues/4094)) ([7bdc781](https://github.com/blackbaud/skyux/commit/7bdc781b45523b4ce49cfaaa48c1c66230016595))
 * **components/tabs:** tab dropdown close button is on the right in modern theme ([#4073](https://github.com/blackbaud/skyux/issues/4073)) ([d7deacb](https://github.com/blackbaud/skyux/commit/d7deacbbc06c15b7adac1fff9e1827b6a1d2afc3)), closes [AB#3614210](https://github.com/AB/issues/3614210)
 * **components/theme:** fix default semantic header styling ([#4093](https://github.com/blackbaud/skyux/issues/4093)) ([8591069](https://github.com/blackbaud/skyux/commit/8591069d032b396cc470b0071036934e08a33b34)), closes [AB#3618574](https://github.com/AB/issues/3618574)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 
-# [13.9.0](https://github.com/blackbaud/skyux/compare/13.8.2...13.9.0) (2025-11-24)
+# [13.9.0](https://github.com/blackbaud/skyux/compare/13.8.2...13.9.0) (2025-11-25)
 
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 
-# [13.9.0](https://github.com/blackbaud/skyux/compare/13.8.2...13.9.0) (2025-11-25)
+# [13.9.0](https://github.com/blackbaud/skyux/compare/13.8.2...13.9.0) (2025-11-26)
 
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 
-## [13.8.3](https://github.com/blackbaud/skyux/compare/13.8.2...13.8.3) (2025-11-17)
+## [13.8.3](https://github.com/blackbaud/skyux/compare/13.8.2...13.8.3) (2025-11-18)
 
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 
-# [13.9.0](https://github.com/blackbaud/skyux/compare/13.8.2...13.9.0) (2025-11-28)
+# [13.9.0](https://github.com/blackbaud/skyux/compare/13.8.2...13.9.0) (2025-11-29)
 
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 
-# [13.9.0](https://github.com/blackbaud/skyux/compare/13.8.2...13.9.0) (2025-11-22)
+# [13.9.0](https://github.com/blackbaud/skyux/compare/13.8.2...13.9.0) (2025-11-23)
 
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Bug Fixes
 
 * **components/ag-grid:** lookup cell editor should not stop editing when adding a new record ([#4086](https://github.com/blackbaud/skyux/issues/4086)) ([cbd547b](https://github.com/blackbaud/skyux/commit/cbd547be48e28e257c8be69f1628174f9cd35d8b)), closes [AB#3619682](https://github.com/AB/issues/3619682)
+* **components/tabs:** tab dropdown close button is on the right in modern theme ([#4073](https://github.com/blackbaud/skyux/issues/4073)) ([d7deacb](https://github.com/blackbaud/skyux/commit/d7deacbbc06c15b7adac1fff9e1827b6a1d2afc3)), closes [AB#3614210](https://github.com/AB/issues/3614210)
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 
-# [13.9.0](https://github.com/blackbaud/skyux/compare/13.8.2...13.9.0) (2025-11-18)
+# [13.9.0](https://github.com/blackbaud/skyux/compare/13.8.2...13.9.0) (2025-11-19)
 
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 
-# [13.9.0](https://github.com/blackbaud/skyux/compare/13.8.2...13.9.0) (2025-11-20)
+# [13.9.0](https://github.com/blackbaud/skyux/compare/13.8.2...13.9.0) (2025-11-21)
 
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 
-# [13.9.0](https://github.com/blackbaud/skyux/compare/13.8.2...13.9.0) (2025-11-19)
+# [13.9.0](https://github.com/blackbaud/skyux/compare/13.8.2...13.9.0) (2025-11-20)
 
 
 ### Bug Fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "skyux",
-  "version": "13.8.2",
+  "version": "13.8.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "skyux",
-      "version": "13.8.2",
+      "version": "13.8.3",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "skyux",
-  "version": "13.8.3",
+  "version": "13.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "skyux",
-      "version": "13.8.3",
+      "version": "13.9.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skyux",
-  "version": "13.8.2",
+  "version": "13.8.3",
   "license": "MIT",
   "scripts": {
     "ng": "nx",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skyux",
-  "version": "13.8.3",
+  "version": "13.9.0",
   "license": "MIT",
   "scripts": {
     "ng": "nx",


### PR DESCRIPTION
# [13.9.0](https://github.com/blackbaud/skyux/compare/13.8.2...13.9.0) (2025-12-01)


### Bug Fixes

* **components/ag-grid:** lookup cell editor should not stop editing when adding a new record ([#4086](https://github.com/blackbaud/skyux/issues/4086)) ([cbd547b](https://github.com/blackbaud/skyux/commit/cbd547be48e28e257c8be69f1628174f9cd35d8b)), closes [AB#3619682](https://github.com/AB/issues/3619682)
* **components/filter-bar:** add top border styling for filter bar in data manager ([#4094](https://github.com/blackbaud/skyux/issues/4094)) ([7bdc781](https://github.com/blackbaud/skyux/commit/7bdc781b45523b4ce49cfaaa48c1c66230016595))
* **components/tabs:** tab dropdown close button is on the right in modern theme ([#4073](https://github.com/blackbaud/skyux/issues/4073)) ([d7deacb](https://github.com/blackbaud/skyux/commit/d7deacbbc06c15b7adac1fff9e1827b6a1d2afc3)), closes [AB#3614210](https://github.com/AB/issues/3614210)
* **components/theme:** fix default semantic header styling ([#4093](https://github.com/blackbaud/skyux/issues/4093)) ([8591069](https://github.com/blackbaud/skyux/commit/8591069d032b396cc470b0071036934e08a33b34)), closes [AB#3618574](https://github.com/AB/issues/3618574)


### Features

* **components/packages:** create schematic to convert SKY UX projects to use standalone components ([#4082](https://github.com/blackbaud/skyux/issues/4082)) ([9c1b329](https://github.com/blackbaud/skyux/commit/9c1b32960cb1a796505bef526c3d912d7f167611)), closes [AB#3603880](https://github.com/AB/issues/3603880)