### PR TITLE
docs: add `documentation.json` scope to the code-examples instructions sheet (#4273)

### DIFF
--- a/.github/instructions/code-examples-unit-testing.instructions.md
+++ b/.github/instructions/code-examples-unit-testing.instructions.md
@@ -1,5 +1,5 @@
 ---
-applyTo: '**/libs/components/code-examples/**'
+applyTo: '**/libs/components/code-examples/**|**/libs/components/*/src/**|**/libs/components/*/documentation.json'
 description: 'SKY UX Copilot instructions for generating code example unit tests.'
 ---
 


### PR DESCRIPTION
:cherries: Cherry picked from #4273 [docs: add `documentation.json` scope to the code-examples instructions sheet](https://github.com/blackbaud/skyux/pull/4273)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded the scope of unit testing instructions to apply to additional file types and paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->