### PR TITLE
fix(components/modals): add font family override for modal header in default

### DIFF
--- a/libs/components/modals/src/lib/modules/modal/modal-header.component.scss
+++ b/libs/components/modals/src/lib/modules/modal/modal-header.component.scss
@@ -6,6 +6,7 @@
   --sky-override-modal-h2-font-size: 16px;
   --sky-override-modal-h2-font-weight: 600;
   --sky-override-modal-h2-line-height: 1.2;
+  --sky-override-modal-h2-font: inherit;
 }
 
 h2.sky-modal-heading {
@@ -23,5 +24,9 @@ h2.sky-modal-heading {
   font-weight: var(
     --sky-override-modal-h2-font-weight,
     var(--sky-font-style-heading-2)
+  );
+  font-family: var(
+    --sky-override-modal-h2-font,
+    var(--sky-font-family-heading-2)
   );
 }


### PR DESCRIPTION
[AB#3648543](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3648543)