### PR TITLE
ci: set release tag target commit (#4206)

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -64,7 +64,14 @@ jobs:
             const releaseExists = await github.rest.repos.getReleaseByTag({ ...context.repo, tag: nextVersion }).then(() => true).catch(() => false);
             if (!releaseExists) {
               const releaseNotes = (await exec.getExecOutput('npx', ['skyux-dev', 'release-notes', `--releaseName=${nextVersion}`])).stdout;
-              await github.rest.repos.createRelease({ ...context.repo, name: `v${nextVersion}`, tag_name: nextVersion, body: releaseNotes, prerelease: nextVersion.includes('-') });
+              await github.rest.repos.createRelease({
+                ...context.repo,
+                name: `v${nextVersion}`,
+                tag_name: nextVersion,
+                target_commitish: context.ref,
+                body: releaseNotes,
+                prerelease: nextVersion.includes('-')
+              });
             }
       - name: Notify Slack (failure)
         if: ${{ failure() }}


### PR DESCRIPTION
:cherries: Cherry picked from #4206 [ci: set release tag target commit](https://github.com/blackbaud/skyux/pull/4206)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the GitHub release creation process to ensure releases are properly targeted to the correct commit reference, enhancing the reliability of release deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->