### PR TITLE
fix(components/action-bars): default theme summary action bar secondary action button dropdown uses correct button class (#4188)

### DIFF
--- a/apps/e2e/toast-storybook/src/app/toast/toast.component.html
+++ b/apps/e2e/toast-storybook/src/app/toast/toast.component.html
@@ -8,12 +8,12 @@
 </button>
 <button
   id="custom-trigger"
-  class="sky-btn sky-btn-secondary sky-margin-inline-default"
+  class="sky-btn sky-btn-default sky-margin-inline-default"
   type="button"
   (click)="openComponents()"
 >
   Open custom toasts
 </button>
-<button class="sky-btn sky-btn-secondary" type="button" (click)="closeAll()">
+<button class="sky-btn sky-btn-default" type="button" (click)="closeAll()">
   Close all
 </button>

--- a/apps/playground/src/app/components/ag-grid/edit-in-modal-grid/ag-grid-edit-modal.component.html
+++ b/apps/playground/src/app/components/ag-grid/edit-in-modal-grid/ag-grid-edit-modal.component.html
@@ -19,7 +19,7 @@
       Save
     </button>
     <button
-      class="sky-btn sky-btn-secondary"
+      class="sky-btn sky-btn-default"
       type="button"
       (click)="instance.cancel()"
     >

--- a/apps/playground/src/app/components/core/resize-observer/modal/resize-observer-modal.component.html
+++ b/apps/playground/src/app/components/core/resize-observer/modal/resize-observer-modal.component.html
@@ -65,7 +65,7 @@
   <sky-modal-footer>
     @if (tabsHidden) {
       <button
-        class="sky-btn sky-btn-secondary"
+        class="sky-btn sky-btn-default"
         type="button"
         (click)="showTabs()"
       >

--- a/apps/playground/src/app/components/indicators/wait/wait.component.html
+++ b/apps/playground/src/app/components/indicators/wait/wait.component.html
@@ -88,6 +88,6 @@
   [isNonBlocking]="isNonBlocking"
 />
 
-<button class="sky-btn sky-btn-secondary" type="button">
+<button class="sky-btn sky-btn-default" type="button">
   I am a button that does nothing, but you can tab navigate to and from me
 </button>

--- a/apps/playground/src/app/components/toast/toast/toast.component.html
+++ b/apps/playground/src/app/components/toast/toast/toast.component.html
@@ -7,13 +7,13 @@
     Open toasts
   </button>
   <button
-    class="sky-btn sky-btn-secondary sky-margin-inline-default"
+    class="sky-btn sky-btn-default sky-margin-inline-default"
     type="button"
     (click)="openComponents()"
   >
     Open custom toasts
   </button>
-  <button class="sky-btn sky-btn-secondary" type="button" (click)="closeAll()">
+  <button class="sky-btn sky-btn-default" type="button" (click)="closeAll()">
     Close all
   </button>
 </div>

--- a/libs/components/action-bars/src/lib/modules/summary-action-bar/actions/summary-action-bar-secondary-action.component.html
+++ b/libs/components/action-bars/src/lib/modules/summary-action-bar/actions/summary-action-bar-secondary-action.component.html
@@ -1,13 +1,9 @@
 @if (!isDropdown) {
   <button
     type="button"
-    class="sky-btn"
+    class="sky-btn sky-btn-default"
     role="menuitem"
     [disabled]="disabled"
-    [skyThemeClass]="{
-      'sky-btn-secondary': 'default',
-      'sky-btn-default': 'modern'
-    }"
     (click)="onButtonClicked()"
   >
     <ng-container *ngTemplateOutlet="summaryActionBarSecondaryAction" />

--- a/libs/components/indicators/src/lib/modules/wait/fixtures/wait.component.fixture.html
+++ b/libs/components/indicators/src/lib/modules/wait/fixtures/wait.component.fixture.html
@@ -15,7 +15,7 @@
 </div>
 } @if (showAnchor0) {
 <button
-  class="sky-btn sky-btn-secondary"
+  class="sky-btn sky-btn-default"
   href="/"
   id="anchor-0"
   type="button"
@@ -27,7 +27,7 @@
   Anchor tag 0
 </button>
 }
-<button class="sky-btn sky-btn-secondary" href="/" id="anchor-1" type="button">
+<button class="sky-btn sky-btn-default" href="/" id="anchor-1" type="button">
   Anchor tag 1
 </button>
 <div class="sky-wait-test-component">
@@ -45,7 +45,7 @@
 <div>
   @if (showAnchor2) {
   <button
-    class="sky-btn sky-btn-secondary"
+    class="sky-btn sky-btn-default"
     href="/"
     id="anchor-2"
     type="button"

--- a/libs/components/modals/src/lib/modules/modal/fixtures/modal-with-close-confirm.component.fixture.html
+++ b/libs/components/modals/src/lib/modules/modal/fixtures/modal-with-close-confirm.component.fixture.html
@@ -4,7 +4,7 @@
     Content
     <button
       id="toggle-btn"
-      class="sky-btn sky-btn-secondary"
+      class="sky-btn sky-btn-default"
       type="button"
       (click)="toggleUnsavedWork()"
     >


### PR DESCRIPTION
:cherries: Cherry picked from #4188 [fix(components/action-bars): default theme summary action bar secondary action button dropdown uses correct button class](https://github.com/blackbaud/skyux/pull/4188)

[AB#3696493](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3696493) 