### PR TITLE
fix: restore module providers

### DIFF
--- a/libs/components/angular-tree-component/src/lib/modules/angular-tree/angular-tree.module.ts
+++ b/libs/components/angular-tree-component/src/lib/modules/angular-tree/angular-tree.module.ts
@@ -1,4 +1,5 @@
 import { NgModule } from '@angular/core';
+import { SkyCoreAdapterService } from '@skyux/core';
 
 import { SkyAngularTreeComponentResourcesModule } from '../shared/sky-angular-tree-component-resources.module';
 
@@ -15,6 +16,7 @@ import { SkyAngularTreeWrapperComponent } from './angular-tree-wrapper.component
     SkyAngularTreeToolbarComponent,
     SkyAngularTreeWrapperComponent,
   ],
+  providers: [SkyCoreAdapterService],
   exports: [SkyAngularTreeNodeComponent, SkyAngularTreeWrapperComponent],
 })
 export class SkyAngularTreeModule {}

--- a/libs/components/avatar/src/lib/modules/avatar/avatar.module.ts
+++ b/libs/components/avatar/src/lib/modules/avatar/avatar.module.ts
@@ -1,10 +1,12 @@
 import { NgModule } from '@angular/core';
+import { SkyFileSizePipe } from '@skyux/forms';
 
 import { SkyAvatarComponent } from './avatar.component';
 import { SkyAvatarInnerComponent } from './avatar.inner.component';
 
 @NgModule({
   imports: [SkyAvatarInnerComponent, SkyAvatarComponent],
+  providers: [SkyFileSizePipe],
   exports: [SkyAvatarComponent],
 })
 export class SkyAvatarModule {}

--- a/libs/components/core/src/lib/modules/numeric/numeric.module.ts
+++ b/libs/components/core/src/lib/modules/numeric/numeric.module.ts
@@ -6,6 +6,7 @@ import { SkyNumericPipe } from './numeric.pipe';
 
 @NgModule({
   imports: [SkyCoreResourcesModule, SkyNumericPipe],
+  providers: [SkyNumericPipe],
   exports: [SkyNumericPipe],
 })
 export class SkyNumericModule {}

--- a/libs/components/core/src/lib/modules/percent-pipe/percent-pipe.module.ts
+++ b/libs/components/core/src/lib/modules/percent-pipe/percent-pipe.module.ts
@@ -6,6 +6,7 @@ import { SkyPercentPipe } from './percent.pipe';
 
 @NgModule({
   imports: [SkyCoreResourcesModule, SkyPercentPipe],
+  providers: [SkyPercentPipe],
   exports: [SkyPercentPipe],
 })
 export class SkyPercentPipeModule {}

--- a/libs/components/datetime/src/lib/modules/date-pipe/date-pipe.module.ts
+++ b/libs/components/datetime/src/lib/modules/date-pipe/date-pipe.module.ts
@@ -7,6 +7,7 @@ import { SkyFuzzyDatePipe } from './fuzzy-date.pipe';
 
 @NgModule({
   imports: [SkyDatetimeResourcesModule, SkyDatePipe, SkyFuzzyDatePipe],
+  providers: [SkyDatePipe, SkyFuzzyDatePipe],
   exports: [SkyDatePipe, SkyFuzzyDatePipe],
 })
 export class SkyDatePipeModule {}


### PR DESCRIPTION
Restores providers that were inadvertently removed in #4045.

[AB#3637634](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3637634)
