### PR TITLE
chore: changelog for 13.14.1 (#4211) 🍒

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 # Changelog
 
 
+## [13.14.1](https://github.com/blackbaud/skyux/compare/13.14.0...13.14.1) (2026-02-12)
+
+
+### Bug Fixes
+
+* run check-workspace on release pr ([#4210](https://github.com/blackbaud/skyux/issues/4210)) ([62908b6](https://github.com/blackbaud/skyux/commit/62908b6ee6d16dc63d12e009a1e850984e66cf18)), closes [AB#3647615](https://github.com/AB/issues/3647615)
+
+
+
 # [13.13.0](https://github.com/blackbaud/skyux/compare/13.12.0...13.13.0) (2026-02-05)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@
 
 
 
+# [13.14.0](https://github.com/blackbaud/skyux/compare/13.13.0...13.14.0) (2026-02-12)
+
+
+### Bug Fixes
+
+* **components/filter-bar:** recast filter value type as interface for documentation parsing ([#4202](https://github.com/blackbaud/skyux/issues/4202)) ([cc87b2c](https://github.com/blackbaud/skyux/commit/cc87b2c5dced44a52852c8ee3e4b7345a23c550f))
+
+
+### Features
+
+* **components/theme:** update design tokens to 4.3.0 ([#4208](https://github.com/blackbaud/skyux/issues/4208)) ([ceebf95](https://github.com/blackbaud/skyux/commit/ceebf957853810d3fc24739fee9bfca644d0f386))
+
+
+
 # [13.13.0](https://github.com/blackbaud/skyux/compare/13.12.0...13.13.0) (2026-02-05)
 
 


### PR DESCRIPTION
:cherries: Cherry picked from #4211 [chore: release 13.14.1](https://github.com/blackbaud/skyux/pull/4211)

[AB#3647615](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3647615) 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated changelog to add release 13.14.1 outlining a bug fix that ensures the workspace check runs on release pull requests.
  * Retained existing 13.14.0 changelog content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->