### PR TITLE
fix(components/forms): icon checkboxes use correct border radius token in modern theme

### DIFF
--- a/libs/components/forms/src/lib/modules/checkbox/checkbox.component.html
+++ b/libs/components/forms/src/lib/modules/checkbox/checkbox.component.html
@@ -32,7 +32,7 @@
       (change)="onInteractionEvent($event)"
     />
     <span
-      class="sky-switch-control sky-rounded-corners"
+      class="sky-switch-control"
       [ngClass]="{
         'sky-switch-control-icon': iconName,
         'sky-switch-control-info': checkboxType === 'info',

--- a/libs/components/forms/src/lib/modules/checkbox/checkbox.component.html
+++ b/libs/components/forms/src/lib/modules/checkbox/checkbox.component.html
@@ -40,6 +40,9 @@
         'sky-switch-control-warning': checkboxType === 'warning',
         'sky-switch-control-danger': checkboxType === 'danger'
       }"
+      [skyThemeClass]="{
+        'sky-rounded-corners': 'default'
+      }"
     >
       @if (iconName) {
         <sky-icon variant="solid" [iconName]="iconName" />

--- a/libs/components/forms/src/lib/modules/checkbox/checkbox.modern.component.scss
+++ b/libs/components/forms/src/lib/modules/checkbox/checkbox.modern.component.scss
@@ -23,7 +23,7 @@
     padding-left: var(--sky-space-gap-label-s);
   }
 
-  .sky-switch-control {
+  .sky-switch-control:not(.sky-switch-control-icon) {
     border-radius: var(--sky-comp-checkbox-border-radius);
   }
 }

--- a/libs/components/forms/src/lib/modules/radio/radio.component.html
+++ b/libs/components/forms/src/lib/modules/radio/radio.component.html
@@ -22,7 +22,6 @@
       class="sky-switch-control"
       [ngClass]="{
         'sky-switch-control-icon': iconName,
-        'sky-rounded-corners': iconName,
         'sky-rounded-circle': !iconName,
         'sky-switch-control-info': iconName && radioType === 'info',
         'sky-switch-control-success': iconName && radioType === 'success',

--- a/libs/components/theme/src/lib/styles/themes/modern/_switch.scss
+++ b/libs/components/theme/src/lib/styles/themes/modern/_switch.scss
@@ -174,6 +174,7 @@
     transition: $sky-form-border-and-color-transitions;
 
     &.sky-switch-control-icon {
+      border-radius: var(--sky-border-radius-s);
       max-width: none;
       width: calc(
         var(--sky-size-icon-m) +
@@ -225,7 +226,6 @@
   .sky-switch-control-icon {
     margin-left: 0;
     margin-right: 0;
-    border-radius: 0;
   }
 
   .sky-switch-control {
@@ -303,9 +303,5 @@
 
   sky-checkbox:last-of-type .sky-switch-control-icon {
     margin-right: 0;
-  }
-
-  sky-radio .sky-switch-control-icon {
-    border-radius: var(--sky-border-radius-s);
   }
 }


### PR DESCRIPTION
[AB#3626328](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3626328)