### PR TITLE
fix(components/core): transition handler emits via microtask when animations disabled

### DIFF
--- a/libs/components/action-bars/src/lib/modules/summary-action-bar/summary-action-bar.component.ts
+++ b/libs/components/action-bars/src/lib/modules/summary-action-bar/summary-action-bar.component.ts
@@ -7,9 +7,11 @@ import {
   ContentChild,
   DestroyRef,
   ElementRef,
+  Injector,
   Input,
   OnDestroy,
   ViewChild,
+  afterNextRender,
   computed,
   inject,
   signal,
@@ -63,6 +65,7 @@ export class SkySummaryActionBarComponent implements AfterViewInit, OnDestroy {
   readonly #changeDetector = inject(ChangeDetectorRef);
   readonly #destroyRef = inject(DestroyRef);
   readonly #elementRef = inject(ElementRef);
+  readonly #injector = inject(Injector);
   readonly #mediaQuerySvc = inject(SkyMediaQueryService);
   readonly #observerService = inject(SkyMutationObserverService);
   readonly #windowRef = inject(SkyAppWindowRef);
@@ -183,10 +186,13 @@ export class SkySummaryActionBarComponent implements AfterViewInit, OnDestroy {
       this.#adapterService.styleBodyElementForActionBar(this.#elementRef);
     }
 
-    // Ensure that the correct chevron is fully rendered prior to setting focus.
-    setTimeout(() => {
-      this.#adapterService.focusChevron(this.chevronElementRef);
-    });
+    // Focus the chevron after Angular renders the updated collapse/expand state.
+    afterNextRender(
+      () => {
+        this.#adapterService.focusChevron(this.chevronElementRef);
+      },
+      { injector: this.#injector },
+    );
   }
 
   #setupReactiveState(): void {

--- a/libs/components/core/src/index.ts
+++ b/libs/components/core/src/index.ts
@@ -15,7 +15,7 @@ export { SkyAffixModule } from './lib/modules/affix/affix.module';
 export { SkyAffixService } from './lib/modules/affix/affix.service';
 export { SkyAffixer } from './lib/modules/affix/affixer';
 
-export { _SkyAnimationTransitionHandlerDirective } from './lib/modules/animations/shared/transition-handler';
+export { _SkyTransitionEndHandlerDirective } from './lib/modules/animations/shared/transition-handler';
 export { _SkyAnimationSlideComponent } from './lib/modules/animations/slide/slide';
 export { provideNoopSkyAnimations } from './lib/modules/animations/utility/provide-noop-animations';
 

--- a/libs/components/core/src/lib/modules/animations/shared/animation-handler.spec.ts
+++ b/libs/components/core/src/lib/modules/animations/shared/animation-handler.spec.ts
@@ -1,0 +1,189 @@
+import { Component, input, signal } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { provideNoopSkyAnimations } from '../utility/provide-noop-animations';
+
+import { _SkyAnimationEndHandlerDirective } from './animation-handler';
+
+@Component({
+  hostDirectives: [
+    {
+      directive: _SkyAnimationEndHandlerDirective,
+      inputs: ['animationTrigger: trigger'],
+      outputs: ['animationEnd'],
+    },
+  ],
+  selector: 'sky-test',
+  template: '<span class="sky-test-child"></span>',
+})
+class TestComponent {}
+
+@Component({
+  imports: [_SkyAnimationEndHandlerDirective],
+  selector: 'sky-test-template',
+  template: `
+    <div
+      skyAnimationEndHandler
+      [animationTrigger]="trigger()"
+      (animationEnd)="onAnimationEnd()"
+    ></div>
+  `,
+})
+class TemplateTestComponent {
+  public readonly trigger = input<unknown>(false);
+  public animationEndEmitted = false;
+
+  protected onAnimationEnd(): void {
+    this.animationEndEmitted = true;
+  }
+}
+
+describe('SkyAnimationEndHandler', () => {
+  function setupTest(options?: { noopAnimations?: boolean }): {
+    fixture: ComponentFixture<TestComponent>;
+    component: TestComponent;
+  } {
+    TestBed.configureTestingModule({
+      imports: [TestComponent],
+      providers: [
+        ...(options?.noopAnimations ? [provideNoopSkyAnimations()] : []),
+      ],
+    });
+
+    const fixture = TestBed.createComponent(TestComponent);
+    fixture.componentRef.setInput('trigger', signal(false));
+    fixture.detectChanges();
+
+    return { fixture, component: fixture.componentInstance };
+  }
+
+  afterEach(() => {
+    document.body.classList.remove('sky-animations-disabled');
+  });
+
+  it('should create the directive', () => {
+    const { fixture } = setupTest();
+
+    const handler = fixture.debugElement.injector.get(
+      _SkyAnimationEndHandlerDirective,
+    );
+
+    expect(handler).toBeTruthy();
+  });
+
+  describe('onAnimationEnd', () => {
+    it('should emit animationEnd when animationend fires on the host element', () => {
+      const { fixture } = setupTest();
+
+      let animationEndEmitted = false;
+
+      const handler = fixture.debugElement.injector.get(
+        _SkyAnimationEndHandlerDirective,
+      );
+
+      handler.animationEnd.subscribe(() => {
+        animationEndEmitted = true;
+      });
+
+      fixture.nativeElement.dispatchEvent(new AnimationEvent('animationend'));
+
+      expect(animationEndEmitted).toBeTrue();
+    });
+
+    it('should emit animationEnd for animationend events that bubble from child elements', () => {
+      const { fixture } = setupTest();
+
+      let animationEndEmitted = false;
+
+      const handler = fixture.debugElement.injector.get(
+        _SkyAnimationEndHandlerDirective,
+      );
+
+      handler.animationEnd.subscribe(() => {
+        animationEndEmitted = true;
+      });
+
+      const child = fixture.nativeElement.querySelector('.sky-test-child');
+
+      child.dispatchEvent(
+        new AnimationEvent('animationend', { bubbles: true }),
+      );
+
+      expect(animationEndEmitted).toBeTrue();
+    });
+  });
+
+  describe('when animations are disabled', () => {
+    it('should not emit animationEnd on initial render', () => {
+      const { fixture } = setupTest({ noopAnimations: true });
+
+      let animationEndEmitted = false;
+
+      const handler = fixture.debugElement.injector.get(
+        _SkyAnimationEndHandlerDirective,
+      );
+      handler.animationEnd.subscribe(() => {
+        animationEndEmitted = true;
+      });
+
+      fixture.detectChanges();
+
+      expect(animationEndEmitted).toBeFalse();
+    });
+
+    it('should emit animationEnd in a microtask when the animationTrigger changes', async () => {
+      const { fixture } = setupTest({ noopAnimations: true });
+
+      let animationEndEmitted = false;
+
+      const handler = fixture.debugElement.injector.get(
+        _SkyAnimationEndHandlerDirective,
+      );
+      handler.animationEnd.subscribe(() => {
+        animationEndEmitted = true;
+      });
+
+      fixture.componentRef.setInput('trigger', signal(true));
+      fixture.detectChanges();
+
+      expect(animationEndEmitted).toBeFalse();
+
+      await fixture.whenStable();
+
+      expect(animationEndEmitted).toBeTrue();
+    });
+  });
+
+  describe('animationTrigger input', () => {
+    function setupTemplateTest(options?: {
+      noopAnimations?: boolean;
+    }): ComponentFixture<TemplateTestComponent> {
+      TestBed.configureTestingModule({
+        imports: [TemplateTestComponent],
+        providers: [
+          ...(options?.noopAnimations ? [provideNoopSkyAnimations()] : []),
+        ],
+      });
+
+      const fixture = TestBed.createComponent(TemplateTestComponent);
+      fixture.detectChanges();
+
+      return fixture;
+    }
+
+    function getDirectiveHost(
+      fixture: ComponentFixture<TemplateTestComponent>,
+    ): HTMLElement {
+      return fixture.nativeElement.querySelector('[skyAnimationEndHandler]');
+    }
+
+    it('should emit animationEnd when animationend fires', () => {
+      const fixture = setupTemplateTest();
+      const host = getDirectiveHost(fixture);
+
+      host.dispatchEvent(new AnimationEvent('animationend'));
+
+      expect(fixture.componentInstance.animationEndEmitted).toBeTrue();
+    });
+  });
+});

--- a/libs/components/core/src/lib/modules/animations/shared/animation-handler.ts
+++ b/libs/components/core/src/lib/modules/animations/shared/animation-handler.ts
@@ -2,13 +2,14 @@ import {
   DestroyRef,
   Directive,
   ElementRef,
-  effect,
   inject,
   input,
   output,
 } from '@angular/core';
 
 import { _skyAnimationsDisabled } from '../utility/animations-disabled';
+
+import { mimicCssMotionEvent } from './mimic-css-motion-event';
 
 /**
  * @internal
@@ -25,8 +26,6 @@ import { _skyAnimationsDisabled } from '../utility/animations-disabled';
   },
 })
 export class _SkyAnimationEndHandlerDirective {
-  readonly #elementRef = inject(ElementRef);
-
   /**
    * Drives animation lifecycle tracking on the host element. When the
    * value changes and animations are disabled, `animationEnd` emits
@@ -42,31 +41,12 @@ export class _SkyAnimationEndHandlerDirective {
 
   constructor() {
     if (_skyAnimationsDisabled()) {
-      const el = this.#elementRef.nativeElement;
-      const destroyRef = inject(DestroyRef);
-
-      let initialized = false;
-      let destroyed = false;
-
-      destroyRef.onDestroy(() => {
-        destroyed = true;
-      });
-
-      effect(() => {
-        this.animationTrigger();
-
-        if (initialized && getComputedStyle(el).display !== 'none') {
-          // Defer the emit to a microtask so it fires after the current
-          // change detection pass, matching real transitionend timing.
-          queueMicrotask(() => {
-            if (!destroyed) {
-              this.animationEnd.emit();
-            }
-          });
-        }
-
-        initialized = true;
-      });
+      mimicCssMotionEvent(
+        inject(ElementRef),
+        inject(DestroyRef),
+        this.animationTrigger,
+        this.animationEnd,
+      );
     }
   }
 

--- a/libs/components/core/src/lib/modules/animations/shared/animation-handler.ts
+++ b/libs/components/core/src/lib/modules/animations/shared/animation-handler.ts
@@ -1,0 +1,77 @@
+import {
+  DestroyRef,
+  Directive,
+  ElementRef,
+  effect,
+  inject,
+  input,
+  output,
+} from '@angular/core';
+
+import { _skyAnimationsDisabled } from '../utility/animations-disabled';
+
+/**
+ * @internal
+ *
+ * Listens for CSS `animationend` events on the host element and emits
+ * an `animationEnd` output when an animation completes. When animations
+ * are globally disabled, the output emits via a microtask whenever the
+ * `animationTrigger` input changes.
+ */
+@Directive({
+  selector: '[skyAnimationEndHandler]',
+  host: {
+    '(animationend)': 'onAnimationEnd($event)',
+  },
+})
+export class _SkyAnimationEndHandlerDirective {
+  readonly #elementRef = inject(ElementRef);
+
+  /**
+   * Drives animation lifecycle tracking on the host element. When the
+   * value changes and animations are disabled, `animationEnd` emits
+   * via a microtask.
+   */
+  public readonly animationTrigger = input.required<unknown>();
+
+  /**
+   * Emits when an `animationend` event fires on the host element, or via a
+   * microtask when animations are disabled.
+   */
+  public readonly animationEnd = output<void>();
+
+  constructor() {
+    if (_skyAnimationsDisabled()) {
+      const el = this.#elementRef.nativeElement;
+      const destroyRef = inject(DestroyRef);
+
+      let initialized = false;
+      let destroyed = false;
+
+      destroyRef.onDestroy(() => {
+        destroyed = true;
+      });
+
+      effect(() => {
+        this.animationTrigger();
+
+        if (initialized && getComputedStyle(el).display !== 'none') {
+          // Defer the emit to a microtask so it fires after the current
+          // change detection pass, matching real transitionend timing.
+          queueMicrotask(() => {
+            if (!destroyed) {
+              this.animationEnd.emit();
+            }
+          });
+        }
+
+        initialized = true;
+      });
+    }
+  }
+
+  protected onAnimationEnd(evt: AnimationEvent): void {
+    this.animationEnd.emit();
+    evt.stopPropagation();
+  }
+}

--- a/libs/components/core/src/lib/modules/animations/shared/mimic-css-motion-event.ts
+++ b/libs/components/core/src/lib/modules/animations/shared/mimic-css-motion-event.ts
@@ -32,6 +32,7 @@ export function mimicCssMotionEvent(
   effect(() => {
     triggerSignal();
 
+    // CSS animation/transition events do not fire when the element is `display: none`
     if (initialized && getComputedStyle(el).display !== 'none') {
       // Defer the emit to a microtask so it fires after the current
       // change detection pass, matching real transitionend timing.

--- a/libs/components/core/src/lib/modules/animations/shared/mimic-css-motion-event.ts
+++ b/libs/components/core/src/lib/modules/animations/shared/mimic-css-motion-event.ts
@@ -1,0 +1,47 @@
+import {
+  DestroyRef,
+  ElementRef,
+  OutputEmitterRef,
+  Signal,
+  effect,
+} from '@angular/core';
+
+/**
+ * Mimics a CSS motion end event (`animationend`/`transitionend`) when
+ * CSS motion is disabled.
+ *
+ * Registers an effect that watches the provided trigger signal and, after the
+ * first change, emits on a microtask when the host element is visible. This
+ * preserves async timing that callers expect from real motion end events.
+ */
+export function mimicCssMotionEvent(
+  elementRef: ElementRef,
+  destroyRef: DestroyRef,
+  triggerSignal: Signal<unknown>,
+  output: OutputEmitterRef<void>,
+): void {
+  const el = elementRef.nativeElement as HTMLElement;
+
+  let destroyed = false;
+  let initialized = false;
+
+  destroyRef.onDestroy(() => {
+    destroyed = true;
+  });
+
+  effect(() => {
+    triggerSignal();
+
+    if (initialized && getComputedStyle(el).display !== 'none') {
+      // Defer the emit to a microtask so it fires after the current
+      // change detection pass, matching real transitionend timing.
+      queueMicrotask(() => {
+        if (!destroyed) {
+          output.emit();
+        }
+      });
+    }
+
+    initialized = true;
+  });
+}

--- a/libs/components/core/src/lib/modules/animations/shared/mimic-css-motion-event.ts
+++ b/libs/components/core/src/lib/modules/animations/shared/mimic-css-motion-event.ts
@@ -32,10 +32,10 @@ export function mimicCssMotionEvent(
   effect(() => {
     triggerSignal();
 
-    // CSS animation/transition events do not fire when the element is `display: none`
+    // CSS animation/transition events do not fire when the element is `display: none`.
     if (initialized && getComputedStyle(el).display !== 'none') {
       // Defer the emit to a microtask so it fires after the current
-      // change detection pass, matching real transitionend timing.
+      // change detection pass, matching real transition timing.
       queueMicrotask(() => {
         if (!destroyed) {
           output.emit();

--- a/libs/components/core/src/lib/modules/animations/shared/transition-handler.spec.ts
+++ b/libs/components/core/src/lib/modules/animations/shared/transition-handler.spec.ts
@@ -1,14 +1,14 @@
-import { Component, ErrorHandler, input, signal } from '@angular/core';
+import { Component, input, signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { provideNoopSkyAnimations } from '../utility/provide-noop-animations';
 
-import { _SkyAnimationTransitionHandlerDirective } from './transition-handler';
+import { _SkyTransitionEndHandlerDirective } from './transition-handler';
 
 @Component({
   hostDirectives: [
     {
-      directive: _SkyAnimationTransitionHandlerDirective,
+      directive: _SkyTransitionEndHandlerDirective,
       inputs: ['transitionTrigger: trigger'],
       outputs: ['transitionEnd'],
     },
@@ -19,11 +19,11 @@ import { _SkyAnimationTransitionHandlerDirective } from './transition-handler';
 class TestComponent {}
 
 @Component({
-  imports: [_SkyAnimationTransitionHandlerDirective],
+  imports: [_SkyTransitionEndHandlerDirective],
   selector: 'sky-test-template',
   template: `
     <div
-      skyAnimationTransitionHandler
+      skyTransitionEndHandler
       [transitionPropertyToTrack]="propertyToTrack()"
       [transitionTrigger]="trigger()"
       (transitionEnd)="onTransitionEnd()"
@@ -31,7 +31,7 @@ class TestComponent {}
   `,
 })
 class TemplateTestComponent {
-  public readonly propertyToTrack = input<string>();
+  public readonly propertyToTrack = input<string>('opacity');
   public readonly trigger = input<unknown>(false);
   public transitionEndEmitted = false;
 
@@ -40,38 +40,30 @@ class TemplateTestComponent {
   }
 }
 
-describe('SkyAnimationTransitionHandler', () => {
-  let errorHandlerSpy: jasmine.Spy;
-
+describe('SkyTransitionEndHandler', () => {
   function setupTest(options?: {
     noopAnimations?: boolean;
     trackProperty?: string;
+    skipTrackProperty?: boolean;
   }): { fixture: ComponentFixture<TestComponent>; component: TestComponent } {
-    const mockErrorHandler = jasmine.createSpyObj('ErrorHandler', [
-      'handleError',
-    ]);
-
-    errorHandlerSpy = mockErrorHandler.handleError;
-
     TestBed.configureTestingModule({
       imports: [TestComponent],
       providers: [
-        { provide: ErrorHandler, useValue: mockErrorHandler },
         ...(options?.noopAnimations ? [provideNoopSkyAnimations()] : []),
       ],
     });
 
     const fixture = TestBed.createComponent(TestComponent);
+    const handler = fixture.debugElement.injector.get(
+      _SkyTransitionEndHandlerDirective,
+    );
+
+    if (!options?.skipTrackProperty) {
+      handler.setPropertyToTrack(options?.trackProperty ?? 'opacity');
+    }
+
     fixture.componentRef.setInput('trigger', signal(false));
     fixture.detectChanges();
-
-    if (options?.trackProperty) {
-      const handler = fixture.debugElement.injector.get(
-        _SkyAnimationTransitionHandlerDirective,
-      );
-
-      handler.setPropertyToTrack(options.trackProperty);
-    }
 
     return { fixture, component: fixture.componentInstance };
   }
@@ -84,7 +76,7 @@ describe('SkyAnimationTransitionHandler', () => {
     const { fixture } = setupTest();
 
     const handler = fixture.debugElement.injector.get(
-      _SkyAnimationTransitionHandlerDirective,
+      _SkyTransitionEndHandlerDirective,
     );
 
     expect(handler).toBeTruthy();
@@ -92,36 +84,42 @@ describe('SkyAnimationTransitionHandler', () => {
 
   describe('onTransitionEnd', () => {
     it('should throw when no CSS property has been specified', () => {
-      const { fixture } = setupTest();
+      const { fixture } = setupTest({ skipTrackProperty: true });
+      const handler = fixture.debugElement.injector.get(
+        _SkyTransitionEndHandlerDirective,
+      );
 
       const evt = new TransitionEvent('transitionend', {
         propertyName: 'opacity',
       });
 
-      fixture.nativeElement.dispatchEvent(evt);
+      Object.defineProperty(evt, 'target', {
+        value: fixture.nativeElement,
+      });
 
-      expect(errorHandlerSpy).toHaveBeenCalledTimes(1);
-
-      const error = errorHandlerSpy.calls.mostRecent().args[0];
-
-      expect(error.message).toMatch(
-        /No CSS property specified for transition tracking/,
-      );
+      expect(() => {
+        (handler as any).onTransitionEnd(evt);
+      }).toThrowError(/No CSS property specified for transition tracking/);
     });
 
     it('should include the element tag name in the error', () => {
-      const { fixture } = setupTest();
+      const { fixture } = setupTest({ skipTrackProperty: true });
+      const handler = fixture.debugElement.injector.get(
+        _SkyTransitionEndHandlerDirective,
+      );
 
       const evt = new TransitionEvent('transitionend', {
         propertyName: 'opacity',
       });
 
-      fixture.nativeElement.dispatchEvent(evt);
+      Object.defineProperty(evt, 'target', {
+        value: fixture.nativeElement,
+      });
 
-      const error = errorHandlerSpy.calls.mostRecent().args[0];
-
-      expect(error.message).toContain(
-        `'<${fixture.nativeElement.tagName.toLowerCase()}>'`,
+      expect(() => {
+        (handler as any).onTransitionEnd(evt);
+      }).toThrowError(
+        new RegExp(`'<${fixture.nativeElement.tagName.toLowerCase()}>'`),
       );
     });
 
@@ -131,7 +129,7 @@ describe('SkyAnimationTransitionHandler', () => {
       let transitionEndEmitted = false;
 
       const handler = fixture.debugElement.injector.get(
-        _SkyAnimationTransitionHandlerDirective,
+        _SkyTransitionEndHandlerDirective,
       );
 
       handler.transitionEnd.subscribe(() => {
@@ -157,7 +155,7 @@ describe('SkyAnimationTransitionHandler', () => {
       let transitionEndEmitted = false;
 
       const handler = fixture.debugElement.injector.get(
-        _SkyAnimationTransitionHandlerDirective,
+        _SkyTransitionEndHandlerDirective,
       );
 
       handler.transitionEnd.subscribe(() => {
@@ -189,7 +187,7 @@ describe('SkyAnimationTransitionHandler', () => {
 
       child.dispatchEvent(evt);
 
-      expect(errorHandlerSpy).not.toHaveBeenCalled();
+      expect().nothing();
     });
   });
 
@@ -200,7 +198,7 @@ describe('SkyAnimationTransitionHandler', () => {
       let transitionEndEmitted = false;
 
       const handler = fixture.debugElement.injector.get(
-        _SkyAnimationTransitionHandlerDirective,
+        _SkyTransitionEndHandlerDirective,
       );
       handler.transitionEnd.subscribe(() => {
         transitionEndEmitted = true;
@@ -211,13 +209,13 @@ describe('SkyAnimationTransitionHandler', () => {
       expect(transitionEndEmitted).toBeFalse();
     });
 
-    it('should emit transitionEnd synchronously when the transitionTrigger changes', () => {
+    it('should emit transitionEnd in a microtask when the transitionTrigger changes', async () => {
       const { fixture } = setupTest({ noopAnimations: true });
 
       let transitionEndEmitted = false;
 
       const handler = fixture.debugElement.injector.get(
-        _SkyAnimationTransitionHandlerDirective,
+        _SkyTransitionEndHandlerDirective,
       );
       handler.transitionEnd.subscribe(() => {
         transitionEndEmitted = true;
@@ -226,6 +224,10 @@ describe('SkyAnimationTransitionHandler', () => {
       // Change the input to a new signal to trigger the effect.
       fixture.componentRef.setInput('trigger', signal(true));
       fixture.detectChanges();
+
+      expect(transitionEndEmitted).toBeFalse();
+
+      await fixture.whenStable();
 
       expect(transitionEndEmitted).toBeTrue();
     });
@@ -252,9 +254,7 @@ describe('SkyAnimationTransitionHandler', () => {
     function getDirectiveHost(
       fixture: ComponentFixture<TemplateTestComponent>,
     ): HTMLElement {
-      return fixture.nativeElement.querySelector(
-        '[skyAnimationTransitionHandler]',
-      );
+      return fixture.nativeElement.querySelector('[skyTransitionEndHandler]');
     }
 
     it('should emit transitionEnd when the tracked property transitions', () => {
@@ -284,7 +284,7 @@ describe('SkyAnimationTransitionHandler', () => {
       const host = getDirectiveHost(fixture);
 
       const handler = fixture.debugElement.children[0].injector.get(
-        _SkyAnimationTransitionHandlerDirective,
+        _SkyTransitionEndHandlerDirective,
       );
 
       // Set a different property programmatically.

--- a/libs/components/core/src/lib/modules/animations/shared/transition-handler.spec.ts
+++ b/libs/components/core/src/lib/modules/animations/shared/transition-handler.spec.ts
@@ -174,6 +174,19 @@ describe('SkyTransitionEndHandler', () => {
     it('should ignore transitionend events that bubble from child elements', () => {
       const { fixture } = setupTest();
 
+      let transitionEndEmitted = false;
+
+      const handler = fixture.debugElement.injector.get(
+        _SkyTransitionEndHandlerDirective,
+      );
+
+      handler.transitionEnd.subscribe(() => {
+        transitionEndEmitted = true;
+      });
+
+      const errorHandler = TestBed.inject(ErrorHandler);
+      spyOn(errorHandler, 'handleError');
+
       const child = fixture.nativeElement.querySelector('.sky-test-child');
 
       const evt = new TransitionEvent('transitionend', {
@@ -183,7 +196,8 @@ describe('SkyTransitionEndHandler', () => {
 
       child.dispatchEvent(evt);
 
-      expect().nothing();
+      expect(transitionEndEmitted).toBeFalse();
+      expect(errorHandler.handleError).not.toHaveBeenCalled();
     });
   });
 

--- a/libs/components/core/src/lib/modules/animations/shared/transition-handler.spec.ts
+++ b/libs/components/core/src/lib/modules/animations/shared/transition-handler.spec.ts
@@ -1,4 +1,4 @@
-import { Component, input, signal } from '@angular/core';
+import { Component, ErrorHandler, input, signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { provideNoopSkyAnimations } from '../utility/provide-noop-animations';
@@ -85,41 +85,37 @@ describe('SkyTransitionEndHandler', () => {
   describe('onTransitionEnd', () => {
     it('should throw when no CSS property has been specified', () => {
       const { fixture } = setupTest({ skipTrackProperty: true });
-      const handler = fixture.debugElement.injector.get(
-        _SkyTransitionEndHandlerDirective,
+      const errorHandler = TestBed.inject(ErrorHandler);
+      const spy = spyOn(errorHandler, 'handleError');
+
+      fixture.nativeElement.dispatchEvent(
+        new TransitionEvent('transitionend', { propertyName: 'opacity' }),
       );
 
-      const evt = new TransitionEvent('transitionend', {
-        propertyName: 'opacity',
-      });
-
-      Object.defineProperty(evt, 'target', {
-        value: fixture.nativeElement,
-      });
-
-      expect(() => {
-        (handler as any).onTransitionEnd(evt);
-      }).toThrowError(/No CSS property specified for transition tracking/);
+      expect(spy).toHaveBeenCalledOnceWith(
+        jasmine.objectContaining({
+          message: jasmine.stringMatching(
+            /No CSS property specified for transition tracking/,
+          ),
+        }),
+      );
     });
 
     it('should include the element tag name in the error', () => {
       const { fixture } = setupTest({ skipTrackProperty: true });
-      const handler = fixture.debugElement.injector.get(
-        _SkyTransitionEndHandlerDirective,
+      const errorHandler = TestBed.inject(ErrorHandler);
+      const spy = spyOn(errorHandler, 'handleError');
+
+      fixture.nativeElement.dispatchEvent(
+        new TransitionEvent('transitionend', { propertyName: 'opacity' }),
       );
 
-      const evt = new TransitionEvent('transitionend', {
-        propertyName: 'opacity',
-      });
-
-      Object.defineProperty(evt, 'target', {
-        value: fixture.nativeElement,
-      });
-
-      expect(() => {
-        (handler as any).onTransitionEnd(evt);
-      }).toThrowError(
-        new RegExp(`'<${fixture.nativeElement.tagName.toLowerCase()}>'`),
+      expect(spy).toHaveBeenCalledOnceWith(
+        jasmine.objectContaining({
+          message: jasmine.stringMatching(
+            new RegExp(`'<${fixture.nativeElement.tagName.toLowerCase()}>'`),
+          ),
+        }),
       );
     });
 

--- a/libs/components/core/src/lib/modules/animations/shared/transition-handler.ts
+++ b/libs/components/core/src/lib/modules/animations/shared/transition-handler.ts
@@ -1,4 +1,5 @@
 import {
+  DestroyRef,
   Directive,
   ElementRef,
   effect,
@@ -16,28 +17,28 @@ import { _skyAnimationsDisabled } from '../utility/animations-disabled';
  * Listens for CSS `transitionend` events on the host element and emits
  * a `transitionEnd` output when the tracked CSS property finishes
  * transitioning. When animations are globally disabled, the output
- * emits synchronously whenever the `transitionTrigger` input changes.
+ * emits via a microtask whenever the `transitionTrigger` input changes.
  *
  * The CSS property to monitor can be set via the `transitionPropertyToTrack`
  * input (for template usage) or by calling `setPropertyToTrack()`
  * (for `hostDirectives` usage).
  */
 @Directive({
-  selector: '[skyAnimationTransitionHandler]',
+  selector: '[skyTransitionEndHandler]',
   host: {
     '(transitionend)': 'onTransitionEnd($event)',
   },
 })
-export class _SkyAnimationTransitionHandlerDirective {
+export class _SkyTransitionEndHandlerDirective {
   readonly #elementRef = inject(ElementRef<HTMLElement>);
 
   /**
    * Drives the CSS transition on the host element. When the value
    * changes and animations are enabled, a CSS transition runs and
    * `transitionEnd` emits on completion. When animations are
-   * disabled, `transitionEnd` emits synchronously instead.
+   * disabled, `transitionEnd` emits via a microtask instead.
    */
-  public readonly transitionTrigger = input.required<unknown>();
+  public readonly transitionTrigger = input.required<boolean>();
 
   /**
    * The CSS property name to monitor for `transitionend` events
@@ -48,7 +49,7 @@ export class _SkyAnimationTransitionHandlerDirective {
 
   /**
    * Emits when the tracked CSS property's `transitionend` event fires
-   * on the host element, or synchronously when animations are disabled.
+   * on the host element, or via a microtask when animations are disabled.
    */
   public readonly transitionEnd = output<void>();
 
@@ -56,13 +57,27 @@ export class _SkyAnimationTransitionHandlerDirective {
 
   constructor() {
     if (_skyAnimationsDisabled()) {
+      const el = this.#elementRef.nativeElement;
+      const destroyRef = inject(DestroyRef);
+
       let initialized = false;
+      let destroyed = false;
+
+      destroyRef.onDestroy(() => {
+        destroyed = true;
+      });
 
       effect(() => {
         this.transitionTrigger();
 
-        if (initialized) {
-          this.transitionEnd.emit();
+        if (initialized && getComputedStyle(el).display !== 'none') {
+          // Defer the emit to a microtask so it fires after the current
+          // change detection pass, matching real transitionend timing.
+          queueMicrotask(() => {
+            if (!destroyed) {
+              this.transitionEnd.emit();
+            }
+          });
         }
 
         initialized = true;
@@ -89,7 +104,7 @@ export class _SkyAnimationTransitionHandlerDirective {
 
     if (!propertyName) {
       throw new Error(
-        `SkyAnimationTransitionHandler: No CSS property specified for transition tracking on element ` +
+        `SkyTransitionEndHandler: No CSS property specified for transition tracking on element ` +
           `'<${this.#elementRef.nativeElement.tagName.toLowerCase()}>'. ` +
           `Set the 'transitionPropertyToTrack' input or call 'setPropertyToTrack()' with a valid CSS property name before a transition occurs.`,
       );

--- a/libs/components/core/src/lib/modules/animations/shared/transition-handler.ts
+++ b/libs/components/core/src/lib/modules/animations/shared/transition-handler.ts
@@ -2,7 +2,6 @@ import {
   DestroyRef,
   Directive,
   ElementRef,
-  effect,
   inject,
   input,
   output,
@@ -10,6 +9,8 @@ import {
 } from '@angular/core';
 
 import { _skyAnimationsDisabled } from '../utility/animations-disabled';
+
+import { mimicCssMotionEvent } from './mimic-css-motion-event';
 
 /**
  * @internal
@@ -57,31 +58,12 @@ export class _SkyTransitionEndHandlerDirective {
 
   constructor() {
     if (_skyAnimationsDisabled()) {
-      const el = this.#elementRef.nativeElement;
-      const destroyRef = inject(DestroyRef);
-
-      let initialized = false;
-      let destroyed = false;
-
-      destroyRef.onDestroy(() => {
-        destroyed = true;
-      });
-
-      effect(() => {
-        this.transitionTrigger();
-
-        if (initialized && getComputedStyle(el).display !== 'none') {
-          // Defer the emit to a microtask so it fires after the current
-          // change detection pass, matching real transitionend timing.
-          queueMicrotask(() => {
-            if (!destroyed) {
-              this.transitionEnd.emit();
-            }
-          });
-        }
-
-        initialized = true;
-      });
+      mimicCssMotionEvent(
+        this.#elementRef,
+        inject(DestroyRef),
+        this.transitionTrigger,
+        this.transitionEnd,
+      );
     }
   }
 

--- a/libs/components/core/src/lib/modules/animations/shared/transition-handler.ts
+++ b/libs/components/core/src/lib/modules/animations/shared/transition-handler.ts
@@ -39,7 +39,7 @@ export class _SkyTransitionEndHandlerDirective {
    * `transitionEnd` emits on completion. When animations are
    * disabled, `transitionEnd` emits via a microtask instead.
    */
-  public readonly transitionTrigger = input.required<boolean>();
+  public readonly transitionTrigger = input.required<unknown>();
 
   /**
    * The CSS property name to monitor for `transitionend` events

--- a/libs/components/core/src/lib/modules/animations/slide/slide.ts
+++ b/libs/components/core/src/lib/modules/animations/slide/slide.ts
@@ -5,7 +5,7 @@ import {
   input,
 } from '@angular/core';
 
-import { _SkyAnimationTransitionHandlerDirective } from '../shared/transition-handler';
+import { _SkyTransitionEndHandlerDirective } from '../shared/transition-handler';
 
 /**
  * @internal
@@ -21,7 +21,7 @@ import { _SkyAnimationTransitionHandlerDirective } from '../shared/transition-ha
   },
   hostDirectives: [
     {
-      directive: _SkyAnimationTransitionHandlerDirective,
+      directive: _SkyTransitionEndHandlerDirective,
       inputs: ['transitionTrigger: opened'],
       outputs: ['transitionEnd'],
     },
@@ -34,8 +34,6 @@ export class _SkyAnimationSlideComponent {
   public readonly opened = input.required<boolean>();
 
   constructor() {
-    inject(_SkyAnimationTransitionHandlerDirective).setPropertyToTrack(
-      'visibility',
-    );
+    inject(_SkyTransitionEndHandlerDirective).setPropertyToTrack('visibility');
   }
 }

--- a/libs/components/flyout/src/lib/modules/flyout/flyout-instance.spec.ts
+++ b/libs/components/flyout/src/lib/modules/flyout/flyout-instance.spec.ts
@@ -4,8 +4,26 @@ import { SkyFlyoutInstance } from './flyout-instance';
 import { SkyFlyoutMessageType } from './types/flyout-message-type';
 
 describe('Flyout instance', () => {
-  it('should expose observables for closed event', () => {
+  function createFlyout(): SkyFlyoutInstance<object> {
+    return new SkyFlyoutInstance({});
+  }
+
+  it('should warn when created without a component instance', () => {
+    const warnSpy = spyOn(console, 'warn');
+
+    // This preserves coverage for the temporary backwards-compatible path.
     const flyout = new SkyFlyoutInstance(undefined);
+
+    expect(flyout.componentInstance).toBeUndefined();
+    expect(warnSpy).toHaveBeenCalledWith(
+      jasmine.stringContaining(
+        "The SkyFlyoutInstance was created without a reference to the flyout's child component instance",
+      ),
+    );
+  });
+
+  it('should expose observables for closed event', () => {
+    const flyout = createFlyout();
 
     let closedCalled = false;
 
@@ -18,7 +36,7 @@ describe('Flyout instance', () => {
   });
 
   it('should expose method to close the flyout', () => {
-    const flyout = new SkyFlyoutInstance(undefined);
+    const flyout = createFlyout();
     const spy = spyOn(flyout.hostController, 'next').and.callThrough();
 
     flyout.close();
@@ -31,7 +49,7 @@ describe('Flyout instance', () => {
   });
 
   it('should expose iterator next button methods to the flyout', () => {
-    const flyout = new SkyFlyoutInstance(undefined);
+    const flyout = createFlyout();
     const spy = spyOn(flyout.hostController, 'next').and.callThrough();
 
     flyout.iteratorNextButtonDisabled = true;
@@ -46,7 +64,7 @@ describe('Flyout instance', () => {
   });
 
   it('should expose iterator previous button methods to the flyout', () => {
-    const flyout = new SkyFlyoutInstance(undefined);
+    const flyout = createFlyout();
     const spy = spyOn(flyout.hostController, 'next').and.callThrough();
 
     flyout.iteratorPreviousButtonDisabled = true;
@@ -61,7 +79,7 @@ describe('Flyout instance', () => {
   });
 
   it('should complete iterator emitters when the flyout closes', () => {
-    const flyout = new SkyFlyoutInstance(undefined);
+    const flyout = createFlyout();
     const previousSpy = spyOn(
       flyout.iteratorPreviousButtonClick,
       'complete',

--- a/libs/components/flyout/src/lib/modules/flyout/flyout.component.html
+++ b/libs/components/flyout/src/lib/modules/flyout/flyout.component.html
@@ -1,8 +1,8 @@
 <div
   #flyoutRef
   class="sky-flyout"
-  skyAnimationTransitionHandler
   skyResponsiveHost
+  skyTransitionEndHandler
   tabindex="-1"
   transitionPropertyToTrack="transform"
   [attr.role]="config.ariaRole ? config.ariaRole : 'dialog'"

--- a/libs/components/flyout/src/lib/modules/flyout/flyout.component.ts
+++ b/libs/components/flyout/src/lib/modules/flyout/flyout.component.ts
@@ -21,7 +21,7 @@ import {
   SkyDynamicComponentService,
   SkyResponsiveHostDirective,
   SkyUIConfigService,
-  _SkyAnimationTransitionHandlerDirective,
+  _SkyTransitionEndHandlerDirective,
 } from '@skyux/core';
 import { SkyLibResourcesService } from '@skyux/i18n';
 import { SkyIconModule } from '@skyux/icon';
@@ -66,7 +66,7 @@ let nextId = 0;
     SkyFlyoutIteratorComponent,
     SkyFlyoutResourcesModule,
     SkyThemeModule,
-    _SkyAnimationTransitionHandlerDirective,
+    _SkyTransitionEndHandlerDirective,
   ],
 })
 export class SkyFlyoutComponent implements OnDestroy, OnInit {

--- a/libs/components/split-view/src/lib/modules/split-view/split-view.component.html
+++ b/libs/components/split-view/src/lib/modules/split-view/split-view.component.html
@@ -13,7 +13,7 @@
 
   <div
     class="sky-split-view-workspace-flex-container"
-    skyAnimationTransitionHandler
+    skyTransitionEndHandler
     transitionPropertyToTrack="transform"
     [class.sky-animation-slide-enter-right]="animationEnabled()"
     [hidden]="!workspaceVisible"

--- a/libs/components/split-view/src/lib/modules/split-view/split-view.component.ts
+++ b/libs/components/split-view/src/lib/modules/split-view/split-view.component.ts
@@ -13,7 +13,7 @@ import {
 import {
   SkyCoreAdapterService,
   SkyResponsiveHostDirective,
-  _SkyAnimationTransitionHandlerDirective,
+  _SkyTransitionEndHandlerDirective,
 } from '@skyux/core';
 
 import { Subject } from 'rxjs';
@@ -33,7 +33,7 @@ import { SkySplitViewMessageType } from './types/split-view-message-type';
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
   hostDirectives: [SkyResponsiveHostDirective],
-  imports: [_SkyAnimationTransitionHandlerDirective],
+  imports: [_SkyTransitionEndHandlerDirective],
   providers: [SkySplitViewAdapterService, SkySplitViewService],
   selector: 'sky-split-view',
   styleUrl: './split-view.component.scss',


### PR DESCRIPTION
Angular's `provideNoopAnimations` does not emit transition events synchronously, but instead zeros-out the transition time and fires a `queueMicrotask` before emitting the "done" events. We need to emulate this behavior in the `provideNoopSkyAnimations` by zero-ing out the transition time and emitting the `transitionEnd` event inside `queueMicrotask`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified and improved animation/transition handling for more reliable end-event detection, including better behavior when animations are globally disabled.
  * Adjusted focus timing for collapse/expand controls to occur after Angular finishes rendering.

* **Bug Fixes**
  * Ensures transition/animation completion events are emitted consistently (including when animations are disabled).

* **Tests**
  * Added comprehensive unit tests covering animation/transition end behavior and disabled-animation scenarios.

* **Other**
  * Added a warning when a flyout is created without a component instance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->