### PR TITLE
fix(components/core): optimize scrollable host clip-path and scroll event handling

### DIFF
--- a/libs/components/core/src/lib/modules/scrollable-host/scrollable-host.service.spec.ts
+++ b/libs/components/core/src/lib/modules/scrollable-host/scrollable-host.service.spec.ts
@@ -3,7 +3,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { SkyAppTestUtility } from '@skyux-sdk/testing';
 
 import { Subject, firstValueFrom, of } from 'rxjs';
-import { delay, take, takeUntil } from 'rxjs/operators';
+import { delay, skip, take, takeUntil } from 'rxjs/operators';
 
 import { SkyMutationObserverService } from '../mutation/mutation-observer-service';
 import { SkyResizeObserverService } from '../resize-observer/resize-observer.service';
@@ -621,6 +621,71 @@ describe('Scrollable host service', () => {
         expect(clipPath).toBe(
           `inset(10px ${viewport.width - 90}px ${viewport.height - 130}px 12px)`,
         );
+        done();
+      });
+  });
+
+  it('should not emit duplicate clip paths for repeated identical updates', (done) => {
+    const scrollableHostSvc = TestBed.inject(SkyScrollableHostService);
+
+    cmp.isParentPositioned = true;
+    cmp.positionedParentWidth = '100px';
+    fixture.detectChanges();
+
+    const done$ = new Subject<void>();
+    let duplicateEmissionCount = 0;
+
+    scrollableHostSvc
+      .watchScrollableHostClipPathChanges(cmp.target)
+      .pipe(skip(1), takeUntil(done$))
+      .subscribe(() => {
+        duplicateEmissionCount++;
+      });
+
+    scrollableHostSvc
+      .watchScrollableHostClipPathChanges(cmp.target)
+      .pipe(take(1))
+      .subscribe(() => {
+        SkyAppTestUtility.fireDomEvent(window, 'scroll');
+        SkyAppTestUtility.fireDomEvent(window, 'scroll');
+
+        setTimeout(() => {
+          expect(duplicateEmissionCount).toBe(0);
+          done$.next();
+          done$.complete();
+          done();
+        });
+      });
+  });
+
+  it('should only observe shared additional host parent once', (done) => {
+    const scrollableHostSvc = TestBed.inject(SkyScrollableHostService);
+    const resizeObserverSvc = TestBed.inject(SkyResizeObserverService);
+
+    cmp.isParentPositioned = true;
+    cmp.positionedParentWidth = '100px';
+    fixture.detectChanges();
+
+    const additionalHost =
+      fixture.nativeElement.querySelector('.additional-host');
+
+    const additionalHosts = of([
+      new ElementRef(additionalHost),
+      new ElementRef(additionalHost),
+    ]);
+
+    const sharedParent = additionalHost.offsetParent as HTMLElement;
+    const observeSpy = spyOn(resizeObserverSvc, 'observe').and.callThrough();
+
+    scrollableHostSvc
+      .watchScrollableHostClipPathChanges(cmp.target, additionalHosts)
+      .pipe(take(1))
+      .subscribe(() => {
+        const parentObserveCalls = observeSpy.calls
+          .allArgs()
+          .filter((args) => args[0].nativeElement === sharedParent);
+
+        expect(parentObserveCalls.length).toBe(1);
         done();
       });
   });

--- a/libs/components/core/src/lib/modules/scrollable-host/scrollable-host.service.ts
+++ b/libs/components/core/src/lib/modules/scrollable-host/scrollable-host.service.ts
@@ -9,6 +9,7 @@ import {
   combineLatestWith,
   concat,
   debounceTime,
+  distinctUntilChanged,
   fromEvent,
   map,
   observeOn,
@@ -31,6 +32,8 @@ function notifySubscribers(
 }
 
 type HostRect = Pick<DOMRect, 'top' | 'left' | 'right' | 'bottom'>;
+
+const SCROLLABLE_OVERFLOW_REGEX = /(auto|scroll)/;
 
 @Injectable({
   providedIn: 'root',
@@ -188,7 +191,9 @@ export class SkyScrollableHostService {
           // Only subscribe to scroll events if the host element is defined.
           /* istanbul ignore else */
           if (newScrollableHost) {
-            scrollEventSubscription = fromEvent(newScrollableHost, 'scroll')
+            scrollEventSubscription = fromEvent(newScrollableHost, 'scroll', {
+              passive: true,
+            })
               .pipe(takeUntil(newScrollableHostObservable))
               .subscribe(() => {
                 notifySubscribers(subscribers);
@@ -239,11 +244,17 @@ export class SkyScrollableHostService {
 
           const hostsParents: HTMLElement[] = additionalHosts
             .map((container) => container.nativeElement?.offsetParent)
-            .filter(Boolean);
+            .filter(Boolean)
+            .filter(
+              (hostsParent, index, parents) =>
+                parents.indexOf(hostsParent) === index,
+            );
           const inputs = [
             of(undefined),
             fromEvent(this.#windowRef.nativeWindow, 'resize'),
-            fromEvent(this.#windowRef.nativeWindow, 'scroll'),
+            fromEvent(this.#windowRef.nativeWindow, 'scroll', {
+              passive: true,
+            }),
             ...additionalHosts.map((container) =>
               resizeObserverSvc.observe(container),
             ),
@@ -292,6 +303,7 @@ export class SkyScrollableHostService {
               left = Math.max(0, left);
               return `inset(${top}px ${viewportSize.width - right}px ${viewportSize.height - bottom}px ${left}px)`;
             }),
+            distinctUntilChanged(),
           );
         }),
       );
@@ -304,7 +316,6 @@ export class SkyScrollableHostService {
   }
 
   #findScrollableHost(element: HTMLElement | undefined): HTMLElement | Window {
-    const regex = /(auto|scroll)/;
     const windowObj = this.#windowRef.nativeWindow;
     const bodyObj = windowObj.document.body;
 
@@ -325,8 +336,8 @@ export class SkyScrollableHostService {
 
       style = windowObj.getComputedStyle(parent);
     } while (
-      !regex.test(style.overflow) &&
-      !regex.test(style.overflowY) &&
+      !SCROLLABLE_OVERFLOW_REGEX.test(style.overflow) &&
+      !SCROLLABLE_OVERFLOW_REGEX.test(style.overflowY) &&
       parent !== bodyObj
     );
 


### PR DESCRIPTION
This PR improves `SkyScrollableHostService` performance in high-frequency scroll/clip-path scenarios while preserving existing behavior.

### Changes

- Added passive scroll listeners where supported to reduce main-thread scroll overhead.
- Deduplicated additional container parent hosts before wiring observer/scroll inputs.
- Suppressed duplicate clip-path emissions with `distinctUntilChanged()`.
- Hoisted the scrollable overflow regex to avoid repeated allocation.

### Tests
Added unit tests to verify:

- duplicate clip-path values are not re-emitted,
- shared additional-host parents are only observed once.

Verified with full core test suite and coverage run.