### PR TITLE
fix(components/ag-grid): cell editors should stop editing on focusout event (#4117)

### DIFF
--- a/libs/components/ag-grid/src/lib/modules/ag-grid/cell-editors/cell-editor-currency/cell-editor-currency.component.spec.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/cell-editors/cell-editor-currency/cell-editor-currency.component.spec.ts
@@ -531,6 +531,37 @@ describe('SkyCellEditorCurrencyComponent', () => {
         expect(input.focus).toHaveBeenCalled();
         expect(cellEditorParams.api?.stopEditing).not.toHaveBeenCalled();
       }));
+
+      it('should call stopEditing when focusout from input and stopEditingWhenCellsLoseFocus is true', fakeAsync(() => {
+        const api = jasmine.createSpyObj<GridApi>([
+          'getDisplayNameForColumn',
+          'stopEditing',
+          'getGridOption',
+        ]);
+        api.getDisplayNameForColumn.and.returnValue('');
+        api.getGridOption.and.returnValue(true);
+
+        currencyEditorComponent.agInit({
+          ...(cellEditorParams as ICellEditorParams),
+          api,
+        });
+        currencyEditorFixture.detectChanges();
+
+        const input = currencyEditorFixture.nativeElement.querySelector(
+          'input',
+        ) as HTMLInputElement;
+
+        currencyEditorComponent.onFocusOut({
+          target: input,
+          relatedTarget: null,
+        } as unknown as FocusEvent);
+        tick();
+
+        expect(api.getGridOption).toHaveBeenCalledWith(
+          'stopEditingWhenCellsLoseFocus',
+        );
+        expect(api.stopEditing).toHaveBeenCalled();
+      }));
     });
 
     it('returns undefined if the value is not set', () => {

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/cell-editors/cell-editor-currency/cell-editor-currency.component.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/cell-editors/cell-editor-currency/cell-editor-currency.component.ts
@@ -63,6 +63,8 @@ export class SkyAgGridCellEditorCurrencyComponent
       // If focus is being set to the grid cell, schedule focus on the input.
       // This happens when the refreshCells API is called.
       this.afterGuiAttached();
+    } else if (event.target === this.input?.nativeElement) {
+      this.#stopEditingOnBlur();
     }
   }
 
@@ -163,5 +165,11 @@ export class SkyAgGridCellEditorCurrencyComponent
       this.params.stopEditing();
     }
     this.#initialized = true;
+  }
+
+  #stopEditingOnBlur(): void {
+    if (this.params?.api.getGridOption('stopEditingWhenCellsLoseFocus')) {
+      this.params?.api.stopEditing();
+    }
   }
 }

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/cell-editors/cell-editor-number/cell-editor-number.component.spec.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/cell-editors/cell-editor-number/cell-editor-number.component.spec.ts
@@ -102,7 +102,7 @@ describe('SkyCellEditorNumberComponent', () => {
       expect(numberEditorComponent.editorForm.get('number')?.value).toBeNull();
       expect(numberEditorComponent.columnWidth).toBeUndefined();
 
-      numberEditorComponent.agInit(cellEditorParams as ICellEditorParams);
+      numberEditorComponent.refresh(cellEditorParams as ICellEditorParams);
 
       expect(numberEditorComponent.editorForm.get('number')?.value).toEqual(
         value,
@@ -407,6 +407,37 @@ describe('SkyCellEditorNumberComponent', () => {
         tick();
         expect(input).toBeVisible();
         expect(input.focus).toHaveBeenCalled();
+      }));
+
+      it('should call stopEditing when focusout from input and stopEditingWhenCellsLoseFocus is true', fakeAsync(() => {
+        const api = jasmine.createSpyObj<GridApi>([
+          'getDisplayNameForColumn',
+          'stopEditing',
+          'getGridOption',
+        ]);
+        api.getDisplayNameForColumn.and.returnValue('');
+        api.getGridOption.and.returnValue(true);
+
+        numberEditorComponent.agInit({
+          ...(cellEditorParams as ICellEditorParams),
+          api,
+        });
+        numberEditorFixture.detectChanges();
+
+        const input = numberEditorFixture.nativeElement.querySelector(
+          'input',
+        ) as HTMLInputElement;
+
+        numberEditorComponent.onFocusOut({
+          target: input,
+          relatedTarget: null,
+        } as unknown as FocusEvent);
+        tick();
+
+        expect(api.getGridOption).toHaveBeenCalledWith(
+          'stopEditingWhenCellsLoseFocus',
+        );
+        expect(api.stopEditing).toHaveBeenCalled();
       }));
 
       describe('cellStartedEdit is true', () => {

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/cell-editors/cell-editor-number/cell-editor-number.component.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/cell-editors/cell-editor-number/cell-editor-number.component.ts
@@ -55,6 +55,8 @@ export class SkyAgGridCellEditorNumberComponent
       // If focus is being set to the grid cell, schedule focus on the input.
       // This happens when the refreshCells API is called.
       this.afterGuiAttached();
+    } else if (event.target === this.input?.nativeElement) {
+      this.#stopEditingOnBlur();
     }
   }
 
@@ -99,6 +101,10 @@ export class SkyAgGridCellEditorNumberComponent
     this.rowHeightWithoutBorders = (this.#params.node.rowHeight as number) - 4;
   }
 
+  public refresh(params: SkyCellEditorNumberParams): void {
+    this.agInit(params);
+  }
+
   /**
    * afterGuiAttached is called by agGrid after the editor is rendered in the DOM. Once it is attached the editor is ready to be focused on.
    */
@@ -122,5 +128,11 @@ export class SkyAgGridCellEditorNumberComponent
   public getValue(): number | undefined {
     const val = this.editorForm.get('number')?.value;
     return val !== undefined && val !== null ? val : undefined;
+  }
+
+  #stopEditingOnBlur(): void {
+    if (this.#params?.api.getGridOption('stopEditingWhenCellsLoseFocus')) {
+      this.#params?.api.stopEditing();
+    }
   }
 }

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/cell-editors/cell-editor-text/cell-editor-text.component.spec.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/cell-editors/cell-editor-text/cell-editor-text.component.spec.ts
@@ -103,7 +103,7 @@ describe('SkyCellEditorTextComponent', () => {
     it('initializes the SkyCellEditorTextComponent properties', () => {
       expect(textEditorComponent.editorForm.get('text')?.value).toBeNull();
 
-      textEditorComponent.agInit(cellEditorParams as ICellEditorParams);
+      textEditorComponent.refresh(cellEditorParams as ICellEditorParams);
 
       expect(textEditorComponent.editorForm.get('text')?.value).toEqual(value);
     });
@@ -144,6 +144,37 @@ describe('SkyCellEditorTextComponent', () => {
       tick();
       expect(input).toBeVisible();
       expect(input.focus).toHaveBeenCalled();
+    }));
+
+    it('should call stopEditing when focusout from input and stopEditingWhenCellsLoseFocus is true', fakeAsync(() => {
+      const api = jasmine.createSpyObj<GridApi>([
+        'getDisplayNameForColumn',
+        'stopEditing',
+        'getGridOption',
+      ]);
+      api.getDisplayNameForColumn.and.returnValue('');
+      api.getGridOption.and.returnValue(true);
+
+      textEditorComponent.agInit({
+        ...(cellEditorParams as ICellEditorParams),
+        api,
+      });
+      textEditorFixture.detectChanges();
+
+      const input = textEditorFixture.nativeElement.querySelector(
+        'input',
+      ) as HTMLInputElement;
+
+      textEditorComponent.onFocusOut({
+        target: input,
+        relatedTarget: null,
+      } as unknown as FocusEvent);
+      tick();
+
+      expect(api.getGridOption).toHaveBeenCalledWith(
+        'stopEditingWhenCellsLoseFocus',
+      );
+      expect(api.stopEditing).toHaveBeenCalled();
     }));
 
     describe('cellStartedEdit is true', () => {

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/cell-editors/cell-editor-text/cell-editor-text.component.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/cell-editors/cell-editor-text/cell-editor-text.component.ts
@@ -33,7 +33,6 @@ import { SkyAgGridCellEditorUtils } from '../../types/cell-editor-utils';
 export class SkyAgGridCellEditorTextComponent
   implements ICellEditorAngularComp
 {
-  public textInputLabel: string | undefined;
   public columnHeader: string | undefined;
   public editorForm = new UntypedFormGroup({
     text: new UntypedFormControl(),
@@ -53,6 +52,8 @@ export class SkyAgGridCellEditorTextComponent
       // If focus is being set to the grid cell, schedule focus on the input.
       // This happens when the refreshCells API is called.
       this.afterGuiAttached();
+    } else if (event.target === this.input?.nativeElement) {
+      this.#stopEditingOnBlur();
     }
   }
 
@@ -93,6 +94,10 @@ export class SkyAgGridCellEditorTextComponent
     this.rowNumber = this.#params.rowIndex + 1;
   }
 
+  public refresh(params: SkyCellEditorTextParams): void {
+    this.agInit(params);
+  }
+
   /**
    * afterGuiAttached is called by agGrid after the editor is rendered in the DOM. Once it is attached the editor is ready to be focused on.
    */
@@ -115,5 +120,11 @@ export class SkyAgGridCellEditorTextComponent
    */
   public getValue(): string | undefined {
     return this.editorForm.get('text')?.value || undefined;
+  }
+
+  #stopEditingOnBlur(): void {
+    if (this.#params?.api.getGridOption('stopEditingWhenCellsLoseFocus')) {
+      this.#params?.api.stopEditing();
+    }
   }
 }


### PR DESCRIPTION
:cherries: Cherry picked from #4117 [fix(components/ag-grid): cell editors should stop editing on focusout event](https://github.com/blackbaud/skyux/pull/4117)

[AB#3644316](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3644316) 