### PR TITLE
fix(components/indicators): use correct info icon matte token (#4161)

### DIFF
--- a/libs/components/indicators/src/lib/modules/alert/alert.modern.component.scss
+++ b/libs/components/indicators/src/lib/modules/alert/alert.modern.component.scss
@@ -102,7 +102,7 @@
   }
 
   &.sky-alert-info .sky-alert-icon {
-    color: var(--sky-color-background-icon_matte-action-heavy);
+    color: var(--sky-color-background-icon_matte-info);
   }
 
   &.sky-alert-success .sky-alert-icon {

--- a/libs/components/indicators/src/lib/modules/label/label.component.scss
+++ b/libs/components/indicators/src/lib/modules/label/label.component.scss
@@ -48,7 +48,7 @@
   .sky-label-info .sky-label-icon {
     color: var(
       --sky-override-label-icon-info-color,
-      var(--sky-color-background-icon_matte-action-heavy)
+      var(--sky-color-background-icon_matte-info)
     );
   }
 

--- a/libs/components/indicators/src/lib/modules/status-indicator/status-indicator.component.scss
+++ b/libs/components/indicators/src/lib/modules/status-indicator/status-indicator.component.scss
@@ -29,7 +29,7 @@
 .sky-status-indicator-icon-info {
   color: var(
     --sky-override-status-indicator-icon-color-info,
-    var(--sky-color-background-icon_matte-action-heavy)
+    var(--sky-color-background-icon_matte-info)
   );
 }
 

--- a/libs/components/toast/src/lib/modules/toast/toast.component.scss
+++ b/libs/components/toast/src/lib/modules/toast/toast.component.scss
@@ -172,7 +172,7 @@ sky-toast {
         ),
         var(
           --sky-override-toast-color-icon-info,
-          var(--sky-color-background-icon_matte-action-heavy)
+          var(--sky-color-background-icon_matte-info)
         ),
         var(
           --sky-override-toast-info-success-exclamation-path-color,


### PR DESCRIPTION
:cherries: Cherry picked from #4161 [fix(components/indicators): use correct info icon matte token](https://github.com/blackbaud/skyux/pull/4161)