### PR TITLE
fix(components/autonumeric): return correct value when typing on an Android device (#4104)

### DIFF
--- a/apps/playground/src/app/components/autonumeric/presets/autonumeric-presets.component.html
+++ b/apps/playground/src/app/components/autonumeric/presets/autonumeric-presets.component.html
@@ -1,9 +1,19 @@
 <form [formGroup]="formGroup">
   <sky-input-box labelText="Donation amount">
     <input
-      formControlName="donationAmount"
+      formControlName="amount"
       type="text"
       [skyAutonumeric]="autonumericOptions"
     />
   </sky-input-box>
+  <p>Raw value: {{ rawValue() }}</p>
+  <p>Value changes count: {{ valueChangesCount() }}</p>
 </form>
+
+<sky-alert class="sky-margin-stacked-xl">
+  Note: On Android devices, when an input is 1) initialized with a value and 2)
+  receives focus, the FIRST key press from the native phone keyboard does NOT
+  register a raw value change when serving the playground in development mode.
+  To see the fix, serve with the "production" configuration:<br />
+  <code>npx nx serve playground --configuration production</code>
+</sky-alert>

--- a/apps/playground/src/app/components/autonumeric/presets/autonumeric-presets.component.ts
+++ b/apps/playground/src/app/components/autonumeric/presets/autonumeric-presets.component.ts
@@ -1,8 +1,14 @@
-import { Component, inject } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  effect,
+  inject,
+  signal,
+} from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
 import {
   FormBuilder,
   FormControl,
-  FormGroup,
   ReactiveFormsModule,
   Validators,
 } from '@angular/forms';
@@ -11,23 +17,41 @@ import {
   SkyAutonumericOptions,
 } from '@skyux/autonumeric';
 import { SkyInputBoxModule } from '@skyux/forms';
+import { SkyAlertModule } from '@skyux/indicators';
 
 /**
  * @title Predefined options
  */
 @Component({
-  selector: 'app-autonumeric-preset',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  selector: 'app-autonumeric-presets',
   templateUrl: './autonumeric-presets.component.html',
-  imports: [ReactiveFormsModule, SkyAutonumericModule, SkyInputBoxModule],
+  imports: [
+    ReactiveFormsModule,
+    SkyAlertModule,
+    SkyAutonumericModule,
+    SkyInputBoxModule,
+  ],
 })
 export class AutonumericPresetsComponent {
+  readonly #amountControl = new FormControl(1234.5678, [Validators.required]);
+
+  protected readonly formGroup = inject(FormBuilder).group({
+    amount: this.#amountControl,
+  });
+
   protected autonumericOptions: SkyAutonumericOptions = 'Chinese';
 
-  protected formGroup: FormGroup;
+  protected readonly rawValue = toSignal(this.#amountControl.valueChanges, {
+    initialValue: this.#amountControl.value,
+  });
+
+  protected readonly valueChangesCount = signal(0);
 
   constructor() {
-    this.formGroup = inject(FormBuilder).group({
-      donationAmount: new FormControl(1234.5678, [Validators.required]),
+    effect(() => {
+      this.rawValue();
+      this.valueChangesCount.update((count) => count + 1);
     });
   }
 }

--- a/apps/playground/src/app/components/components.module.ts
+++ b/apps/playground/src/app/components/components.module.ts
@@ -26,6 +26,13 @@ export const componentRoutes: Routes = [
       ),
   },
   {
+    path: 'autonumeric',
+    loadChildren: () =>
+      import('./autonumeric/autonumeric.module').then(
+        (m) => m.AutonumericModule,
+      ),
+  },
+  {
     path: 'avatar',
     loadChildren: () =>
       import('./avatar/avatar.module').then((m) => m.AvatarModule),

--- a/libs/components/autonumeric/src/lib/modules/autonumeric/autonumeric.directive.ts
+++ b/libs/components/autonumeric/src/lib/modules/autonumeric/autonumeric.directive.ts
@@ -67,6 +67,7 @@ export class SkyAutonumericDirective
   #autonumericOptions: SkyAutonumericOptions | undefined;
   #control: AbstractControl | undefined;
   #isFirstChange = true;
+  #isWritingValue = false;
   #value: number | undefined;
 
   #ngUnsubscribe = new Subject<void>();
@@ -100,13 +101,7 @@ export class SkyAutonumericDirective
     fromEvent(this.#elementRef.nativeElement, 'input')
       .pipe(takeUntil(this.#ngUnsubscribe))
       .subscribe(() => {
-        const numericValue: number | undefined = this.#getNumericValue();
-
-        /* istanbul ignore else */
-        if (this.#value !== numericValue) {
-          this.#value = numericValue;
-          this.#onChange(numericValue);
-        }
+        this.#handleValueChange();
 
         /* istanbul ignore else */
         if (this.#control && !this.#control.dirty) {
@@ -114,6 +109,19 @@ export class SkyAutonumericDirective
         }
 
         this.#changeDetector.markForCheck();
+      });
+
+    // On Android browsers, the native `input` event fires before AutoNumeric's
+    // `autoNumeric:rawValueModified` event (on other browsers, the order is reversed).
+    // To support Android without breaking existing behavior, we listen to both events.
+    // See: https://github.com/autoNumeric/autoNumeric/issues/781
+    fromEvent(this.#elementRef.nativeElement, 'autoNumeric:rawValueModified')
+      .pipe(takeUntil(this.#ngUnsubscribe))
+      .subscribe(() => {
+        // Prevent processing during programmatic changes via writeValue().
+        if (!this.#isWritingValue) {
+          this.#handleValueChange();
+        }
       });
   }
 
@@ -135,6 +143,8 @@ export class SkyAutonumericDirective
   }
 
   public writeValue(value: number | undefined): void {
+    this.#isWritingValue = true;
+
     if (this.#value !== value) {
       this.#value = value;
       this.#onChange(value);
@@ -155,6 +165,8 @@ export class SkyAutonumericDirective
     } else {
       this.#autonumericInstance.clear();
     }
+
+    this.#isWritingValue = false;
   }
 
   public validate(control: AbstractControl): ValidationErrors | null {
@@ -188,6 +200,15 @@ export class SkyAutonumericDirective
   @HostListener('blur')
   public onBlur(): void {
     this.#onTouched();
+  }
+
+  #handleValueChange(): void {
+    const numericValue = this.#getNumericValue();
+
+    if (this.#value !== numericValue) {
+      this.#value = numericValue;
+      this.#onChange(numericValue);
+    }
   }
 
   #getNumericValue(): number | undefined {


### PR DESCRIPTION
[AB#3617801](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3617801)

This pull request is a workaround. ~I've created a [PR into AutoNumeric](https://github.com/autoNumeric/autoNumeric/pull/821) to fix the source, but we may need to merge this in if it doesn't work out.~ The "fix" felt like a hack. The AutoNumeric team recognizes that the event handling is complex and [needs a
refactor](https://github.com/autoNumeric/autoNumeric/issues/400); let's add this workaround until they've had a chance to clean things up on their end.