### PR TITLE
fix(components/lists): disconnect `MutationObserver` in infinite scroll adapter on destroy

### DIFF
--- a/libs/components/lists/src/lib/modules/infinite-scroll/infinite-scroll-dom-adapter.service.ts
+++ b/libs/components/lists/src/lib/modules/infinite-scroll/infinite-scroll-dom-adapter.service.ts
@@ -31,6 +31,7 @@ export class SkyInfiniteScrollDomAdapterService implements OnDestroy {
     this.#parentChanges.complete();
     this.#ngUnsubscribe.next();
     this.#ngUnsubscribe.complete();
+    this.#observer?.disconnect();
   }
 
   /**

--- a/libs/components/lists/src/lib/modules/infinite-scroll/infinite-scroll.component.spec.ts
+++ b/libs/components/lists/src/lib/modules/infinite-scroll/infinite-scroll.component.spec.ts
@@ -59,6 +59,23 @@ describe('Infinite scroll', () => {
     fixture.detectChanges();
   }
 
+  function getScrollableWrapper(): HTMLElement {
+    const wrapper = fixture.componentInstance.wrapper
+      ?.nativeElement as HTMLElement;
+
+    wrapper.setAttribute('style', 'height:200px;overflow:auto;');
+
+    return wrapper;
+  }
+
+  async function waitForMutationObserverTurn(): Promise<void> {
+    await new Promise<void>((resolve) => {
+      requestAnimationFrame(() => {
+        resolve();
+      });
+    });
+  }
+
   it('should set defaults', () => {
     expect(fixture.componentInstance.infiniteScrollComponent.enabled).toEqual(
       false,
@@ -171,8 +188,7 @@ describe('Infinite scroll', () => {
   });
 
   it('should emit a scrollEnd event on scroll when an element is the scrollable parent', () => {
-    const wrapper = fixture.componentInstance.wrapper?.nativeElement;
-    wrapper.setAttribute('style', 'height:200px;overflow:auto;');
+    const wrapper = getScrollableWrapper();
 
     fixture.componentInstance.enabled = true;
     fixture.componentInstance.loadItems(1000);
@@ -299,14 +315,13 @@ describe('Infinite scroll', () => {
   });
 
   it('should notify of parent changes when elements are added outside the infinite scroll element', async () => {
-    const wrapper = fixture.componentInstance.wrapper?.nativeElement;
-    wrapper.setAttribute('style', 'height:200px;overflow:auto;');
+    const wrapper = getScrollableWrapper();
 
     fixture.componentInstance.enabled = true;
     fixture.detectChanges();
 
     // Wait for any initial MutationObserver callbacks from the first render.
-    await new Promise((resolve) => setTimeout(resolve));
+    await waitForMutationObserverTurn();
 
     // Set isWaiting to true so we can verify it gets reset by parentChanges.
     fixture.componentInstance.infiniteScrollComponent.isWaiting = true;
@@ -317,7 +332,7 @@ describe('Infinite scroll', () => {
     wrapper.appendChild(newElement);
 
     // Wait for the MutationObserver callback to fire.
-    await new Promise((resolve) => setTimeout(resolve));
+    await waitForMutationObserverTurn();
 
     expect(fixture.componentInstance.infiniteScrollComponent.isWaiting).toBe(
       false,
@@ -327,14 +342,13 @@ describe('Infinite scroll', () => {
   });
 
   it('should not notify of parent changes when elements are added inside the infinite scroll element', async () => {
-    const wrapper = fixture.componentInstance.wrapper?.nativeElement;
-    wrapper.setAttribute('style', 'height:200px;overflow:auto;');
+    getScrollableWrapper();
 
     fixture.componentInstance.enabled = true;
     fixture.detectChanges();
 
     // Wait for any initial MutationObserver callbacks from the first render.
-    await new Promise((resolve) => setTimeout(resolve));
+    await waitForMutationObserverTurn();
 
     fixture.componentInstance.infiniteScrollComponent.isWaiting = true;
 
@@ -348,7 +362,7 @@ describe('Infinite scroll', () => {
     infiniteScrollEl.appendChild(newElement);
 
     // Wait for the MutationObserver callback to fire.
-    await new Promise((resolve) => setTimeout(resolve));
+    await waitForMutationObserverTurn();
 
     expect(fixture.componentInstance.infiniteScrollComponent.isWaiting).toBe(
       true,

--- a/libs/components/lists/src/lib/modules/infinite-scroll/infinite-scroll.component.spec.ts
+++ b/libs/components/lists/src/lib/modules/infinite-scroll/infinite-scroll.component.spec.ts
@@ -284,6 +284,79 @@ describe('Infinite scroll', () => {
     expect(spy).toHaveBeenCalled();
   });
 
+  it('should disconnect the MutationObserver on destroy', () => {
+    const disconnectSpy = spyOn(
+      MutationObserver.prototype,
+      'disconnect',
+    ).and.callThrough();
+
+    fixture.componentInstance.enabled = true;
+    fixture.detectChanges();
+
+    adapter.ngOnDestroy();
+
+    expect(disconnectSpy).toHaveBeenCalled();
+  });
+
+  it('should notify of parent changes when elements are added outside the infinite scroll element', async () => {
+    const wrapper = fixture.componentInstance.wrapper?.nativeElement;
+    wrapper.setAttribute('style', 'height:200px;overflow:auto;');
+
+    fixture.componentInstance.enabled = true;
+    fixture.detectChanges();
+
+    // Wait for any initial MutationObserver callbacks from the first render.
+    await new Promise((resolve) => setTimeout(resolve));
+
+    // Set isWaiting to true so we can verify it gets reset by parentChanges.
+    fixture.componentInstance.infiniteScrollComponent.isWaiting = true;
+
+    // Add an element to the wrapper (outside the infinite scroll element)
+    // to trigger the MutationObserver callback with hasUpdates = true.
+    const newElement = document.createElement('div');
+    wrapper.appendChild(newElement);
+
+    // Wait for the MutationObserver callback to fire.
+    await new Promise((resolve) => setTimeout(resolve));
+
+    expect(fixture.componentInstance.infiniteScrollComponent.isWaiting).toBe(
+      false,
+    );
+
+    wrapper.removeChild(newElement);
+  });
+
+  it('should not notify of parent changes when elements are added inside the infinite scroll element', async () => {
+    const wrapper = fixture.componentInstance.wrapper?.nativeElement;
+    wrapper.setAttribute('style', 'height:200px;overflow:auto;');
+
+    fixture.componentInstance.enabled = true;
+    fixture.detectChanges();
+
+    // Wait for any initial MutationObserver callbacks from the first render.
+    await new Promise((resolve) => setTimeout(resolve));
+
+    fixture.componentInstance.infiniteScrollComponent.isWaiting = true;
+
+    // Add an element inside the infinite scroll element. The MutationObserver
+    // callback should detect that the mutation target is contained within
+    // the infinite scroll element and NOT emit a parentChanges event.
+    const infiniteScrollEl = fixture.nativeElement.querySelector(
+      'sky-infinite-scroll',
+    );
+    const newElement = document.createElement('div');
+    infiniteScrollEl.appendChild(newElement);
+
+    // Wait for the MutationObserver callback to fire.
+    await new Promise((resolve) => setTimeout(resolve));
+
+    expect(fixture.componentInstance.infiniteScrollComponent.isWaiting).toBe(
+      true,
+    );
+
+    infiniteScrollEl.removeChild(newElement);
+  });
+
   it('should be accessible', async () => {
     fixture.detectChanges();
     await fixture.whenStable();


### PR DESCRIPTION
Disconnects the `MutationObserver` in `SkyInfiniteScrollDomAdapterService.ngOnDestroy()` to prevent it from continuing to observe DOM mutations after the service is destroyed. Added unit tests for the observer disconnect and for the `MutationObserver` callback itself, bringing the file to 100% coverage.