### PR TITLE
fix(sdk/skyux-eslint)!: remove skyId exemption for input box `prefer-label-text`

### DIFF
--- a/docs/addressing-breaking-changes/README.md
+++ b/docs/addressing-breaking-changes/README.md
@@ -1,3 +1,4 @@
 ## Addressing Breaking Changes
 
+- [Input box label text migration instructions](./input-box-label-text/README.md)
 - [Simplified pattern for methods that query child harnesses instructions](./simplified-child-harness-methods/README.md)

--- a/docs/addressing-breaking-changes/input-box-label-text/README.md
+++ b/docs/addressing-breaking-changes/input-box-label-text/README.md
@@ -1,0 +1,170 @@
+# Migrating from Input Box "Hard Mode"
+
+## Overview
+
+The `skyux-eslint-template/prefer-label-text` rule now applies to **all** `<sky-input-box>` components, including those that previously used "hard mode" (manual ID management with the `skyId` directive).
+
+Previously, the rule would skip validation if it detected the `skyId` directive on a child input element, allowing developers to continue using the deprecated `<label>` element pattern. This exemption has been removed to ensure all input boxes benefit from the accessibility and usability features provided by the `labelText` input property.
+
+## What Changed
+
+**Before:** The linting rule allowed this pattern without errors when `skyId` was present:
+
+```html
+<sky-input-box>
+  <label [for]="myInput.id">My label</label>
+  <input #myInput="skyId" skyId class="sky-form-control" type="text" />
+</sky-input-box>
+```
+
+**After:** The linting rule now reports an error and suggests using `labelText` instead:
+
+```html
+<sky-input-box labelText="My label">
+  <input type="text" />
+</sky-input-box>
+```
+
+## Why This Matters
+
+Using the `labelText` input property provides several benefits:
+
+- **Automatic accessibility**: Proper label-input association without manual ID management
+- **Responsive design**: Labels automatically adapt to mobile/desktop layouts
+- **Consistent styling**: Labels follow SKY UX design patterns
+- **Reduced complexity**: No need to manage unique IDs or template references
+- **Better maintenance**: Less code and fewer potential bugs
+
+## Migration Steps
+
+### Step 1: Enable Auto-Fix
+
+The linting rule includes an auto-fix capability. Run ESLint with the `--fix` flag:
+
+```bash
+npx eslint --fix
+```
+
+This will automatically:
+
+- Move the label text to the `labelText` input property
+- Remove the `<label>` element
+- Remove the `sky-form-control` CSS class from the input element
+- Preserve the input element (but you can now safely remove `skyId`)
+
+### Step 2: Remove `skyId` Directive (Optional but Recommended)
+
+After auto-fix, your code will look like this:
+
+```html
+<sky-input-box labelText="My label">
+  <input #myInput="skyId" skyId type="text" />
+</sky-input-box>
+```
+
+Since `labelText` handles ID management automatically, you can remove the `skyId` directive and template reference:
+
+```html
+<sky-input-box labelText="My label">
+  <input type="text" />
+</sky-input-box>
+```
+
+**Note:** Only remove `skyId` if it's not being used elsewhere in your component template or code.
+
+### Step 3: Update Form Control References (If Applicable)
+
+If your component code references the input element using the template reference variable (e.g., `@ViewChild('myInput')`), you'll need to update those references:
+
+**Before:**
+
+```typescript
+@ViewChild('myInput', { read: ElementRef })
+public myInput: ElementRef<HTMLInputElement> | undefined;
+```
+
+**After:**
+
+```typescript
+@ViewChild('input', { read: ElementRef })
+public myInput: ElementRef<HTMLInputElement> | undefined;
+```
+
+Or use a more specific selector:
+
+```html
+<sky-input-box labelText="My label">
+  <input #myInputRef type="text" />
+</sky-input-box>
+```
+
+```typescript
+@ViewChild('myInputRef', { read: ElementRef })
+public myInput: ElementRef<HTMLInputElement> | undefined;
+```
+
+## Edge Cases
+
+### Complex Label Content
+
+If your label contains complex content (child elements, Angular control flow syntax, or double quotes), the auto-fix will **not** be applied. You'll see a linting error but will need to migrate manually:
+
+**Example with child elements (no auto-fix):**
+
+```html
+<!-- Not auto-fixable -->
+<sky-input-box>
+  <label [for]="myInput.id"> <strong>Important:</strong> First name </label>
+  <input #myInput="skyId" skyId type="text" />
+</sky-input-box>
+```
+
+**Solution:** Simplify the label or use heading elements separately:
+
+```html
+<div>
+  <strong>Important:</strong>
+  <sky-input-box labelText="First name">
+    <input type="text" />
+  </sky-input-box>
+</div>
+```
+
+### Internationalization (i18n)
+
+If you're using resource strings, the auto-fix handles them correctly:
+
+**Before:**
+
+```html
+<sky-input-box>
+  <label>{{ 'first_name' | skyAppResources }}</label>
+  <input type="text" />
+</sky-input-box>
+```
+
+**After (auto-fixed):**
+
+```html
+<sky-input-box labelText="{{ 'first_name' | skyAppResources }}">
+  <input type="text" />
+</sky-input-box>
+```
+
+Or use property binding:
+
+```html
+<sky-input-box [labelText]="'first_name' | skyAppResources">
+  <input type="text" />
+</sky-input-box>
+```
+
+## Additional Resources
+
+- [SKY UX Input Box Documentation](https://developer.blackbaud.com/skyux/components/input-box)
+- [`skyId` Directive Documentation](https://developer.blackbaud.com/skyux/components/id)
+- [ESLint Rule: `prefer-label-text`](../../libs/sdk/skyux-eslint/docs/rules/template/prefer-label-text.md)
+
+## Need Help?
+
+If you encounter issues during migration or have questions, please reach out to the SKY UX team or file an issue in the [SKY UX GitHub repository](https://github.com/blackbaud/skyux/issues).

--- a/libs/sdk/skyux-eslint/src/rules/template/prefer-label-text.spec.ts
+++ b/libs/sdk/skyux-eslint/src/rules/template/prefer-label-text.spec.ts
@@ -13,9 +13,8 @@ ruleTester.run(RULE_NAME, rule, {
     `<sky-checkbox [labelText]="foo">`,
     `<sky-checkbox labelText="{{ foo }}">`,
     `
-    <sky-input-box>
-      <label [for]="myInput.id">My label</label>
-      <input #myInput="skyId" skyId class="sky-form-control" type="text" />
+    <sky-input-box labelText="My label">
+      <input type="text" />
     </sky-input-box>`,
   ],
   invalid: [
@@ -349,6 +348,96 @@ ruleTester.run(RULE_NAME, rule, {
         selector: 'sky-checkbox',
         labelInputName: 'labelText',
         labelSelector: 'sky-checkbox-label',
+      },
+    }),
+    convertAnnotatedSourceToFailureCase({
+      description:
+        'should fail even if skyId directive is used (hard mode no longer supported)',
+      annotatedSource: `
+        <sky-input-box>
+        ~~~~~~~~~~~~~~~
+          <label>My label</label>
+          ~~~~~~~~~~~~~~~~~~~~~~~
+          <input #myInput="skyId" skyId class="sky-form-control" type="text" />
+          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        </sky-input-box>
+        ~~~~~~~~~~~~~~~~
+      `,
+      annotatedOutput: `
+        <sky-input-box labelText="My label">
+        ~
+          ~
+          ~
+          <input #myInput="skyId" skyId  type="text" />
+          ~
+        </sky-input-box>
+        ~
+      `,
+      messageId,
+      data: {
+        selector: 'sky-input-box',
+        labelInputName: 'labelText',
+        labelSelector: 'label',
+      },
+    }),
+    convertAnnotatedSourceToFailureCase({
+      description:
+        'should handle input-box with input element that has no class attribute',
+      annotatedSource: `
+        <sky-input-box>
+        ~~~~~~~~~~~~~~~
+          <label>My label</label>
+          ~~~~~~~~~~~~~~~~~~~~~~~
+          <input type="text" />
+          ~~~~~~~~~~~~~~~~~~~~~
+        </sky-input-box>
+        ~~~~~~~~~~~~~~~~
+      `,
+      annotatedOutput: `
+        <sky-input-box labelText="My label">
+        ~
+          ~
+          ~
+          <input type="text" />
+          ~
+        </sky-input-box>
+        ~
+      `,
+      messageId,
+      data: {
+        selector: 'sky-input-box',
+        labelInputName: 'labelText',
+        labelSelector: 'label',
+      },
+    }),
+    convertAnnotatedSourceToFailureCase({
+      description:
+        'should handle input-box with input element that has class but not sky-form-control',
+      annotatedSource: `
+        <sky-input-box>
+        ~~~~~~~~~~~~~~~
+          <label>My label</label>
+          ~~~~~~~~~~~~~~~~~~~~~~~
+          <input class="my-custom-class" type="text" />
+          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        </sky-input-box>
+        ~~~~~~~~~~~~~~~~
+      `,
+      annotatedOutput: `
+        <sky-input-box labelText="My label">
+        ~
+          ~
+          ~
+          <input class="my-custom-class" type="text" />
+          ~
+        </sky-input-box>
+        ~
+      `,
+      messageId,
+      data: {
+        selector: 'sky-input-box',
+        labelInputName: 'labelText',
+        labelSelector: 'label',
       },
     }),
   ],

--- a/libs/sdk/skyux-eslint/src/rules/template/prefer-label-text.ts
+++ b/libs/sdk/skyux-eslint/src/rules/template/prefer-label-text.ts
@@ -164,17 +164,6 @@ export const rule = createESLintTemplateRule({
         const inputEl = getChildNodeOf(el, ['input', 'select', 'textarea']);
 
         if (labelEl) {
-          // Abort if the `skyId` directive is used on a child input of the
-          // `<sky-input-box />` component since its inclusion usually means the
-          // user wishes to implement "hard mode".
-          if (
-            el.name === 'sky-input-box' &&
-            inputEl &&
-            getAttributeByName(inputEl, 'skyId')
-          ) {
-            return;
-          }
-
           const hasElementChildren = labelEl.children.some(
             (child) => child instanceof TmplAstElement,
           );


### PR DESCRIPTION
[AB#3673971](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3673971)

BREAKING CHANGE

Linting rules no longer ignore `sky-input-box` components not using `labelText` inputs even if they included a `skyId`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added migration guidance for updating Input Box components to use the new labelText approach.

* **Bug Fixes**
  * Fixed ESLint rule to properly handle and auto-fix Input Box component transformations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->