### PR TITLE
feat!: @angular/animations is deprecated; replace with what Angular recommends

### DIFF
--- a/libs/components/action-bars/src/lib/modules/summary-action-bar/summary-action-bar.component.ts
+++ b/libs/components/action-bars/src/lib/modules/summary-action-bar/summary-action-bar.component.ts
@@ -16,7 +16,6 @@ import {
   signal,
 } from '@angular/core';
 import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
-import { skyAnimationSlide } from '@skyux/animations';
 import {
   SkyAppWindowRef,
   SkyMediaQueryService,
@@ -45,7 +44,6 @@ let nextId = 0;
  * `sky-summary-action-bar-summary` components.
  */
 @Component({
-  animations: [skyAnimationSlide],
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
     CommonModule,

--- a/libs/components/flyout/src/lib/modules/flyout/flyout.component.ts
+++ b/libs/components/flyout/src/lib/modules/flyout/flyout.component.ts
@@ -1,11 +1,4 @@
-import {
-  AnimationEvent,
-  animate,
-  state,
-  style,
-  transition,
-  trigger,
-} from '@angular/animations';
+import { AnimationEvent } from '@angular/animations';
 import { A11yModule } from '@angular/cdk/a11y';
 import { CommonModule } from '@angular/common';
 import {
@@ -64,17 +57,6 @@ let nextId = 0;
   templateUrl: './flyout.component.html',
   styleUrls: ['./flyout.component.scss'],
   providers: [SkyFlyoutAdapterService],
-  animations: [
-    trigger('flyoutState', [
-      state(FLYOUT_OPEN_STATE, style({ transform: 'initial' })),
-      state(FLYOUT_CLOSED_STATE, style({ transform: 'translateX(100%)' })),
-      transition('void => *', [
-        style({ transform: 'translateX(100%)' }),
-        animate(250),
-      ]),
-      transition(`* <=> *`, animate('250ms ease-in')),
-    ]),
-  ],
   // Allow automatic change detection for child components.
   changeDetection: ChangeDetectionStrategy.Default,
   imports: [

--- a/libs/components/indicators/src/lib/modules/tokens/tokens.component.ts
+++ b/libs/components/indicators/src/lib/modules/tokens/tokens.component.ts
@@ -1,4 +1,3 @@
-import { animate, style, transition, trigger } from '@angular/animations';
 import {
   ChangeDetectionStrategy,
   ChangeDetectorRef,
@@ -34,33 +33,6 @@ const DISPLAY_WITH_DEFAULT = 'name';
   templateUrl: './tokens.component.html',
   styleUrls: ['./tokens.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
-  animations: [
-    trigger('blockAnimationOnLoad', [transition(':enter', [])]),
-    trigger('dismiss', [
-      transition(':enter', [
-        style({
-          opacity: 0,
-          width: 0,
-        }),
-        animate(
-          '150ms ease-in',
-          style({
-            opacity: 1,
-            width: '*',
-          }),
-        ),
-      ]),
-      transition(':leave', [
-        animate(
-          '150ms ease-in',
-          style({
-            opacity: 0,
-            width: 0,
-          }),
-        ),
-      ]),
-    ]),
-  ],
   standalone: false,
 })
 export class SkyTokensComponent implements OnDestroy {

--- a/libs/components/inline-form/src/lib/modules/inline-form/inline-form.component.ts
+++ b/libs/components/inline-form/src/lib/modules/inline-form/inline-form.component.ts
@@ -17,7 +17,6 @@ import { SkyLibResourcesService } from '@skyux/i18n';
 import { Observable, ReplaySubject, Subject, zip as observableZip } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 
-import { skySlideDissolve } from './animations/slide-dissolve';
 import { SkyInlineFormAdapterService } from './inline-form-adapter.service';
 import { SkyInlineFormButtonConfig } from './types/inline-form-button-config';
 import { SkyInlineFormButtonLayout } from './types/inline-form-button-layout';
@@ -33,7 +32,6 @@ import { SkyInlineFormConfig } from './types/inline-form-config';
   styleUrls: ['./inline-form.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
   providers: [SkyInlineFormAdapterService],
-  animations: [skySlideDissolve],
   standalone: false,
 })
 export class SkyInlineFormComponent implements OnInit, OnDestroy {

--- a/libs/components/layout/src/lib/modules/inline-delete/inline-delete.component.ts
+++ b/libs/components/layout/src/lib/modules/inline-delete/inline-delete.component.ts
@@ -1,12 +1,4 @@
-import {
-  AnimationEvent,
-  animate,
-  group,
-  query,
-  style,
-  transition,
-  trigger,
-} from '@angular/animations';
+import { AnimationEvent } from '@angular/animations';
 import {
   ChangeDetectorRef,
   Component,
@@ -32,54 +24,6 @@ let nextId = 0;
   selector: 'sky-inline-delete',
   styleUrls: ['./inline-delete.component.scss'],
   templateUrl: './inline-delete.component.html',
-  animations: [
-    trigger('inlineDeleteAnimation', [
-      transition('* => shown', [
-        style({
-          opacity: 0,
-        }),
-        query(
-          '.sky-inline-delete-content-animation-container',
-          style({ transform: 'scale(0.0)' }),
-        ),
-        group([
-          animate('300ms ease-in-out', style({ opacity: 1 })),
-          query(
-            '.sky-inline-delete-content-animation-container',
-            animate(
-              '300ms ease-in-out',
-              style({
-                transform: 'scale(1)',
-              }),
-            ),
-          ),
-        ]),
-      ]),
-      transition(`shown <=> *`, [
-        query(
-          '.sky-inline-delete-content-animation-container',
-          style({ transform: 'scale(1)' }),
-        ),
-        group([
-          animate(
-            '300ms ease-in-out',
-            style({
-              opacity: 0,
-            }),
-          ),
-          query(
-            '.sky-inline-delete-content-animation-container',
-            animate(
-              '300ms ease-in-out',
-              style({
-                transform: 'scale(0.0)',
-              }),
-            ),
-          ),
-        ]),
-      ]),
-    ]),
-  ],
   providers: [SkyCoreAdapterService, SkyInlineDeleteAdapterService],
   standalone: false,
 })

--- a/libs/components/layout/src/lib/modules/text-expand-repeater/text-expand-repeater.component.ts
+++ b/libs/components/layout/src/lib/modules/text-expand-repeater/text-expand-repeater.component.ts
@@ -1,11 +1,4 @@
 import {
-  animate,
-  state,
-  style,
-  transition,
-  trigger,
-} from '@angular/animations';
-import {
   ChangeDetectorRef,
   Component,
   ElementRef,
@@ -30,28 +23,6 @@ import { SkyTextExpandRepeaterListStyleType } from './types/text-expand-repeater
 let nextId = 0;
 
 @Component({
-  animations: [
-    trigger('expansionAnimation', [
-      transition(':enter', []),
-      state(
-        'true',
-        style({
-          maxHeight: '{{transitionHeight}}px',
-        }),
-        { params: { transitionHeight: 0 } },
-      ),
-      state(
-        'false',
-        style({
-          maxHeight: '{{transitionHeight}}px',
-        }),
-        { params: { transitionHeight: 0 } },
-      ),
-      transition('true => false', animate('250ms ease')),
-      transition('false => true', animate('250ms ease')),
-      transition('void => *', []),
-    ]),
-  ],
   selector: 'sky-text-expand-repeater',
   templateUrl: './text-expand-repeater.component.html',
   styleUrls: ['./text-expand-repeater.component.scss'],

--- a/libs/components/layout/src/lib/modules/text-expand/text-expand.component.ts
+++ b/libs/components/layout/src/lib/modules/text-expand/text-expand.component.ts
@@ -1,11 +1,4 @@
 import {
-  animate,
-  state,
-  style,
-  transition,
-  trigger,
-} from '@angular/animations';
-import {
   AfterContentInit,
   Component,
   ElementRef,
@@ -28,28 +21,6 @@ import { SkyTextExpandModalComponent } from './text-expand-modal.component';
 let nextId = 0;
 
 @Component({
-  animations: [
-    trigger('expansionAnimation', [
-      transition(':enter', []),
-      state(
-        'true',
-        style({
-          maxHeight: '{{transitionHeight}}px',
-        }),
-        { params: { transitionHeight: 0 } },
-      ),
-      state(
-        'false',
-        style({
-          maxHeight: '{{transitionHeight}}px',
-        }),
-        { params: { transitionHeight: 0 } },
-      ),
-      transition('true => false', animate('250ms ease')),
-      transition('false => true', animate('250ms ease')),
-      transition('void => *', []),
-    ]),
-  ],
   selector: 'sky-text-expand',
   templateUrl: './text-expand.component.html',
   styleUrls: ['./text-expand.component.scss'],

--- a/libs/components/lists/src/lib/modules/repeater/repeater-item.component.ts
+++ b/libs/components/lists/src/lib/modules/repeater/repeater-item.component.ts
@@ -18,7 +18,6 @@ import {
   ViewEncapsulation,
   inject,
 } from '@angular/core';
-import { skyAnimationSlide } from '@skyux/animations';
 import { SkyContentInfoProvider, SkyIdService } from '@skyux/core';
 import { SkyCheckboxChange } from '@skyux/forms';
 import { SkyLibResourcesService } from '@skyux/i18n';
@@ -46,7 +45,6 @@ let nextContentId = 0;
   selector: 'sky-repeater-item',
   styleUrls: ['./repeater-item.component.scss'],
   templateUrl: './repeater-item.component.html',
-  animations: [skyAnimationSlide],
   providers: [SkyContentInfoProvider],
   encapsulation: ViewEncapsulation.None,
   standalone: false,

--- a/libs/components/lookup/src/lib/modules/search/search.component.ts
+++ b/libs/components/lookup/src/lib/modules/search/search.component.ts
@@ -1,11 +1,4 @@
-import {
-  AnimationEvent,
-  animate,
-  state,
-  style,
-  transition,
-  trigger,
-} from '@angular/animations';
+import { AnimationEvent } from '@angular/animations';
 import {
   ChangeDetectorRef,
   Component,
@@ -45,25 +38,6 @@ const EXPAND_MODE_NONE = 'none';
   templateUrl: './search.component.html',
   styleUrls: ['./search.component.scss'],
   encapsulation: ViewEncapsulation.None,
-  animations: [
-    trigger('inputState', [
-      state(
-        INPUT_HIDDEN_STATE,
-        style({
-          opacity: 0,
-          width: 0,
-        }),
-      ),
-      state(
-        INPUT_SHOWN_STATE,
-        style({
-          opacity: 1,
-          width: '100%',
-        }),
-      ),
-      transition('* <=> *', animate('150ms')),
-    ]),
-  ],
   providers: [SkySearchAdapterService],
   standalone: false,
 })

--- a/libs/components/phone-field/src/lib/modules/phone-field/phone-field.component.ts
+++ b/libs/components/phone-field/src/lib/modules/phone-field/phone-field.component.ts
@@ -1,10 +1,4 @@
-import {
-  AnimationEvent,
-  animate,
-  style,
-  transition,
-  trigger,
-} from '@angular/animations';
+import { AnimationEvent } from '@angular/animations';
 import { CommonModule } from '@angular/common';
 import {
   ChangeDetectionStrategy,
@@ -88,73 +82,6 @@ const DEFAULT_COUNTRY_CODE = 'us';
       provide: SKY_COUNTRY_FIELD_CONTEXT,
       useValue: { inPhoneField: true },
     },
-  ],
-  animations: [
-    trigger('blockAnimationOnLoad', [transition(':enter', [])]),
-    trigger('countrySearchAnimation', [
-      transition('void => open', [
-        style({
-          opacity: 0,
-          width: 0,
-        }),
-        animate(
-          '200ms ease-in',
-          style({
-            opacity: 1,
-            width: '*',
-          }),
-        ),
-      ]),
-      transition('open => void', [
-        animate(
-          '200ms ease-in',
-          style({
-            opacity: 0,
-            width: 0,
-          }),
-        ),
-      ]),
-      transition('void => open-modern', [
-        style({
-          opacity: 0,
-        }),
-        animate(
-          '200ms ease-in',
-          style({
-            opacity: 1,
-          }),
-        ),
-      ]),
-      transition('open-modern => void', [
-        animate(
-          '200ms ease-in',
-          style({
-            opacity: 0,
-          }),
-        ),
-      ]),
-    ]),
-    trigger('phoneInputAnimation', [
-      transition('void => open', [
-        style({
-          opacity: 0,
-        }),
-        animate(
-          '200ms ease-in',
-          style({
-            opacity: 1,
-          }),
-        ),
-      ]),
-      transition('open => void', [
-        animate(
-          '200ms ease-in',
-          style({
-            opacity: 0,
-          }),
-        ),
-      ]),
-    ]),
   ],
 })
 export class SkyPhoneFieldComponent implements OnDestroy, OnInit {

--- a/libs/components/popovers/src/lib/modules/popover/popover-content.component.ts
+++ b/libs/components/popovers/src/lib/modules/popover/popover-content.component.ts
@@ -30,7 +30,6 @@ import {
   takeUntil,
 } from 'rxjs';
 
-import { skyPopoverAnimation } from './popover-animation';
 import { SkyPopoverAnimationState } from './popover-animation-state';
 import { SkyPopoverContext } from './popover-context';
 import {
@@ -48,7 +47,6 @@ import { SkyPopoverType } from './types/popover-type';
   selector: 'sky-popover-content',
   templateUrl: './popover-content.component.html',
   styleUrls: ['./popover-content.component.scss'],
-  animations: [skyPopoverAnimation],
   standalone: false,
 })
 export class SkyPopoverContentComponent implements OnInit, OnDestroy {

--- a/libs/components/split-view/src/lib/modules/split-view/split-view.component.ts
+++ b/libs/components/split-view/src/lib/modules/split-view/split-view.component.ts
@@ -1,10 +1,3 @@
-import {
-  animate,
-  state,
-  style,
-  transition,
-  trigger,
-} from '@angular/animations';
 import { CommonModule } from '@angular/common';
 import {
   ChangeDetectionStrategy,
@@ -33,17 +26,6 @@ import { SkySplitViewMessageType } from './types/split-view-message-type';
  * and take actions.
  */
 @Component({
-  animations: [
-    trigger('blockAnimationOnLoad', [transition(':enter', [])]),
-    trigger('drawerEnter', [
-      state('false', style({ transform: 'translate(-100%)' })),
-      transition('* => true', animate('150ms ease-in')),
-    ]),
-    trigger('workspaceEnter', [
-      state('false', style({ transform: 'translate(100%)' })),
-      transition('* => true', animate('150ms ease-in')),
-    ]),
-  ],
   changeDetection: ChangeDetectionStrategy.OnPush,
   hostDirectives: [SkyResponsiveHostDirective],
   imports: [CommonModule],

--- a/libs/components/tabs/src/lib/modules/sectioned-form/sectioned-form.component.ts
+++ b/libs/components/tabs/src/lib/modules/sectioned-form/sectioned-form.component.ts
@@ -1,4 +1,3 @@
-import { animate, style, transition, trigger } from '@angular/animations';
 import {
   AfterViewChecked,
   ChangeDetectionStrategy,
@@ -20,7 +19,6 @@ import { distinctUntilChanged, takeUntil } from 'rxjs/operators';
 import { SkyTabIdService } from '../shared/tab-id.service';
 
 import {
-  HIDDEN_STATE,
   SkyVerticalTabsetService,
   VISIBLE_STATE,
 } from './../vertical-tabset/vertical-tabset.service';
@@ -36,20 +34,6 @@ import { SkySectionedFormMessageType } from './types/sectioned-form-message-type
   styleUrls: ['./sectioned-form.component.scss'],
   providers: [SkyTabIdService, SkyVerticalTabsetService],
   changeDetection: ChangeDetectionStrategy.OnPush,
-  animations: [
-    trigger('tabEnter', [
-      transition(`${HIDDEN_STATE} => ${VISIBLE_STATE}`, [
-        style({ transform: 'translate(-100%)' }),
-        animate('150ms ease-in'),
-      ]),
-    ]),
-    trigger('contentEnter', [
-      transition(`${HIDDEN_STATE} => ${VISIBLE_STATE}`, [
-        style({ transform: 'translate(100%)' }),
-        animate('150ms ease-in'),
-      ]),
-    ]),
-  ],
   standalone: false,
 })
 export class SkySectionedFormComponent

--- a/libs/components/tabs/src/lib/modules/vertical-tabset/vertical-tabset-group.component.ts
+++ b/libs/components/tabs/src/lib/modules/vertical-tabset/vertical-tabset-group.component.ts
@@ -1,12 +1,4 @@
 import {
-  AnimationTriggerMetadata,
-  animate,
-  state,
-  style,
-  transition,
-  trigger,
-} from '@angular/animations';
-import {
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
@@ -19,7 +11,6 @@ import {
   ViewChild,
   inject,
 } from '@angular/core';
-import { skyAnimationSlide } from '@skyux/animations';
 import { SkyIdService } from '@skyux/core';
 
 import { Subject } from 'rxjs';
@@ -32,44 +23,11 @@ import { SkyVerticalTabsetAdapterService } from './vertical-tabset-adapter.servi
 import { SkyVerticalTabsetGroupService } from './vertical-tabset-group.service';
 import { SkyVerticalTabsetService } from './vertical-tabset.service';
 
-// Due to how we leave the content element in the DOM - we need to ensure that the padding for the content area is animated away along with the height.
-// The timing here matches what the slide animation uses to ensure they happen together.
-const skyVerticalTabsetPaddingAnimation: AnimationTriggerMetadata = trigger(
-  'skyVerticalTabsetPaddingAnimation',
-  [
-    state(
-      'down',
-      style({
-        'padding-top': 'var(--sky-comp-tab-vertical-subgroup-space-inset-top)',
-        'padding-bottom':
-          'var(--sky-comp-tab-vertical-subgroup-space-inset-bottom)',
-      }),
-    ),
-    state(
-      'up',
-      style({
-        'padding-top': '0',
-        'padding-bottom': '0',
-      }),
-    ),
-    state(
-      'void',
-      style({
-        'padding-top': '0',
-        'padding-bottom': '0',
-      }),
-    ),
-    // Same timing as skyAnimationSlide to stay synchronized
-    transition('up <=> down', animate('150ms ease-in')),
-  ],
-);
-
 @Component({
   selector: 'sky-vertical-tabset-group',
   templateUrl: './vertical-tabset-group.component.html',
   styleUrls: ['./vertical-tabset-group.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
-  animations: [skyAnimationSlide, skyVerticalTabsetPaddingAnimation],
   providers: [SkyVerticalTabsetGroupService],
   standalone: false,
 })

--- a/libs/components/tabs/src/lib/modules/vertical-tabset/vertical-tabset.component.ts
+++ b/libs/components/tabs/src/lib/modules/vertical-tabset/vertical-tabset.component.ts
@@ -1,4 +1,3 @@
-import { animate, style, transition, trigger } from '@angular/animations';
 import {
   AfterViewChecked,
   ChangeDetectionStrategy,
@@ -21,7 +20,6 @@ import { SkyTabIdService } from '../shared/tab-id.service';
 
 import { SkyVerticalTabsetAdapterService } from './vertical-tabset-adapter.service';
 import {
-  HIDDEN_STATE,
   SkyVerticalTabsetService,
   VISIBLE_STATE,
 } from './vertical-tabset.service';
@@ -32,20 +30,6 @@ import {
   styleUrls: ['./vertical-tabset.component.scss'],
   providers: [SkyTabIdService, SkyVerticalTabsetService],
   changeDetection: ChangeDetectionStrategy.OnPush,
-  animations: [
-    trigger('tabGroupEnter', [
-      transition(`${HIDDEN_STATE} => ${VISIBLE_STATE}`, [
-        style({ transform: 'translate(-100%)' }),
-        animate('150ms ease-in'),
-      ]),
-    ]),
-    trigger('contentEnter', [
-      transition(`${HIDDEN_STATE} => ${VISIBLE_STATE}`, [
-        style({ transform: 'translate(100%)' }),
-        animate('150ms ease-in'),
-      ]),
-    ]),
-  ],
   standalone: false,
 })
 export class SkyVerticalTabsetComponent

--- a/libs/components/tiles/src/lib/modules/tiles/tile/tile.component.ts
+++ b/libs/components/tiles/src/lib/modules/tiles/tile/tile.component.ts
@@ -15,7 +15,6 @@ import {
   ViewChild,
   inject,
 } from '@angular/core';
-import { skyAnimationSlide } from '@skyux/animations';
 import { SkyIdModule, SkyIdService, SkyLogService } from '@skyux/core';
 import { SkyHelpInlineModule } from '@skyux/help-inline';
 import { SkyIconModule } from '@skyux/icon';
@@ -38,7 +37,6 @@ import { SkyTileTitleComponent } from './tile-title.component';
   selector: 'sky-tile',
   styleUrls: ['./tile.component.scss'],
   templateUrl: './tile.component.html',
-  animations: [skyAnimationSlide],
   imports: [
     CommonModule,
     SkyChevronModule,

--- a/libs/components/toast/src/lib/modules/toast/toast.component.ts
+++ b/libs/components/toast/src/lib/modules/toast/toast.component.ts
@@ -13,7 +13,6 @@ import {
   ViewEncapsulation,
   inject,
 } from '@angular/core';
-import { skyAnimationEmerge } from '@skyux/animations';
 import { SkyIdModule } from '@skyux/core';
 import { SkyIconModule } from '@skyux/icon';
 import { SkyThemeModule } from '@skyux/theme';
@@ -36,7 +35,6 @@ const SKY_TOAST_TYPE_DEFAULT = SkyToastType.Info;
   selector: 'sky-toast',
   templateUrl: './toast.component.html',
   styleUrls: ['./toast.component.scss'],
-  animations: [skyAnimationEmerge],
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
   imports: [


### PR DESCRIPTION
**Breaking Change Implementation**

<div><a href="https://angular.dev/guide/animations/migration">https://angular.dev/guide/animations/migration</a><br> </div><div><br> </div><div>Affected projects: </div><div><ul><li><span>action</span> </li><li>animations </li><li>lists </li><li>tabs </li><li>tiles </li><li>toast </li> </ul><span></span> </div><div> </div>

---
**Work Item:** https://dev.azure.com/blackbaud/Products/_workitems/edit/3584234

This change was generated by Claude Sonnet 4.5 using the breaking changes context.