### PR TITLE
feat(components/filter-bar): extend generics for filter types in filter items (#4175)

### DIFF
--- a/libs/components/filter-bar/src/lib/modules/filter-bar/filter-bar.service.ts
+++ b/libs/components/filter-bar/src/lib/modules/filter-bar/filter-bar.service.ts
@@ -25,12 +25,15 @@ export class SkyFilterBarService {
    * @param filterId the
    * @returns
    */
-  public getFilterValueUpdates(
+  public getFilterValueUpdates<TValue = unknown>(
     filterId: string,
-  ): Observable<SkyFilterBarFilterValue | undefined> {
+  ): Observable<SkyFilterBarFilterValue<TValue> | undefined> {
     return this.#filterValueUpdates.pipe(
       filter((update) => update.filterId === filterId),
-      map((item) => item.filterValue),
+      map(
+        (item) =>
+          item.filterValue as SkyFilterBarFilterValue<TValue> | undefined,
+      ),
     );
   }
   /**

--- a/libs/components/filter-bar/src/lib/modules/filter-bar/filter-items/filter-item-modal.component.ts
+++ b/libs/components/filter-bar/src/lib/modules/filter-bar/filter-items/filter-item-modal.component.ts
@@ -47,8 +47,7 @@ import { SKY_FILTER_ITEM } from './filter-item.token';
 export class SkyFilterItemModalComponent<
   TData = Record<string, unknown> | undefined,
   TValue = unknown,
-> implements SkyFilterItem<TValue>
-{
+> implements SkyFilterItem<TValue> {
   /**
    * A unique identifier for the filter item.
    * @required

--- a/libs/components/filter-bar/src/lib/modules/filter-bar/filter-items/filter-item-modal.component.ts
+++ b/libs/components/filter-bar/src/lib/modules/filter-bar/filter-items/filter-item-modal.component.ts
@@ -46,7 +46,8 @@ import { SKY_FILTER_ITEM } from './filter-item.token';
 })
 export class SkyFilterItemModalComponent<
   TData = Record<string, unknown> | undefined,
-> implements SkyFilterItem
+  TValue = unknown,
+> implements SkyFilterItem<TValue>
 {
   /**
    * A unique identifier for the filter item.
@@ -67,7 +68,7 @@ export class SkyFilterItemModalComponent<
    * @required
    */
   public readonly modalComponent =
-    input.required<Type<SkyFilterItemModal<TData>>>();
+    input.required<Type<SkyFilterItemModal<TData, TValue>>>();
 
   /**
    * The size of the modal to display. The valid options are `"small"`, `"medium"`, `"large"`, and `"fullScreen"`.
@@ -90,7 +91,7 @@ export class SkyFilterItemModalComponent<
   public readonly filterValue = toSignal(
     toObservable(this.filterId).pipe(
       switchMap((filterId) =>
-        this.#filterBarSvc.getFilterValueUpdates(filterId),
+        this.#filterBarSvc.getFilterValueUpdates<TValue>(filterId),
       ),
     ),
   );
@@ -102,7 +103,7 @@ export class SkyFilterItemModalComponent<
     const filterValue = this.filterValue();
 
     this.#openFilterCallback().subscribe((additionalContext) => {
-      const context = new SkyFilterItemModalContext<TData>({
+      const context = new SkyFilterItemModalContext<TData, TValue>({
         filterLabelText: labelText,
         filterValue,
         additionalContext,
@@ -116,14 +117,14 @@ export class SkyFilterItemModalComponent<
       runInInjectionContext(injector, () => {
         const destroyRef = injector.get(DestroyRef);
 
-        const saved = new Subject<SkyFilterItemModalSavedArgs>();
+        const saved = new Subject<SkyFilterItemModalSavedArgs<TValue>>();
         const canceled = new Subject<void>();
 
-        const context = inject<SkyFilterItemModalContext<TData>>(
+        const context = inject<SkyFilterItemModalContext<TData, TValue>>(
           SkyFilterItemModalContext,
         );
 
-        const filterModalInstance: SkyFilterItemModalInstance<TData> = {
+        const filterModalInstance: SkyFilterItemModalInstance<TData, TValue> = {
           context,
           cancel() {
             canceled.next();

--- a/libs/components/filter-bar/src/lib/modules/filter-bar/models/filter-bar-item.ts
+++ b/libs/components/filter-bar/src/lib/modules/filter-bar/models/filter-bar-item.ts
@@ -2,9 +2,10 @@ import { SkyFilterBarFilterValue } from './filter-bar-filter-value';
 
 /**
  * An internal representation of a filter item displayed on the filter bar.
+ * @typeParam TValue - The type of the filter value. Defaults to `unknown` for backward compatibility.
  * @internal
  */
-export interface SkyFilterBarItem {
+export interface SkyFilterBarItem<TValue = unknown> {
   /**
    * A unique identifier for the filter.
    */
@@ -16,5 +17,5 @@ export interface SkyFilterBarItem {
   /**
    * The value of the filter, if it is set.
    */
-  filterValue?: SkyFilterBarFilterValue;
+  filterValue?: SkyFilterBarFilterValue<TValue>;
 }

--- a/libs/components/filter-bar/src/lib/modules/filter-bar/models/filter-item-lookup-search-async-args.ts
+++ b/libs/components/filter-bar/src/lib/modules/filter-bar/models/filter-item-lookup-search-async-args.ts
@@ -5,8 +5,9 @@ import { SkyFilterItemLookupSearchAsyncResult } from './filter-item-lookup-searc
 /**
  * Arguments passed when an asynchronous search is executed from the selection modal opened by a
  * filter item lookup component.
+ * @typeParam TValue - The type of the filter value. Defaults to `unknown` for backward compatibility.
  */
-export interface SkyFilterItemLookupSearchAsyncArgs {
+export interface SkyFilterItemLookupSearchAsyncArgs<TValue = unknown> {
   /**
    * The unique identifier for the filter.
    */
@@ -35,5 +36,5 @@ export interface SkyFilterItemLookupSearchAsyncArgs {
    * when the event fires so the filter item lookup component can subscribe
    * to it and then display the results.
    */
-  result?: Observable<SkyFilterItemLookupSearchAsyncResult>;
+  result?: Observable<SkyFilterItemLookupSearchAsyncResult<TValue>>;
 }

--- a/libs/components/filter-bar/src/lib/modules/filter-bar/models/filter-item-lookup-search-async-result.ts
+++ b/libs/components/filter-bar/src/lib/modules/filter-bar/models/filter-item-lookup-search-async-result.ts
@@ -1,7 +1,8 @@
 /**
  * The result of searching for items to display in a filter item lookup selection modal.
+ * @typeParam TValue - The type of the filter value. Defaults to `unknown` for backward compatibility.
  */
-export interface SkyFilterItemLookupSearchAsyncResult {
+export interface SkyFilterItemLookupSearchAsyncResult<TValue = unknown> {
   /**
    * Data provided on "load more" search result requests. Use this property for
    * information such as a continuation token for paged database queries.
@@ -16,7 +17,7 @@ export interface SkyFilterItemLookupSearchAsyncResult {
    * the search criteria, set the `hasMore` property to `true`. More records can be lazy-loaded
    * as users scrolls through the search results.
    */
-  items: unknown[];
+  items: TValue[];
   /**
    * The total number of records that match the search criteria, including items not returned in
    * the current list.

--- a/libs/components/filter-bar/src/lib/modules/filter-bar/models/filter-item-modal-context.ts
+++ b/libs/components/filter-bar/src/lib/modules/filter-bar/models/filter-item-modal-context.ts
@@ -2,9 +2,13 @@ import { SkyFilterBarFilterValue } from './filter-bar-filter-value';
 
 /**
  * The context object that is provided to a filter modal.
+ * @typeParam TValue - The type of the filter value. Defaults to `unknown` for backward compatibility.
  * @typeParam TData - The type of the additional context data. Defaults to `Record<string, unknown>`.
  */
-export class SkyFilterItemModalContext<TData = Record<string, unknown>> {
+export class SkyFilterItemModalContext<
+  TData = Record<string, unknown>,
+  TValue = unknown,
+> {
   /**
    * The name of the filter. We recommend using this value for the modal's heading.
    */
@@ -12,7 +16,7 @@ export class SkyFilterItemModalContext<TData = Record<string, unknown>> {
   /**
    * The value of the filter.
    */
-  public readonly filterValue?: SkyFilterBarFilterValue;
+  public readonly filterValue?: SkyFilterBarFilterValue<TValue>;
   /**
    * An untyped property that can track any config information relevant to the filter modal
    * that existing options do not include.
@@ -21,7 +25,7 @@ export class SkyFilterItemModalContext<TData = Record<string, unknown>> {
 
   constructor(args: {
     filterLabelText: string;
-    filterValue?: SkyFilterBarFilterValue;
+    filterValue?: SkyFilterBarFilterValue<TValue>;
     additionalContext?: TData;
   }) {
     this.filterLabelText = args.filterLabelText;

--- a/libs/components/filter-bar/src/lib/modules/filter-bar/models/filter-item-modal-instance.ts
+++ b/libs/components/filter-bar/src/lib/modules/filter-bar/models/filter-item-modal-instance.ts
@@ -3,15 +3,17 @@ import { SkyFilterItemModalSavedArgs } from './filter-item-modal-saved-args';
 
 /**
  * A specialized `SkyModalInstance` wrapper.
+ * @typeParam TValue - The type of the filter value. Defaults to `unknown` for backward compatibility.
  * @typeParam TData - The type of the additional context data. Defaults to `Record<string, unknown>`.
  */
 export abstract class SkyFilterItemModalInstance<
   TData = Record<string, unknown>,
+  TValue = unknown,
 > {
   /**
    * The context provided to the filter modal component.
    */
-  public abstract readonly context: SkyFilterItemModalContext<TData>;
+  public abstract readonly context: SkyFilterItemModalContext<TData, TValue>;
 
   /**
    * Closes the modal instance with `reason="cancel"`.
@@ -22,5 +24,5 @@ export abstract class SkyFilterItemModalInstance<
    * Closes the modal instance with `reason="save"`.
    * @param args
    */
-  public abstract save(args: SkyFilterItemModalSavedArgs): void;
+  public abstract save(args: SkyFilterItemModalSavedArgs<TValue>): void;
 }

--- a/libs/components/filter-bar/src/lib/modules/filter-bar/models/filter-item-modal-saved-args.ts
+++ b/libs/components/filter-bar/src/lib/modules/filter-bar/models/filter-item-modal-saved-args.ts
@@ -2,10 +2,11 @@ import { SkyFilterBarFilterValue } from './filter-bar-filter-value';
 
 /**
  * Arguments passed back from a filter modal when the user has saved.
+ * @typeParam TValue - The type of the filter value. Defaults to `unknown` for backward compatibility.
  */
-export interface SkyFilterItemModalSavedArgs {
+export interface SkyFilterItemModalSavedArgs<TValue = unknown> {
   /**
    * The filter value.
    */
-  filterValue: SkyFilterBarFilterValue | undefined;
+  filterValue: SkyFilterBarFilterValue<TValue> | undefined;
 }

--- a/libs/components/filter-bar/src/lib/modules/filter-bar/models/filter-item-modal.ts
+++ b/libs/components/filter-bar/src/lib/modules/filter-bar/models/filter-item-modal.ts
@@ -5,9 +5,10 @@ import { SkyFilterItemModalInstance } from './filter-item-modal-instance';
  */
 export interface SkyFilterItemModal<
   TData = Record<string, unknown> | undefined,
+  TValue = unknown,
 > {
   /**
    * The filter modal instance to be injected into the component.
    */
-  readonly modalInstance: SkyFilterItemModalInstance<TData>;
+  readonly modalInstance: SkyFilterItemModalInstance<TData, TValue>;
 }

--- a/libs/components/filter-bar/src/lib/modules/filter-bar/models/filter-item.ts
+++ b/libs/components/filter-bar/src/lib/modules/filter-bar/models/filter-item.ts
@@ -4,9 +4,10 @@ import { SkyFilterBarFilterValue } from './filter-bar-filter-value';
 
 /**
  * Defines the common properties various filter item types must implement to work with the filter bar component.
+ * @typeParam TValue - The type of the filter value. Defaults to `unknown` for backward compatibility.
  * @internal
  */
-export interface SkyFilterItem {
+export interface SkyFilterItem<TValue = unknown> {
   /**
    * A unique identifier for the filter item.
    */
@@ -24,5 +25,5 @@ export interface SkyFilterItem {
    * The value of the filter item.
    * @internal
    */
-  filterValue: Signal<SkyFilterBarFilterValue | undefined>;
+  filterValue: Signal<SkyFilterBarFilterValue<TValue> | undefined>;
 }


### PR DESCRIPTION
:cherries: Cherry picked from #4175 [feat(components/filter-bar): extend generics for filter types in filter items](https://github.com/blackbaud/skyux/pull/4175)