### PR TITLE
fix(components/list-builder): stop overriding dropdown button padding (#4181)

### DIFF
--- a/apps/e2e/lists-storybook/src/app/list-view-grid/list-view-grid.component.html
+++ b/apps/e2e/lists-storybook/src/app/list-view-grid/list-view-grid.component.html
@@ -4,6 +4,11 @@
       [gridView]="grid"
       (helpOpened)="onHelpOpened($event)"
     />
+    <sky-list-secondary-actions>
+      <sky-list-secondary-action>
+        <button type="button">Option</button>
+      </sky-list-secondary-action>
+    </sky-list-secondary-actions>
   </sky-list-toolbar>
   <sky-list-view-grid
     #grid

--- a/apps/e2e/lists-storybook/src/app/list-view-grid/list-view-grid.module.ts
+++ b/apps/e2e/lists-storybook/src/app/list-view-grid/list-view-grid.module.ts
@@ -1,6 +1,10 @@
 import { NgModule } from '@angular/core';
 import { SkyToolbarModule } from '@skyux/layout';
-import { SkyListModule, SkyListToolbarModule } from '@skyux/list-builder';
+import {
+  SkyListModule,
+  SkyListSecondaryActionsModule,
+  SkyListToolbarModule,
+} from '@skyux/list-builder';
 import { SkyListViewGridModule } from '@skyux/list-builder-view-grids';
 import { SkyDropdownModule } from '@skyux/popovers';
 
@@ -13,6 +17,7 @@ import { ListViewGridComponent } from './list-view-grid.component';
     SkyListToolbarModule,
     SkyListModule,
     SkyToolbarModule,
+    SkyListSecondaryActionsModule,
   ],
   declarations: [ListViewGridComponent],
   exports: [ListViewGridComponent],

--- a/libs/components/list-builder/src/lib/modules/list-toolbar/list-secondary-actions/list-secondary-actions-host.component.scss
+++ b/libs/components/list-builder/src/lib/modules/list-toolbar/list-secondary-actions/list-secondary-actions-host.component.scss
@@ -1,11 +1,5 @@
 @use 'libs/components/theme/src/lib/styles/mixins' as mixins;
 
-.sky-list-secondary-actions {
-  ::ng-deep .sky-dropdown-button-type-select {
-    padding: 6px 12px;
-  }
-}
-
 .sky-list-secondary-actions-hidden {
   display: none;
 }


### PR DESCRIPTION
:cherries: Cherry picked from #4181 [fix(components/list-builder): stop overriding dropdown button padding](https://github.com/blackbaud/skyux/pull/4181)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added secondary action functionality to list toolbars, enabling users to access an "Option" button with additional list-level actions

* **Style**
  * Refined dropdown button styling within secondary action areas for improved visual consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->