### PR TITLE
fix(sdk/skyux-eslint): `no-barrel-exports` rule should not break exports

### DIFF
--- a/libs/sdk/eslint-schematics/migrations.json
+++ b/libs/sdk/eslint-schematics/migrations.json
@@ -4,6 +4,11 @@
       "version": "0.0.0-PLACEHOLDER",
       "factory": "./src/schematics/migrations/noop/noop.schematic",
       "description": "Update skyux-eslint dependencies"
+    },
+    "flatten-barrel-exports": {
+      "version": "0.0.0-PLACEHOLDER",
+      "factory": "./src/schematics/migrations/flatten-barrel-exports/flatten-barrel-exports.schematic",
+      "description": "Iteratively flatten barrel (export *) re-exports into explicit named exports"
     }
   }
 }

--- a/libs/sdk/eslint-schematics/package.json
+++ b/libs/sdk/eslint-schematics/package.json
@@ -30,7 +30,8 @@
     }
   },
   "peerDependencies": {
-    "@angular/cli": "^21.2.0"
+    "@angular/cli": "^21.2.0",
+    "typescript": ">=5.5.0"
   },
   "dependencies": {
     "jsonc-parser": "3.3.1",

--- a/libs/sdk/eslint-schematics/package.json
+++ b/libs/sdk/eslint-schematics/package.json
@@ -31,7 +31,7 @@
   },
   "peerDependencies": {
     "@angular/cli": "^21.2.0",
-    "typescript": ">=5.5.0"
+    "typescript": "^5.9.3"
   },
   "dependencies": {
     "jsonc-parser": "3.3.1",

--- a/libs/sdk/eslint-schematics/src/schematics/migrations/flatten-barrel-exports/barrel-export-utils.spec.ts
+++ b/libs/sdk/eslint-schematics/src/schematics/migrations/flatten-barrel-exports/barrel-export-utils.spec.ts
@@ -42,9 +42,9 @@ describe('extractNamedExports', () => {
     });
   });
 
-  it('should not flag namespace re-exports as wildcards', () => {
+  it('should extract namespace re-export name as value export', () => {
     expect(extractNamedExports("export * as ns from './bar';")).toEqual({
-      valueExports: [],
+      valueExports: ['ns'],
       typeExports: [],
       hasWildcardReExports: false,
     });
@@ -105,6 +105,11 @@ describe('findWildcardReExports', () => {
 
   it('should not include namespace re-exports', () => {
     const content = "export * as ns from './foo';";
+    expect(findWildcardReExports(content)).toHaveLength(0);
+  });
+
+  it('should not include type-only wildcard re-exports', () => {
+    const content = "export type * from './foo';";
     expect(findWildcardReExports(content)).toHaveLength(0);
   });
 

--- a/libs/sdk/eslint-schematics/src/schematics/migrations/flatten-barrel-exports/barrel-export-utils.spec.ts
+++ b/libs/sdk/eslint-schematics/src/schematics/migrations/flatten-barrel-exports/barrel-export-utils.spec.ts
@@ -1,0 +1,259 @@
+import { HostTree } from '@angular-devkit/schematics';
+import { UnitTestTree } from '@angular-devkit/schematics/testing';
+
+import {
+  buildNamedExportStatement,
+  extractNamedExports,
+  findWildcardReExports,
+  resolveInTree,
+  topologicalSort,
+} from './barrel-export-utils';
+
+describe('extractNamedExports', () => {
+  it('should extract value and type exports', () => {
+    const content = ['export class Foo {}', 'export interface Bar {}'].join(
+      '\n',
+    );
+
+    expect(extractNamedExports(content)).toEqual({
+      valueExports: ['Foo'],
+      typeExports: ['Bar'],
+      hasWildcardReExports: false,
+    });
+  });
+
+  it('should detect wildcard re-exports', () => {
+    expect(extractNamedExports("export * from './bar';")).toEqual({
+      valueExports: [],
+      typeExports: [],
+      hasWildcardReExports: true,
+    });
+  });
+
+  it('should detect wildcard re-exports alongside named exports', () => {
+    const content = ['export class Foo {}', "export * from './bar';"].join(
+      '\n',
+    );
+
+    expect(extractNamedExports(content)).toEqual({
+      valueExports: ['Foo'],
+      typeExports: [],
+      hasWildcardReExports: true,
+    });
+  });
+
+  it('should not flag namespace re-exports as wildcards', () => {
+    expect(extractNamedExports("export * as ns from './bar';")).toEqual({
+      valueExports: [],
+      typeExports: [],
+      hasWildcardReExports: false,
+    });
+  });
+
+  it('should extract function exports', () => {
+    expect(extractNamedExports('export function foo() {}')).toEqual({
+      valueExports: ['foo'],
+      typeExports: [],
+      hasWildcardReExports: false,
+    });
+  });
+
+  it('should extract enum exports', () => {
+    expect(extractNamedExports('export enum Color { Red }')).toEqual({
+      valueExports: ['Color'],
+      typeExports: [],
+      hasWildcardReExports: false,
+    });
+  });
+
+  it('should extract type alias exports', () => {
+    expect(extractNamedExports('export type ID = string;')).toEqual({
+      valueExports: [],
+      typeExports: ['ID'],
+      hasWildcardReExports: false,
+    });
+  });
+
+  it('should extract type-only re-exports', () => {
+    expect(extractNamedExports("export type { Foo } from './foo';")).toEqual({
+      valueExports: [],
+      typeExports: ['Foo'],
+      hasWildcardReExports: false,
+    });
+  });
+});
+
+describe('findWildcardReExports', () => {
+  it('should find bare wildcard re-exports', () => {
+    const content = "export * from './foo';";
+    const results = findWildcardReExports(content);
+
+    expect(results).toHaveLength(1);
+    expect(results[0].specifier).toBe('./foo');
+  });
+
+  it('should find multiple wildcard re-exports', () => {
+    const content = ["export * from './foo';", "export * from './bar';"].join(
+      '\n',
+    );
+    const results = findWildcardReExports(content);
+
+    expect(results).toHaveLength(2);
+    expect(results[0].specifier).toBe('./foo');
+    expect(results[1].specifier).toBe('./bar');
+  });
+
+  it('should not include namespace re-exports', () => {
+    const content = "export * as ns from './foo';";
+    expect(findWildcardReExports(content)).toHaveLength(0);
+  });
+
+  it('should not include named re-exports', () => {
+    const content = "export { Foo } from './foo';";
+    expect(findWildcardReExports(content)).toHaveLength(0);
+  });
+
+  it('should return correct start and end offsets', () => {
+    const content = "export * from './foo';";
+    const results = findWildcardReExports(content);
+
+    expect(content.slice(results[0].start, results[0].end)).toBe(
+      "export * from './foo';",
+    );
+  });
+});
+
+describe('resolveInTree', () => {
+  let tree: UnitTestTree;
+
+  beforeEach(() => {
+    tree = new UnitTestTree(new HostTree());
+  });
+
+  it('should resolve a .ts file', () => {
+    tree.create('/src/foo.ts', 'export class Foo {}');
+
+    expect(resolveInTree(tree, '/src/index.ts', './foo')).toBe('/src/foo.ts');
+  });
+
+  it('should resolve an index.ts file', () => {
+    tree.create('/src/bar/index.ts', 'export class Bar {}');
+
+    expect(resolveInTree(tree, '/src/index.ts', './bar')).toBe(
+      '/src/bar/index.ts',
+    );
+  });
+
+  it('should return undefined for non-existent module', () => {
+    expect(
+      resolveInTree(tree, '/src/index.ts', './nonexistent'),
+    ).toBeUndefined();
+  });
+
+  it('should return undefined for non-relative specifiers', () => {
+    expect(
+      resolveInTree(tree, '/src/index.ts', 'some-package'),
+    ).toBeUndefined();
+  });
+
+  it('should prefer .ts over index.ts', () => {
+    tree.create('/src/foo.ts', 'export class Foo {}');
+    tree.create('/src/foo/index.ts', 'export class FooIndex {}');
+
+    expect(resolveInTree(tree, '/src/index.ts', './foo')).toBe('/src/foo.ts');
+  });
+});
+
+describe('buildNamedExportStatement', () => {
+  it('should build value export statement', () => {
+    const result = buildNamedExportStatement(
+      {
+        valueExports: ['Foo', 'Bar'],
+        typeExports: [],
+        hasWildcardReExports: false,
+      },
+      './foo',
+    );
+
+    expect(result).toBe("export { Foo, Bar } from './foo';");
+  });
+
+  it('should build type export statement', () => {
+    const result = buildNamedExportStatement(
+      { valueExports: [], typeExports: ['Foo'], hasWildcardReExports: false },
+      './foo',
+    );
+
+    expect(result).toBe("export type { Foo } from './foo';");
+  });
+
+  it('should build mixed export statements', () => {
+    const result = buildNamedExportStatement(
+      {
+        valueExports: ['FooComponent'],
+        typeExports: ['FooConfig'],
+        hasWildcardReExports: false,
+      },
+      './foo',
+    );
+
+    expect(result).toBe(
+      "export { FooComponent } from './foo';\nexport type { FooConfig } from './foo';",
+    );
+  });
+});
+
+describe('topologicalSort', () => {
+  it('should return leaf nodes first', () => {
+    const graph = new Map<string, string[]>();
+    graph.set('/a.ts', ['/b.ts']);
+    graph.set('/b.ts', []);
+
+    const sorted = topologicalSort(graph);
+
+    expect(sorted.indexOf('/b.ts')).toBeLessThan(sorted.indexOf('/a.ts'));
+  });
+
+  it('should handle multi-level chains', () => {
+    const graph = new Map<string, string[]>();
+    graph.set('/index.ts', ['/a.ts']);
+    graph.set('/a.ts', ['/b.ts']);
+    graph.set('/b.ts', []);
+
+    const sorted = topologicalSort(graph);
+
+    expect(sorted.indexOf('/b.ts')).toBeLessThan(sorted.indexOf('/a.ts'));
+    expect(sorted.indexOf('/a.ts')).toBeLessThan(sorted.indexOf('/index.ts'));
+  });
+
+  it('should handle circular dependencies without crashing', () => {
+    const graph = new Map<string, string[]>();
+    graph.set('/a.ts', ['/b.ts']);
+    graph.set('/b.ts', ['/a.ts']);
+
+    const sorted = topologicalSort(graph);
+
+    expect(sorted).toHaveLength(2);
+    expect(sorted).toContain('/a.ts');
+    expect(sorted).toContain('/b.ts');
+  });
+
+  it('should handle independent nodes', () => {
+    const graph = new Map<string, string[]>();
+    graph.set('/a.ts', []);
+    graph.set('/b.ts', []);
+
+    const sorted = topologicalSort(graph);
+
+    expect(sorted).toHaveLength(2);
+  });
+
+  it('should handle deps pointing outside the graph', () => {
+    const graph = new Map<string, string[]>();
+    graph.set('/a.ts', ['/external.ts']);
+
+    const sorted = topologicalSort(graph);
+
+    expect(sorted).toContain('/a.ts');
+  });
+});

--- a/libs/sdk/eslint-schematics/src/schematics/migrations/flatten-barrel-exports/barrel-export-utils.spec.ts
+++ b/libs/sdk/eslint-schematics/src/schematics/migrations/flatten-barrel-exports/barrel-export-utils.spec.ts
@@ -238,6 +238,18 @@ describe('topologicalSort', () => {
     expect(sorted).toContain('/b.ts');
   });
 
+  it('should handle diamond dependencies', () => {
+    const graph = new Map<string, string[]>();
+    graph.set('/index.ts', ['/a.ts', '/b.ts']);
+    graph.set('/a.ts', []);
+    graph.set('/b.ts', []);
+
+    const sorted = topologicalSort(graph);
+
+    expect(sorted.indexOf('/a.ts')).toBeLessThan(sorted.indexOf('/index.ts'));
+    expect(sorted.indexOf('/b.ts')).toBeLessThan(sorted.indexOf('/index.ts'));
+  });
+
   it('should handle independent nodes', () => {
     const graph = new Map<string, string[]>();
     graph.set('/a.ts', []);
@@ -246,14 +258,5 @@ describe('topologicalSort', () => {
     const sorted = topologicalSort(graph);
 
     expect(sorted).toHaveLength(2);
-  });
-
-  it('should handle deps pointing outside the graph', () => {
-    const graph = new Map<string, string[]>();
-    graph.set('/a.ts', ['/external.ts']);
-
-    const sorted = topologicalSort(graph);
-
-    expect(sorted).toContain('/a.ts');
   });
 });

--- a/libs/sdk/eslint-schematics/src/schematics/migrations/flatten-barrel-exports/barrel-export-utils.ts
+++ b/libs/sdk/eslint-schematics/src/schematics/migrations/flatten-barrel-exports/barrel-export-utils.ts
@@ -189,24 +189,6 @@ export function buildNamedExportStatement(
  * Returns nodes in leaf-first order (nodes with no dependencies first).
  */
 export function topologicalSort(graph: Map<string, string[]>): string[] {
-  // Build in-degree map (how many files depend on this file).
-  const inDegree = new Map<string, number>();
-  for (const node of graph.keys()) {
-    /* istanbul ignore else */
-    if (!inDegree.has(node)) {
-      inDegree.set(node, 0);
-    }
-  }
-  for (const deps of graph.values()) {
-    for (const dep of deps) {
-      inDegree.set(dep, (inDegree.get(dep) ?? 0) + 1);
-    }
-  }
-
-  // Start with leaf nodes (no one depends on them in the wildcard graph,
-  // but they themselves may have deps that are already resolved).
-  // Actually, we want nodes whose dependencies are all outside the graph
-  // (i.e., they don't depend on other barrel files).
   const queue: string[] = [];
   const outDegree = new Map<string, number>();
 
@@ -223,12 +205,10 @@ export function topologicalSort(graph: Map<string, string[]>): string[] {
     const node = queue.shift()!;
     sorted.push(node);
 
-    // Find all nodes that depend on this node and decrement their out-degree.
     for (const [other, deps] of graph) {
       if (deps.includes(node)) {
         const newDeg = outDegree.get(other)! - 1;
         outDegree.set(other, newDeg);
-        /* istanbul ignore else */
         if (newDeg === 0) {
           queue.push(other);
         }

--- a/libs/sdk/eslint-schematics/src/schematics/migrations/flatten-barrel-exports/barrel-export-utils.ts
+++ b/libs/sdk/eslint-schematics/src/schematics/migrations/flatten-barrel-exports/barrel-export-utils.ts
@@ -1,0 +1,247 @@
+import type { Tree } from '@angular-devkit/schematics';
+
+import { dirname, resolve } from 'node:path';
+import * as ts from 'typescript';
+
+export interface ExtractedNamedExports {
+  valueExports: string[];
+  typeExports: string[];
+  hasWildcardReExports: boolean;
+}
+
+/**
+ * Extracts named exports from TypeScript source text using the compiler API.
+ * Returns sorted, deduplicated arrays of value and type exports, plus a flag
+ * indicating whether the file contains any `export * from` re-exports.
+ */
+export function extractNamedExports(
+  fileContent: string,
+): ExtractedNamedExports {
+  const sourceFile = ts.createSourceFile(
+    'file.ts',
+    fileContent,
+    ts.ScriptTarget.Latest,
+    false,
+  );
+
+  const valueExports: string[] = [];
+  const typeExports: string[] = [];
+  let hasWildcardReExports = false;
+
+  for (const statement of sourceFile.statements) {
+    if (ts.isExportDeclaration(statement)) {
+      if (!statement.exportClause) {
+        // export * from '...'
+        hasWildcardReExports = true;
+      } else if (ts.isNamedExports(statement.exportClause)) {
+        for (const specifier of statement.exportClause.elements) {
+          const name = specifier.name.text;
+          if (statement.isTypeOnly || specifier.isTypeOnly) {
+            typeExports.push(name);
+          } else {
+            valueExports.push(name);
+          }
+        }
+      }
+      continue;
+    }
+
+    const modifiers = ts.getModifiers(statement as ts.HasModifiers) ?? [];
+    if (
+      !modifiers.some((m) => m.kind === ts.SyntaxKind.ExportKeyword) ||
+      modifiers.some((m) => m.kind === ts.SyntaxKind.DefaultKeyword)
+    ) {
+      continue;
+    }
+
+    /* istanbul ignore else */
+    if (ts.isClassDeclaration(statement) && statement.name) {
+      valueExports.push(statement.name.text);
+    } else if (ts.isFunctionDeclaration(statement) && statement.name) {
+      valueExports.push(statement.name.text);
+    } else if (ts.isEnumDeclaration(statement)) {
+      valueExports.push(statement.name.text);
+    } else if (ts.isInterfaceDeclaration(statement)) {
+      typeExports.push(statement.name.text);
+    } else if (ts.isTypeAliasDeclaration(statement)) {
+      typeExports.push(statement.name.text);
+    } else if (ts.isVariableStatement(statement)) {
+      for (const decl of statement.declarationList.declarations) {
+        /* istanbul ignore else */
+        if (ts.isIdentifier(decl.name)) {
+          valueExports.push(decl.name.text);
+        }
+      }
+    }
+  }
+
+  const valueSet = new Set(valueExports);
+
+  return {
+    valueExports: [...valueSet].sort(),
+    typeExports: [...new Set(typeExports)]
+      .filter((name) => !valueSet.has(name))
+      .sort(),
+    hasWildcardReExports,
+  };
+}
+
+export interface WildcardReExport {
+  /** The module specifier (e.g., './foo'). */
+  specifier: string;
+  /** Start offset of the `export * from '...'` statement in the source. */
+  start: number;
+  /** End offset of the statement (including trailing semicolon/newline). */
+  end: number;
+}
+
+/**
+ * Finds all bare `export * from '...'` statements in a file.
+ * Excludes `export * as ns from '...'` (namespace re-exports).
+ */
+export function findWildcardReExports(content: string): WildcardReExport[] {
+  const sourceFile = ts.createSourceFile(
+    'file.ts',
+    content,
+    ts.ScriptTarget.Latest,
+    false,
+  );
+
+  const results: WildcardReExport[] = [];
+
+  for (const statement of sourceFile.statements) {
+    if (
+      ts.isExportDeclaration(statement) &&
+      !statement.exportClause &&
+      statement.moduleSpecifier &&
+      ts.isStringLiteral(statement.moduleSpecifier)
+    ) {
+      results.push({
+        specifier: statement.moduleSpecifier.text,
+        start: statement.getStart(sourceFile),
+        end: statement.getEnd(),
+      });
+    }
+  }
+
+  return results;
+}
+
+/**
+ * Resolves a relative module specifier to a file path within the Tree.
+ * Tries .ts, .tsx, /index.ts, /index.tsx extensions.
+ * Only handles relative specifiers (starting with '.').
+ */
+export function resolveInTree(
+  tree: Tree,
+  fromFilePath: string,
+  specifier: string,
+): string | undefined {
+  if (!specifier.startsWith('.')) {
+    return undefined;
+  }
+
+  const dir = dirname(fromFilePath);
+  const basePath = resolve(dir, specifier);
+
+  const candidates = [
+    basePath + '.ts',
+    basePath + '.tsx',
+    basePath + '/index.ts',
+    basePath + '/index.tsx',
+  ];
+
+  for (const candidate of candidates) {
+    if (tree.exists(candidate)) {
+      return candidate;
+    }
+  }
+
+  return undefined;
+}
+
+/**
+ * Builds explicit named export statement(s) from extracted exports.
+ */
+export function buildNamedExportStatement(
+  namedExports: ExtractedNamedExports,
+  specifier: string,
+): string {
+  const parts: string[] = [];
+
+  if (namedExports.valueExports.length > 0) {
+    parts.push(
+      `export { ${namedExports.valueExports.join(', ')} } from '${specifier}';`,
+    );
+  }
+
+  if (namedExports.typeExports.length > 0) {
+    parts.push(
+      `export type { ${namedExports.typeExports.join(', ')} } from '${specifier}';`,
+    );
+  }
+
+  return parts.join('\n');
+}
+
+/**
+ * Topological sort using Kahn's algorithm.
+ * Returns nodes in leaf-first order (nodes with no dependencies first).
+ */
+export function topologicalSort(graph: Map<string, string[]>): string[] {
+  // Build in-degree map (how many files depend on this file).
+  const inDegree = new Map<string, number>();
+  for (const node of graph.keys()) {
+    /* istanbul ignore else */
+    if (!inDegree.has(node)) {
+      inDegree.set(node, 0);
+    }
+  }
+  for (const deps of graph.values()) {
+    for (const dep of deps) {
+      inDegree.set(dep, (inDegree.get(dep) ?? 0) + 1);
+    }
+  }
+
+  // Start with leaf nodes (no one depends on them in the wildcard graph,
+  // but they themselves may have deps that are already resolved).
+  // Actually, we want nodes whose dependencies are all outside the graph
+  // (i.e., they don't depend on other barrel files).
+  const queue: string[] = [];
+  const outDegree = new Map<string, number>();
+
+  for (const [node, deps] of graph) {
+    outDegree.set(node, deps.length);
+    if (deps.length === 0) {
+      queue.push(node);
+    }
+  }
+
+  const sorted: string[] = [];
+
+  while (queue.length > 0) {
+    const node = queue.shift()!;
+    sorted.push(node);
+
+    // Find all nodes that depend on this node and decrement their out-degree.
+    for (const [other, deps] of graph) {
+      if (deps.includes(node)) {
+        const newDeg = outDegree.get(other)! - 1;
+        outDegree.set(other, newDeg);
+        /* istanbul ignore else */
+        if (newDeg === 0) {
+          queue.push(other);
+        }
+      }
+    }
+  }
+
+  // Any remaining nodes are in cycles — append them at the end.
+  for (const node of graph.keys()) {
+    if (!sorted.includes(node)) {
+      sorted.push(node);
+    }
+  }
+
+  return sorted;
+}

--- a/libs/sdk/eslint-schematics/src/schematics/migrations/flatten-barrel-exports/barrel-export-utils.ts
+++ b/libs/sdk/eslint-schematics/src/schematics/migrations/flatten-barrel-exports/barrel-export-utils.ts
@@ -42,6 +42,9 @@ export function extractNamedExports(
             valueExports.push(name);
           }
         }
+      } else if (ts.isNamespaceExport(statement.exportClause)) {
+        // export * as ns from '...' — the namespace name is a value export
+        valueExports.push(statement.exportClause.name.text);
       }
       continue;
     }
@@ -113,6 +116,7 @@ export function findWildcardReExports(content: string): WildcardReExport[] {
     if (
       ts.isExportDeclaration(statement) &&
       !statement.exportClause &&
+      !statement.isTypeOnly &&
       statement.moduleSpecifier &&
       ts.isStringLiteral(statement.moduleSpecifier)
     ) {

--- a/libs/sdk/eslint-schematics/src/schematics/migrations/flatten-barrel-exports/barrel-export-utils.ts
+++ b/libs/sdk/eslint-schematics/src/schematics/migrations/flatten-barrel-exports/barrel-export-utils.ts
@@ -1,6 +1,6 @@
 import type { Tree } from '@angular-devkit/schematics';
 
-import { dirname, resolve } from 'node:path';
+import { dirname, resolve } from 'node:path/posix';
 import * as ts from 'typescript';
 
 export interface ExtractedNamedExports {

--- a/libs/sdk/eslint-schematics/src/schematics/migrations/flatten-barrel-exports/barrel-export-utils.ts
+++ b/libs/sdk/eslint-schematics/src/schematics/migrations/flatten-barrel-exports/barrel-export-utils.ts
@@ -91,7 +91,7 @@ export interface WildcardReExport {
   specifier: string;
   /** Start offset of the `export * from '...'` statement in the source. */
   start: number;
-  /** End offset of the statement (including trailing semicolon/newline). */
+  /** End offset of the statement text (including trailing semicolon if present). */
   end: number;
 }
 

--- a/libs/sdk/eslint-schematics/src/schematics/migrations/flatten-barrel-exports/flatten-barrel-exports.schematic.spec.ts
+++ b/libs/sdk/eslint-schematics/src/schematics/migrations/flatten-barrel-exports/flatten-barrel-exports.schematic.spec.ts
@@ -1,0 +1,178 @@
+import { HostTree } from '@angular-devkit/schematics';
+import {
+  SchematicTestRunner,
+  UnitTestTree,
+} from '@angular-devkit/schematics/testing';
+
+import path from 'node:path';
+
+const MIGRATIONS_PATH = path.resolve(__dirname, '../../../../migrations.json');
+
+describe('flatten-barrel-exports migration', () => {
+  let runner: SchematicTestRunner;
+
+  beforeEach(() => {
+    runner = new SchematicTestRunner('migrations', MIGRATIONS_PATH);
+  });
+
+  async function runMigration(tree: UnitTestTree): Promise<UnitTestTree> {
+    return await runner.runSchematic('flatten-barrel-exports', {}, tree);
+  }
+
+  it('should flatten a single-level barrel export', async () => {
+    const tree = new UnitTestTree(new HostTree());
+    tree.create('/src/foo.ts', 'export class Foo {}\nexport const bar = 1;');
+    tree.create('/src/index.ts', "export * from './foo';");
+
+    const result = await runMigration(tree);
+
+    expect(result.readText('/src/index.ts')).toBe(
+      "export { Foo, bar } from './foo';",
+    );
+  });
+
+  it('should flatten a two-level cascade', async () => {
+    const tree = new UnitTestTree(new HostTree());
+    tree.create('/src/leaf.ts', 'export class Leaf {}');
+    tree.create('/src/mid.ts', "export * from './leaf';");
+    tree.create('/src/index.ts', "export * from './mid';");
+
+    const result = await runMigration(tree);
+
+    expect(result.readText('/src/mid.ts')).toBe(
+      "export { Leaf } from './leaf';",
+    );
+    expect(result.readText('/src/index.ts')).toBe(
+      "export { Leaf } from './mid';",
+    );
+  });
+
+  it('should handle mixed named and wildcard exports', async () => {
+    const tree = new UnitTestTree(new HostTree());
+    tree.create('/src/foo.ts', 'export class Foo {}');
+    tree.create(
+      '/src/index.ts',
+      "export const LOCAL = 1;\nexport * from './foo';",
+    );
+
+    const result = await runMigration(tree);
+
+    expect(result.readText('/src/index.ts')).toBe(
+      "export const LOCAL = 1;\nexport { Foo } from './foo';",
+    );
+  });
+
+  it('should handle value and type exports', async () => {
+    const tree = new UnitTestTree(new HostTree());
+    tree.create(
+      '/src/foo.ts',
+      'export class FooComponent {}\nexport interface FooConfig {}',
+    );
+    tree.create('/src/index.ts', "export * from './foo';");
+
+    const result = await runMigration(tree);
+
+    expect(result.readText('/src/index.ts')).toBe(
+      "export { FooComponent } from './foo';\nexport type { FooConfig } from './foo';",
+    );
+  });
+
+  it('should skip circular dependencies without crashing', async () => {
+    const tree = new UnitTestTree(new HostTree());
+    tree.create('/src/a.ts', "export * from './b';");
+    tree.create('/src/b.ts', "export * from './a';");
+
+    const result = await runMigration(tree);
+
+    // Both files should be unchanged since they form a cycle.
+    expect(result.readText('/src/a.ts')).toBe("export * from './b';");
+    expect(result.readText('/src/b.ts')).toBe("export * from './a';");
+  });
+
+  it('should skip unresolvable specifiers', async () => {
+    const tree = new UnitTestTree(new HostTree());
+    tree.create('/src/index.ts', "export * from 'some-package';");
+
+    const result = await runMigration(tree);
+
+    expect(result.readText('/src/index.ts')).toBe(
+      "export * from 'some-package';",
+    );
+  });
+
+  it('should skip namespace re-exports', async () => {
+    const tree = new UnitTestTree(new HostTree());
+    tree.create('/src/foo.ts', 'export class Foo {}');
+    tree.create('/src/index.ts', "export * as ns from './foo';");
+
+    const result = await runMigration(tree);
+
+    // Namespace re-exports are not bare wildcards, so findWildcardReExports
+    // ignores them and the file stays unchanged.
+    expect(result.readText('/src/index.ts')).toBe(
+      "export * as ns from './foo';",
+    );
+  });
+
+  it('should skip files in node_modules', async () => {
+    const tree = new UnitTestTree(new HostTree());
+    tree.create('/node_modules/pkg/index.ts', "export * from './internal';");
+    tree.create('/node_modules/pkg/internal.ts', 'export class Internal {}');
+
+    const result = await runMigration(tree);
+
+    expect(result.readText('/node_modules/pkg/index.ts')).toBe(
+      "export * from './internal';",
+    );
+  });
+
+  it('should handle multiple wildcard exports in one file', async () => {
+    const tree = new UnitTestTree(new HostTree());
+    tree.create('/src/foo.ts', 'export class Foo {}');
+    tree.create('/src/bar.ts', 'export class Bar {}');
+    tree.create(
+      '/src/index.ts',
+      "export * from './foo';\nexport * from './bar';",
+    );
+
+    const result = await runMigration(tree);
+
+    expect(result.readText('/src/index.ts')).toBe(
+      "export { Foo } from './foo';\nexport { Bar } from './bar';",
+    );
+  });
+
+  it('should do nothing when no barrel exports exist', async () => {
+    const tree = new UnitTestTree(new HostTree());
+    tree.create('/src/index.ts', "export { Foo } from './foo';");
+    tree.create('/src/foo.ts', 'export class Foo {}');
+
+    const result = await runMigration(tree);
+
+    expect(result.readText('/src/index.ts')).toBe(
+      "export { Foo } from './foo';",
+    );
+  });
+
+  it('should resolve index.ts files', async () => {
+    const tree = new UnitTestTree(new HostTree());
+    tree.create('/src/foo/index.ts', 'export class Foo {}');
+    tree.create('/src/index.ts', "export * from './foo';");
+
+    const result = await runMigration(tree);
+
+    expect(result.readText('/src/index.ts')).toBe(
+      "export { Foo } from './foo';",
+    );
+  });
+
+  it('should skip targets with no exports', async () => {
+    const tree = new UnitTestTree(new HostTree());
+    tree.create('/src/empty.ts', 'const internal = 1;');
+    tree.create('/src/index.ts', "export * from './empty';");
+
+    const result = await runMigration(tree);
+
+    expect(result.readText('/src/index.ts')).toBe("export * from './empty';");
+  });
+});

--- a/libs/sdk/eslint-schematics/src/schematics/migrations/flatten-barrel-exports/flatten-barrel-exports.schematic.ts
+++ b/libs/sdk/eslint-schematics/src/schematics/migrations/flatten-barrel-exports/flatten-barrel-exports.schematic.ts
@@ -1,0 +1,112 @@
+import type { Rule } from '@angular-devkit/schematics';
+
+import {
+  type WildcardReExport,
+  buildNamedExportStatement,
+  extractNamedExports,
+  findWildcardReExports,
+  resolveInTree,
+  topologicalSort,
+} from './barrel-export-utils';
+
+export default function flattenBarrelExports(): Rule {
+  return (tree, context) => {
+    // 1. Scan all .ts files for wildcard re-exports.
+    const filesWithWildcards = new Map<string, WildcardReExport[]>();
+
+    tree.visit((filePath) => {
+      if (!filePath.endsWith('.ts') || filePath.includes('node_modules')) {
+        return;
+      }
+
+      const content = tree.readText(filePath);
+      const wildcards = findWildcardReExports(content);
+
+      if (wildcards.length > 0) {
+        filesWithWildcards.set(filePath, wildcards);
+      }
+    });
+
+    if (filesWithWildcards.size === 0) {
+      context.logger.info(
+        'No barrel exports (export * from) found. Nothing to do.',
+      );
+      return;
+    }
+
+    context.logger.info(
+      `Found ${filesWithWildcards.size} file(s) with barrel exports.`,
+    );
+
+    // 2. Build dependency graph and topologically sort (leaf-first).
+    const graph = new Map<string, string[]>();
+
+    for (const [filePath, wildcards] of filesWithWildcards) {
+      const deps: string[] = [];
+
+      for (const wc of wildcards) {
+        const resolved = resolveInTree(tree, filePath, wc.specifier);
+
+        if (resolved && filesWithWildcards.has(resolved)) {
+          deps.push(resolved);
+        }
+      }
+
+      graph.set(filePath, deps);
+    }
+
+    const sorted = topologicalSort(graph);
+
+    // 3. Process each file in leaf-first order.
+    let fixedCount = 0;
+
+    for (const filePath of sorted) {
+      const content = tree.readText(filePath);
+      const wildcards = findWildcardReExports(content);
+
+      // Process replacements from end to start to preserve character offsets.
+      const sortedByPos = [...wildcards].sort((a, b) => b.start - a.start);
+      let updated = content;
+
+      for (const wc of sortedByPos) {
+        const resolved = resolveInTree(tree, filePath, wc.specifier);
+
+        if (!resolved) {
+          continue;
+        }
+
+        const targetContent = tree.readText(resolved);
+        const targetExports = extractNamedExports(targetContent);
+
+        // Skip if target still has unresolved wildcards.
+        if (targetExports.hasWildcardReExports) {
+          continue;
+        }
+
+        if (
+          targetExports.valueExports.length === 0 &&
+          targetExports.typeExports.length === 0
+        ) {
+          continue;
+        }
+
+        const replacement = buildNamedExportStatement(
+          targetExports,
+          wc.specifier,
+        );
+        updated =
+          updated.slice(0, wc.start) + replacement + updated.slice(wc.end);
+      }
+
+      if (updated !== content) {
+        tree.overwrite(filePath, updated);
+        fixedCount++;
+        context.logger.info(`Flattened barrel exports in ${filePath}`);
+      }
+    }
+
+    context.logger.info(
+      `Done. Flattened barrel exports in ${fixedCount} file(s).`,
+    );
+  };
+}

--- a/libs/sdk/eslint-schematics/src/schematics/migrations/flatten-barrel-exports/flatten-barrel-exports.schematic.ts
+++ b/libs/sdk/eslint-schematics/src/schematics/migrations/flatten-barrel-exports/flatten-barrel-exports.schematic.ts
@@ -15,7 +15,7 @@ export default function flattenBarrelExports(): Rule {
     const filesWithWildcards = new Map<string, WildcardReExport[]>();
 
     tree.visit((filePath) => {
-      if (!filePath.endsWith('.ts') || filePath.includes('node_modules')) {
+      if (!filePath.endsWith('.ts') || filePath.includes('/node_modules/')) {
         return;
       }
 

--- a/libs/sdk/skyux-eslint/src/rules/no-barrel-exports.spec.ts
+++ b/libs/sdk/skyux-eslint/src/rules/no-barrel-exports.spec.ts
@@ -27,26 +27,46 @@ jest.mock('./utils/resolve-exports', () => ({
     if (specifier === './empty-exports') {
       return '/fake/empty-exports.ts';
     }
+    if (specifier === './resolvable-with-wildcard') {
+      return '/fake/resolvable-with-wildcard.ts';
+    }
     return undefined;
   },
   getNamedExportsFromFile: (filePath: string) => {
     if (filePath === '/fake/resolvable.ts') {
-      return { valueExports: ['Bar', 'Foo'], typeExports: [] };
+      return {
+        valueExports: ['Bar', 'Foo'],
+        typeExports: [],
+        hasWildcardReExports: false,
+      };
     }
     if (filePath === '/fake/resolvable-mixed.ts') {
       return {
         valueExports: ['FooComponent'],
         typeExports: ['FooConfig', 'FooType'],
+        hasWildcardReExports: false,
       };
     }
     if (filePath === '/fake/resolvable-overlap.ts') {
       return {
         valueExports: ['Foo'],
         typeExports: ['Bar'],
+        hasWildcardReExports: false,
       };
     }
     if (filePath === '/fake/resolvable-types-only.ts') {
-      return { valueExports: [], typeExports: ['BarConfig', 'FooConfig'] };
+      return {
+        valueExports: [],
+        typeExports: ['BarConfig', 'FooConfig'],
+        hasWildcardReExports: false,
+      };
+    }
+    if (filePath === '/fake/resolvable-with-wildcard.ts') {
+      return {
+        valueExports: ['Foo'],
+        typeExports: [],
+        hasWildcardReExports: true,
+      };
     }
     return undefined;
   },
@@ -131,6 +151,11 @@ ruleTester.run(RULE_NAME, rule, {
     {
       code: `export * from './resolvable';`,
       filename: '<input>',
+      errors: [{ messageId }],
+    },
+    {
+      code: `export * from './resolvable-with-wildcard';`,
+      filename: '/fake/index.ts',
       errors: [{ messageId }],
     },
   ],

--- a/libs/sdk/skyux-eslint/src/rules/no-barrel-exports.ts
+++ b/libs/sdk/skyux-eslint/src/rules/no-barrel-exports.ts
@@ -55,7 +55,7 @@ export const rule = createESLintRule({
 
             const namedExports = getNamedExportsFromFile(resolvedPath);
 
-            if (!namedExports) {
+            if (!namedExports || namedExports.hasWildcardReExports) {
               return null;
             }
 

--- a/libs/sdk/skyux-eslint/src/rules/utils/resolve-exports.spec.ts
+++ b/libs/sdk/skyux-eslint/src/rules/utils/resolve-exports.spec.ts
@@ -133,6 +133,7 @@ describe('getNamedExportsFromFile', () => {
     expect(getNamedExportsFromFile(filePath)).toEqual({
       valueExports: ['Foo', 'bar'],
       typeExports: [],
+      hasWildcardReExports: false,
     });
   });
 
@@ -155,6 +156,7 @@ describe('extractNamedExports', () => {
     expect(extractNamedExports('export class Foo {}')).toEqual({
       valueExports: ['Foo'],
       typeExports: [],
+      hasWildcardReExports: false,
     });
   });
 
@@ -162,6 +164,7 @@ describe('extractNamedExports', () => {
     expect(extractNamedExports('export abstract class Foo {}')).toEqual({
       valueExports: ['Foo'],
       typeExports: [],
+      hasWildcardReExports: false,
     });
   });
 
@@ -169,6 +172,7 @@ describe('extractNamedExports', () => {
     expect(extractNamedExports('export interface Foo {}')).toEqual({
       valueExports: [],
       typeExports: ['Foo'],
+      hasWildcardReExports: false,
     });
   });
 
@@ -176,6 +180,7 @@ describe('extractNamedExports', () => {
     expect(extractNamedExports('export type Foo = string;')).toEqual({
       valueExports: [],
       typeExports: ['Foo'],
+      hasWildcardReExports: false,
     });
   });
 
@@ -183,6 +188,7 @@ describe('extractNamedExports', () => {
     expect(extractNamedExports('export function foo() {}')).toEqual({
       valueExports: ['foo'],
       typeExports: [],
+      hasWildcardReExports: false,
     });
   });
 
@@ -190,6 +196,7 @@ describe('extractNamedExports', () => {
     expect(extractNamedExports('export async function foo() {}')).toEqual({
       valueExports: ['foo'],
       typeExports: [],
+      hasWildcardReExports: false,
     });
   });
 
@@ -197,6 +204,7 @@ describe('extractNamedExports', () => {
     expect(extractNamedExports('export const foo = 1;')).toEqual({
       valueExports: ['foo'],
       typeExports: [],
+      hasWildcardReExports: false,
     });
   });
 
@@ -204,6 +212,7 @@ describe('extractNamedExports', () => {
     expect(extractNamedExports('export let foo = 1;')).toEqual({
       valueExports: ['foo'],
       typeExports: [],
+      hasWildcardReExports: false,
     });
   });
 
@@ -211,6 +220,7 @@ describe('extractNamedExports', () => {
     expect(extractNamedExports('export var foo = 1;')).toEqual({
       valueExports: ['foo'],
       typeExports: [],
+      hasWildcardReExports: false,
     });
   });
 
@@ -218,6 +228,7 @@ describe('extractNamedExports', () => {
     expect(extractNamedExports('export enum Foo { A, B }')).toEqual({
       valueExports: ['Foo'],
       typeExports: [],
+      hasWildcardReExports: false,
     });
   });
 
@@ -225,6 +236,7 @@ describe('extractNamedExports', () => {
     expect(extractNamedExports('export declare const foo: string;')).toEqual({
       valueExports: ['foo'],
       typeExports: [],
+      hasWildcardReExports: false,
     });
   });
 
@@ -232,6 +244,7 @@ describe('extractNamedExports', () => {
     expect(extractNamedExports('export const a = 1, b = 2;')).toEqual({
       valueExports: ['a', 'b'],
       typeExports: [],
+      hasWildcardReExports: false,
     });
   });
 
@@ -239,6 +252,7 @@ describe('extractNamedExports', () => {
     expect(extractNamedExports("export { Foo, Bar } from './foo';")).toEqual({
       valueExports: ['Bar', 'Foo'],
       typeExports: [],
+      hasWildcardReExports: false,
     });
   });
 
@@ -246,25 +260,35 @@ describe('extractNamedExports', () => {
     expect(extractNamedExports("export { Foo as Bar } from './foo';")).toEqual({
       valueExports: ['Bar'],
       typeExports: [],
+      hasWildcardReExports: false,
     });
   });
 
   it('should extract type-only named re-exports (export type { })', () => {
     expect(
       extractNamedExports("export type { Foo, Bar } from './foo';"),
-    ).toEqual({ valueExports: [], typeExports: ['Bar', 'Foo'] });
+    ).toEqual({
+      valueExports: [],
+      typeExports: ['Bar', 'Foo'],
+      hasWildcardReExports: false,
+    });
   });
 
   it('should extract inline type specifiers in export { type Foo, Bar }', () => {
     expect(
       extractNamedExports("export { type Foo, Bar } from './foo';"),
-    ).toEqual({ valueExports: ['Bar'], typeExports: ['Foo'] });
+    ).toEqual({
+      valueExports: ['Bar'],
+      typeExports: ['Foo'],
+      hasWildcardReExports: false,
+    });
   });
 
   it('should handle empty specifiers from trailing commas gracefully', () => {
     expect(extractNamedExports("export { Foo, } from './foo';")).toEqual({
       valueExports: ['Foo'],
       typeExports: [],
+      hasWildcardReExports: false,
     });
   });
 
@@ -276,6 +300,7 @@ describe('extractNamedExports', () => {
     expect(extractNamedExports(content)).toEqual({
       valueExports: ['Foo'],
       typeExports: [],
+      hasWildcardReExports: false,
     });
   });
 
@@ -286,6 +311,7 @@ describe('extractNamedExports', () => {
     expect(extractNamedExports(content)).toEqual({
       valueExports: ['Foo'],
       typeExports: [],
+      hasWildcardReExports: false,
     });
   });
 
@@ -298,6 +324,7 @@ describe('extractNamedExports', () => {
     expect(extractNamedExports(content)).toEqual({
       valueExports: ['Alpha', 'Middle', 'Zebra'],
       typeExports: [],
+      hasWildcardReExports: false,
     });
   });
 
@@ -313,6 +340,7 @@ describe('extractNamedExports', () => {
     expect(extractNamedExports(content)).toEqual({
       valueExports: ['BarService', 'FOO_TOKEN', 'FooComponent', 'FooEnum'],
       typeExports: ['FooConfig', 'FooType'],
+      hasWildcardReExports: false,
     });
   });
 
@@ -320,6 +348,7 @@ describe('extractNamedExports', () => {
     expect(extractNamedExports('const foo = 1;')).toEqual({
       valueExports: [],
       typeExports: [],
+      hasWildcardReExports: false,
     });
   });
 
@@ -327,6 +356,7 @@ describe('extractNamedExports', () => {
     expect(extractNamedExports('export default class Foo {}')).toEqual({
       valueExports: [],
       typeExports: [],
+      hasWildcardReExports: false,
     });
   });
 
@@ -334,6 +364,7 @@ describe('extractNamedExports', () => {
     expect(extractNamedExports('// export class Fake {}')).toEqual({
       valueExports: [],
       typeExports: [],
+      hasWildcardReExports: false,
     });
   });
 
@@ -341,13 +372,18 @@ describe('extractNamedExports', () => {
     expect(extractNamedExports('const s = "export class Fake {}";')).toEqual({
       valueExports: [],
       typeExports: [],
+      hasWildcardReExports: false,
     });
   });
 
   it('should extract aliased type re-exports using the alias name', () => {
     expect(
       extractNamedExports("export type { Foo as Bar } from './foo';"),
-    ).toEqual({ valueExports: [], typeExports: ['Bar'] });
+    ).toEqual({
+      valueExports: [],
+      typeExports: ['Bar'],
+      hasWildcardReExports: false,
+    });
   });
 
   it('should handle multi-line export specifiers', () => {
@@ -356,6 +392,26 @@ describe('extractNamedExports', () => {
     ).toEqual({
       valueExports: ['Bar', 'Foo'],
       typeExports: [],
+      hasWildcardReExports: false,
+    });
+  });
+
+  it('should detect wildcard re-exports', () => {
+    expect(extractNamedExports("export * from './bar';")).toEqual({
+      valueExports: [],
+      typeExports: [],
+      hasWildcardReExports: true,
+    });
+  });
+
+  it('should detect wildcard re-exports alongside named exports', () => {
+    const content = ['export class Foo {}', "export * from './bar';"].join(
+      '\n',
+    );
+    expect(extractNamedExports(content)).toEqual({
+      valueExports: ['Foo'],
+      typeExports: [],
+      hasWildcardReExports: true,
     });
   });
 });

--- a/libs/sdk/skyux-eslint/src/rules/utils/resolve-exports.spec.ts
+++ b/libs/sdk/skyux-eslint/src/rules/utils/resolve-exports.spec.ts
@@ -404,6 +404,14 @@ describe('extractNamedExports', () => {
     });
   });
 
+  it('should extract namespace re-export name as value export', () => {
+    expect(extractNamedExports("export * as ns from './bar';")).toEqual({
+      valueExports: ['ns'],
+      typeExports: [],
+      hasWildcardReExports: false,
+    });
+  });
+
   it('should detect wildcard re-exports alongside named exports', () => {
     const content = ['export class Foo {}', "export * from './bar';"].join(
       '\n',

--- a/libs/sdk/skyux-eslint/src/rules/utils/resolve-exports.ts
+++ b/libs/sdk/skyux-eslint/src/rules/utils/resolve-exports.ts
@@ -85,6 +85,7 @@ export function resetResolveCache(): void {
 export interface ExtractedNamedExports {
   valueExports: string[];
   typeExports: string[];
+  hasWildcardReExports: boolean;
 }
 
 /**
@@ -104,11 +105,15 @@ export function extractNamedExports(
 
   const valueExports: string[] = [];
   const typeExports: string[] = [];
+  let hasWildcardReExports = false;
 
   for (const statement of sourceFile.statements) {
     // ExportDeclaration: export { A, B }, export type { A }, export { type A, B }
     if (ts.isExportDeclaration(statement)) {
-      if (statement.exportClause && ts.isNamedExports(statement.exportClause)) {
+      if (!statement.exportClause) {
+        // export * from '...' — bare wildcard re-export
+        hasWildcardReExports = true;
+      } else if (ts.isNamedExports(statement.exportClause)) {
         for (const specifier of statement.exportClause.elements) {
           const name = specifier.name.text;
           if (statement.isTypeOnly || specifier.isTypeOnly) {
@@ -159,6 +164,7 @@ export function extractNamedExports(
     typeExports: [...new Set(typeExports)]
       .filter((name) => !valueSet.has(name))
       .sort(),
+    hasWildcardReExports,
   };
 }
 

--- a/libs/sdk/skyux-eslint/src/rules/utils/resolve-exports.ts
+++ b/libs/sdk/skyux-eslint/src/rules/utils/resolve-exports.ts
@@ -122,6 +122,9 @@ export function extractNamedExports(
             valueExports.push(name);
           }
         }
+      } else if (ts.isNamespaceExport(statement.exportClause)) {
+        // export * as ns from '...' — the namespace name is a value export
+        valueExports.push(statement.exportClause.name.text);
       }
       continue;
     }


### PR DESCRIPTION
- [ ] add a schematic to handle the initial fix for chained barrel files
- [ ] update the lint rule to not fix when the target has mixed export formats

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a migration to iteratively replace wildcard (export *) barrel re-exports with explicit named exports and a utility to analyze barrel exports.

* **Bug Fixes**
  * Avoided unsafe automatic fixes for the barrel-export rule when wildcard re-exports are present.

* **Tests**
  * Added comprehensive unit tests covering extraction, resolution, sorting, and migration scenarios (including wildcard and circular cases).

* **Chores**
  * Bumped TypeScript peer dependency to ^5.9.3.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->