### PR TITLE
fix(components/filter-bar): recast filter value type as interface for documentation parsing (#4202)

### DIFF
--- a/libs/components/filter-bar/src/lib/modules/filter-bar/models/filter-bar-filter-value.ts
+++ b/libs/components/filter-bar/src/lib/modules/filter-bar/models/filter-bar-filter-value.ts
@@ -4,6 +4,6 @@ import { SkyFilterStateFilterValue } from '@skyux/lists';
  * Represents a value for a filter item.
  * @typeParam TValue - The type of the filter value. Defaults to `unknown` for backward compatibility.
  */
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type
-export type SkyFilterBarFilterValue<TValue = unknown> =
-  SkyFilterStateFilterValue<TValue>;
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type, @typescript-eslint/no-empty-interface
+export interface SkyFilterBarFilterValue<TValue = unknown>
+  extends SkyFilterStateFilterValue<TValue> {}

--- a/libs/components/filter-bar/src/lib/modules/filter-bar/models/filter-bar-filter-value.ts
+++ b/libs/components/filter-bar/src/lib/modules/filter-bar/models/filter-bar-filter-value.ts
@@ -5,5 +5,6 @@ import { SkyFilterStateFilterValue } from '@skyux/lists';
  * @typeParam TValue - The type of the filter value. Defaults to `unknown` for backward compatibility.
  */
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type, @typescript-eslint/no-empty-interface
-export interface SkyFilterBarFilterValue<TValue = unknown>
-  extends SkyFilterStateFilterValue<TValue> {}
+export interface SkyFilterBarFilterValue<
+  TValue = unknown,
+> extends SkyFilterStateFilterValue<TValue> {}


### PR DESCRIPTION
:cherries: Cherry picked from #4202 [fix(components/filter-bar): recast filter value type as interface for documentation parsing](https://github.com/blackbaud/skyux/pull/4202)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated a public type declaration from an alias to an interface to preserve compatibility and enable future extensibility of filter-related types. ESLint rules adjusted accordingly; no runtime behavior changes expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->