### PR TITLE
chore: release 13.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 # Changelog
 
 
+## [13.9.1](https://github.com/blackbaud/skyux/compare/13.9.0...13.9.1) (2025-12-02)
+
+
+### Bug Fixes
+
+* restore module providers ([#4096](https://github.com/blackbaud/skyux/issues/4096)) ([ed5703d](https://github.com/blackbaud/skyux/commit/ed5703d72369897c29ce8016417939818d65f994)), closes [#4045](https://github.com/blackbaud/skyux/issues/4045) [AB#3637634](https://github.com/AB/issues/3637634)
+
+
+
 # [13.9.0](https://github.com/blackbaud/skyux/compare/13.8.2...13.9.0) (2025-12-01)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "skyux",
-  "version": "13.9.0",
+  "version": "13.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "skyux",
-      "version": "13.9.0",
+      "version": "13.9.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skyux",
-  "version": "13.9.0",
+  "version": "13.9.1",
   "license": "MIT",
   "scripts": {
     "ng": "nx",


### PR DESCRIPTION
## [13.9.1](https://github.com/blackbaud/skyux/compare/13.9.0...13.9.1) (2025-12-02)


### Bug Fixes

* restore module providers ([#4096](https://github.com/blackbaud/skyux/issues/4096)) ([ed5703d](https://github.com/blackbaud/skyux/commit/ed5703d72369897c29ce8016417939818d65f994)), closes [#4045](https://github.com/blackbaud/skyux/issues/4045) [AB#3637634](https://github.com/AB/issues/3637634)