### PR TITLE
fix(components/autonumeric): return correct value when typing on an Android device

### DIFF
--- a/apps/playground/src/app/components/autonumeric/autonumeric.module.ts
+++ b/apps/playground/src/app/components/autonumeric/autonumeric.module.ts
@@ -1,0 +1,25 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+
+const routes: Routes = [
+  {
+    path: 'autonumeric',
+    loadChildren: () =>
+      import('./presets/autonumeric-presets.module').then(
+        (m) => m.AutonumericPresetsModule,
+      ),
+  },
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule],
+})
+export class AutonumericRoutingModule {}
+
+@NgModule({
+  imports: [AutonumericRoutingModule],
+})
+export class AutonumericModule {
+  public static routes = routes;
+}

--- a/apps/playground/src/app/components/autonumeric/presets/autonumeric-presets-routing.module.ts
+++ b/apps/playground/src/app/components/autonumeric/presets/autonumeric-presets-routing.module.ts
@@ -1,0 +1,25 @@
+import { NgModule } from '@angular/core';
+import { RouterModule } from '@angular/router';
+
+import { ComponentRouteInfo } from '../../../shared/component-info/component-route-info';
+
+import { AutonumericPresetsComponent } from './autonumeric-presets.component';
+
+const routes: ComponentRouteInfo[] = [
+  {
+    path: '',
+    component: AutonumericPresetsComponent,
+    data: {
+      name: 'Autonumeric (presets)',
+      icon: 'calculator',
+      library: 'autonumeric',
+    },
+  },
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+})
+export class AutonumericPresetsRoutingModule {
+  public static routes = routes;
+}

--- a/apps/playground/src/app/components/autonumeric/presets/autonumeric-presets.component.html
+++ b/apps/playground/src/app/components/autonumeric/presets/autonumeric-presets.component.html
@@ -7,4 +7,5 @@
     />
   </sky-input-box>
   <pre>{{ donationAmount.value | json }}</pre>
+  <p>Value changes count: {{ valueChangesCount }}</p>
 </form>

--- a/apps/playground/src/app/components/autonumeric/presets/autonumeric-presets.component.html
+++ b/apps/playground/src/app/components/autonumeric/presets/autonumeric-presets.component.html
@@ -1,11 +1,11 @@
 <form [formGroup]="formGroup">
   <sky-input-box labelText="Donation amount">
     <input
-      formControlName="donationAmount"
+      formControlName="amount"
       type="text"
       [skyAutonumeric]="autonumericOptions"
     />
   </sky-input-box>
-  <pre>{{ donationAmount.value | json }}</pre>
-  <p>Value changes count: {{ valueChangesCount }}</p>
+  <p>Raw value: {{ rawValue() }}</p>
+  <p>Value changes count: {{ valueChangesCount() }}</p>
 </form>

--- a/apps/playground/src/app/components/autonumeric/presets/autonumeric-presets.component.html
+++ b/apps/playground/src/app/components/autonumeric/presets/autonumeric-presets.component.html
@@ -1,0 +1,10 @@
+<form [formGroup]="formGroup">
+  <sky-input-box labelText="Donation amount">
+    <input
+      formControlName="donationAmount"
+      type="text"
+      [skyAutonumeric]="autonumericOptions"
+    />
+  </sky-input-box>
+  <pre>{{ donationAmount.value | json }}</pre>
+</form>

--- a/apps/playground/src/app/components/autonumeric/presets/autonumeric-presets.component.html
+++ b/apps/playground/src/app/components/autonumeric/presets/autonumeric-presets.component.html
@@ -1,10 +1,3 @@
-<sky-alert>
-  On Android devices, when an input is 1) initialized with a value and 2)
-  receives focus, the FIRST key press from the native phone keyboard does NOT
-  register a raw value change when serving the playground in development mode.
-  To see the fix, serve with the "production" configuration:
-  <code>npx nx serve playground --configuration production</code>.
-</sky-alert>
 <form [formGroup]="formGroup">
   <sky-input-box labelText="Donation amount">
     <input
@@ -16,3 +9,11 @@
   <p>Raw value: {{ rawValue() }}</p>
   <p>Value changes count: {{ valueChangesCount() }}</p>
 </form>
+
+<sky-alert class="sky-margin-stacked-xl">
+  Note: On Android devices, when an input is 1) initialized with a value and 2)
+  receives focus, the FIRST key press from the native phone keyboard does NOT
+  register a raw value change when serving the playground in development mode.
+  To see the fix, serve with the "production" configuration:<br />
+  <code>npx nx serve playground --configuration production</code>
+</sky-alert>

--- a/apps/playground/src/app/components/autonumeric/presets/autonumeric-presets.component.html
+++ b/apps/playground/src/app/components/autonumeric/presets/autonumeric-presets.component.html
@@ -1,3 +1,10 @@
+<sky-alert>
+  On Android devices, when an input is 1) initialized with a value and 2)
+  receives focus, the FIRST key press from the native phone keyboard does NOT
+  register a raw value change when serving the playground in development mode.
+  To see the fix, serve with the "production" configuration:
+  <code>npx nx serve playground --configuration production</code>.
+</sky-alert>
 <form [formGroup]="formGroup">
   <sky-input-box labelText="Donation amount">
     <input

--- a/apps/playground/src/app/components/autonumeric/presets/autonumeric-presets.component.ts
+++ b/apps/playground/src/app/components/autonumeric/presets/autonumeric-presets.component.ts
@@ -1,0 +1,40 @@
+import { JsonPipe } from '@angular/common';
+import { Component, inject } from '@angular/core';
+import {
+  FormBuilder,
+  FormControl,
+  FormGroup,
+  ReactiveFormsModule,
+  Validators,
+} from '@angular/forms';
+import {
+  SkyAutonumericModule,
+  SkyAutonumericOptions,
+} from '@skyux/autonumeric';
+import { SkyInputBoxModule } from '@skyux/forms';
+
+/**
+ * @title Predefined options
+ */
+@Component({
+  selector: 'app-autonumeric-preset',
+  templateUrl: './autonumeric-presets.component.html',
+  imports: [
+    JsonPipe,
+    ReactiveFormsModule,
+    SkyAutonumericModule,
+    SkyInputBoxModule,
+  ],
+})
+export class AutonumericPresetsComponent {
+  protected autonumericOptions: SkyAutonumericOptions = 'Chinese';
+
+  protected formGroup: FormGroup;
+  protected donationAmount = new FormControl(1234.5678, [Validators.required]);
+
+  constructor() {
+    this.formGroup = inject(FormBuilder).group({
+      donationAmount: this.donationAmount,
+    });
+  }
+}

--- a/apps/playground/src/app/components/autonumeric/presets/autonumeric-presets.component.ts
+++ b/apps/playground/src/app/components/autonumeric/presets/autonumeric-presets.component.ts
@@ -32,9 +32,15 @@ export class AutonumericPresetsComponent {
   protected formGroup: FormGroup;
   protected donationAmount = new FormControl(1234.5678, [Validators.required]);
 
+  protected valueChangesCount = 0;
+
   constructor() {
     this.formGroup = inject(FormBuilder).group({
       donationAmount: this.donationAmount,
+    });
+
+    this.donationAmount.valueChanges.subscribe(() => {
+      this.valueChangesCount++;
     });
   }
 }

--- a/apps/playground/src/app/components/autonumeric/presets/autonumeric-presets.component.ts
+++ b/apps/playground/src/app/components/autonumeric/presets/autonumeric-presets.component.ts
@@ -17,6 +17,7 @@ import {
   SkyAutonumericOptions,
 } from '@skyux/autonumeric';
 import { SkyInputBoxModule } from '@skyux/forms';
+import { SkyAlertModule } from '@skyux/indicators';
 
 /**
  * @title Predefined options
@@ -25,7 +26,12 @@ import { SkyInputBoxModule } from '@skyux/forms';
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'app-autonumeric-presets',
   templateUrl: './autonumeric-presets.component.html',
-  imports: [ReactiveFormsModule, SkyAutonumericModule, SkyInputBoxModule],
+  imports: [
+    ReactiveFormsModule,
+    SkyAlertModule,
+    SkyAutonumericModule,
+    SkyInputBoxModule,
+  ],
 })
 export class AutonumericPresetsComponent {
   readonly #amountControl = new FormControl(1234.5678, [Validators.required]);

--- a/apps/playground/src/app/components/autonumeric/presets/autonumeric-presets.module.ts
+++ b/apps/playground/src/app/components/autonumeric/presets/autonumeric-presets.module.ts
@@ -1,0 +1,11 @@
+import { NgModule } from '@angular/core';
+
+import { AutonumericPresetsRoutingModule } from './autonumeric-presets-routing.module';
+import { AutonumericPresetsComponent } from './autonumeric-presets.component';
+
+@NgModule({
+  imports: [AutonumericPresetsComponent, AutonumericPresetsRoutingModule],
+})
+export class AutonumericPresetsModule {
+  public static routes = AutonumericPresetsRoutingModule.routes;
+}

--- a/apps/playground/src/app/components/components.module.ts
+++ b/apps/playground/src/app/components/components.module.ts
@@ -26,6 +26,13 @@ export const componentRoutes: Routes = [
       ),
   },
   {
+    path: 'autonumeric',
+    loadChildren: () =>
+      import('./autonumeric/autonumeric.module').then(
+        (m) => m.AutonumericModule,
+      ),
+  },
+  {
     path: 'avatar',
     loadChildren: () =>
       import('./avatar/avatar.module').then((m) => m.AvatarModule),

--- a/libs/components/autonumeric/src/lib/modules/autonumeric/autonumeric.directive.spec.ts
+++ b/libs/components/autonumeric/src/lib/modules/autonumeric/autonumeric.directive.spec.ts
@@ -270,6 +270,35 @@ describe('Autonumeric directive', () => {
     await expectAsync(fixture.nativeElement).toBeAccessible();
   });
 
+  it('should handle autoNumeric:rawValueModified event for Android Chrome workaround', fakeAsync(() => {
+    detectChangesTick();
+
+    const input = fixture.nativeElement.querySelector('input');
+
+    // Set value programmatically first to ensure we have a baseline
+    setValue(1000);
+    expect(fixture.componentInstance.formControl.value).toEqual(1000);
+
+    // Simulate user interaction - set the input value directly and fire input event
+    input.value = '2500';
+    SkyAppTestUtility.fireDomEvent(input, 'input');
+    detectChangesTick();
+
+    // Verify the input event updated the value
+    const valueAfterInput = fixture.componentInstance.formControl.value;
+
+    // Now fire the autoNumeric:rawValueModified event
+    // This simulates the Android Chrome behavior where this event provides
+    // the correct value when the input event lags behind
+    SkyAppTestUtility.fireDomEvent(input, 'autoNumeric:rawValueModified');
+    detectChangesTick();
+
+    // The value should be updated (even if input event didn't catch it)
+    expect(fixture.componentInstance.formControl.value).toEqual(
+      valueAfterInput,
+    );
+  }));
+
   describe('global configuration', () => {
     beforeEach(() => {
       TestBed.resetTestingModule();

--- a/libs/components/autonumeric/src/lib/modules/autonumeric/autonumeric.directive.spec.ts
+++ b/libs/components/autonumeric/src/lib/modules/autonumeric/autonumeric.directive.spec.ts
@@ -290,6 +290,21 @@ describe('Autonumeric directive', () => {
     expect(getModelValue()).toEqual(1000);
   }));
 
+  it('should not mark control as dirty when value is set programmatically', fakeAsync(() => {
+    detectChangesTick();
+
+    verifyFormControlStatuses({
+      dirty: false,
+    });
+
+    fixture.componentInstance.formControl.setValue(500);
+    fixture.detectChanges();
+
+    verifyFormControlStatuses({
+      dirty: false, // Should remain false as this is programmatic, not user interaction
+    });
+  }));
+
   describe('global configuration', () => {
     beforeEach(() => {
       TestBed.resetTestingModule();

--- a/libs/components/autonumeric/src/lib/modules/autonumeric/autonumeric.directive.spec.ts
+++ b/libs/components/autonumeric/src/lib/modules/autonumeric/autonumeric.directive.spec.ts
@@ -273,30 +273,21 @@ describe('Autonumeric directive', () => {
   it('should handle autoNumeric:rawValueModified event for Android Chrome workaround', fakeAsync(() => {
     detectChangesTick();
 
-    const input = fixture.nativeElement.querySelector('input');
-
-    // Set value programmatically first to ensure we have a baseline
+    // Set initial value
     setValue(1000);
-    expect(fixture.componentInstance.formControl.value).toEqual(1000);
+    expect(getModelValue()).toEqual(1000);
 
-    // Simulate user interaction - set the input value directly and fire input event
-    input.value = '2500';
+    const input = getReactiveInput();
+
+    // Simulate the autoNumeric:rawValueModified event being fired
+    // In real Android Chrome, this would fire alongside input events
     SkyAppTestUtility.fireDomEvent(input, 'input');
-    detectChangesTick();
-
-    // Verify the input event updated the value
-    const valueAfterInput = fixture.componentInstance.formControl.value;
-
-    // Now fire the autoNumeric:rawValueModified event
-    // This simulates the Android Chrome behavior where this event provides
-    // the correct value when the input event lags behind
     SkyAppTestUtility.fireDomEvent(input, 'autoNumeric:rawValueModified');
     detectChangesTick();
 
-    // The value should be updated (even if input event didn't catch it)
-    expect(fixture.componentInstance.formControl.value).toEqual(
-      valueAfterInput,
-    );
+    // The event handler should process without errors
+    // The value should remain 1000 since we didn't actually change the input
+    expect(getModelValue()).toEqual(1000);
   }));
 
   describe('global configuration', () => {

--- a/libs/components/autonumeric/src/lib/modules/autonumeric/autonumeric.directive.ts
+++ b/libs/components/autonumeric/src/lib/modules/autonumeric/autonumeric.directive.ts
@@ -1,14 +1,15 @@
 import {
   ChangeDetectorRef,
+  DestroyRef,
   Directive,
   ElementRef,
-  HostListener,
   Input,
   OnDestroy,
-  OnInit,
   Renderer2,
   forwardRef,
+  inject,
 } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import {
   AbstractControl,
   ControlValueAccessor,
@@ -19,8 +20,7 @@ import {
 } from '@angular/forms';
 
 import AutoNumeric from 'autonumeric';
-import { Subject, fromEvent } from 'rxjs';
-import { takeUntil } from 'rxjs/operators';
+import { filter, fromEvent } from 'rxjs';
 
 import { SkyAutonumericOptions } from './autonumeric-options';
 import { SkyAutonumericOptionsProvider } from './autonumeric-options-provider';
@@ -45,10 +45,19 @@ const SKY_AUTONUMERIC_VALIDATOR = {
   selector: 'input[skyAutonumeric]',
   providers: [SKY_AUTONUMERIC_VALUE_ACCESSOR, SKY_AUTONUMERIC_VALIDATOR],
   standalone: false,
+  host: {
+    '(blur)': 'onBlur()',
+  },
 })
 export class SkyAutonumericDirective
-  implements OnInit, OnDestroy, ControlValueAccessor, Validator
+  implements OnDestroy, ControlValueAccessor, Validator
 {
+  readonly #destroyRef = inject(DestroyRef);
+  readonly #elementRef = inject(ElementRef<HTMLInputElement>);
+  readonly #globalConfig = inject(SkyAutonumericOptionsProvider);
+  readonly #renderer = inject(Renderer2);
+  readonly #changeDetector = inject(ChangeDetectorRef);
+
   /**
    * Assigns the name of a property from `SkyAutonumericOptionsProvider`.
    */
@@ -64,118 +73,49 @@ export class SkyAutonumericDirective
   @Input()
   public skyAutonumericFormChangesUnformatted: boolean | undefined = false;
 
-  #autonumericInstance: AutoNumeric;
-  #autonumericOptions: SkyAutonumericOptions | undefined;
   #control: AbstractControl | undefined;
-  #isFirstChange = true;
   #value: number | undefined;
+  #isFirstChange = true;
+  #isWritingValue = false;
+  #userInteracted = false;
 
-  #ngUnsubscribe = new Subject<void>();
+  #autonumericInstance: AutoNumeric;
+  #autonumericOptions = this.#globalConfig.getConfig();
 
-  #elementRef: ElementRef;
-  #globalConfig: SkyAutonumericOptionsProvider;
-  #renderer: Renderer2;
-  #changeDetector: ChangeDetectorRef;
-
-  constructor(
-    elementRef: ElementRef,
-    globalConfig: SkyAutonumericOptionsProvider,
-    renderer: Renderer2,
-    changeDetector: ChangeDetectorRef,
-  ) {
-    this.#elementRef = elementRef;
-    this.#globalConfig = globalConfig;
-    this.#renderer = renderer;
-    this.#changeDetector = changeDetector;
-
-    this.#autonumericInstance = new AutoNumeric(elementRef.nativeElement);
-  }
-
-  public ngOnInit(): void {
-    // Ensure that we set the global config even if no local config has been given.
-    if (!this.#autonumericOptions) {
-      this.#autonumericOptions = this.#globalConfig.getConfig();
-    }
+  constructor() {
+    this.#autonumericInstance = new AutoNumeric(this.#elementRef.nativeElement);
     this.#updateAutonumericInstance();
-
-    fromEvent(this.#elementRef.nativeElement, 'input')
-      .pipe(takeUntil(this.#ngUnsubscribe))
-      .subscribe(() => {
-        const numericValue: number | undefined = this.#getNumericValue();
-
-        /* istanbul ignore else */
-        if (this.#value !== numericValue) {
-          this.#value = numericValue;
-          this.#onChange(numericValue);
-        }
-
-        /* istanbul ignore else */
-        if (this.#control && !this.#control.dirty) {
-          this.#control.markAsDirty();
-        }
-
-        this.#changeDetector.markForCheck();
-      });
+    this.#setupValueChangeListeners();
   }
 
   public ngOnDestroy(): void {
     this.#autonumericInstance.remove();
-    this.#ngUnsubscribe.next();
-    this.#ngUnsubscribe.complete();
   }
 
-  /**
-   * Implemented as part of ControlValueAccessor.
-   */
+  public writeValue(value: number | undefined): void {
+    this.#value = value;
+    this.#markPristineOnFirstChange();
+    this.#updateViewValue(value);
+  }
+
+  public validate(control: AbstractControl): ValidationErrors | null {
+    this.#control ??= control;
+
+    if (control.value === null || control.value === undefined) {
+      return null;
+    }
+
+    return typeof control.value === 'number'
+      ? null
+      : { notTypeOfNumber: { value: control.value } };
+  }
+
   public setDisabledState(value: boolean): void {
     this.#renderer.setProperty(
       this.#elementRef.nativeElement,
       'disabled',
       value,
     );
-  }
-
-  public writeValue(value: number | undefined): void {
-    if (this.#value !== value) {
-      this.#value = value;
-      this.#onChange(value);
-
-      // Mark the control as "pristine" if it is initialized with a value.
-      if (this.#isFirstChange && this.#control && this.#value !== null) {
-        this.#isFirstChange = false;
-        this.#control.markAsPristine();
-      }
-    }
-
-    if (typeof value === 'number') {
-      if (this.skyAutonumericFormChangesUnformatted) {
-        this.#autonumericInstance.setUnformatted(value.toString());
-      } else {
-        this.#autonumericInstance.set(value.toString());
-      }
-    } else {
-      this.#autonumericInstance.clear();
-    }
-  }
-
-  public validate(control: AbstractControl): ValidationErrors | null {
-    const noErrors = null;
-
-    if (!this.#control) {
-      this.#control = control;
-    }
-
-    if (control.value === null || control.value === undefined) {
-      return noErrors;
-    }
-
-    if (typeof control.value !== 'number') {
-      return {
-        notTypeOfNumber: { value: control.value },
-      };
-    }
-
-    return noErrors;
   }
 
   public registerOnChange(fn: (value: number | undefined) => void): void {
@@ -186,19 +126,114 @@ export class SkyAutonumericDirective
     this.#onTouched = fn;
   }
 
-  @HostListener('blur')
   public onBlur(): void {
     this.#onTouched();
   }
 
+  /**
+   * Setup event listeners for value changes.
+   * Workaround for https://github.com/autoNumeric/autoNumeric/issues/781
+   * On Android Chrome, the 'input' event may lag behind actual input.
+   * We listen to both 'input' and 'autoNumeric:rawValueModified' events.
+   */
+  #setupValueChangeListeners(): void {
+    // The 'input' event indicates user interaction.
+    fromEvent(this.#elementRef.nativeElement, 'input')
+      .pipe(takeUntilDestroyed(this.#destroyRef))
+      .subscribe(() => {
+        this.#userInteracted = true;
+        this.#handleValueChange();
+      });
+
+    // The 'autoNumeric:rawValueModified' event can fire on both user interaction
+    // and programmatic changes, so we handle value updates here.
+    fromEvent(this.#elementRef.nativeElement, 'autoNumeric:rawValueModified')
+      .pipe(
+        // Ignore events during writeValue to prevent interfering with validation
+        filter(() => !this.#isWritingValue),
+        takeUntilDestroyed(this.#destroyRef),
+      )
+      .subscribe(() => this.#handleValueChange());
+  }
+
+  /**
+   * Handle value changes from user input or AutoNumeric events.
+   */
+  #handleValueChange(): void {
+    const numericValue = this.#getNumericValue();
+
+    if (this.#value !== numericValue) {
+      this.#value = numericValue;
+      this.#onChange(numericValue);
+    }
+
+    if (this.#control && !this.#control.dirty && this.#userInteracted) {
+      this.#control.markAsDirty();
+    }
+
+    this.#changeDetector.markForCheck();
+  }
+
+  /**
+   * Mark the control as pristine on first change with a value.
+   */
+  #markPristineOnFirstChange(): void {
+    if (
+      this.#isFirstChange &&
+      this.#control &&
+      this.#value !== null &&
+      this.#value !== undefined
+    ) {
+      this.#isFirstChange = false;
+      this.#control.markAsPristine();
+    }
+  }
+
+  /**
+   * Get the current numeric value from the input.
+   * Returns undefined if the input is empty or contains only the currency symbol.
+   */
   #getNumericValue(): number | undefined {
-    const inputValue = this.#getInputValue();
+    const inputValue = this.#elementRef.nativeElement.value;
+    if (!inputValue || this.#isInputValueTheCurrencySymbol(inputValue)) {
+      return undefined;
+    }
+
     const numericValue = this.#autonumericInstance.getNumber();
-    return inputValue &&
-      !this.#isInputValueTheCurrencySymbol(inputValue) &&
-      typeof numericValue === 'number'
-      ? numericValue
-      : undefined;
+    if (typeof numericValue === 'number') {
+      return numericValue;
+    }
+
+    /* istanbul ignore next: safety check */
+    return undefined;
+  }
+
+  /**
+   * Update the view (input element) with the new value.
+   */
+  #updateViewValue(value: number | undefined): void {
+    this.#isWritingValue = true;
+    try {
+      if (typeof value === 'number') {
+        this.#setNumericValue(value);
+      } else {
+        this.#autonumericInstance.clear();
+      }
+    } finally {
+      this.#isWritingValue = false;
+    }
+  }
+
+  /**
+   * Set a numeric value using AutoNumeric.
+   */
+  #setNumericValue(value: number): void {
+    const valueString = value.toString();
+    if (this.skyAutonumericFormChangesUnformatted) {
+      this.#autonumericInstance.setUnformatted(valueString);
+    } else {
+      this.#autonumericInstance.set(valueString);
+    }
   }
 
   /**
@@ -212,11 +247,8 @@ export class SkyAutonumericDirective
     const currencySymbol = (
       (this.#autonumericOptions as AutoNumeric.Options)?.currencySymbol ?? ''
     ).trim();
-    return !!currencySymbol && inputValue === currencySymbol;
-  }
 
-  #getInputValue(): string {
-    return this.#elementRef.nativeElement.value;
+    return !!currencySymbol && inputValue === currencySymbol;
   }
 
   #updateAutonumericInstance(): void {
@@ -225,27 +257,39 @@ export class SkyAutonumericDirective
     );
   }
 
+  /**
+   * Merge global and local AutoNumeric options.
+   */
   #mergeOptions(
     value: SkyAutonumericOptions | undefined,
   ): SkyAutonumericOptions {
-    const globalOptions: SkyAutonumericOptions = this.#globalConfig.getConfig();
+    const globalOptions = this.#globalConfig.getConfig();
+    const localOptions = this.#resolveOptions(value);
 
-    let newOptions: SkyAutonumericOptions | undefined;
+    return Object.assign({}, globalOptions, localOptions);
+  }
+
+  /**
+   * Resolve options from string preset name or return as-is.
+   */
+  #resolveOptions(
+    value: SkyAutonumericOptions | undefined,
+  ): SkyAutonumericOptions | undefined {
     if (typeof value === 'string') {
       const predefinedOptions = AutoNumeric.getPredefinedOptions();
-      newOptions = predefinedOptions[
+
+      return predefinedOptions[
         value as keyof AutoNumeric.Options
       ] as AutoNumeric.Options;
-    } else {
-      newOptions = value;
     }
 
-    return Object.assign({}, globalOptions, newOptions);
+    return value;
   }
 
   // istanbul ignore next
   // eslint-disable-next-line @typescript-eslint/no-empty-function , @typescript-eslint/no-unused-vars
   #onChange = (_: number | undefined): void => {};
+
   // istanbul ignore next
   // eslint-disable-next-line @typescript-eslint/no-empty-function
   #onTouched = (): void => {};

--- a/libs/components/autonumeric/src/lib/modules/autonumeric/autonumeric.directive.ts
+++ b/libs/components/autonumeric/src/lib/modules/autonumeric/autonumeric.directive.ts
@@ -120,11 +120,9 @@ export class SkyAutonumericDirective
       .pipe(takeUntil(this.#ngUnsubscribe))
       .subscribe(() => {
         // Prevent processing during programmatic changes via writeValue().
-        if (this.#isWritingValue) {
-          return;
+        if (!this.#isWritingValue) {
+          this.#handleValueChange();
         }
-
-        this.#handleValueChange();
       });
   }
 

--- a/libs/components/autonumeric/src/lib/modules/autonumeric/autonumeric.directive.ts
+++ b/libs/components/autonumeric/src/lib/modules/autonumeric/autonumeric.directive.ts
@@ -204,7 +204,7 @@ export class SkyAutonumericDirective
   }
 
   #handleValueChange(): void {
-    const numericValue: number | undefined = this.#getNumericValue();
+    const numericValue = this.#getNumericValue();
 
     if (this.#value !== numericValue) {
       this.#value = numericValue;

--- a/libs/components/autonumeric/src/lib/modules/autonumeric/autonumeric.directive.ts
+++ b/libs/components/autonumeric/src/lib/modules/autonumeric/autonumeric.directive.ts
@@ -111,8 +111,11 @@ export class SkyAutonumericDirective
         this.#changeDetector.markForCheck();
       });
 
-    // Workaround for Android Chrome input lag issue:
-    // https://github.com/autoNumeric/autoNumeric/issues/781
+    // On Android browsers, the native `input` event fires before AutoNumeric's
+    // `autoNumeric:rawValueModified` event (on other browsers, the order is reversed).
+    // To support Android without breaking existing behavior, we listen to both events.
+    // The filter prevents processing during programmatic changes via writeValue().
+    // See: https://github.com/autoNumeric/autoNumeric/issues/781
     fromEvent(this.#elementRef.nativeElement, 'autoNumeric:rawValueModified')
       .pipe(
         filter(() => !this.#isWritingValue),

--- a/libs/components/autonumeric/src/lib/modules/autonumeric/autonumeric.directive.ts
+++ b/libs/components/autonumeric/src/lib/modules/autonumeric/autonumeric.directive.ts
@@ -69,7 +69,6 @@ export class SkyAutonumericDirective
   #control: AbstractControl | undefined;
   #isFirstChange = true;
   #isWritingValue = false;
-  #userInteracted = false;
   #value: number | undefined;
 
   #ngUnsubscribe = new Subject<void>();
@@ -103,8 +102,13 @@ export class SkyAutonumericDirective
     fromEvent(this.#elementRef.nativeElement, 'input')
       .pipe(takeUntil(this.#ngUnsubscribe))
       .subscribe(() => {
-        this.#userInteracted = true;
         this.#handleValueChange();
+
+        if (this.#control && !this.#control.dirty) {
+          this.#control.markAsDirty();
+        }
+
+        this.#changeDetector.markForCheck();
       });
 
     // Workaround for Android Chrome input lag issue:
@@ -199,18 +203,10 @@ export class SkyAutonumericDirective
   #handleValueChange(): void {
     const numericValue: number | undefined = this.#getNumericValue();
 
-    /* istanbul ignore else */
     if (this.#value !== numericValue) {
       this.#value = numericValue;
       this.#onChange(numericValue);
     }
-
-    /* istanbul ignore else */
-    if (this.#userInteracted && this.#control && !this.#control.dirty) {
-      this.#control.markAsDirty();
-    }
-
-    this.#changeDetector.markForCheck();
   }
 
   #getNumericValue(): number | undefined {


### PR DESCRIPTION
[AB#3617801](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3617801)

This pull request is a workaround. ~I've created a [PR into AutoNumeric](https://github.com/autoNumeric/autoNumeric/pull/821) to fix the source, but we may need to merge this in if it doesn't work out.~ The "fix" felt like a hack. The AutoNumeric team recognizes that the event handling is complex and [needs a refactor](https://github.com/autoNumeric/autoNumeric/issues/400); let's add this workaround until they've had a chance to clean things up on their end.
