### PR TITLE
fix(components/layout)!: replace `@angular/animations` with CSS transitions for inline delete component

### DIFF
--- a/libs/components/code-examples/src/lib/modules/layout/inline-delete/custom/example.component.spec.ts
+++ b/libs/components/code-examples/src/lib/modules/layout/inline-delete/custom/example.component.spec.ts
@@ -1,6 +1,6 @@
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { provideNoopSkyAnimations } from '@skyux/core';
 import { SkyInlineDeleteHarness } from '@skyux/layout/testing';
 
 import { LayoutInlineDeleteCustomExampleComponent } from './example.component';
@@ -11,7 +11,8 @@ describe('Custom component inline delete example', () => {
     fixture: ComponentFixture<LayoutInlineDeleteCustomExampleComponent>;
   }> {
     TestBed.configureTestingModule({
-      imports: [LayoutInlineDeleteCustomExampleComponent, NoopAnimationsModule],
+      imports: [LayoutInlineDeleteCustomExampleComponent],
+      providers: [provideNoopSkyAnimations()],
     });
     const fixture = TestBed.createComponent(
       LayoutInlineDeleteCustomExampleComponent,

--- a/libs/components/code-examples/src/lib/modules/layout/inline-delete/repeater/example.component.spec.ts
+++ b/libs/components/code-examples/src/lib/modules/layout/inline-delete/repeater/example.component.spec.ts
@@ -1,6 +1,6 @@
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { provideNoopSkyAnimations } from '@skyux/core';
 import { SkyInlineDeleteHarness } from '@skyux/layout/testing';
 
 import { LayoutInlineDeleteRepeaterExampleComponent } from './example.component';
@@ -11,10 +11,8 @@ describe('Custom component inline delete example', () => {
     fixture: ComponentFixture<LayoutInlineDeleteRepeaterExampleComponent>;
   }> {
     TestBed.configureTestingModule({
-      imports: [
-        LayoutInlineDeleteRepeaterExampleComponent,
-        NoopAnimationsModule,
-      ],
+      imports: [LayoutInlineDeleteRepeaterExampleComponent],
+      providers: [provideNoopSkyAnimations()],
     });
     const fixture = TestBed.createComponent(
       LayoutInlineDeleteRepeaterExampleComponent,

--- a/libs/components/core/src/index.ts
+++ b/libs/components/core/src/index.ts
@@ -15,6 +15,7 @@ export { SkyAffixModule } from './lib/modules/affix/affix.module';
 export { SkyAffixService } from './lib/modules/affix/affix.service';
 export { SkyAffixer } from './lib/modules/affix/affixer';
 
+export { _SkyAnimationEndHandlerDirective } from './lib/modules/animations/shared/animation-handler';
 export { _SkyTransitionEndHandlerDirective } from './lib/modules/animations/shared/transition-handler';
 export { _SkyAnimationSlideComponent } from './lib/modules/animations/slide/slide';
 export { provideNoopSkyAnimations } from './lib/modules/animations/utility/provide-noop-animations';

--- a/libs/components/core/src/lib/modules/animations/shared/animation-handler.spec.ts
+++ b/libs/components/core/src/lib/modules/animations/shared/animation-handler.spec.ts
@@ -7,7 +7,7 @@ import { _SkyAnimationEndHandlerDirective } from './animation-handler';
   hostDirectives: [
     {
       directive: _SkyAnimationEndHandlerDirective,
-      inputs: ['animationTrigger: trigger'],
+      inputs: ['animationTrigger: trigger', 'emitOnAnimateEnter'],
       outputs: ['animationEnd'],
     },
   ],
@@ -195,6 +195,33 @@ describe('SkyAnimationEndHandler', () => {
       await fixture.whenStable();
 
       expect(animationEndEmitted).toBeFalse();
+    });
+
+    it('should emit on initial render when emitOnAnimateEnter is true', async () => {
+      TestBed.configureTestingModule({
+        imports: [TestComponent],
+      });
+
+      const fixture = TestBed.createComponent(TestComponent);
+      fixture.componentRef.setInput('trigger', signal(true));
+      fixture.componentRef.setInput('emitOnAnimateEnter', true);
+      fixture.detectChanges();
+
+      let animationEndEmitted = false;
+
+      const handler = fixture.debugElement.injector.get(
+        _SkyAnimationEndHandlerDirective,
+      );
+
+      handler.animationEnd.subscribe(() => {
+        animationEndEmitted = true;
+      });
+
+      fixture.detectChanges();
+
+      await fixture.whenStable();
+
+      expect(animationEndEmitted).toBeTrue();
     });
   });
 

--- a/libs/components/core/src/lib/modules/animations/shared/animation-handler.ts
+++ b/libs/components/core/src/lib/modules/animations/shared/animation-handler.ts
@@ -2,6 +2,7 @@ import {
   DestroyRef,
   Directive,
   ElementRef,
+  booleanAttribute,
   inject,
   input,
   output,
@@ -26,6 +27,16 @@ import { watchForDisabledCssAnimations } from './utils';
 })
 export class _SkyAnimationEndHandlerDirective {
   /**
+   * When `true` and the host element uses `animate.enter`, the
+   * disabled-animation fallback emits `animationEnd` on the initial
+   * render. Use this when the element's insertion into the DOM is
+   * the animation event.
+   */
+  public readonly emitOnAnimateEnter = input(false, {
+    transform: booleanAttribute,
+  });
+
+  /**
    * Drives animation lifecycle tracking on the host element. When the
    * value changes and the CSS animation is disabled, `animationEnd`
    * emits via a microtask.
@@ -42,6 +53,7 @@ export class _SkyAnimationEndHandlerDirective {
     watchForDisabledCssAnimations({
       destroyRef: inject(DestroyRef),
       elementRef: inject(ElementRef),
+      emitOnAnimateEnter: this.emitOnAnimateEnter,
       emitter: this.animationEnd,
       trigger: this.animationTrigger,
     });

--- a/libs/components/core/src/lib/modules/animations/shared/utils.ts
+++ b/libs/components/core/src/lib/modules/animations/shared/utils.ts
@@ -14,6 +14,9 @@ interface WatchMotionArgs {
   /** A reference to the host element whose computed styles are inspected. */
   elementRef: ElementRef<Element>;
 
+  /** When `true`, the disabled-animation fallback fires on the first effect run instead of skipping it. */
+  emitOnAnimateEnter?: Signal<boolean>;
+
   /** The output emitter to call when CSS motion is disabled. */
   emitter: OutputEmitterRef<void>;
 
@@ -79,7 +82,7 @@ function emitWhenMotionDisabled(
   args: WatchMotionArgs,
   isMotionDisabled: (style: CSSStyleDeclaration) => boolean,
 ): void {
-  const { destroyRef, elementRef, emitter, trigger } = args;
+  const { destroyRef, elementRef, emitOnAnimateEnter, emitter, trigger } = args;
   const el = elementRef.nativeElement;
 
   let destroyed = false;
@@ -91,6 +94,11 @@ function emitWhenMotionDisabled(
 
   effect(() => {
     trigger();
+
+    // On the first run, check if emitOnAnimateEnter opts out of skipping.
+    if (!initialized && emitOnAnimateEnter) {
+      initialized = untracked(() => emitOnAnimateEnter());
+    }
 
     const style = getComputedStyle(el);
     const isRendered = style.display !== 'none';

--- a/libs/components/core/src/lib/modules/animations/shared/utils.ts
+++ b/libs/components/core/src/lib/modules/animations/shared/utils.ts
@@ -75,8 +75,10 @@ export function watchForDisabledCssTransitions(
 
 /**
  * Creates an effect that watches a trigger signal and emits via a microtask
- * when the host element's CSS motion is disabled. Skips the initial effect
- * run and unrendered elements to match native CSS behavior.
+ * when the host element's CSS motion is disabled. By default, skips the
+ * initial effect run to match native CSS behavior. When `emitOnAnimateEnter`
+ * is `true`, the first run is not skipped, allowing emission for elements
+ * that use `animate.enter` (where DOM insertion is the animation event).
  */
 function emitWhenMotionDisabled(
   args: WatchMotionArgs,
@@ -103,8 +105,9 @@ function emitWhenMotionDisabled(
     const style = getComputedStyle(el);
     const isRendered = style.display !== 'none';
 
-    // Skip the first effect run (and unrendered elements) to match native CSS behavior.
-    // Motion events only fire on rendered elements when a property value changes.
+    // By default, skip the first effect run (and unrendered elements) to match
+    // native CSS behavior. When emitOnAnimateEnter is true, the first run is
+    // treated as initialized, allowing emission for enter animations.
     if (initialized && isRendered && untracked(() => isMotionDisabled(style))) {
       // Defer the emit to a microtask so it fires after the current
       // change detection pass, matching real transition timing.

--- a/libs/components/layout/package.json
+++ b/libs/components/layout/package.json
@@ -16,7 +16,6 @@
   },
   "homepage": "https://github.com/blackbaud/skyux#readme",
   "peerDependencies": {
-    "@angular/animations": "^21.2.0",
     "@angular/cdk": "^21.2.0",
     "@angular/common": "^21.2.0",
     "@angular/core": "^21.2.0",

--- a/libs/components/layout/src/lib/modules/inline-delete/fixtures/inline-delete-fixtures.module.ts
+++ b/libs/components/layout/src/lib/modules/inline-delete/fixtures/inline-delete-fixtures.module.ts
@@ -1,5 +1,4 @@
 import { NgModule } from '@angular/core';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
 import { SkyInlineDeleteModule } from '../inline-delete.module';
 
@@ -7,7 +6,7 @@ import { InlineDeleteTestComponent } from './inline-delete.component.fixture';
 
 @NgModule({
   declarations: [InlineDeleteTestComponent],
-  imports: [NoopAnimationsModule, SkyInlineDeleteModule],
+  imports: [SkyInlineDeleteModule],
   exports: [InlineDeleteTestComponent],
 })
 export class SkyInlineDeleteFixturesModule {}

--- a/libs/components/layout/src/lib/modules/inline-delete/fixtures/inline-delete.component.fixture.html
+++ b/libs/components/layout/src/lib/modules/inline-delete/fixtures/inline-delete.component.fixture.html
@@ -1,7 +1,7 @@
 @if (showExtraButtons) {
 <button id="noop-button-1" type="button">Noop Button 1</button>
 }
-<div id="inline-delete-fixture" [@.disabled]="true" [tabIndex]="parentTabIndex">
+<div id="inline-delete-fixture" [tabIndex]="parentTabIndex">
   @if (showCoveredButtons) {
   <button id="covered-button" type="button">Covered Button</button>
   <button id="covered-button-2" type="button">Covered Button 2</button>

--- a/libs/components/layout/src/lib/modules/inline-delete/inline-delete.component.html
+++ b/libs/components/layout/src/lib/modules/inline-delete/inline-delete.component.html
@@ -2,10 +2,10 @@
   class="sky-inline-delete sky-inline-delete-{{ type }}"
   role="alertdialog"
   skyAnimationEndHandler
+  emitOnAnimateEnter
   animate.enter="sky-inline-delete-entering"
   animate.leave="sky-inline-delete-leaving"
   [animationTrigger]="enterAnimationTrigger()"
-  emitOnAnimateEnter
   [attr.aria-describedby]="assistiveTextId"
   [attr.aria-label]="'skyux_inline_delete_confirm_deletion' | skyLibResources"
   (animationEnd)="onAnimationEnd()"

--- a/libs/components/layout/src/lib/modules/inline-delete/inline-delete.component.html
+++ b/libs/components/layout/src/lib/modules/inline-delete/inline-delete.component.html
@@ -5,6 +5,7 @@
   animate.enter="sky-inline-delete-entering"
   animate.leave="sky-inline-delete-leaving"
   [animationTrigger]="enterAnimationTrigger()"
+  emitOnAnimateEnter
   [attr.aria-describedby]="assistiveTextId"
   [attr.aria-label]="'skyux_inline_delete_confirm_deletion' | skyLibResources"
   (animationEnd)="onAnimationEnd()"

--- a/libs/components/layout/src/lib/modules/inline-delete/inline-delete.component.html
+++ b/libs/components/layout/src/lib/modules/inline-delete/inline-delete.component.html
@@ -1,10 +1,13 @@
 <div
   class="sky-inline-delete sky-inline-delete-{{ type }}"
   role="alertdialog"
+  skyAnimationEndHandler
   animate.enter="sky-inline-delete-entering"
   animate.leave="sky-inline-delete-leaving"
+  [animationTrigger]="enterAnimationTrigger()"
   [attr.aria-describedby]="assistiveTextId"
   [attr.aria-label]="'skyux_inline_delete_confirm_deletion' | skyLibResources"
+  (animationEnd)="onAnimationEnd()"
 >
   <span
     class="sky-inline-delete-assistive-text sky-screen-reader-only"

--- a/libs/components/layout/src/lib/modules/inline-delete/inline-delete.component.html
+++ b/libs/components/layout/src/lib/modules/inline-delete/inline-delete.component.html
@@ -1,10 +1,10 @@
 <div
   class="sky-inline-delete sky-inline-delete-{{ type }}"
   role="alertdialog"
-  [@inlineDeleteAnimation]="animationState"
+  animate.enter="sky-inline-delete-entering"
+  animate.leave="sky-inline-delete-leaving"
   [attr.aria-describedby]="assistiveTextId"
   [attr.aria-label]="'skyux_inline_delete_confirm_deletion' | skyLibResources"
-  (@inlineDeleteAnimation.done)="onAnimationDone($event)"
 >
   <span
     class="sky-inline-delete-assistive-text sky-screen-reader-only"

--- a/libs/components/layout/src/lib/modules/inline-delete/inline-delete.component.scss
+++ b/libs/components/layout/src/lib/modules/inline-delete/inline-delete.component.scss
@@ -98,17 +98,21 @@
 }
 
 .sky-inline-delete-entering {
-  animation: sky-inline-delete-enter-overlay 300ms ease-in-out;
+  animation: sky-inline-delete-enter-overlay var(--sky-transition-time-medium)
+    ease-in-out;
 }
 
 .sky-inline-delete-entering .sky-inline-delete-content-animation-container {
-  animation: sky-inline-delete-enter-content 300ms ease-in-out;
+  animation: sky-inline-delete-enter-content var(--sky-transition-time-medium)
+    ease-in-out;
 }
 
 .sky-inline-delete-leaving {
-  animation: sky-inline-delete-leave-overlay 300ms ease-in-out forwards;
+  animation: sky-inline-delete-leave-overlay var(--sky-transition-time-medium)
+    ease-in-out forwards;
 }
 
 .sky-inline-delete-leaving .sky-inline-delete-content-animation-container {
-  animation: sky-inline-delete-leave-content 300ms ease-in-out forwards;
+  animation: sky-inline-delete-leave-content var(--sky-transition-time-medium)
+    ease-in-out forwards;
 }

--- a/libs/components/layout/src/lib/modules/inline-delete/inline-delete.component.scss
+++ b/libs/components/layout/src/lib/modules/inline-delete/inline-delete.component.scss
@@ -60,3 +60,55 @@
 .sky-inline-delete-wait {
   height: 100%;
 }
+
+@keyframes sky-inline-delete-enter-overlay {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes sky-inline-delete-enter-content {
+  from {
+    transform: scale(0);
+  }
+  to {
+    transform: scale(1);
+  }
+}
+
+@keyframes sky-inline-delete-leave-overlay {
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
+  }
+}
+
+@keyframes sky-inline-delete-leave-content {
+  from {
+    transform: scale(1);
+  }
+  to {
+    transform: scale(0);
+  }
+}
+
+.sky-inline-delete-entering {
+  animation: sky-inline-delete-enter-overlay 300ms ease-in-out;
+}
+
+.sky-inline-delete-entering .sky-inline-delete-content-animation-container {
+  animation: sky-inline-delete-enter-content 300ms ease-in-out;
+}
+
+.sky-inline-delete-leaving {
+  animation: sky-inline-delete-leave-overlay 300ms ease-in-out forwards;
+}
+
+.sky-inline-delete-leaving .sky-inline-delete-content-animation-container {
+  animation: sky-inline-delete-leave-content 300ms ease-in-out forwards;
+}

--- a/libs/components/layout/src/lib/modules/inline-delete/inline-delete.component.spec.ts
+++ b/libs/components/layout/src/lib/modules/inline-delete/inline-delete.component.spec.ts
@@ -5,6 +5,7 @@ import {
   tick,
 } from '@angular/core/testing';
 import { SkyAppTestUtility, expect, expectAsync } from '@skyux-sdk/testing';
+import { provideNoopSkyAnimations } from '@skyux/core';
 
 import { SkyInlineDeleteFixturesModule } from './fixtures/inline-delete-fixtures.module';
 import { InlineDeleteTestComponent } from './fixtures/inline-delete.component.fixture';
@@ -18,18 +19,13 @@ describe('Inline delete component', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [SkyInlineDeleteFixturesModule],
+      providers: [provideNoopSkyAnimations()],
     });
 
     fixture = TestBed.createComponent(InlineDeleteTestComponent);
     cmp = fixture.componentInstance;
     el = fixture.nativeElement;
   });
-
-  function simulateAnimationEnd(): void {
-    el.querySelector('.sky-inline-delete').dispatchEvent(
-      new AnimationEvent('animationend', { bubbles: true }),
-    );
-  }
 
   afterEach(fakeAsync(() => {
     cmp.showDelete = false;
@@ -101,7 +97,7 @@ describe('Inline delete component', () => {
   describe('focus handling', () => {
     it('should focus the delete button on load', async () => {
       fixture.detectChanges();
-      simulateAnimationEnd();
+      fixture.detectChanges();
       await fixture.whenStable();
       expect(document.activeElement).toBe(el.querySelector('.sky-btn-danger'));
     });
@@ -109,7 +105,6 @@ describe('Inline delete component', () => {
     it('should skip items that are under the overlay when tabbing forward', fakeAsync(() => {
       fixture.componentInstance.showExtraButtons = true;
       fixture.detectChanges();
-      simulateAnimationEnd();
       tick();
       fixture.detectChanges();
       el.querySelector('#noop-button-1').focus();
@@ -129,7 +124,6 @@ describe('Inline delete component', () => {
     it('should skip items that are under the overlay when tabbing backward', fakeAsync(() => {
       fixture.componentInstance.showExtraButtons = true;
       fixture.detectChanges();
-      simulateAnimationEnd();
       tick();
       el.querySelector('.sky-btn-danger').focus();
       SkyAppTestUtility.fireDomEvent(
@@ -147,7 +141,6 @@ describe('Inline delete component', () => {
 
     it('should wrap around to the next focusable item on the screen when no direct item is found and tabbing backwards', fakeAsync(() => {
       fixture.detectChanges();
-      simulateAnimationEnd();
       tick();
       fixture.detectChanges();
       el.querySelector('.sky-btn-danger').focus();

--- a/libs/components/layout/src/lib/modules/inline-delete/inline-delete.component.spec.ts
+++ b/libs/components/layout/src/lib/modules/inline-delete/inline-delete.component.spec.ts
@@ -25,6 +25,12 @@ describe('Inline delete component', () => {
     el = fixture.nativeElement;
   });
 
+  function simulateAnimationEnd(): void {
+    el.querySelector('.sky-inline-delete').dispatchEvent(
+      new AnimationEvent('animationend', { bubbles: true }),
+    );
+  }
+
   afterEach(fakeAsync(() => {
     cmp.showDelete = false;
     fixture.detectChanges();
@@ -95,6 +101,7 @@ describe('Inline delete component', () => {
   describe('focus handling', () => {
     it('should focus the delete button on load', async () => {
       fixture.detectChanges();
+      simulateAnimationEnd();
       await fixture.whenStable();
       expect(document.activeElement).toBe(el.querySelector('.sky-btn-danger'));
     });
@@ -102,6 +109,7 @@ describe('Inline delete component', () => {
     it('should skip items that are under the overlay when tabbing forward', fakeAsync(() => {
       fixture.componentInstance.showExtraButtons = true;
       fixture.detectChanges();
+      simulateAnimationEnd();
       tick();
       fixture.detectChanges();
       el.querySelector('#noop-button-1').focus();
@@ -121,6 +129,7 @@ describe('Inline delete component', () => {
     it('should skip items that are under the overlay when tabbing backward', fakeAsync(() => {
       fixture.componentInstance.showExtraButtons = true;
       fixture.detectChanges();
+      simulateAnimationEnd();
       tick();
       el.querySelector('.sky-btn-danger').focus();
       SkyAppTestUtility.fireDomEvent(
@@ -138,6 +147,7 @@ describe('Inline delete component', () => {
 
     it('should wrap around to the next focusable item on the screen when no direct item is found and tabbing backwards', fakeAsync(() => {
       fixture.detectChanges();
+      simulateAnimationEnd();
       tick();
       fixture.detectChanges();
       el.querySelector('.sky-btn-danger').focus();

--- a/libs/components/layout/src/lib/modules/inline-delete/inline-delete.component.spec.ts
+++ b/libs/components/layout/src/lib/modules/inline-delete/inline-delete.component.spec.ts
@@ -97,7 +97,6 @@ describe('Inline delete component', () => {
   describe('focus handling', () => {
     it('should focus the delete button on load', async () => {
       fixture.detectChanges();
-      fixture.detectChanges();
       await fixture.whenStable();
       expect(document.activeElement).toBe(el.querySelector('.sky-btn-danger'));
     });

--- a/libs/components/layout/src/lib/modules/inline-delete/inline-delete.component.ts
+++ b/libs/components/layout/src/lib/modules/inline-delete/inline-delete.component.ts
@@ -1,11 +1,11 @@
 import {
+  AfterViewInit,
   ChangeDetectorRef,
   Component,
   ElementRef,
   EventEmitter,
   Input,
   OnDestroy,
-  OnInit,
   Output,
   ViewChild,
   signal,
@@ -27,7 +27,7 @@ let nextId = 0;
   providers: [SkyCoreAdapterService, SkyInlineDeleteAdapterService],
   standalone: false,
 })
-export class SkyInlineDeleteComponent implements OnDestroy, OnInit {
+export class SkyInlineDeleteComponent implements AfterViewInit, OnDestroy {
   /**
    * Whether the deletion is pending.
    * @default false
@@ -49,8 +49,6 @@ export class SkyInlineDeleteComponent implements OnDestroy, OnInit {
 
   public assistiveTextId = `sky-inline-delete-assistive-text-${++nextId}`;
 
-  public enterAnimationTrigger = signal(false);
-
   public type: SkyInlineDeleteType = SkyInlineDeleteType.Standard;
 
   @ViewChild('delete', {
@@ -59,9 +57,12 @@ export class SkyInlineDeleteComponent implements OnDestroy, OnInit {
   })
   public deleteButton: ElementRef | undefined;
 
+  protected readonly enterAnimationTrigger = signal(false);
+
   #adapterService: SkyInlineDeleteAdapterService;
   #changeDetector: ChangeDetectorRef;
   #elRef: ElementRef;
+  #initialized = false;
 
   constructor(
     adapterService: SkyInlineDeleteAdapterService,
@@ -73,27 +74,19 @@ export class SkyInlineDeleteComponent implements OnDestroy, OnInit {
     this.#elRef = elRef;
   }
 
-  /**
-   * @internal
-   */
-  public ngOnInit(): void {
+  public ngAfterViewInit(): void {
     this.enterAnimationTrigger.set(true);
   }
 
-  /**
-   * @internal
-   */
-  public onAnimationEnd(): void {
-    this.deleteButton?.nativeElement.focus();
-    /* istanbul ignore else */
-    if (this.#elRef) {
+  protected onAnimationEnd(): void {
+    if (!this.#initialized) {
+      this.#initialized = true;
       this.#adapterService.setEl(this.#elRef.nativeElement);
     }
+
+    this.deleteButton?.nativeElement.focus();
   }
 
-  /**
-   * @internal
-   */
   public ngOnDestroy(): void {
     this.#adapterService.clearListeners();
     this.cancelTriggered.complete();

--- a/libs/components/layout/src/lib/modules/inline-delete/inline-delete.component.ts
+++ b/libs/components/layout/src/lib/modules/inline-delete/inline-delete.component.ts
@@ -77,9 +77,12 @@ export class SkyInlineDeleteComponent implements OnDestroy {
     if (!this.#initialized) {
       this.#initialized = true;
       this.#adapterService.setEl(this.#elRef.nativeElement);
-    }
 
-    this.deleteButton?.nativeElement.focus();
+      // Defer focus so it runs after the animationend event handler completes.
+      setTimeout(() => {
+        this.deleteButton?.nativeElement.focus();
+      });
+    }
   }
 
   public ngOnDestroy(): void {

--- a/libs/components/layout/src/lib/modules/inline-delete/inline-delete.component.ts
+++ b/libs/components/layout/src/lib/modules/inline-delete/inline-delete.component.ts
@@ -1,5 +1,4 @@
 import {
-  AfterViewInit,
   ChangeDetectorRef,
   Component,
   ElementRef,
@@ -27,7 +26,7 @@ let nextId = 0;
   providers: [SkyCoreAdapterService, SkyInlineDeleteAdapterService],
   standalone: false,
 })
-export class SkyInlineDeleteComponent implements AfterViewInit, OnDestroy {
+export class SkyInlineDeleteComponent implements OnDestroy {
   /**
    * Whether the deletion is pending.
    * @default false
@@ -57,7 +56,7 @@ export class SkyInlineDeleteComponent implements AfterViewInit, OnDestroy {
   })
   public deleteButton: ElementRef | undefined;
 
-  protected readonly enterAnimationTrigger = signal(false);
+  protected readonly enterAnimationTrigger = signal(true);
 
   #adapterService: SkyInlineDeleteAdapterService;
   #changeDetector: ChangeDetectorRef;
@@ -72,10 +71,6 @@ export class SkyInlineDeleteComponent implements AfterViewInit, OnDestroy {
     this.#adapterService = adapterService;
     this.#changeDetector = changeDetector;
     this.#elRef = elRef;
-  }
-
-  public ngAfterViewInit(): void {
-    this.enterAnimationTrigger.set(true);
   }
 
   protected onAnimationEnd(): void {

--- a/libs/components/layout/src/lib/modules/inline-delete/inline-delete.component.ts
+++ b/libs/components/layout/src/lib/modules/inline-delete/inline-delete.component.ts
@@ -1,13 +1,14 @@
 import {
-  AfterViewInit,
   ChangeDetectorRef,
   Component,
   ElementRef,
   EventEmitter,
   Input,
   OnDestroy,
+  OnInit,
   Output,
   ViewChild,
+  signal,
 } from '@angular/core';
 import { SkyCoreAdapterService } from '@skyux/core';
 
@@ -26,7 +27,7 @@ let nextId = 0;
   providers: [SkyCoreAdapterService, SkyInlineDeleteAdapterService],
   standalone: false,
 })
-export class SkyInlineDeleteComponent implements AfterViewInit, OnDestroy {
+export class SkyInlineDeleteComponent implements OnDestroy, OnInit {
   /**
    * Whether the deletion is pending.
    * @default false
@@ -47,6 +48,8 @@ export class SkyInlineDeleteComponent implements AfterViewInit, OnDestroy {
   public deleteTriggered = new EventEmitter<void>();
 
   public assistiveTextId = `sky-inline-delete-assistive-text-${++nextId}`;
+
+  public enterAnimationTrigger = signal(false);
 
   public type: SkyInlineDeleteType = SkyInlineDeleteType.Standard;
 
@@ -73,7 +76,14 @@ export class SkyInlineDeleteComponent implements AfterViewInit, OnDestroy {
   /**
    * @internal
    */
-  public ngAfterViewInit(): void {
+  public ngOnInit(): void {
+    this.enterAnimationTrigger.set(true);
+  }
+
+  /**
+   * @internal
+   */
+  public onAnimationEnd(): void {
     this.deleteButton?.nativeElement.focus();
     /* istanbul ignore else */
     if (this.#elRef) {

--- a/libs/components/layout/src/lib/modules/inline-delete/inline-delete.component.ts
+++ b/libs/components/layout/src/lib/modules/inline-delete/inline-delete.component.ts
@@ -1,20 +1,11 @@
 import {
-  AnimationEvent,
-  animate,
-  group,
-  query,
-  style,
-  transition,
-  trigger,
-} from '@angular/animations';
-import {
+  AfterViewInit,
   ChangeDetectorRef,
   Component,
   ElementRef,
   EventEmitter,
   Input,
   OnDestroy,
-  OnInit,
   Output,
   ViewChild,
 } from '@angular/core';
@@ -32,58 +23,10 @@ let nextId = 0;
   selector: 'sky-inline-delete',
   styleUrls: ['./inline-delete.component.scss'],
   templateUrl: './inline-delete.component.html',
-  animations: [
-    trigger('inlineDeleteAnimation', [
-      transition('* => shown', [
-        style({
-          opacity: 0,
-        }),
-        query(
-          '.sky-inline-delete-content-animation-container',
-          style({ transform: 'scale(0.0)' }),
-        ),
-        group([
-          animate('300ms ease-in-out', style({ opacity: 1 })),
-          query(
-            '.sky-inline-delete-content-animation-container',
-            animate(
-              '300ms ease-in-out',
-              style({
-                transform: 'scale(1)',
-              }),
-            ),
-          ),
-        ]),
-      ]),
-      transition(`shown <=> *`, [
-        query(
-          '.sky-inline-delete-content-animation-container',
-          style({ transform: 'scale(1)' }),
-        ),
-        group([
-          animate(
-            '300ms ease-in-out',
-            style({
-              opacity: 0,
-            }),
-          ),
-          query(
-            '.sky-inline-delete-content-animation-container',
-            animate(
-              '300ms ease-in-out',
-              style({
-                transform: 'scale(0.0)',
-              }),
-            ),
-          ),
-        ]),
-      ]),
-    ]),
-  ],
   providers: [SkyCoreAdapterService, SkyInlineDeleteAdapterService],
   standalone: false,
 })
-export class SkyInlineDeleteComponent implements OnDestroy, OnInit {
+export class SkyInlineDeleteComponent implements AfterViewInit, OnDestroy {
   /**
    * Whether the deletion is pending.
    * @default false
@@ -102,8 +45,6 @@ export class SkyInlineDeleteComponent implements OnDestroy, OnInit {
    */
   @Output()
   public deleteTriggered = new EventEmitter<void>();
-
-  public animationState = 'shown';
 
   public assistiveTextId = `sky-inline-delete-assistive-text-${++nextId}`;
 
@@ -130,15 +71,17 @@ export class SkyInlineDeleteComponent implements OnDestroy, OnInit {
   }
 
   /**
-   * Initialization lifecycle hook
    * @internal
    */
-  public ngOnInit(): void {
-    this.animationState = 'shown';
+  public ngAfterViewInit(): void {
+    this.deleteButton?.nativeElement.focus();
+    /* istanbul ignore else */
+    if (this.#elRef) {
+      this.#adapterService.setEl(this.#elRef.nativeElement);
+    }
   }
 
   /**
-   * Destruction lifecycle hook
    * @internal
    */
   public ngOnDestroy(): void {
@@ -151,7 +94,7 @@ export class SkyInlineDeleteComponent implements OnDestroy, OnInit {
    * @internal
    */
   public onCancelClick(): void {
-    this.animationState = 'hidden';
+    this.cancelTriggered.emit();
   }
 
   /**
@@ -169,22 +112,5 @@ export class SkyInlineDeleteComponent implements OnDestroy, OnInit {
   public setType(type: SkyInlineDeleteType): void {
     this.type = type;
     this.#changeDetector.detectChanges();
-  }
-
-  /**
-   * Handles actions that should be taken after the inline delete animates
-   * @param event The animation event
-   * @internal
-   */
-  public onAnimationDone(event: AnimationEvent): void {
-    if (event.toState === 'hidden') {
-      this.cancelTriggered.emit();
-    } else {
-      this.deleteButton?.nativeElement.focus();
-      /* istanbul ignore else */
-      if (this.#elRef) {
-        this.#adapterService.setEl(this.#elRef.nativeElement);
-      }
-    }
   }
 }

--- a/libs/components/layout/src/lib/modules/inline-delete/inline-delete.module.ts
+++ b/libs/components/layout/src/lib/modules/inline-delete/inline-delete.module.ts
@@ -1,4 +1,5 @@
 import { NgModule } from '@angular/core';
+import { _SkyAnimationEndHandlerDirective } from '@skyux/core';
 import { SkyWaitModule } from '@skyux/indicators';
 
 import { SkyLayoutResourcesModule } from '../shared/sky-layout-resources.module';
@@ -7,7 +8,11 @@ import { SkyInlineDeleteComponent } from './inline-delete.component';
 
 @NgModule({
   declarations: [SkyInlineDeleteComponent],
-  imports: [SkyLayoutResourcesModule, SkyWaitModule],
+  imports: [
+    _SkyAnimationEndHandlerDirective,
+    SkyLayoutResourcesModule,
+    SkyWaitModule,
+  ],
   exports: [SkyInlineDeleteComponent],
 })
 export class SkyInlineDeleteModule {}

--- a/libs/components/layout/testing/src/modules/inline-delete/inline-delete-harness.spec.ts
+++ b/libs/components/layout/testing/src/modules/inline-delete/inline-delete-harness.spec.ts
@@ -1,7 +1,6 @@
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { SkyInlineDeleteModule } from '@skyux/layout';
 
 import { SkyInlineDeleteHarness } from './inline-delete-harness';
@@ -33,7 +32,7 @@ describe('Inline delete harness', () => {
     fixture: ComponentFixture<TestComponent>;
   }> {
     await TestBed.configureTestingModule({
-      imports: [TestComponent, NoopAnimationsModule],
+      imports: [TestComponent],
     });
     const fixture = TestBed.createComponent(TestComponent);
     const loader = TestbedHarnessEnvironment.loader(fixture);

--- a/libs/components/layout/testing/src/modules/inline-delete/inline-delete-harness.spec.ts
+++ b/libs/components/layout/testing/src/modules/inline-delete/inline-delete-harness.spec.ts
@@ -1,6 +1,7 @@
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideNoopSkyAnimations } from '@skyux/core';
 import { SkyInlineDeleteModule } from '@skyux/layout';
 
 import { SkyInlineDeleteHarness } from './inline-delete-harness';
@@ -33,6 +34,7 @@ describe('Inline delete harness', () => {
   }> {
     await TestBed.configureTestingModule({
       imports: [TestComponent],
+      providers: [provideNoopSkyAnimations()],
     });
     const fixture = TestBed.createComponent(TestComponent);
     const loader = TestbedHarnessEnvironment.loader(fixture);


### PR DESCRIPTION
BREAKING CHANGE

`SkyInlineDeleteComponent ` has replaced `@angular/animations` with CSS transitions. Tests that interact with inline delete may need to add `provideNoopSkyAnimations()` from `@skyux/core` to their `TestBed` providers to disable SKY UX CSS transitions during tests.

```
import { provideNoopSkyAnimations } from '@skyux/core';

TestBed.configureTestingModule({
  providers: [provideNoopSkyAnimations()],
});
```

[AB#3913627](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3913627)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Refactored inline-delete component's animation system to provide enhanced flexibility and control over transition behavior
  * Added improved CSS animations for component entry and exit states with optimized timing and easing
  * Streamlined animation infrastructure and dependencies while maintaining consistent visual behavior and performance
<!-- end of auto-generated comment: release notes by coderabbit.ai -->