### PR TITLE
chore: release 14.0.0-alpha.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 
-## [14.0.0-alpha.6](https://github.com/blackbaud/skyux/compare/14.0.0-alpha.5...14.0.0-alpha.6) (2026-03-09)
+## [14.0.0-alpha.6](https://github.com/blackbaud/skyux/compare/14.0.0-alpha.5...14.0.0-alpha.6) (2026-03-10)
 
 
 ### ⚠ BREAKING CHANGES
@@ -11,15 +11,6 @@
 ### Features
 
 * update `google-libphonenumber` and `intl-tel-input` and localize country names in phone field and country field ([#4271](https://github.com/blackbaud/skyux/issues/4271)) ([e175ac9](https://github.com/blackbaud/skyux/commit/e175ac993952f4b1eff778a4a4a9ba5f1fcb55db))
-
-## [13.14.3](https://github.com/blackbaud/skyux/compare/13.14.2...14.0.0-alpha.5) (2026-03-03)
-
-
-### Bug Fixes
-
-* update to `@angular/build@20.3.18` ([#4255](https://github.com/blackbaud/skyux/issues/4255)) ([f822ac9](https://github.com/blackbaud/skyux/commit/f822ac986316791797bb1a5019bcd1d967c2eb96))
-
-
 
 ## [13.14.3](https://github.com/blackbaud/skyux/compare/13.14.2...13.14.3) (2026-03-03)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,26 @@
 # Changelog
 
 
+## [14.0.0-alpha.6](https://github.com/blackbaud/skyux/compare/14.0.0-alpha.5...14.0.0-alpha.6) (2026-03-09)
+
+
+### ⚠ BREAKING CHANGES
+
+* Along with changes in `google-libphonenumber` and `intl-tel-input`, country names are now localized in the country field and phone field components.
+
+### Features
+
+* update `google-libphonenumber` and `intl-tel-input` and localize country names in phone field and country field ([#4271](https://github.com/blackbaud/skyux/issues/4271)) ([e175ac9](https://github.com/blackbaud/skyux/commit/e175ac993952f4b1eff778a4a4a9ba5f1fcb55db))
+
+## [13.14.3](https://github.com/blackbaud/skyux/compare/13.14.2...14.0.0-alpha.5) (2026-03-03)
+
+
+### Bug Fixes
+
+* update to `@angular/build@20.3.18` ([#4255](https://github.com/blackbaud/skyux/issues/4255)) ([f822ac9](https://github.com/blackbaud/skyux/commit/f822ac986316791797bb1a5019bcd1d967c2eb96))
+
+
+
 ## [13.14.3](https://github.com/blackbaud/skyux/compare/13.14.2...13.14.3) (2026-03-03)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,12 @@
 
 ### ⚠ BREAKING CHANGES
 
+* **components/animations:** deprecate `@skyux/animations` (#4270)
 * Along with changes in `google-libphonenumber` and `intl-tel-input`, country names are now localized in the country field and phone field components.
 
 ### Features
 
+* **components/animations:** deprecate `@skyux/animations` ([#4270](https://github.com/blackbaud/skyux/issues/4270)) ([ba7f9e8](https://github.com/blackbaud/skyux/commit/ba7f9e88e1e04ab13378149cc3d7df5aea89dd61))
 * update `google-libphonenumber` and `intl-tel-input` and localize country names in phone field and country field ([#4271](https://github.com/blackbaud/skyux/issues/4271)) ([e175ac9](https://github.com/blackbaud/skyux/commit/e175ac993952f4b1eff778a4a4a9ba5f1fcb55db))
 
 ## [13.14.3](https://github.com/blackbaud/skyux/compare/13.14.2...13.14.3) (2026-03-03)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "skyux",
-  "version": "14.0.0-alpha.5",
+  "version": "14.0.0-alpha.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "skyux",
-      "version": "14.0.0-alpha.5",
+      "version": "14.0.0-alpha.6",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skyux",
-  "version": "14.0.0-alpha.5",
+  "version": "14.0.0-alpha.6",
   "license": "MIT",
   "scripts": {
     "ng": "nx",


### PR DESCRIPTION
## [14.0.0-alpha.6](https://github.com/blackbaud/skyux/compare/14.0.0-alpha.5...14.0.0-alpha.6) (2026-03-10)


### ⚠ BREAKING CHANGES

* **components/animations:** deprecate `@skyux/animations` (#4270)
* Along with changes in `google-libphonenumber` and `intl-tel-input`, country names are now localized in the country field and phone field components.

### Features

* **components/animations:** deprecate `@skyux/animations` ([#4270](https://github.com/blackbaud/skyux/issues/4270)) ([ba7f9e8](https://github.com/blackbaud/skyux/commit/ba7f9e88e1e04ab13378149cc3d7df5aea89dd61))
* update `google-libphonenumber` and `intl-tel-input` and localize country names in phone field and country field ([#4271](https://github.com/blackbaud/skyux/issues/4271)) ([e175ac9](https://github.com/blackbaud/skyux/commit/e175ac993952f4b1eff778a4a4a9ba5f1fcb55db))

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Deprecated @skyux/animations module—users should plan migration to alternative solutions
  * Updated localization implementation for country and phone field components

* **New Features**
  * Enhanced google-libphonenumber and intl-tel-input libraries with improved localization support for country selection and phone field functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->