### PR TITLE
fix(components/docs-tools): allow for code examples without specifying `componentType`

### DIFF
--- a/libs/components/docs-tools/src/lib/modules/code-example-viewer/code-example-viewer.component.html
+++ b/libs/components/docs-tools/src/lib/modules/code-example-viewer/code-example-viewer.component.html
@@ -17,8 +17,9 @@
     <div
       class="sky-docs-code-example-viewer-demo sky-padding-even-md sky-margin-stacked-lg"
     >
-      @if (!demoHidden() && componentType()) {
-        <ng-template [ngComponentOutlet]="componentType()" />
+      @let component = componentType();
+      @if (!demoHidden() && component) {
+        <ng-template [ngComponentOutlet]="component" />
       } @else {
         {{
           'sky_docs_code_example_viewer_demo_hidden_message' | skyLibResources

--- a/libs/components/docs-tools/src/lib/modules/code-example-viewer/code-example-viewer.component.html
+++ b/libs/components/docs-tools/src/lib/modules/code-example-viewer/code-example-viewer.component.html
@@ -17,7 +17,7 @@
     <div
       class="sky-docs-code-example-viewer-demo sky-padding-even-md sky-margin-stacked-lg"
     >
-      @if (!demoHidden()) {
+      @if (!demoHidden() && componentType()) {
         <ng-template [ngComponentOutlet]="componentType()" />
       } @else {
         {{

--- a/libs/components/docs-tools/src/lib/modules/code-example-viewer/code-example-viewer.component.spec.ts
+++ b/libs/components/docs-tools/src/lib/modules/code-example-viewer/code-example-viewer.component.spec.ts
@@ -196,4 +196,57 @@ class FooExampleComponent {}`,
       'Value "cs" is not a supported language type.',
     );
   });
+
+  it('should work without a componentType', async () => {
+    const fixture = TestBed.createComponent(SkyDocsCodeExampleViewerComponent);
+    const loader = TestbedHarnessEnvironment.loader(fixture);
+
+    const componentRef = fixture.componentRef;
+    componentRef.setInput('componentName', defaults.componentName);
+    componentRef.setInput('componentSelector', defaults.componentSelector);
+    // Do not set componentType
+    componentRef.setInput('files', defaults.files);
+    componentRef.setInput('primaryFile', defaults.primaryFile);
+    componentRef.setInput('headingText', defaults.headingText);
+
+    fixture.detectChanges();
+
+    const boxHarness = await loader.getHarness(SkyBoxHarness);
+
+    await expectAsync(boxHarness.getHeadingText()).toBeResolvedTo(
+      'Foo basic example',
+    );
+
+    // Demo wrapper should be present but empty since no component provided
+    const demoEl = getDemoWrapper(fixture);
+    expect(demoEl).toBeTruthy();
+
+    expectCodeVisible(fixture, false);
+
+    await expectAsync(fixture.nativeElement).toBeAccessible();
+  });
+
+  it('should toggle code visibility without a componentType', () => {
+    const fixture = TestBed.createComponent(SkyDocsCodeExampleViewerComponent);
+
+    const componentRef = fixture.componentRef;
+    componentRef.setInput('componentName', defaults.componentName);
+    componentRef.setInput('componentSelector', defaults.componentSelector);
+    // Do not set componentType
+    componentRef.setInput('files', defaults.files);
+    componentRef.setInput('primaryFile', defaults.primaryFile);
+    componentRef.setInput('headingText', defaults.headingText);
+
+    fixture.detectChanges();
+
+    expectCodeVisible(fixture, false);
+
+    toggleCodeVisibility(fixture);
+
+    expectCodeVisible(fixture, true);
+
+    toggleCodeVisibility(fixture);
+
+    expectCodeVisible(fixture, false);
+  });
 });

--- a/libs/components/docs-tools/src/lib/modules/code-example-viewer/code-example-viewer.component.ts
+++ b/libs/components/docs-tools/src/lib/modules/code-example-viewer/code-example-viewer.component.ts
@@ -49,7 +49,7 @@ export class SkyDocsCodeExampleViewerComponent {
 
   public readonly componentName = input.required<string>();
   public readonly componentSelector = input.required<string>();
-  public readonly componentType = input.required<Type<unknown>>();
+  public readonly componentType = input<Type<unknown> | undefined>();
   public readonly files = input.required<Record<string, string>>();
   public readonly headingText = input.required<string>();
   public readonly primaryFile = input.required<string>();


### PR DESCRIPTION
[AB#3583748](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3583748)