### PR TITLE
fix(components/core): run viewkeeper sync event outside Angular zone

### DIFF
--- a/libs/components/core/src/lib/modules/viewkeeper/viewkeeper.directive.spec.ts
+++ b/libs/components/core/src/lib/modules/viewkeeper/viewkeeper.directive.spec.ts
@@ -318,11 +318,7 @@ describe('Viewkeeper directive', () => {
     );
     const el1 = fixture.nativeElement.querySelector('.el1');
 
-    // Fire the event outside of fakeAsync zone control since the callback
-    // runs outside Angular's zone with a real animationFrameScheduler.
-    ngZone.runOutsideAngular(() => {
-      SkyAppTestUtility.fireDomEvent(el1, 'afterViewkeeperSync');
-    });
+    SkyAppTestUtility.fireDomEvent(el1, 'afterViewkeeperSync');
     tick(16);
 
     expect(shadowEl.classList).toContain('sky-viewkeeper-shadow--active');

--- a/libs/components/core/src/lib/modules/viewkeeper/viewkeeper.directive.spec.ts
+++ b/libs/components/core/src/lib/modules/viewkeeper/viewkeeper.directive.spec.ts
@@ -99,6 +99,13 @@ describe('Viewkeeper directive', () => {
     }
   }
 
+  function flushNextAnimationFrame(): void {
+    // The viewkeeper sync stream uses animationFrameScheduler. A full frame at
+    // 60Hz is ~16.67ms, so we tick slightly beyond that to avoid boundary
+    // timing flakes across environments.
+    tick(20);
+  }
+
   beforeEach(() => {
     mutationCallbacks = [];
 
@@ -158,7 +165,7 @@ describe('Viewkeeper directive', () => {
     expect(shadowEl).toBeTruthy();
     const el1 = fixture.nativeElement.querySelector('.el1');
     SkyAppTestUtility.fireDomEvent(el1, 'afterViewkeeperSync');
-    tick(16);
+    flushNextAnimationFrame();
     expect(shadowEl.classList).toContain('sky-viewkeeper-shadow--active');
 
     fixture.componentInstance.showEl1 = false;
@@ -166,7 +173,7 @@ describe('Viewkeeper directive', () => {
     triggerMutationChange();
     const el2 = fixture.nativeElement.querySelector('.el2');
     SkyAppTestUtility.fireDomEvent(el2, 'afterViewkeeperSync');
-    tick(16);
+    flushNextAnimationFrame();
     expect(shadowEl.classList).not.toContain('sky-viewkeeper-shadow--active');
   }));
 
@@ -291,7 +298,7 @@ describe('Viewkeeper directive', () => {
     expect(mockMutationObserver.disconnect).toHaveBeenCalledTimes(3);
   });
 
-  it('should subscribe to afterViewkeeperSync outside Angular zone', fakeAsync(() => {
+  it('should subscribe to afterViewkeeperSync outside Angular zone', async () => {
     const ngZone = TestBed.inject(NgZone);
     const originalRunOutsideAngular = ngZone.runOutsideAngular.bind(ngZone);
     let outsideAngularCallbackCount = 0;
@@ -319,8 +326,12 @@ describe('Viewkeeper directive', () => {
     const el1 = fixture.nativeElement.querySelector('.el1');
 
     SkyAppTestUtility.fireDomEvent(el1, 'afterViewkeeperSync');
-    tick(16);
+    await new Promise<void>((resolve) => {
+      requestAnimationFrame(() => {
+        resolve();
+      });
+    });
 
     expect(shadowEl.classList).toContain('sky-viewkeeper-shadow--active');
-  }));
+  });
 });

--- a/libs/components/core/src/lib/modules/viewkeeper/viewkeeper.directive.spec.ts
+++ b/libs/components/core/src/lib/modules/viewkeeper/viewkeeper.directive.spec.ts
@@ -1,3 +1,4 @@
+import { NgZone } from '@angular/core';
 import {
   ComponentFixture,
   TestBed,
@@ -289,4 +290,41 @@ describe('Viewkeeper directive', () => {
     // Called twice from the scrollable host service when we unsubscribe from the observable and once for the viewkeepers own mutation observer.
     expect(mockMutationObserver.disconnect).toHaveBeenCalledTimes(3);
   });
+
+  it('should subscribe to afterViewkeeperSync outside Angular zone', fakeAsync(() => {
+    const ngZone = TestBed.inject(NgZone);
+    const originalRunOutsideAngular = ngZone.runOutsideAngular.bind(ngZone);
+    let outsideAngularCallbackCount = 0;
+
+    spyOn(ngZone, 'runOutsideAngular').and.callFake((fn: () => never) => {
+      outsideAngularCallbackCount++;
+      return originalRunOutsideAngular(fn);
+    });
+
+    const fixture = TestBed.createComponent(ViewkeeperTestComponent);
+    fixture.componentInstance.scrollableHost = true;
+
+    const callCountBefore = outsideAngularCallbackCount;
+    fixture.detectChanges();
+    triggerMutationChange();
+    const callCountAfter = outsideAngularCallbackCount;
+
+    // The directive should call runOutsideAngular at least once when detecting elements.
+    expect(callCountAfter).toBeGreaterThan(callCountBefore);
+
+    // Verify the subscription still works correctly outside the zone.
+    const shadowEl = fixture.nativeElement.querySelector(
+      '.sky-viewkeeper-shadow',
+    );
+    const el1 = fixture.nativeElement.querySelector('.el1');
+
+    // Fire the event outside of fakeAsync zone control since the callback
+    // runs outside Angular's zone with a real animationFrameScheduler.
+    ngZone.runOutsideAngular(() => {
+      SkyAppTestUtility.fireDomEvent(el1, 'afterViewkeeperSync');
+    });
+    tick(16);
+
+    expect(shadowEl.classList).toContain('sky-viewkeeper-shadow--active');
+  }));
 });

--- a/libs/components/core/src/lib/modules/viewkeeper/viewkeeper.directive.ts
+++ b/libs/components/core/src/lib/modules/viewkeeper/viewkeeper.directive.ts
@@ -3,6 +3,7 @@ import {
   Directive,
   ElementRef,
   Input,
+  NgZone,
   OnDestroy,
   OnInit,
   Optional,
@@ -57,6 +58,7 @@ export class SkyViewkeeperDirective
 
   #viewkeeperSvc: SkyViewkeeperService;
 
+  readonly #ngZone = inject(NgZone);
   readonly #renderer = inject(RendererFactory2).createRenderer(undefined, null);
   #shadowElement: HTMLElement | undefined;
 
@@ -189,53 +191,56 @@ export class SkyViewkeeperDirective
             }
           });
       }
+
       this.#scrollableHostWatchUnsubscribe.pipe(take(1)).subscribe(() => {
         this.#shadowElement?.classList.remove('sky-viewkeeper-shadow--active');
       });
-      fromEvent(viewkeeperEls, 'afterViewkeeperSync')
-        .pipe(
-          takeUntil(this.#scrollableHostWatchUnsubscribe),
-          observeOn(animationFrameScheduler),
-        )
-        .subscribe(() => {
-          const applicable = viewkeeperEls.filter(
-            (el) =>
-              el.classList.contains('sky-viewkeeper-fixed') &&
-              (!this.skyViewkeeperOmitShadow ||
-                !el.matches(this.skyViewkeeperOmitShadow)),
-          );
-          if (applicable.length === 0) {
-            this.#shadowElement?.classList.remove(
-              'sky-viewkeeper-shadow--active',
+
+      const unsubscribe = this.#scrollableHostWatchUnsubscribe;
+
+      this.#ngZone.runOutsideAngular(() => {
+        fromEvent(viewkeeperEls, 'afterViewkeeperSync')
+          .pipe(takeUntil(unsubscribe), observeOn(animationFrameScheduler))
+          .subscribe(() => {
+            const applicable = viewkeeperEls.filter(
+              (el) =>
+                el.classList.contains('sky-viewkeeper-fixed') &&
+                (!this.skyViewkeeperOmitShadow ||
+                  !el.matches(this.skyViewkeeperOmitShadow)),
             );
-            return;
-          }
-          this.#shadowElement?.classList.add('sky-viewkeeper-shadow--active');
-          const boundingRectangles = applicable.map((el) =>
-            el.getBoundingClientRect(),
-          );
-          const left = boundingRectangles.reduce(
-            (num, rect) => Math.min(num, rect.left),
-            Number.POSITIVE_INFINITY,
-          );
-          const right = boundingRectangles.reduce(
-            (num, rect) => Math.max(num, rect.right),
-            Number.NEGATIVE_INFINITY,
-          );
-          const top = boundingRectangles.reduce(
-            (num, rect) => Math.min(num, rect.top),
-            Number.POSITIVE_INFINITY,
-          );
-          const bottom = boundingRectangles.reduce(
-            (num, rect) => Math.max(num, rect.bottom),
-            Number.NEGATIVE_INFINITY,
-          );
-          this.#renderer.setStyle(
-            this.#shadowElement,
-            'inset',
-            `${top}px ${window.innerWidth - right}px ${window.innerHeight - bottom}px ${left}px`,
-          );
-        });
+            if (applicable.length === 0) {
+              this.#shadowElement?.classList.remove(
+                'sky-viewkeeper-shadow--active',
+              );
+              return;
+            }
+            this.#shadowElement?.classList.add('sky-viewkeeper-shadow--active');
+            const boundingRectangles = applicable.map((el) =>
+              el.getBoundingClientRect(),
+            );
+            const left = boundingRectangles.reduce(
+              (num, rect) => Math.min(num, rect.left),
+              Number.POSITIVE_INFINITY,
+            );
+            const right = boundingRectangles.reduce(
+              (num, rect) => Math.max(num, rect.right),
+              Number.NEGATIVE_INFINITY,
+            );
+            const top = boundingRectangles.reduce(
+              (num, rect) => Math.min(num, rect.top),
+              Number.POSITIVE_INFINITY,
+            );
+            const bottom = boundingRectangles.reduce(
+              (num, rect) => Math.max(num, rect.bottom),
+              Number.NEGATIVE_INFINITY,
+            );
+            this.#renderer.setStyle(
+              this.#shadowElement,
+              'inset',
+              `${top}px ${window.innerWidth - right}px ${window.innerHeight - bottom}px ${left}px`,
+            );
+          });
+      });
 
       this.#currentViewkeeperEls = viewkeeperEls;
     }


### PR DESCRIPTION
The `fromEvent` + `animationFrameScheduler` subscription in the viewkeeper directive was running inside Angular's zone, causing two problems:

1. Unnecessary change detection — Every `afterViewkeeperSync` event and every `requestAnimationFrame` callback triggered a full change detection cycle, even though the subscriber only performs DOM reads/writes and never mutates Angular state.
2. Zone instability — The `animationFrameScheduler` registers a pending macrotask on each emission. During scroll, these fire continuously, keeping `NgZone.isStable` permanently false. This causes CDK test harnesses (which internally `await fixture.whenStable()`) to hang indefinitely in any test that renders a component using the viewkeeper directive.
The fix wraps the subscription in `NgZone.runOutsideAngular()` so the event listener and `requestAnimationFrame` callbacks bypass Angular's zone entirely. This is safe in zoneless applications as well, where `runOutsideAngular` is a no-op.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a test validating the viewkeeper behavior when applicable elements are detected, ensuring its post-sync work runs outside the Angular zone and results in the expected DOM state.

* **Refactor**
  * Improved viewkeeper performance by moving post-sync work outside the Angular zone, optimizing subscription handling, adding an early-exit when no elements apply, and refining geometry and styling application for the shadow element.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->