### PR TITLE
feat(components/indicators): add `getNames()` method to illustration resolver service (#4289)

### DIFF
--- a/libs/components/indicators/src/lib/modules/illustration/illustration-resolver.service.spec.ts
+++ b/libs/components/indicators/src/lib/modules/illustration/illustration-resolver.service.spec.ts
@@ -1,0 +1,25 @@
+import { SkyIllustrationResolverService } from './illustration-resolver.service';
+
+class TestDefaultHrefResolverService extends SkyIllustrationResolverService {
+  public resolveUrl(name: string): Promise<string> {
+    return Promise.resolve(`https://example.com/${name}.svg`);
+  }
+}
+
+describe('Illustration resolver service', () => {
+  let resolverSvc: TestDefaultHrefResolverService;
+
+  beforeEach(() => {
+    resolverSvc = new TestDefaultHrefResolverService();
+  });
+
+  it('should return default value for resolveHref()', async () => {
+    await expectAsync(resolverSvc.resolveHref('foo')).toBeResolvedTo('');
+  });
+
+  it('should return default value for getNames()', async () => {
+    await expectAsync(resolverSvc.getNames()).toBeResolvedTo(
+      jasmine.arrayWithExactContents([]),
+    );
+  });
+});

--- a/libs/components/indicators/src/lib/modules/illustration/illustration-resolver.service.ts
+++ b/libs/components/indicators/src/lib/modules/illustration/illustration-resolver.service.ts
@@ -17,4 +17,11 @@ export abstract class SkyIllustrationResolverService {
   public resolveHref(name: string): Promise<string> {
     return Promise.resolve('');
   }
+
+  /**
+   * Gets the names of all available illustrations.
+   */
+  public getNames(): Promise<string[]> {
+    return Promise.resolve([]);
+  }
 }


### PR DESCRIPTION
:cherries: Cherry picked from #4289 [feat(components/indicators): add `getNames()` method to illustration resolver service](https://github.com/blackbaud/skyux/pull/4289)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added method to retrieve all available illustration names asynchronously.

* **Tests**
  * Added comprehensive unit tests for the illustration resolver service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->