### PR TITLE
fix(sdk/skyux-eslint)!: modify `skyux-eslint-template/prefer-label-text` ESLint rule to require `labelText` for all `sky-input-box` implementations

### DIFF
--- a/libs/sdk/skyux-eslint/docs/rules/template/prefer-label-text.md
+++ b/libs/sdk/skyux-eslint/docs/rules/template/prefer-label-text.md
@@ -2,6 +2,8 @@
 
 Ensures form components set the `labelText` (or `headingText`) attribute, which automatically activates key usability and accessibility features.
 
+Setting `labelText` (or `headingText`) on a component is the preferred, modern approach to labeling SKY UX form components. It replaces older patterns that placed a dedicated label child element (e.g. `<sky-checkbox-label>`, `<sky-input-box><label>`) inside the component.
+
 - Type: problem
 - 🔧 Supports autofix (`--fix`)
 
@@ -10,6 +12,62 @@ Ensures form components set the `labelText` (or `headingText`) attribute, which 
 ## Rule Options
 
 The rule does not have any configuration options.
+
+<br>
+
+## Affected Components
+
+### `<sky-box>`
+
+Replaces the deprecated `<sky-box-header>` child element. Setting `headingText` enables:
+
+- **Inline help** — The `helpPopoverContent` and `helpKey` inputs only activate when `headingText` is also set.
+
+### `<sky-checkbox>`
+
+Replaces the deprecated `<sky-checkbox-label>` child element. Setting `labelText` enables:
+
+- **Inline help** — The `helpPopoverContent` and `helpKey` inputs only activate when `labelText` is also set.
+- **Hint text** — The `hintText` input provides persistent inline guidance below the checkbox.
+- **Automatic error messages** — Built-in validation error messages include the `labelText` value to provide meaningful context to users.
+
+### `<sky-file-attachment>`
+
+Replaces the deprecated `<sky-file-attachment-label>` child element. Setting `labelText` enables:
+
+- **Inline help** — The `helpPopoverContent` and `helpKey` inputs only activate when `labelText` is also set.
+- **Hint text** — The `hintText` input provides persistent inline guidance below the file attachment.
+
+### `<sky-input-box>`
+
+Replaces the `<label>` child element pattern. Setting `labelText` enables:
+
+- **Automatic label association** — The label is automatically linked to the component's internal input element. No `skyId` directive, `[for]` binding, or manual `id` management is required.
+- **Inline help** — The `helpPopoverContent` and `helpKey` inputs only activate when `labelText` is also set.
+- **Hint text** — The `hintText` input provides persistent inline guidance below the input.
+- **Character count** — The `characterLimit` input places a character count indicator on the input.
+- **Automatic error messages** — Built-in validation error messages include the `labelText` value to provide meaningful context to users.
+
+When autofixing, the rule also removes the `sky-form-control` CSS class from child `<input>`, `<select>`, and `<textarea>` elements, since that class is no longer needed when `labelText` is used.
+
+### `<sky-modal>`
+
+Replaces the deprecated `<sky-modal-header>` child element. Setting `headingText` enables:
+
+- **Inline help** — The `helpPopoverContent` and `helpKey` inputs only activate when `headingText` is also set.
+
+### `<sky-radio>`
+
+Replaces the deprecated `<sky-radio-label>` child element. Setting `labelText` enables:
+
+- **Inline help** — The `helpPopoverContent` and `helpKey` inputs only activate when `labelText` is also set.
+- **Hint text** — The `hintText` input provides persistent inline guidance below the radio button.
+
+### `<sky-toggle-switch>`
+
+Replaces the deprecated `<sky-toggle-switch-label>` child element. Setting `labelText` enables:
+
+- **Inline help** — The `helpPopoverContent` and `helpKey` inputs only activate when `labelText` is also set.
 
 <br>
 
@@ -30,6 +88,7 @@ The rule does not have any configuration options.
 #### ❌ Invalid Code
 
 ```html
+<!-- sky-checkbox: using a legacy label child element -->
 <sky-checkbox>
 ~~~~~~~~~~~~~~
   <sky-checkbox-label>
@@ -40,6 +99,21 @@ The rule does not have any configuration options.
   ~~~~~~~~~~~~~~~~~~~~~
 </sky-checkbox>
 ~~~~~~~~~~~~~~~
+
+<!-- sky-input-box: using a <label> child element -->
+<sky-input-box>
+~~~~~~~~~~~~~~~
+  <label>First name</label>
+  ~~~~~~~~~~~~~~~~~~~~~~~~~
+  <input class="sky-form-control" type="text" />
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</sky-input-box>
+~~~~~~~~~~~~~~~~
+
+<!-- sky-modal: using a legacy header child element -->
+<sky-modal>
+  <sky-modal-header>My modal</sky-modal-header>
+</sky-modal>
 ```
 
 <br>
@@ -47,5 +121,14 @@ The rule does not have any configuration options.
 #### ✅ Valid Code
 
 ```html
+<!-- sky-checkbox: labelText enables helpKey, hintText, and error messages -->
 <sky-checkbox [labelText]="'first_name' | skyAppResources" />
+
+<!-- sky-input-box: labelText handles label association automatically -->
+<sky-input-box labelText="First name">
+  <input type="text" />
+</sky-input-box>
+
+<!-- sky-modal: headingText enables helpKey and helpPopoverContent -->
+<sky-modal headingText="My modal" />
 ```

--- a/libs/sdk/skyux-eslint/docs/rules/template/prefer-label-text.md
+++ b/libs/sdk/skyux-eslint/docs/rules/template/prefer-label-text.md
@@ -88,7 +88,6 @@ Replaces the deprecated `<sky-toggle-switch-label>` child element. Setting `labe
 #### ❌ Invalid Code
 
 ```html
-<!-- sky-checkbox: using a legacy label child element -->
 <sky-checkbox>
 ~~~~~~~~~~~~~~
   <sky-checkbox-label>
@@ -100,7 +99,6 @@ Replaces the deprecated `<sky-toggle-switch-label>` child element. Setting `labe
 </sky-checkbox>
 ~~~~~~~~~~~~~~~
 
-<!-- sky-input-box: using a <label> child element -->
 <sky-input-box>
 ~~~~~~~~~~~~~~~
   <label>First name</label>
@@ -110,7 +108,6 @@ Replaces the deprecated `<sky-toggle-switch-label>` child element. Setting `labe
 </sky-input-box>
 ~~~~~~~~~~~~~~~~
 
-<!-- sky-modal: using a legacy header child element -->
 <sky-modal>
   <sky-modal-header>My modal</sky-modal-header>
 </sky-modal>
@@ -121,14 +118,11 @@ Replaces the deprecated `<sky-toggle-switch-label>` child element. Setting `labe
 #### ✅ Valid Code
 
 ```html
-<!-- sky-checkbox: labelText enables helpKey, hintText, and error messages -->
 <sky-checkbox [labelText]="'first_name' | skyAppResources" />
 
-<!-- sky-input-box: labelText handles label association automatically -->
 <sky-input-box labelText="First name">
   <input type="text" />
 </sky-input-box>
 
-<!-- sky-modal: headingText enables helpKey and helpPopoverContent -->
 <sky-modal headingText="My modal" />
 ```

--- a/libs/sdk/skyux-eslint/docs/rules/template/prefer-label-text.md
+++ b/libs/sdk/skyux-eslint/docs/rules/template/prefer-label-text.md
@@ -37,6 +37,7 @@ Replaces the deprecated `<sky-file-attachment-label>` child element. Setting `la
 
 - **Inline help** — The `helpPopoverContent` and `helpKey` inputs only activate when `labelText` is also set.
 - **Hint text** — The `hintText` input provides persistent inline guidance below the file attachment.
+- **Automatic error messages** — Built-in validation error messages include the `labelText` value to provide meaningful context to users.
 
 ### `<sky-input-box>`
 

--- a/libs/sdk/skyux-eslint/docs/rules/template/prefer-label-text.md
+++ b/libs/sdk/skyux-eslint/docs/rules/template/prefer-label-text.md
@@ -1,6 +1,6 @@
 # skyux-eslint-template/prefer-label-text
 
-Ensures form components set the `labelText` (or `headingText`) attribute, which automatically activates key usability and accessibility features.
+Ensures form components set the `labelText` (or `headingText`) attribute, which automatically activates key usability and accessibility features, including proper ARIA labeling and label-to-control association without requiring manual `id` or `aria-*` attribute management.
 
 Setting `labelText` (or `headingText`) on a component is the preferred, modern approach to labeling SKY UX form components. It replaces older patterns that placed a dedicated label child element (e.g. `<sky-checkbox-label>`, `<sky-input-box><label>`) inside the component.
 

--- a/libs/sdk/skyux-eslint/src/rules/template/prefer-label-text.spec.ts
+++ b/libs/sdk/skyux-eslint/src/rules/template/prefer-label-text.spec.ts
@@ -12,11 +12,6 @@ ruleTester.run(RULE_NAME, rule, {
     `<sky-checkbox labelText="foo">`,
     `<sky-checkbox [labelText]="foo">`,
     `<sky-checkbox labelText="{{ foo }}">`,
-    `
-    <sky-input-box>
-      <label [for]="myInput.id">My label</label>
-      <input #myInput="skyId" skyId class="sky-form-control" type="text" />
-    </sky-input-box>`,
   ],
   invalid: [
     convertAnnotatedSourceToFailureCase({
@@ -87,6 +82,36 @@ ruleTester.run(RULE_NAME, rule, {
       annotatedOutput: `
         <sky-input-box labelText="foo"></sky-input-box>
         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      `,
+      messageId,
+      data: {
+        selector: 'sky-input-box',
+        labelInputName: 'labelText',
+        labelSelector: 'label',
+      },
+    }),
+    convertAnnotatedSourceToFailureCase({
+      description:
+        'should fix sky-input-box with label and input without class',
+      annotatedSource: `
+        <sky-input-box>
+        ~~~~~~~~~~~~~~~~
+          <label>My label</label>
+          ~~~~~~~~~~~~~~~~~~~~~~~
+          <input type="text" />
+          ~~~~~~~~~~~~~~~~~~~~~
+        </sky-input-box>
+        ~~~~~~~~~~~~~~~~
+      `,
+      annotatedOutput: `
+        <sky-input-box labelText="My label">
+        ~
+          ~
+          ~
+          <input type="text" />
+          ~
+        </sky-input-box>
+        ~
       `,
       messageId,
       data: {
@@ -327,6 +352,26 @@ ruleTester.run(RULE_NAME, rule, {
         selector: 'sky-checkbox',
         labelInputName: 'labelText',
         labelSelector: 'sky-checkbox-label',
+      },
+    }),
+    convertAnnotatedSourceToFailureCase({
+      description:
+        'should fail but not fix for sky-input-box with label using [for] binding',
+      annotatedSource: `
+        <sky-input-box>
+        ~~~~~~~~~~~~~~~
+          <label [for]="myInput.id">My label</label>
+          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+          <input #myInput="skyId" skyId class="sky-form-control" type="text" />
+          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        </sky-input-box>
+        ~~~~~~~~~~~~~~~~
+      `,
+      messageId,
+      data: {
+        selector: 'sky-input-box',
+        labelInputName: 'labelText',
+        labelSelector: 'label',
       },
     }),
     convertAnnotatedSourceToFailureCase({

--- a/libs/sdk/skyux-eslint/src/rules/template/prefer-label-text.ts
+++ b/libs/sdk/skyux-eslint/src/rules/template/prefer-label-text.ts
@@ -164,17 +164,6 @@ export const rule = createESLintTemplateRule({
         const inputEl = getChildNodeOf(el, ['input', 'select', 'textarea']);
 
         if (labelEl) {
-          // Abort if the `skyId` directive is used on a child input of the
-          // `<sky-input-box />` component since its inclusion usually means the
-          // user wishes to implement "hard mode".
-          if (
-            el.name === 'sky-input-box' &&
-            inputEl &&
-            getAttributeByName(inputEl, 'skyId')
-          ) {
-            return;
-          }
-
           const hasElementChildren = labelEl.children.some(
             (child) => child instanceof TmplAstElement,
           );


### PR DESCRIPTION
BREAKING CHANGE
The `skyux-eslint-template/prefer-label-text` ESLint rule now always reports an error for `<sky-input-box>` components that use a `<label>` child element instead of the `labelText` input. Previously, `<sky-input-box>` instances that used the `skyId` directive on a child input element were exempt from this rule, as this pattern was used to implement "hard mode" label association. This exemption has been removed. All `<sky-input-box>` components must now use the `labelText` input for labeling. Run `ng lint --fix` to automatically migrate eligible usages.

[AB#3673971](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3673971)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded labeling guidance with detailed before/after examples, affected components, modern label patterns, autofix notes, and updated usage snippets.

* **Improvements**
  * Rule now covers additional input/label scenarios previously bypassed, including cases with internal identifiers.

* **Tests**
  * Broadened test coverage to include autofix conversions and explicit non-fix cases (e.g., bound labels).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->