### PR TITLE
fix(components/filter-bar): ensure order of selected filters remains constant (#4158)

### DIFF
--- a/libs/components/filter-bar/src/lib/modules/filter-bar/filter-bar.component.spec.ts
+++ b/libs/components/filter-bar/src/lib/modules/filter-bar/filter-bar.component.spec.ts
@@ -223,6 +223,37 @@ describe('Filter bar component', () => {
       });
       expect(filterValues?.find((f) => f.filterId === '2')).toBeUndefined();
     });
+
+    it('should retain order of selected filters when updated selection', () => {
+      // Set up initial state with multiple filters having values
+      component.appliedFilters.set([
+        { filterId: '1', filterValue: { value: 'value1' } },
+        { filterId: '2', filterValue: { value: 'value2' } },
+        { filterId: '3', filterValue: { value: 'value3' } },
+      ]);
+
+      component.selectedFilterIds.set(['2', '3', '1']);
+      fixture.detectChanges();
+
+      // User deselects filter '2', keeping only '1' and '3'
+      const closed$ = of({
+        reason: 'save',
+        selectedItems: [
+          { filterId: '1', labelText: 'filter 1' },
+          { filterId: '2', labelText: 'filter 2' },
+        ],
+      });
+      selectionModalServiceSpy.open.and.returnValue({
+        closed: closed$,
+      } as SkySelectionModalInstance);
+
+      getFilterPickerButton()?.click();
+
+      expect(selectionModalServiceSpy.open).toHaveBeenCalled();
+
+      // Verify selectedFilters is updated to only include selected items in the original order
+      expect(component.selectedFilterIds()).toEqual(['2', '1']);
+    });
   });
 
   describe('filter management', () => {

--- a/libs/components/filter-bar/src/lib/modules/filter-bar/filter-bar.component.ts
+++ b/libs/components/filter-bar/src/lib/modules/filter-bar/filter-bar.component.ts
@@ -203,13 +203,24 @@ export class SkyFilterBarComponent {
   #getExistingFilterItems(): SkyFilterBarItem[] {
     /* istanbul ignore next: safety check */
     const selectedIds = this.selectedFilterIds() ?? [];
-    return this.filterItems()
-      .filter((item) => selectedIds.includes(item.filterId()))
-      .map((item) => ({
-        filterId: item.filterId(),
-        labelText: item.labelText(),
-        filterValue: item.filterValue(),
-      }));
+    const filterItems = this.filterItems();
+
+    return selectedIds
+      .map((selectedId) => {
+        const filterItem = filterItems.find(
+          (item) => item.filterId() === selectedId,
+        );
+
+        /* istanbul ignore next: safety check */
+        return filterItem
+          ? {
+              filterId: filterItem.filterId(),
+              labelText: filterItem.labelText(),
+              filterValue: filterItem.filterValue(),
+            }
+          : undefined;
+      })
+      .filter((item) => !!item);
   }
 
   #handleFilterSelection(


### PR DESCRIPTION
:cherries: Cherry picked from #4158 [fix(components/filter-bar): ensure order of selected filters remains constant](https://github.com/blackbaud/skyux/pull/4158)