### PR TITLE
fix(components/lookup): lookup and selections modals use correct footer button spacing in modern theme

### DIFF
--- a/libs/components/lookup/src/lib/modules/lookup/lookup-show-more-modal.component.html
+++ b/libs/components/lookup/src/lib/modules/lookup/lookup-show-more-modal.component.html
@@ -138,12 +138,15 @@
   </sky-modal-content>
   <sky-modal-footer>
     <button
-      class="sky-btn sky-btn-primary sky-margin-inline-compact sky-lookup-show-more-modal-save"
+      class="sky-btn sky-btn-primary sky-lookup-show-more-modal-save"
       type="button"
       [attr.aria-label]="
         'skyux_lookup_show_more_select_context'
           | skyLibResources: context.userConfig.selectionDescriptor
       "
+      [skyThemeClass]="{
+        'sky-margin-inline-compact': 'default'
+      }"
       (click)="modalInstance.save(selectedItems)"
     >
       {{ 'skyux_lookup_show_more_select' | skyLibResources }}

--- a/libs/components/lookup/src/lib/modules/selection-modal/selection-modal.component.html
+++ b/libs/components/lookup/src/lib/modules/selection-modal/selection-modal.component.html
@@ -147,13 +147,16 @@
   </sky-modal-content>
   <sky-modal-footer>
     <button
-      class="sky-btn sky-btn-primary sky-margin-inline-compact sky-lookup-show-more-modal-save"
+      class="sky-btn sky-btn-primary sky-lookup-show-more-modal-save"
       type="button"
       [attr.aria-label]="
         'skyux_lookup_show_more_select_context'
           | skyLibResources: context.selectionDescriptor
       "
       [disabled]="isSearching"
+      [skyThemeClass]="{
+        'sky-margin-inline-compact': 'default'
+      }"
       (click)="save()"
     >
       {{ 'skyux_lookup_show_more_select' | skyLibResources }}


### PR DESCRIPTION
[AB#3704526](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3704526)