### PR TITLE
chore: release 13.16.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 # Changelog
 
 
+## [13.16.2](https://github.com/blackbaud/skyux/compare/13.16.1...13.16.2) (2026-03-17)
+
+
+### Bug Fixes
+
+* **components/data-manager:** address data mutation during view updates ([#4309](https://github.com/blackbaud/skyux/issues/4309)) ([328efab](https://github.com/blackbaud/skyux/commit/328efabc7ef53c81f59db64cc8619faa3b4c033f)), closes [AB#3705639](https://github.com/AB/issues/3705639)
+
+
+
 ## [13.16.1](https://github.com/blackbaud/skyux/compare/13.16.0...13.16.1) (2026-03-12)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "skyux",
-  "version": "13.16.1",
+  "version": "13.16.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "skyux",
-      "version": "13.16.1",
+      "version": "13.16.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skyux",
-  "version": "13.16.1",
+  "version": "13.16.2",
   "license": "MIT",
   "scripts": {
     "ng": "nx",


### PR DESCRIPTION
## [13.16.2](https://github.com/blackbaud/skyux/compare/13.16.1...13.16.2) (2026-03-17)


### Bug Fixes

* **components/data-manager:** address data mutation during view updates ([#4309](https://github.com/blackbaud/skyux/issues/4309)) ([328efab](https://github.com/blackbaud/skyux/commit/328efabc7ef53c81f59db64cc8619faa3b4c033f)), closes [AB#3705639](https://github.com/AB/issues/3705639)