### PR TITLE
fix(components/lookup): update search background when using expand mode fit (#4290)

### DIFF
--- a/apps/e2e/lookup-storybook/src/app/search/search.component.html
+++ b/apps/e2e/lookup-storybook/src/app/search/search.component.html
@@ -4,3 +4,19 @@
 <div id="empty-search" class="search-visual-wrapper">
   <sky-search />
 </div>
+<div class="sky-padding-even-md">
+  <sky-box>
+    <sky-box-content>
+      <sky-toolbar>
+        <sky-toolbar-item>
+          <sky-search />
+        </sky-toolbar-item>
+      </sky-toolbar>
+      <sky-toolbar>
+        <sky-toolbar-item>
+          <sky-search expandMode="fit" />
+        </sky-toolbar-item>
+      </sky-toolbar>
+    </sky-box-content>
+  </sky-box>
+</div>

--- a/apps/e2e/lookup-storybook/src/app/search/search.module.ts
+++ b/apps/e2e/lookup-storybook/src/app/search/search.module.ts
@@ -1,6 +1,7 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
+import { SkyBoxModule, SkyToolbarModule } from '@skyux/layout';
 import { SkySearchModule } from '@skyux/lookup';
 
 import { SearchComponent } from './search.component';
@@ -8,7 +9,13 @@ import { SearchComponent } from './search.component';
 const routes: Routes = [{ path: '', component: SearchComponent }];
 @NgModule({
   declarations: [SearchComponent],
-  imports: [CommonModule, RouterModule.forChild(routes), SkySearchModule],
+  imports: [
+    CommonModule,
+    RouterModule.forChild(routes),
+    SkyBoxModule,
+    SkySearchModule,
+    SkyToolbarModule,
+  ],
   exports: [SearchComponent],
 })
 export class SearchModule {}

--- a/libs/components/lookup/src/lib/modules/search/search.component.scss
+++ b/libs/components/lookup/src/lib/modules/search/search.component.scss
@@ -150,10 +150,7 @@ sky-search {
     position: absolute;
     background-color: var(
       --sky-override-search-mobile-background-color,
-      var(
-        --sky-comp-override-list-header-background-color,
-        var(--sky-background-color-page-default)
-      )
+      var(--sky-comp-override-list-header-background-color)
     );
     top: 0;
     left: 0;


### PR DESCRIPTION
:cherries: Cherry picked from #4290 [fix(components/lookup): update search background when using expand mode fit](https://github.com/blackbaud/skyux/pull/4290)

[AB#3647693](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3647693) 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
- Added new search interface featuring multiple search controls with layout flexibility, including an expandable search control option.

## Style
- Refined styling of search interface components to improve visual consistency throughout the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->