### PR TITLE
chore: release 13.11.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Bug Fixes
 
+* **sdk/skyux-eslint:** add clarification regarding input box to `no-unbound-id` docs ([#4142](https://github.com/blackbaud/skyux/issues/4142)) ([d01129a](https://github.com/blackbaud/skyux/commit/d01129a8bc71e51d87224c795bbd2e2eb0e90bef))
 * **sdk/skyux-eslint:** fix lint rule help URLs ([#4141](https://github.com/blackbaud/skyux/issues/4141)) ([feef5f1](https://github.com/blackbaud/skyux/commit/feef5f1142fe427b707d4b6483e670a72dbdd40a))
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 # Changelog
 
 
+## [13.11.5](https://github.com/blackbaud/skyux/compare/13.11.4...13.11.5) (2026-01-08)
+
+
+### Bug Fixes
+
+* **sdk/skyux-eslint:** fix lint rule help URLs ([#4141](https://github.com/blackbaud/skyux/issues/4141)) ([feef5f1](https://github.com/blackbaud/skyux/commit/feef5f1142fe427b707d4b6483e670a72dbdd40a))
+
+
+
 ## [13.11.4](https://github.com/blackbaud/skyux/compare/13.11.3...13.11.4) (2025-12-19)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "skyux",
-  "version": "13.11.4",
+  "version": "13.11.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "skyux",
-      "version": "13.11.4",
+      "version": "13.11.5",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skyux",
-  "version": "13.11.4",
+  "version": "13.11.5",
   "license": "MIT",
   "scripts": {
     "ng": "nx",


### PR DESCRIPTION
## [13.11.5](https://github.com/blackbaud/skyux/compare/13.11.4...13.11.5) (2026-01-08)


### Bug Fixes

* **sdk/skyux-eslint:** add clarification regarding input box to `no-unbound-id` docs ([#4142](https://github.com/blackbaud/skyux/issues/4142)) ([d01129a](https://github.com/blackbaud/skyux/commit/d01129a8bc71e51d87224c795bbd2e2eb0e90bef))
* **sdk/skyux-eslint:** fix lint rule help URLs ([#4141](https://github.com/blackbaud/skyux/issues/4141)) ([feef5f1](https://github.com/blackbaud/skyux/commit/feef5f1142fe427b707d4b6483e670a72dbdd40a))