### PR TITLE
fix(components/theme): reduce viewport observer churn and skip redundant viewport css updates

### DIFF
--- a/libs/components/theme/src/lib/viewport/viewport.service.spec.ts
+++ b/libs/components/theme/src/lib/viewport/viewport.service.spec.ts
@@ -27,6 +27,140 @@ describe('Viewport service', () => {
     expect(svc.visible instanceof ReplaySubject).toEqual(true);
   });
 
+  it('should register a passive scroll listener', () => {
+    const addEventListenerSpy = spyOn(document, 'addEventListener');
+
+    TestBed.runInInjectionContext(() => new SkyAppViewportService());
+
+    expect(addEventListenerSpy).toHaveBeenCalledWith(
+      'scroll',
+      jasmine.any(Function),
+      jasmine.objectContaining({ passive: true }),
+    );
+  });
+
+  it('should recompute visibility from DOM geometry when observer callback runs', async () => {
+    const originalIntersectionObserver = window.IntersectionObserver;
+    let callback: IntersectionObserverCallback | undefined;
+    let capturedOptions: IntersectionObserverInit | undefined;
+
+    class FakeIntersectionObserver implements IntersectionObserver {
+      public readonly root: Element | Document | null = null;
+      public readonly rootMargin = '0px';
+      public readonly thresholds = [0, 1];
+
+      public constructor(
+        cb: IntersectionObserverCallback,
+        options?: IntersectionObserverInit,
+      ) {
+        callback = cb;
+        capturedOptions = options;
+      }
+
+      public disconnect(): void {
+        return;
+      }
+
+      public observe(_target: Element): void {
+        return;
+      }
+
+      public takeRecords(): IntersectionObserverEntry[] {
+        return [];
+      }
+
+      public unobserve(_target: Element): void {
+        return;
+      }
+    }
+
+    Object.defineProperty(window, 'IntersectionObserver', {
+      configurable: true,
+      value: FakeIntersectionObserver,
+      writable: true,
+    });
+
+    try {
+      const service = TestBed.runInInjectionContext(
+        () => new SkyAppViewportService(),
+      );
+
+      const element = document.createElement('div');
+      let inView = true;
+      spyOn(element, 'getBoundingClientRect').and.callFake(
+        (): DOMRect =>
+          ({
+            bottom: inView ? 100 : -20,
+            height: 40,
+            left: 0,
+            right: 100,
+            top: inView ? 60 : -60,
+            width: 100,
+            x: 0,
+            y: inView ? 60 : -60,
+            toJSON: (): object => ({}),
+          }) as DOMRect,
+      );
+      spyOn(document, 'elementFromPoint').and.returnValue(element);
+
+      service.reserveSpace({
+        id: 'observer-callback-test',
+        position: 'top',
+        reserveForElement: element,
+        size: 25,
+      });
+
+      await new Promise((resolve) => requestAnimationFrame(resolve));
+      validateViewportSpace('top', 25);
+
+      inView = false;
+      callback?.([], {} as IntersectionObserver);
+
+      await new Promise((resolve) => requestAnimationFrame(resolve));
+      validateViewportSpace('top', 0);
+
+      expect(capturedOptions?.threshold).toEqual([0, 1]);
+
+      service.unreserveSpace('observer-callback-test');
+      await new Promise((resolve) => requestAnimationFrame(resolve));
+    } finally {
+      Object.defineProperty(window, 'IntersectionObserver', {
+        configurable: true,
+        value: originalIntersectionObserver,
+        writable: true,
+      });
+    }
+  });
+
+  it('should not rewrite CSS variables when reserved values are unchanged', async () => {
+    const setPropertySpy = spyOn(
+      document.documentElement.style,
+      'setProperty',
+    ).and.callThrough();
+
+    svc.reserveSpace({
+      id: 'left-test-a',
+      position: 'left',
+      size: 20,
+    });
+
+    await new Promise((resolve) => requestAnimationFrame(resolve));
+    const initialSetPropertyCalls = setPropertySpy.calls.count();
+
+    svc.reserveSpace({
+      id: 'left-test-b',
+      position: 'left',
+      size: 0,
+    });
+
+    await new Promise((resolve) => requestAnimationFrame(resolve));
+    expect(setPropertySpy.calls.count()).toBe(initialSetPropertyCalls);
+
+    svc.unreserveSpace('left-test-b');
+    svc.unreserveSpace('left-test-a');
+    await new Promise((resolve) => requestAnimationFrame(resolve));
+  });
+
   it('should reserve and unreserve space', async () => {
     svc.reserveSpace({
       id: 'left-test',

--- a/libs/components/theme/src/lib/viewport/viewport.service.ts
+++ b/libs/components/theme/src/lib/viewport/viewport.service.ts
@@ -41,7 +41,7 @@ export class SkyAppViewportService {
     () =>
       new IntersectionObserver(
         () => this.#ngZone.run(() => this.#updateViewportArea()),
-        { threshold: Array.from({ length: 101 }, (_, i) => i / 100) },
+        { threshold: [0, 1] },
       ),
   );
   #reservedSpaces: Record<SkyAppViewportReservedPositionType, number> = {
@@ -51,20 +51,28 @@ export class SkyAppViewportService {
     top: 0,
   };
 
+  #stylesInitialized = false;
+
   constructor() {
     const onScroll = (): void => {
       if (this.#conditionallyReserveItems.size > 0) {
         this.#updateViewportArea();
       }
     };
-    this.#document.addEventListener('scroll', onScroll);
+
+    const eventOptions: AddEventListenerOptions = { passive: true };
+
+    this.#ngZone.runOutsideAngular(() => {
+      this.#document.addEventListener('scroll', onScroll, eventOptions);
+    });
+
     inject(DestroyRef).onDestroy(() => {
       /* istanbul ignore next */
       if (this.#updateRequest !== undefined) {
         cancelAnimationFrame(this.#updateRequest);
       }
       this.#intersectionObserver.disconnect();
-      this.#document.removeEventListener('scroll', onScroll);
+      this.#document.removeEventListener('scroll', onScroll, eventOptions);
     });
   }
 
@@ -114,15 +122,23 @@ export class SkyAppViewportService {
         }
       }
 
-      this.#reservedSpaces = reservedSpaces;
       const documentElementStyle = this.#document.documentElement.style;
 
       for (const [position, size] of Object.entries(reservedSpaces)) {
-        documentElementStyle.setProperty(
-          `--sky-viewport-${position}`,
-          size + 'px',
-        );
+        if (
+          !this.#stylesInitialized ||
+          size !==
+            this.#reservedSpaces[position as SkyAppViewportReservedPositionType]
+        ) {
+          documentElementStyle.setProperty(
+            `--sky-viewport-${position}`,
+            size + 'px',
+          );
+        }
       }
+
+      this.#reservedSpaces = reservedSpaces;
+      this.#stylesInitialized = true;
     });
   }
 


### PR DESCRIPTION
This PR improves viewport performance in the theme service by reducing unnecessary work during scroll/visibility updates.

### Changes

- Uses a `passive` scroll listener and registers it outside Angular’s zone.
- Switches `IntersectionObserver` thresholds to coarse boundary checks (`[0, 1]`) to reduce callback churn.
- Avoids redundant CSS custom property writes when viewport reserve values haven’t changed.
- Ensures initial CSS viewport variables are still written to prevent stale values.