### PR TITLE
feat(sdk/testing): remove support for older versions of axe-core

### DIFF
--- a/apps/code-examples/src/assets/stack-blitz/package-lock.json
+++ b/apps/code-examples/src/assets/stack-blitz/package-lock.json
@@ -78,7 +78,7 @@
         "@skyux-sdk/testing": "^13.11.5",
         "@types/jasmine": "~5.1.8",
         "@types/node": "^20.19.4",
-        "axe-core": "^4.10.3",
+        "axe-core": "^4.11.1",
         "jasmine-core": "~5.8.0",
         "karma": "~6.4.4",
         "karma-chrome-launcher": "~3.2.0",
@@ -2526,9 +2526,9 @@
       }
     },
     "node_modules/@blackbaud/skyux-design-tokens": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@blackbaud/skyux-design-tokens/-/skyux-design-tokens-4.0.2.tgz",
-      "integrity": "sha512-G6T+iNbPArcGEVYZyv89+noI/NnQjY27kP1gwTDfvnpLmQ5cN4NvzcIKd3JU+RvZ+1nkfZHU7sFI44hpZTQ2eA==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@blackbaud/skyux-design-tokens/-/skyux-design-tokens-4.1.0.tgz",
+      "integrity": "sha512-S5FxAx25OaOORgCC4Lz9cmQHQ8XNC/a/lnO0jUbrBAbJSJV2iSh13OxvevcT90oWaPNhdkEsruUAR3nv/MmAYA==",
       "license": "MIT",
       "engines": {
         "node": ">= 4.2.1",
@@ -7172,10 +7172,11 @@
       }
     },
     "node_modules/axe-core": {
-      "version": "4.10.3",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.10.3.tgz",
-      "integrity": "sha512-Xm7bpRXnDSX2YE2YFfBk2FnF0ep6tmG7xPh8iHee8MIcrgq762Nkce856dYtJYLkuIoYZvGfTs/PbZhideTcEg==",
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.1.tgz",
+      "integrity": "sha512-BASOg+YwO2C+346x3LZOeoovTIoTrRqEsqMa6fmfAV0P+U9mFr9NsyOEpiYvFjbc64NMrSswhV50WdXzdb/Z5A==",
       "devOptional": true,
+      "license": "MPL-2.0",
       "engines": {
         "node": ">=4"
       }

--- a/apps/code-examples/src/assets/stack-blitz/package.json
+++ b/apps/code-examples/src/assets/stack-blitz/package.json
@@ -81,7 +81,7 @@
     "@skyux-sdk/testing": "^13.11.5",
     "@types/jasmine": "~5.1.8",
     "@types/node": "^20.19.4",
-    "axe-core": "^4.11.1",
+    "axe-core": "~4.11.1",
     "jasmine-core": "~5.8.0",
     "karma-chrome-launcher": "~3.2.0",
     "karma-coverage": "~2.2.1",

--- a/apps/code-examples/src/assets/stack-blitz/package.json
+++ b/apps/code-examples/src/assets/stack-blitz/package.json
@@ -81,7 +81,7 @@
     "@skyux-sdk/testing": "^13.11.5",
     "@types/jasmine": "~5.1.8",
     "@types/node": "^20.19.4",
-    "axe-core": "^4.10.3",
+    "axe-core": "^4.11.1",
     "jasmine-core": "~5.8.0",
     "karma-chrome-launcher": "~3.2.0",
     "karma-coverage": "~2.2.1",

--- a/libs/sdk/testing/package.json
+++ b/libs/sdk/testing/package.json
@@ -27,7 +27,7 @@
     "@angular/core": "^21.1.2",
     "@angular/platform-browser": "^21.1.2",
     "@skyux/i18n": "0.0.0-PLACEHOLDER",
-    "axe-core": "^3.5.6 || ~4.6.3 || ~4.7.2 || ~4.11.1"
+    "axe-core": "~4.11.1"
   },
   "dependencies": {
     "tslib": "^2.8.1"


### PR DESCRIPTION
[AB#3696250](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3696250)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated axe-core to v4.11.1 for development and testing to align tooling.
  * Narrowed peer dependency constraint to the exact 4.11.1 patch to ensure consistent compatibility across environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->