### PR TITLE
chore: release 13.11.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Bug Fixes
 
+* **components/modals:** add font family override for modal header in default ([#4135](https://github.com/blackbaud/skyux/issues/4135)) ([60aaa32](https://github.com/blackbaud/skyux/commit/60aaa320728d2bb57e3e813ec0cd44cb85764544)), closes [AB#3648543](https://github.com/AB/issues/3648543)
 * **components/select-field:** update menu icon ([#4132](https://github.com/blackbaud/skyux/issues/4132)) ([55f8ced](https://github.com/blackbaud/skyux/commit/55f8ced54859d5bb9b04112d6d238eca247e2d7f)), closes [AB#3653804](https://github.com/AB/issues/3653804)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 # Changelog
 
 
+## [13.11.4](https://github.com/blackbaud/skyux/compare/13.11.3...13.11.4) (2025-12-19)
+
+
+### Bug Fixes
+
+* **components/select-field:** update menu icon ([#4132](https://github.com/blackbaud/skyux/issues/4132)) ([55f8ced](https://github.com/blackbaud/skyux/commit/55f8ced54859d5bb9b04112d6d238eca247e2d7f)), closes [AB#3653804](https://github.com/AB/issues/3653804)
+
+
+
 ## [13.11.3](https://github.com/blackbaud/skyux/compare/13.11.2...13.11.3) (2025-12-16)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "skyux",
-  "version": "13.11.3",
+  "version": "13.11.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "skyux",
-      "version": "13.11.3",
+      "version": "13.11.4",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skyux",
-  "version": "13.11.3",
+  "version": "13.11.4",
   "license": "MIT",
   "scripts": {
     "ng": "nx",


### PR DESCRIPTION
## [13.11.4](https://github.com/blackbaud/skyux/compare/13.11.3...13.11.4) (2025-12-19)


### Bug Fixes

* **components/modals:** add font family override for modal header in default ([#4135](https://github.com/blackbaud/skyux/issues/4135)) ([60aaa32](https://github.com/blackbaud/skyux/commit/60aaa320728d2bb57e3e813ec0cd44cb85764544)), closes [AB#3648543](https://github.com/AB/issues/3648543)
* **components/select-field:** update menu icon ([#4132](https://github.com/blackbaud/skyux/issues/4132)) ([55f8ced](https://github.com/blackbaud/skyux/commit/55f8ced54859d5bb9b04112d6d238eca247e2d7f)), closes [AB#3653804](https://github.com/AB/issues/3653804)