### PR TITLE
chore: release 14.0.0-alpha.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 
-## [14.0.0-alpha.12](https://github.com/blackbaud/skyux/compare/14.0.0-alpha.11...14.0.0-alpha.12) (2026-03-20)
+## [14.0.0-alpha.12](https://github.com/blackbaud/skyux/compare/14.0.0-alpha.11...14.0.0-alpha.12) (2026-03-21)
 
 
 ### ⚠ BREAKING CHANGES

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 
-## [14.0.0-alpha.12](https://github.com/blackbaud/skyux/compare/14.0.0-alpha.11...14.0.0-alpha.12) (2026-03-21)
+## [14.0.0-alpha.12](https://github.com/blackbaud/skyux/compare/14.0.0-alpha.11...14.0.0-alpha.12) (2026-03-22)
 
 
 ### ⚠ BREAKING CHANGES

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 
-## [14.0.0-alpha.12](https://github.com/blackbaud/skyux/compare/14.0.0-alpha.11...14.0.0-alpha.12) (2026-03-22)
+## [14.0.0-alpha.12](https://github.com/blackbaud/skyux/compare/14.0.0-alpha.11...14.0.0-alpha.12) (2026-03-23)
 
 
 ### ⚠ BREAKING CHANGES

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * **components/action-bars:** cache split view element refs for style cleanup on destroy ([#4326](https://github.com/blackbaud/skyux/issues/4326)) ([0a7e5b4](https://github.com/blackbaud/skyux/commit/0a7e5b4e9dd2d73614b86283929e08eae14b1943))
 * **components/layout:** replace `@angular/animations` with CSS transitions for inline delete component ([#4323](https://github.com/blackbaud/skyux/issues/4323)) ([1b94ac1](https://github.com/blackbaud/skyux/commit/1b94ac19a02a7bb99193de1292df8ef74360d31f))
 * **components/theme:** use design tokens for duration values ([#4327](https://github.com/blackbaud/skyux/issues/4327)) ([9e842bc](https://github.com/blackbaud/skyux/commit/9e842bcad9ecb536be58691a5aa26cba246e84d7))
+* replace static duration values with design tokens ([#4328](https://github.com/blackbaud/skyux/issues/4328)) ([77041aa](https://github.com/blackbaud/skyux/commit/77041aa2d5b9b25be1c6da720718c217f1872ed4))
 
 ## [14.0.0-alpha.11](https://github.com/blackbaud/skyux/compare/14.0.0-alpha.10...14.0.0-alpha.11) (2026-03-19)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 * **components/action-bars:** cache split view element refs for style cleanup on destroy ([#4326](https://github.com/blackbaud/skyux/issues/4326)) ([0a7e5b4](https://github.com/blackbaud/skyux/commit/0a7e5b4e9dd2d73614b86283929e08eae14b1943))
 * **components/layout:** replace `@angular/animations` with CSS transitions for inline delete component ([#4323](https://github.com/blackbaud/skyux/issues/4323)) ([1b94ac1](https://github.com/blackbaud/skyux/commit/1b94ac19a02a7bb99193de1292df8ef74360d31f))
+* **components/theme:** use design tokens for duration values ([#4327](https://github.com/blackbaud/skyux/issues/4327)) ([9e842bc](https://github.com/blackbaud/skyux/commit/9e842bcad9ecb536be58691a5aa26cba246e84d7))
 
 ## [14.0.0-alpha.11](https://github.com/blackbaud/skyux/compare/14.0.0-alpha.10...14.0.0-alpha.11) (2026-03-19)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 # Changelog
 
 
+## [14.0.0-alpha.12](https://github.com/blackbaud/skyux/compare/14.0.0-alpha.11...14.0.0-alpha.12) (2026-03-20)
+
+
+### ⚠ BREAKING CHANGES
+
+* **components/layout:** replace `@angular/animations` with CSS transitions for inline delete component (#4323)
+
+### Bug Fixes
+
+* **components/layout:** replace `@angular/animations` with CSS transitions for inline delete component ([#4323](https://github.com/blackbaud/skyux/issues/4323)) ([1b94ac1](https://github.com/blackbaud/skyux/commit/1b94ac19a02a7bb99193de1292df8ef74360d31f))
+
 ## [14.0.0-alpha.11](https://github.com/blackbaud/skyux/compare/14.0.0-alpha.10...14.0.0-alpha.11) (2026-03-19)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Bug Fixes
 
+* **components/action-bars:** cache split view element refs for style cleanup on destroy ([#4326](https://github.com/blackbaud/skyux/issues/4326)) ([0a7e5b4](https://github.com/blackbaud/skyux/commit/0a7e5b4e9dd2d73614b86283929e08eae14b1943))
 * **components/layout:** replace `@angular/animations` with CSS transitions for inline delete component ([#4323](https://github.com/blackbaud/skyux/issues/4323)) ([1b94ac1](https://github.com/blackbaud/skyux/commit/1b94ac19a02a7bb99193de1292df8ef74360d31f))
 
 ## [14.0.0-alpha.11](https://github.com/blackbaud/skyux/compare/14.0.0-alpha.10...14.0.0-alpha.11) (2026-03-19)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "skyux",
-  "version": "14.0.0-alpha.11",
+  "version": "14.0.0-alpha.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "skyux",
-      "version": "14.0.0-alpha.11",
+      "version": "14.0.0-alpha.12",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skyux",
-  "version": "14.0.0-alpha.11",
+  "version": "14.0.0-alpha.12",
   "license": "MIT",
   "scripts": {
     "ng": "nx",


### PR DESCRIPTION
## [14.0.0-alpha.12](https://github.com/blackbaud/skyux/compare/14.0.0-alpha.11...14.0.0-alpha.12) (2026-03-23)


### ⚠ BREAKING CHANGES

* **components/layout:** replace `@angular/animations` with CSS transitions for inline delete component (#4323)

### Bug Fixes

* **components/action-bars:** cache split view element refs for style cleanup on destroy ([#4326](https://github.com/blackbaud/skyux/issues/4326)) ([0a7e5b4](https://github.com/blackbaud/skyux/commit/0a7e5b4e9dd2d73614b86283929e08eae14b1943))
* **components/layout:** replace `@angular/animations` with CSS transitions for inline delete component ([#4323](https://github.com/blackbaud/skyux/issues/4323)) ([1b94ac1](https://github.com/blackbaud/skyux/commit/1b94ac19a02a7bb99193de1292df8ef74360d31f))
* **components/theme:** use design tokens for duration values ([#4327](https://github.com/blackbaud/skyux/issues/4327)) ([9e842bc](https://github.com/blackbaud/skyux/commit/9e842bcad9ecb536be58691a5aa26cba246e84d7))
* replace static duration values with design tokens ([#4328](https://github.com/blackbaud/skyux/issues/4328)) ([77041aa](https://github.com/blackbaud/skyux/commit/77041aa2d5b9b25be1c6da720718c217f1872ed4))

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release 14.0.0-alpha.12

* **Breaking Changes**
  * Inline delete component now uses CSS transitions instead of Angular animations.

* **Bug Fixes**
  * Fixed style cleanup on element destruction.
  * Updated inline delete animation handling.
  * Replaced static duration values with design tokens for theme consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->