### PR TITLE
fix(sdk/skyux-eslint): avoid creating duplicate identifiers

### DIFF
--- a/libs/sdk/skyux-eslint/src/rules/no-barrel-exports.spec.ts
+++ b/libs/sdk/skyux-eslint/src/rules/no-barrel-exports.spec.ts
@@ -21,6 +21,9 @@ jest.mock('./utils/resolve-exports', () => ({
     if (specifier === './resolvable-types-only') {
       return '/fake/resolvable-types-only.ts';
     }
+    if (specifier === './resolvable-overlap') {
+      return '/fake/resolvable-overlap.ts';
+    }
     if (specifier === './empty-exports') {
       return '/fake/empty-exports.ts';
     }
@@ -34,6 +37,12 @@ jest.mock('./utils/resolve-exports', () => ({
       return {
         valueExports: ['FooComponent'],
         typeExports: ['FooConfig', 'FooType'],
+      };
+    }
+    if (filePath === '/fake/resolvable-overlap.ts') {
+      return {
+        valueExports: ['Foo'],
+        typeExports: ['Bar'],
       };
     }
     if (filePath === '/fake/resolvable-types-only.ts') {
@@ -95,6 +104,12 @@ ruleTester.run(RULE_NAME, rule, {
       code: `export * from './resolvable-mixed';`,
       filename: '/fake/index.ts',
       output: `export { FooComponent } from './resolvable-mixed';\nexport type { FooConfig, FooType } from './resolvable-mixed';`,
+      errors: [{ messageId }],
+    },
+    {
+      code: `export * from './resolvable-overlap';`,
+      filename: '/fake/index.ts',
+      output: `export { Foo } from './resolvable-overlap';\nexport type { Bar } from './resolvable-overlap';`,
       errors: [{ messageId }],
     },
     {

--- a/libs/sdk/skyux-eslint/src/rules/utils/resolve-exports.spec.ts
+++ b/libs/sdk/skyux-eslint/src/rules/utils/resolve-exports.spec.ts
@@ -279,6 +279,16 @@ describe('extractNamedExports', () => {
     });
   });
 
+  it('should exclude type exports that overlap with value exports', () => {
+    const content = ['export class Foo {}', 'export interface Foo {}'].join(
+      '\n',
+    );
+    expect(extractNamedExports(content)).toEqual({
+      valueExports: ['Foo'],
+      typeExports: [],
+    });
+  });
+
   it('should sort exports alphabetically', () => {
     const content = [
       'export class Zebra {}',

--- a/libs/sdk/skyux-eslint/src/rules/utils/resolve-exports.ts
+++ b/libs/sdk/skyux-eslint/src/rules/utils/resolve-exports.ts
@@ -152,9 +152,13 @@ export function extractNamedExports(
     }
   }
 
+  const valueSet = new Set(valueExports);
+
   return {
-    valueExports: [...new Set(valueExports)].sort(),
-    typeExports: [...new Set(typeExports)].sort(),
+    valueExports: [...valueSet].sort(),
+    typeExports: [...new Set(typeExports)]
+      .filter((name) => !valueSet.has(name))
+      .sort(),
   };
 }
 


### PR DESCRIPTION
[AB#3614172](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3614172)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved barrel export handling for overlapping value and type exports. When re-exporting with wildcards, value exports now correctly take precedence over type exports with the same name, preventing export conflicts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->