### PR TITLE
fix(components/filter-bar): filter items can be created via for loop (#4287)

### DIFF
--- a/libs/components/filter-bar/src/lib/modules/filter-bar/filter-bar.component.spec.ts
+++ b/libs/components/filter-bar/src/lib/modules/filter-bar/filter-bar.component.spec.ts
@@ -17,7 +17,9 @@ import { SkyModalCloseArgs } from '@skyux/modals';
 
 import { Subject, of } from 'rxjs';
 
+import { SkyFilterBarForLoopTestComponent } from './fixtures/filter-bar-for-loop.component.fixture';
 import { SkyFilterBarTestComponent } from './fixtures/filter-bar.component.fixture';
+import { SkyFilterBarModalTestComponent } from './fixtures/filter-modal-test.component.fixture';
 import { SkyFilterBarFilterItem } from './models/filter-bar-filter-item';
 import { SkyFilterItemModalInstance } from './models/filter-item-modal-instance';
 
@@ -326,6 +328,38 @@ describe('Filter bar component', () => {
       const secondButton = filterItems[1].querySelector('button');
       expect(firstButton?.getAttribute('aria-pressed')).toBe('false');
       expect(secondButton?.getAttribute('aria-pressed')).toBe('false');
+    });
+
+    it('should clear a filter value when appliedFilters is updated to a non-empty array that omits it', () => {
+      // Start with two filters applied
+      component.appliedFilters.set([
+        { filterId: '1', filterValue: { value: 'value1' } },
+        { filterId: '2', filterValue: { value: 'value2' } },
+      ]);
+      fixture.detectChanges();
+
+      const filter1Button = fixture.nativeElement.querySelector(
+        '[data-filter-id="1"]',
+      ) as HTMLButtonElement;
+      const filter2Button = fixture.nativeElement.querySelector(
+        '[data-filter-id="2"]',
+      ) as HTMLButtonElement;
+
+      expect(filter1Button.getAttribute('aria-pressed')).toBe('true');
+      expect(filter2Button.getAttribute('aria-pressed')).toBe('true');
+
+      // Update to a non-empty array that no longer includes filter 1
+      component.appliedFilters.set([
+        { filterId: '2', filterValue: { value: 'value2' } },
+      ]);
+      fixture.detectChanges();
+
+      // Filter 1 should be unset even though appliedFilters is still non-empty
+      expect(filter1Button.getAttribute('aria-pressed')).toBe('false');
+      expect(filter1Button.querySelector('.sky-filter-item-value')).toBeNull();
+
+      // Filter 2 should still be set
+      expect(filter2Button.getAttribute('aria-pressed')).toBe('true');
     });
 
     it('should emit filterUpdated event when filter item is updated', () => {
@@ -1346,6 +1380,94 @@ describe('Filter bar component', () => {
         },
         'skyFilterBar',
       );
+    });
+  });
+
+  describe('dynamic filter items via @for loop', () => {
+    let forLoopFixture: ComponentFixture<SkyFilterBarForLoopTestComponent>;
+
+    beforeEach(async () => {
+      await TestBed.configureTestingModule({
+        imports: [SkyFilterBarForLoopTestComponent],
+        providers: [
+          provideNoopAnimations(),
+          {
+            provide: SkyConfirmService,
+            useValue: jasmine.createSpyObj('SkyConfirmService', ['open']),
+          },
+          {
+            provide: SkySelectionModalService,
+            useValue: jasmine.createSpyObj('SkySelectionModalService', [
+              'open',
+            ]),
+          },
+        ],
+      }).compileComponents();
+
+      forLoopFixture = TestBed.createComponent(
+        SkyFilterBarForLoopTestComponent,
+      );
+      forLoopFixture.detectChanges();
+    });
+
+    it('should create a filter bar with filter items generated via @for loop', () => {
+      expect(() => {
+        forLoopFixture.componentInstance.filterItems = [
+          {
+            filterId: 'filter-1',
+            modalComponent: SkyFilterBarModalTestComponent,
+          },
+          {
+            filterId: 'filter-2',
+            modalComponent: SkyFilterBarModalTestComponent,
+          },
+          {
+            filterId: 'filter-3',
+            modalComponent: SkyFilterBarModalTestComponent,
+          },
+        ];
+        forLoopFixture.detectChanges();
+      }).not.toThrow();
+    });
+
+    it('should update visible filters when @for list changes', () => {
+      forLoopFixture.componentInstance.filterItems = [
+        {
+          filterId: 'filter-1',
+          modalComponent: SkyFilterBarModalTestComponent,
+        },
+        {
+          filterId: 'filter-2',
+          modalComponent: SkyFilterBarModalTestComponent,
+        },
+      ];
+      forLoopFixture.detectChanges();
+
+      expect(
+        forLoopFixture.nativeElement.querySelectorAll('sky-filter-item-base')
+          .length,
+      ).toBe(2);
+
+      forLoopFixture.componentInstance.filterItems = [
+        {
+          filterId: 'filter-1',
+          modalComponent: SkyFilterBarModalTestComponent,
+        },
+        {
+          filterId: 'filter-2',
+          modalComponent: SkyFilterBarModalTestComponent,
+        },
+        {
+          filterId: 'filter-3',
+          modalComponent: SkyFilterBarModalTestComponent,
+        },
+      ];
+      forLoopFixture.detectChanges();
+
+      expect(
+        forLoopFixture.nativeElement.querySelectorAll('sky-filter-item-base')
+          .length,
+      ).toBe(3);
     });
   });
 });

--- a/libs/components/filter-bar/src/lib/modules/filter-bar/filter-bar.component.ts
+++ b/libs/components/filter-bar/src/lib/modules/filter-bar/filter-bar.component.ts
@@ -112,10 +112,22 @@ export class SkyFilterBarComponent {
       }
     });
 
-    // Push filter value updates to child filter items
+    // Push filter value updates to child filter items. When applied filters
+    // are changed, use the previous value to determine which items to reset
+    // rather than reading filterId() from content children, which may
+    // not have their required inputs bound yet (e.g. when used with @for).
+    let previousFilterIds: string[] = [];
     effect(() => {
-      const filters = this.appliedFilters();
-      this.#updateFilters(filters);
+      const appliedFilters = this.appliedFilters() ?? [];
+      const newFilterIds = new Set(appliedFilters.map((f) => f.filterId));
+
+      // Send clear signals for filters that were previously set but are no longer present.
+      const removedFilters = previousFilterIds
+        .filter((id) => !newFilterIds.has(id))
+        .map((filterId) => ({ filterId }));
+
+      this.#filterBarSvc.updateFilters([...appliedFilters, ...removedFilters]);
+      previousFilterIds = [...newFilterIds];
     });
 
     // If a filter state service is present, subscribe to its updates and reflect into local signals.
@@ -236,7 +248,7 @@ export class SkyFilterBarComponent {
     this.selectedFilterIds.set(selectedIds);
 
     if (removedFilterItems.length) {
-      this.#updateFilters(removedFilterItems);
+      this.#filterBarSvc.updateFilters(removedFilterItems);
       const newFilters = newFilterItems.filter(
         (filter) => !!filter.filterValue,
       );
@@ -328,7 +340,7 @@ export class SkyFilterBarComponent {
         if (updatedFilter.filterValue) {
           newFilterValues.push(updatedFilter);
         } else {
-          this.#updateFilters([updatedFilter]);
+          this.#filterBarSvc.updateFilters([updatedFilter]);
         }
         replaceFilter = true;
       } else {
@@ -344,18 +356,6 @@ export class SkyFilterBarComponent {
       newFilterValues.length ? newFilterValues : undefined,
     );
     this.#updateFilterData();
-  }
-
-  #updateFilters(updatedFilters: SkyFilterBarFilterItem[] | undefined): void {
-    if (updatedFilters?.length) {
-      this.#filterBarSvc.updateFilters(updatedFilters);
-    } else {
-      this.#filterBarSvc.updateFilters(
-        untracked(() => this.filterItems()).map((filterItem) => ({
-          filterId: filterItem.filterId(),
-        })),
-      );
-    }
   }
 
   #updateFilterData(): void {

--- a/libs/components/filter-bar/src/lib/modules/filter-bar/fixtures/filter-bar-for-loop.component.fixture.ts
+++ b/libs/components/filter-bar/src/lib/modules/filter-bar/fixtures/filter-bar-for-loop.component.fixture.ts
@@ -1,0 +1,27 @@
+import { Component } from '@angular/core';
+
+import { SkyFilterBarModule } from '../filter-bar.module';
+
+import { SkyFilterBarModalTestComponent } from './filter-modal-test.component.fixture';
+
+@Component({
+  selector: 'sky-filter-bar-for-loop-test',
+  imports: [SkyFilterBarModule],
+  template: `
+    <sky-filter-bar>
+      @for (filter of filterItems; track filter.filterId) {
+        <sky-filter-item-modal
+          labelText="Hide Orange"
+          modalSize="small"
+          [filterId]="filter.filterId"
+          [modalComponent]="filter.modalComponent"
+        />
+      }
+    </sky-filter-bar>
+  `,
+})
+export class SkyFilterBarForLoopTestComponent {
+  public filterItems = [
+    { filterId: 'filter-1', modalComponent: SkyFilterBarModalTestComponent },
+  ];
+}


### PR DESCRIPTION
:cherries: Cherry picked from #4287 [fix(components/filter-bar): filter items can be created via for loop](https://github.com/blackbaud/skyux/pull/4287)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added new test fixtures and comprehensive test coverage for dynamically rendered filter components using loop syntax.
  * Expanded test scenarios covering filter removal and filter value updates.

* **Refactor**
  * Internal improvements to filter update mechanism for enhanced code consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->