### PR TITLE
fix(components/data-manager): address data mutation during view updates (#4309)

### DIFF
--- a/libs/components/ag-grid/src/lib/modules/ag-grid/ag-grid-data-manager-adapter.directive.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/ag-grid-data-manager-adapter.directive.ts
@@ -18,6 +18,7 @@ import {
   SkyDataManagerService,
   SkyDataManagerState,
   SkyDataViewColumnWidths,
+  SkyDataViewState,
 } from '@skyux/data-manager';
 
 import { AgGridAngular } from 'ag-grid-angular';
@@ -300,7 +301,7 @@ export class SkyAgGridDataManagerAdapterDirective implements OnDestroy {
           const viewConfig = this.#viewConfig();
           if (viewConfig && this.#currentDataState) {
             const row = event.node;
-            const selectedIds = this.#currentDataState.selectedIds || [];
+            const selectedIds = [...(this.#currentDataState.selectedIds || [])];
             const rowIndex = selectedIds.indexOf(row.data.id);
 
             if (row.isSelected() && rowIndex === -1) {
@@ -309,11 +310,12 @@ export class SkyAgGridDataManagerAdapterDirective implements OnDestroy {
               selectedIds.splice(rowIndex, 1);
             }
 
-            this.#currentDataState.selectedIds = selectedIds;
-            this.#dataManagerSvc.updateDataState(
-              this.#currentDataState,
-              viewConfig.id,
+            const newState = new SkyDataManagerState(
+              this.#currentDataState.getStateOptions(),
             );
+            newState.selectedIds = selectedIds;
+            this.#currentDataState = newState;
+            this.#dataManagerSvc.updateDataState(newState, viewConfig.id);
 
             this.#changeDetector.markForCheck();
           }
@@ -330,23 +332,24 @@ export class SkyAgGridDataManagerAdapterDirective implements OnDestroy {
           gridColumnStates?.find((aGridColumnState) => aGridColumnState.sort);
 
         if (viewConfig && this.#currentDataState) {
+          const newState = new SkyDataManagerState(
+            this.#currentDataState.getStateOptions(),
+          );
           if (activeSortColumnState) {
             const activeSortColumnDef = agGrid.api.getColumnDef(
               activeSortColumnState.colId,
             );
-            this.#currentDataState.activeSortOption = {
+            newState.activeSortOption = {
               descending: activeSortColumnState.sort === 'desc',
               id: activeSortColumnState.colId,
               propertyName: activeSortColumnDef?.field || '',
               label: activeSortColumnDef?.headerName || '',
             };
           } else {
-            this.#currentDataState.activeSortOption = undefined;
+            newState.activeSortOption = undefined;
           }
-          this.#dataManagerSvc.updateDataState(
-            this.#currentDataState,
-            viewConfig.id,
-          );
+          this.#currentDataState = newState;
+          this.#dataManagerSvc.updateDataState(newState, viewConfig.id);
         }
       });
     }
@@ -364,12 +367,17 @@ export class SkyAgGridDataManagerAdapterDirective implements OnDestroy {
         (viewState.displayedColumnIds.length !== columnOrder.length ||
           viewState.displayedColumnIds.some((col, i) => col !== columnOrder[i]))
       ) {
-        viewState.displayedColumnIds = columnOrder;
-
-        this.#dataManagerSvc.updateDataState(
-          this.#currentDataState.addOrUpdateView(viewConfig.id, viewState),
-          viewConfig.id,
+        const updatedViewState = new SkyDataViewState(
+          viewState.getViewStateOptions(),
         );
+        updatedViewState.displayedColumnIds = columnOrder;
+
+        const newDataState = this.#currentDataState.addOrUpdateView(
+          viewConfig.id,
+          updatedViewState,
+        );
+        this.#currentDataState = newDataState;
+        this.#dataManagerSvc.updateDataState(newDataState, viewConfig.id);
       }
     }
   }
@@ -440,15 +448,19 @@ export class SkyAgGridDataManagerAdapterDirective implements OnDestroy {
     const viewState =
       viewId && this.#currentDataState?.getViewStateById(viewId);
     if (viewState && viewId && this.#currentDataState) {
-      const currentWidths = viewState?.columnWidths;
-
-      currentWidths[toColumnWidthName(breakpoint)][colId] = width;
-
-      viewState.columnWidths = currentWidths;
-      this.#dataManagerSvc.updateDataState(
-        this.#currentDataState.addOrUpdateView(viewId, viewState),
-        viewId,
+      const updatedViewState = new SkyDataViewState(
+        viewState.getViewStateOptions(),
       );
+
+      updatedViewState.columnWidths[toColumnWidthName(breakpoint)][colId] =
+        width;
+
+      const newDataState = this.#currentDataState.addOrUpdateView(
+        viewId,
+        updatedViewState,
+      );
+      this.#currentDataState = newDataState;
+      this.#dataManagerSvc.updateDataState(newDataState, viewId);
     }
   }
 
@@ -458,18 +470,21 @@ export class SkyAgGridDataManagerAdapterDirective implements OnDestroy {
       viewId && this.#currentDataState?.getViewStateById(viewId);
 
     if (viewState && viewId && this.#currentDataState) {
-      const currentWidths = viewState?.columnWidths;
+      const updatedViewState = new SkyDataViewState(
+        viewState.getViewStateOptions(),
+      );
 
       for (const colId of colIds) {
-        delete currentWidths['xs'][colId];
-        delete currentWidths['sm'][colId];
+        delete updatedViewState.columnWidths['xs'][colId];
+        delete updatedViewState.columnWidths['sm'][colId];
       }
 
-      viewState.columnWidths = currentWidths;
-      this.#dataManagerSvc.updateDataState(
-        this.#currentDataState.addOrUpdateView(viewId, viewState),
+      const newDataState = this.#currentDataState.addOrUpdateView(
         viewId,
+        updatedViewState,
       );
+      this.#currentDataState = newDataState;
+      this.#dataManagerSvc.updateDataState(newDataState, viewId);
     }
   }
 

--- a/libs/components/data-manager/src/lib/modules/data-manager/data-manager.service.spec.ts
+++ b/libs/components/data-manager/src/lib/modules/data-manager/data-manager.service.spec.ts
@@ -2,7 +2,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { expect } from '@skyux-sdk/testing';
 import { SkyUIConfigService } from '@skyux/core';
 
-import { Observable, Subject } from 'rxjs';
+import { Observable, Subject, Subscription } from 'rxjs';
 
 import { SkyDataManagerService } from './data-manager.service';
 import { DataViewCardFixtureComponent } from './fixtures/data-manager-card-view.component.fixture';
@@ -19,6 +19,7 @@ describe('SkyDataManagerService', () => {
   let dataManagerService: SkyDataManagerService;
   let initialDataState: SkyDataManagerState;
   let uiConfigService: SkyUIConfigService;
+  let subscription: Subscription;
 
   const sourceId = 'unitTests';
 
@@ -42,6 +43,11 @@ describe('SkyDataManagerService', () => {
 
     dataManagerService = TestBed.inject(SkyDataManagerService);
     uiConfigService = TestBed.inject(SkyUIConfigService);
+    subscription = new Subscription();
+  });
+
+  afterEach(() => {
+    subscription.unsubscribe();
   });
 
   describe('initDataManager', () => {
@@ -176,9 +182,11 @@ describe('SkyDataManagerService', () => {
     beforeEach(() => {
       initTestComponent();
 
-      dataManagerService
-        .getDataStateUpdates(sourceId)
-        .subscribe((state) => (currentDataState = state));
+      subscription.add(
+        dataManagerService
+          .getDataStateUpdates(sourceId)
+          .subscribe((state) => (currentDataState = state)),
+      );
     });
 
     it('should update the data state of all subscribed components', () => {
@@ -201,9 +209,11 @@ describe('SkyDataManagerService', () => {
             dataManagerService.getDataStateUpdates(sourceId);
           dataState = currentDataState;
 
-          dataStateObservable.subscribe((state) => {
-            dataState = state;
-          });
+          subscription.add(
+            dataStateObservable.subscribe((state) => {
+              dataState = state;
+            }),
+          );
         });
 
         it('should emit new values when the sourceId of the change is different from the given sourceId', () => {
@@ -238,9 +248,11 @@ describe('SkyDataManagerService', () => {
           );
           dataState = currentDataState;
 
-          dataStateObservable.subscribe((state) => {
-            dataState = state;
-          });
+          subscription.add(
+            dataStateObservable.subscribe((state) => {
+              dataState = state;
+            }),
+          );
         });
 
         it('should emit new values when one of the given filter properties changes', () => {
@@ -289,9 +301,11 @@ describe('SkyDataManagerService', () => {
           );
           dataState = currentDataState;
 
-          dataStateObservable.subscribe((state) => {
-            dataState = state;
-          });
+          subscription.add(
+            dataStateObservable.subscribe((state) => {
+              dataState = state;
+            }),
+          );
         });
 
         it('should emit new values when the comparator detects changes', () => {
@@ -356,9 +370,11 @@ describe('SkyDataManagerService', () => {
         dataManagerService.getDataManagerConfigUpdates();
       let dataConfig = initialDataConfig;
 
-      dataConfigObservable.subscribe((config) => {
-        dataConfig = config;
-      });
+      subscription.add(
+        dataConfigObservable.subscribe((config) => {
+          dataConfig = config;
+        }),
+      );
 
       expect(dataConfig).toEqual(initialDataConfig);
 
@@ -390,9 +406,11 @@ describe('SkyDataManagerService', () => {
         dataManagerService.getActiveViewIdUpdates();
       let activeViewId = initialActiveViewId;
 
-      activeViewIdObservable.subscribe((id) => {
-        activeViewId = id;
-      });
+      subscription.add(
+        activeViewIdObservable.subscribe((id) => {
+          activeViewId = id;
+        }),
+      );
 
       expect(activeViewId).toEqual(initialActiveViewId);
 
@@ -411,9 +429,11 @@ describe('SkyDataManagerService', () => {
     it('should create a new view config and view state when a data state has been set', async () => {
       let currentDataState: SkyDataManagerState | undefined;
 
-      dataManagerService
-        .getDataStateUpdates(sourceId)
-        .subscribe((state) => (currentDataState = state));
+      subscription.add(
+        dataManagerService
+          .getDataStateUpdates(sourceId)
+          .subscribe((state) => (currentDataState = state)),
+      );
       dataManagerService.updateDataState(new SkyDataManagerState({}), 'test');
 
       dataManagerFixture.detectChanges();
@@ -450,9 +470,11 @@ describe('SkyDataManagerService', () => {
      state but has not been initialized`, async () => {
       let currentDataState: SkyDataManagerState | undefined;
 
-      dataManagerService
-        .getDataStateUpdates(sourceId)
-        .subscribe((state) => (currentDataState = state));
+      subscription.add(
+        dataManagerService
+          .getDataStateUpdates(sourceId)
+          .subscribe((state) => (currentDataState = state)),
+      );
       dataManagerService.updateDataState(
         new SkyDataManagerState({
           views: [
@@ -497,9 +519,11 @@ describe('SkyDataManagerService', () => {
     it(`should not update available or displayed column IDs on an existing view state if current columns match`, async () => {
       let currentDataState: SkyDataManagerState | undefined;
 
-      dataManagerService
-        .getDataStateUpdates(sourceId)
-        .subscribe((state) => (currentDataState = state));
+      subscription.add(
+        dataManagerService
+          .getDataStateUpdates(sourceId)
+          .subscribe((state) => (currentDataState = state)),
+      );
       dataManagerService.updateDataState(
         new SkyDataManagerState({
           views: [
@@ -559,9 +583,11 @@ describe('SkyDataManagerService', () => {
     it(`should update available or displayed column IDs on an existing view state if a new column exists`, async () => {
       let currentDataState: SkyDataManagerState | undefined;
 
-      dataManagerService
-        .getDataStateUpdates(sourceId)
-        .subscribe((state) => (currentDataState = state));
+      subscription.add(
+        dataManagerService
+          .getDataStateUpdates(sourceId)
+          .subscribe((state) => (currentDataState = state)),
+      );
       dataManagerService.updateDataState(
         new SkyDataManagerState({
           views: [
@@ -626,9 +652,11 @@ describe('SkyDataManagerService', () => {
     column exists with 'initialHide'`, async () => {
       let currentDataState: SkyDataManagerState | undefined;
 
-      dataManagerService
-        .getDataStateUpdates(sourceId)
-        .subscribe((state) => (currentDataState = state));
+      subscription.add(
+        dataManagerService
+          .getDataStateUpdates(sourceId)
+          .subscribe((state) => (currentDataState = state)),
+      );
       dataManagerService.updateDataState(
         new SkyDataManagerState({
           views: [
@@ -694,9 +722,11 @@ describe('SkyDataManagerService', () => {
      columns weren't previously given`, async () => {
       let currentDataState: SkyDataManagerState | undefined;
 
-      dataManagerService
-        .getDataStateUpdates(sourceId)
-        .subscribe((state) => (currentDataState = state));
+      subscription.add(
+        dataManagerService
+          .getDataStateUpdates(sourceId)
+          .subscribe((state) => (currentDataState = state)),
+      );
       dataManagerService.updateDataState(
         new SkyDataManagerState({
           views: [
@@ -761,9 +791,11 @@ describe('SkyDataManagerService', () => {
     it(`should update available and displayed column ids on a new view`, async () => {
       let currentDataState: SkyDataManagerState | undefined;
 
-      dataManagerService
-        .getDataStateUpdates(sourceId)
-        .subscribe((state) => (currentDataState = state));
+      subscription.add(
+        dataManagerService
+          .getDataStateUpdates(sourceId)
+          .subscribe((state) => (currentDataState = state)),
+      );
       dataManagerService.updateDataState(new SkyDataManagerState({}), 'test');
 
       dataManagerFixture.detectChanges();
@@ -860,6 +892,183 @@ describe('SkyDataManagerService', () => {
     });
   });
 
+  describe('distinctUntilChanged with shared mutable state', () => {
+    const otherSourceId = 'otherSource';
+
+    beforeEach(() => {
+      initTestComponent();
+    });
+
+    it('should emit via getDataStateUpdates with property filter after updateDataState', () => {
+      let emitCount = 0;
+
+      subscription.add(
+        dataManagerService
+          .getDataStateUpdates(otherSourceId, {
+            properties: ['searchText'],
+          })
+          .subscribe(() => {
+            emitCount++;
+          }),
+      );
+
+      // Capture the initial emit count before updateDataState is called.
+      // The subsequent updateDataState call should trigger another emission.
+      const initialEmitCount = emitCount;
+
+      dataManagerService.updateDataState(
+        new SkyDataManagerState({ searchText: 'changed' }),
+        'someSource',
+      );
+
+      expect(emitCount).toBeGreaterThan(initialEmitCount);
+    });
+
+    it('should emit after in-place mutation of state followed by updateDataState', () => {
+      let latestState: SkyDataManagerState | undefined;
+      let emitCount = 0;
+
+      subscription.add(
+        dataManagerService
+          .getDataStateUpdates(otherSourceId, {
+            properties: ['selectedIds'],
+          })
+          .subscribe((state) => {
+            latestState = state;
+            emitCount++;
+          }),
+      );
+
+      const emitCountAfterInit = emitCount;
+
+      // Simulate consumer mutating state in-place then calling updateDataState
+      const stateToMutate = new SkyDataManagerState({
+        selectedIds: ['1', '2'],
+      });
+      dataManagerService.updateDataState(stateToMutate, 'someSource');
+
+      const emitCountAfterFirst = emitCount;
+      expect(emitCountAfterFirst).toBeGreaterThan(emitCountAfterInit);
+
+      // Mutate the previously emitted state in-place and update again
+      stateToMutate.selectedIds?.push('3');
+      dataManagerService.updateDataState(stateToMutate, 'someSource');
+
+      expect(emitCount).toBeGreaterThan(emitCountAfterFirst);
+      expect(latestState?.selectedIds).toEqual(['1', '2', '3']);
+    });
+
+    it('should preserve onlyShowSelected through addOrUpdateView', () => {
+      let latestState: SkyDataManagerState | undefined;
+
+      subscription.add(
+        dataManagerService
+          .getDataStateUpdates(otherSourceId)
+          .subscribe((state) => {
+            latestState = state;
+          }),
+      );
+
+      const stateWithFlag = new SkyDataManagerState({
+        onlyShowSelected: true,
+        searchText: 'test',
+      });
+      dataManagerService.updateDataState(stateWithFlag, 'someSource');
+
+      // Now add a view — addOrUpdateView should preserve onlyShowSelected
+      const newView: SkyDataViewConfig = {
+        id: 'testView',
+        name: 'Test View',
+      };
+      dataManagerService.initDataView(newView);
+
+      expect(latestState?.onlyShowSelected).toBeTrue();
+    });
+
+    it('should return cloned additionalData from SkyDataViewState getViewStateOptions', () => {
+      const additionalData = { nested: { value: 42 }, list: [1, 2, 3] };
+      const viewState = new SkyDataViewState({
+        viewId: 'view1',
+        additionalData,
+      });
+
+      const options = viewState.getViewStateOptions();
+
+      expect(options.additionalData).toEqual(additionalData);
+      expect(options.additionalData).not.toBe(additionalData);
+      expect(options.additionalData.nested).not.toBe(additionalData.nested);
+
+      // Mutating the clone should not affect the original
+      options.additionalData.nested.value = 999;
+      expect(viewState.additionalData.nested.value).toBe(42);
+    });
+
+    it('should return cloned activeSortOption, additionalData, and filterData without filters from SkyDataManagerState getStateOptions', () => {
+      const activeSortOption = {
+        id: 'sort1',
+        label: 'Name',
+        propertyName: 'name',
+        descending: false,
+      };
+      const additionalData = { key: 'value', items: [1, 2] };
+      const state = new SkyDataManagerState({
+        activeSortOption,
+        additionalData,
+        filterData: { filtersApplied: true },
+      });
+
+      const options = state.getStateOptions();
+
+      expect(options.activeSortOption).toEqual(activeSortOption);
+      expect(options.activeSortOption).not.toBe(activeSortOption);
+
+      expect(options.additionalData).toEqual(additionalData);
+      expect(options.additionalData).not.toBe(additionalData);
+
+      expect(options.filterData).toEqual({
+        filtersApplied: true,
+        filters: undefined,
+      });
+      expect(options.filterData).not.toBe(state.filterData);
+
+      // Mutating clones should not affect the original
+      options.activeSortOption!.descending = true;
+      expect(state.activeSortOption!.descending).toBe(false);
+
+      options.additionalData.items.push(3);
+      expect(state.additionalData.items).toEqual([1, 2]);
+    });
+
+    it('should add a new view via addOrUpdateView when another view already exists', () => {
+      const state = new SkyDataManagerState({
+        searchText: 'test',
+        views: [{ viewId: 'existingView', columnIds: ['col1'] }],
+      });
+
+      const newView = new SkyDataViewState({
+        viewId: 'newView',
+        columnIds: ['col2', 'col3'],
+      });
+
+      const updatedState = state.addOrUpdateView('newView', newView);
+
+      expect(updatedState.views.length).toBe(2);
+      expect(updatedState.getViewStateById('existingView')).toBeDefined();
+      expect(updatedState.getViewStateById('existingView')?.columnIds).toEqual([
+        'col1',
+      ]);
+      expect(updatedState.getViewStateById('newView')).toBeDefined();
+      expect(updatedState.getViewStateById('newView')?.columnIds).toEqual([
+        'col2',
+        'col3',
+      ]);
+      expect(updatedState.searchText).toBe('test');
+
+      // Original state should not be mutated
+      expect(state.views.length).toBe(1);
+    });
+  });
+
   it('should set the viewkeeper classes for the given viewId when setViewkeeperClasses is called', () => {
     initTestComponent();
 
@@ -867,8 +1076,10 @@ describe('SkyDataManagerService', () => {
     const viewId = 'testId';
     let viewkeeperClasses: Record<string, string[]> | undefined;
 
-    dataManagerService.viewkeeperClasses.subscribe(
-      (classes) => (viewkeeperClasses = classes),
+    subscription.add(
+      dataManagerService.viewkeeperClasses.subscribe(
+        (classes) => (viewkeeperClasses = classes),
+      ),
     );
 
     dataManagerService.setViewkeeperClasses(viewId, [newClass]);

--- a/libs/components/data-manager/src/lib/modules/data-manager/data-manager.service.ts
+++ b/libs/components/data-manager/src/lib/modules/data-manager/data-manager.service.ts
@@ -178,6 +178,10 @@ export class SkyDataManagerService implements OnDestroy {
 
           this.updateDataState(newDataState, this.#initSource);
         } else {
+          const updatedViewState = new SkyDataViewState(
+            currentViewState.getViewStateOptions(),
+          );
+
           const currentAvailableColumnIds =
             viewConfig.columnOptions?.map((columnOptions) => {
               return columnOptions.id;
@@ -187,9 +191,9 @@ export class SkyDataManagerService implements OnDestroy {
           // add new columns to the `displayedColumnIds` as long as they are not `initialHide`.
           // We only add columns to `displayedColumnsIds` if we had previously tracked
           // `columnIds` to avoid breaking changes.
-          if (currentViewState.columnIds.length > 0) {
+          if (updatedViewState.columnIds.length > 0) {
             let newColumnIds = currentAvailableColumnIds?.filter(
-              (id) => currentViewState.columnIds.indexOf(id) < 0,
+              (id) => updatedViewState.columnIds.indexOf(id) < 0,
             );
             newColumnIds = newColumnIds?.filter((columnId) => {
               return viewConfig.columnOptions?.find(
@@ -200,16 +204,16 @@ export class SkyDataManagerService implements OnDestroy {
 
             // Add the column IDs that now exist to the data manager state both as available
             // and as shown.
-            currentViewState.displayedColumnIds =
-              currentViewState.displayedColumnIds.concat(newColumnIds);
+            updatedViewState.displayedColumnIds =
+              updatedViewState.displayedColumnIds.concat(newColumnIds);
           }
           // Add the column IDs that now exist to the data manager state both as available
           // and as shown.
-          currentViewState.columnIds = currentAvailableColumnIds;
+          updatedViewState.columnIds = currentAvailableColumnIds;
 
           const newDataState = dataState.addOrUpdateView(
             viewConfig.id,
-            currentViewState,
+            updatedViewState,
           );
 
           this.updateDataState(newDataState, this.#initSource);

--- a/libs/components/data-manager/src/lib/modules/data-manager/models/data-manager-state.ts
+++ b/libs/components/data-manager/src/lib/modules/data-manager/models/data-manager-state.ts
@@ -3,6 +3,7 @@ import { SkyDataManagerSortOption } from './data-manager-sort-option';
 import { SkyDataManagerStateOptions } from './data-manager-state-options';
 import { SkyDataViewState } from './data-view-state';
 import { SkyDataViewStateOptions } from './data-view-state-options';
+import { safeStructuredClone } from './safe-structured-clone';
 
 /**
  * Provides options that control which data to display.
@@ -63,12 +64,25 @@ export class SkyDataManagerState {
     });
 
     return {
-      activeSortOption: this.activeSortOption,
-      additionalData: this.additionalData,
-      filterData: this.filterData,
+      activeSortOption: this.activeSortOption
+        ? { ...this.activeSortOption }
+        : undefined,
+      additionalData:
+        this.additionalData !== undefined
+          ? safeStructuredClone(this.additionalData)
+          : undefined,
+      filterData: this.filterData
+        ? {
+            filtersApplied: this.filterData.filtersApplied,
+            filters:
+              this.filterData.filters !== undefined
+                ? safeStructuredClone(this.filterData.filters)
+                : undefined,
+          }
+        : undefined,
       onlyShowSelected: this.onlyShowSelected,
       searchText: this.searchText,
-      selectedIds: this.selectedIds,
+      selectedIds: this.selectedIds ? [...this.selectedIds] : undefined,
       views: viewStates,
     };
   }
@@ -94,19 +108,16 @@ export class SkyDataManagerState {
   ): SkyDataManagerState {
     const existingViewIndex = this.views.findIndex((v) => v.viewId === viewId);
 
+    const newViews = this.views.slice();
     if (existingViewIndex !== -1) {
-      this.views[existingViewIndex] = view;
+      newViews.splice(existingViewIndex, 1, view);
     } else {
-      this.views.push(view);
+      newViews.push(view);
     }
 
-    return new SkyDataManagerState({
-      activeSortOption: this.activeSortOption,
-      additionalData: this.additionalData,
-      filterData: this.filterData,
-      searchText: this.searchText,
-      selectedIds: this.selectedIds,
-      views: this.views,
-    });
+    const options = this.getStateOptions();
+    options.views = newViews.map((v) => v.getViewStateOptions());
+
+    return new SkyDataManagerState(options);
   }
 }

--- a/libs/components/data-manager/src/lib/modules/data-manager/models/data-view-state.spec.ts
+++ b/libs/components/data-manager/src/lib/modules/data-manager/models/data-view-state.spec.ts
@@ -1,0 +1,32 @@
+import { SkyDataViewColumnWidths } from './data-view-column-widths';
+import { SkyDataViewState } from './data-view-state';
+
+describe('SkyDataViewState', () => {
+  describe('constructor', () => {
+    it('should default xs and sm to empty objects when columnWidths sub-properties are undefined', () => {
+      const state = new SkyDataViewState({
+        viewId: 'test',
+        columnWidths: {
+          xs: undefined,
+          sm: undefined,
+        } as unknown as SkyDataViewColumnWidths,
+      });
+
+      expect(state.columnWidths).toEqual({ xs: {}, sm: {} });
+    });
+  });
+
+  describe('getViewStateOptions', () => {
+    it('should default xs and sm to empty objects when columnWidths sub-properties are undefined', () => {
+      const state = new SkyDataViewState({ viewId: 'test' });
+      state.columnWidths = {
+        xs: undefined,
+        sm: undefined,
+      } as unknown as SkyDataViewColumnWidths;
+
+      const options = state.getViewStateOptions();
+
+      expect(options.columnWidths).toEqual({ xs: {}, sm: {} });
+    });
+  });
+});

--- a/libs/components/data-manager/src/lib/modules/data-manager/models/data-view-state.ts
+++ b/libs/components/data-manager/src/lib/modules/data-manager/models/data-view-state.ts
@@ -1,5 +1,6 @@
 import { SkyDataViewColumnWidths } from './data-view-column-widths';
 import { SkyDataViewStateOptions } from './data-view-state-options';
+import { safeStructuredClone } from './safe-structured-clone';
 
 /**
  * Provides options for defining how data is displayed, such as which columns appear.
@@ -32,7 +33,11 @@ export class SkyDataViewState {
   constructor(data: SkyDataViewStateOptions) {
     this.viewId = data.viewId;
     this.columnIds = data.columnIds || [];
-    this.columnWidths = data.columnWidths || { xs: {}, sm: {} };
+    const widths = data.columnWidths || { xs: {}, sm: {} };
+    this.columnWidths = {
+      xs: widths.xs ?? {},
+      sm: widths.sm ?? {},
+    };
     this.displayedColumnIds = data.displayedColumnIds || [];
     this.additionalData = data.additionalData;
   }
@@ -44,10 +49,16 @@ export class SkyDataViewState {
   public getViewStateOptions(): SkyDataViewStateOptions {
     return {
       viewId: this.viewId,
-      columnIds: this.columnIds,
-      columnWidths: this.columnWidths,
-      displayedColumnIds: this.displayedColumnIds,
-      additionalData: this.additionalData,
+      columnIds: [...this.columnIds],
+      columnWidths: {
+        xs: { ...(this.columnWidths?.xs ?? {}) },
+        sm: { ...(this.columnWidths?.sm ?? {}) },
+      },
+      displayedColumnIds: [...this.displayedColumnIds],
+      additionalData:
+        this.additionalData !== undefined
+          ? safeStructuredClone(this.additionalData)
+          : undefined,
     };
   }
 }

--- a/libs/components/data-manager/src/lib/modules/data-manager/models/safe-structured-clone.spec.ts
+++ b/libs/components/data-manager/src/lib/modules/data-manager/models/safe-structured-clone.spec.ts
@@ -1,0 +1,28 @@
+import { safeStructuredClone } from './safe-structured-clone';
+
+describe('safeStructuredClone', () => {
+  it('should return undefined when given undefined', () => {
+    expect(safeStructuredClone(undefined)).toBeUndefined();
+  });
+
+  it('should return null when given null', () => {
+    expect(safeStructuredClone(null)).toBeNull();
+  });
+
+  it('should return a deep clone for a cloneable value', () => {
+    const original = { nested: { value: 42 }, list: [1, 2, 3] };
+    const cloned = safeStructuredClone(original);
+
+    expect(cloned).toEqual(original);
+    expect(cloned).not.toBe(original);
+    expect(cloned.nested).not.toBe(original.nested);
+  });
+
+  it('should return the original reference when structuredClone throws', () => {
+    // Functions are not cloneable by structuredClone.
+    const fn = (): string => 'hello';
+    const result = safeStructuredClone(fn);
+
+    expect(result).toBe(fn);
+  });
+});

--- a/libs/components/data-manager/src/lib/modules/data-manager/models/safe-structured-clone.ts
+++ b/libs/components/data-manager/src/lib/modules/data-manager/models/safe-structured-clone.ts
@@ -1,0 +1,16 @@
+/**
+ * @internal
+ */
+export function safeStructuredClone<T>(value: T): T {
+  if (value === undefined || value === null) {
+    return value;
+  }
+
+  try {
+    // structuredClone may throw if the value is not cloneable.
+    return structuredClone(value);
+  } catch {
+    // Fall back to returning the original reference to avoid unexpected runtime errors.
+    return value;
+  }
+}


### PR DESCRIPTION
:cherries: Cherry picked from #4309 [fix(components/data-manager): address data mutation during view updates](https://github.com/blackbaud/skyux/pull/4309)

[AB#3705639](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3705639) 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved state management consistency through immutable state updates in the data manager, enhancing data integrity and reliability.

* **Tests**
  * Expanded test coverage for edge cases in state handling and column configuration with improved test infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->