### PR TITLE
chore: remove all usage of `NoopAnimationsModule`, `provideAnimations`, and `provideNoopAnimations`

### DIFF
--- a/.github/instructions/code-examples-unit-testing.instructions.md
+++ b/.github/instructions/code-examples-unit-testing.instructions.md
@@ -57,7 +57,7 @@ These tests should be **thorough showcases** of test harness capabilities, not j
 ### Dependencies
 
 - Import test harnesses from appropriate testing modules
-- Use `NoopAnimationsModule` for animations
+- Use `provideNoopSkyAnimations()` from `@skyux/core` to suppress animations
 - Follow Angular testing best practices
 
 ### Test Patterns

--- a/apps/code-examples/src/main.ts
+++ b/apps/code-examples/src/main.ts
@@ -1,7 +1,6 @@
 import { provideHttpClient } from '@angular/common/http';
 import { provideZoneChangeDetection } from '@angular/core';
 import { bootstrapApplication } from '@angular/platform-browser';
-import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
 import {
   provideRouter,
   withHashLocation,
@@ -23,7 +22,6 @@ const CODE_EXAMPLES = codeExampleExports as SkyDocsCodeExampleComponentTypes;
 bootstrapApplication(AppComponent, {
   providers: [
     provideZoneChangeDetection(),
-    provideAnimationsAsync(),
     provideHttpClient(),
     provideInitialTheme('modern'),
     provideRouter(

--- a/apps/e2e/a11y-storybook/src/main.ts
+++ b/apps/e2e/a11y-storybook/src/main.ts
@@ -1,6 +1,5 @@
 import { provideZoneChangeDetection } from '@angular/core';
 import { bootstrapApplication } from '@angular/platform-browser';
-import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
 import {
   provideRouter,
   withEnabledBlockingInitialNavigation,
@@ -12,7 +11,6 @@ import { routes } from './app/app.routes';
 bootstrapApplication(AppComponent, {
   providers: [
     provideZoneChangeDetection(),
-    provideAnimationsAsync(),
     provideRouter(routes, withEnabledBlockingInitialNavigation()),
   ],
 }).catch((err) => console.error(err));

--- a/apps/e2e/action-bars-storybook/src/main.ts
+++ b/apps/e2e/action-bars-storybook/src/main.ts
@@ -1,6 +1,5 @@
 import { provideZoneChangeDetection } from '@angular/core';
 import { bootstrapApplication } from '@angular/platform-browser';
-import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
 import {
   provideRouter,
   withEnabledBlockingInitialNavigation,
@@ -12,7 +11,6 @@ import { routes } from './app/app.routes';
 bootstrapApplication(AppComponent, {
   providers: [
     provideZoneChangeDetection(),
-    provideAnimationsAsync(),
     provideRouter(routes, withEnabledBlockingInitialNavigation()),
   ],
 }).catch((err) => console.error(err));

--- a/apps/e2e/ag-grid-storybook/src/main.ts
+++ b/apps/e2e/ag-grid-storybook/src/main.ts
@@ -1,6 +1,5 @@
 import { provideZoneChangeDetection } from '@angular/core';
 import { bootstrapApplication } from '@angular/platform-browser';
-import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
 import {
   provideRouter,
   withEnabledBlockingInitialNavigation,
@@ -14,7 +13,6 @@ bootstrapApplication(AppComponent, {
   providers: [
     provideZoneChangeDetection(),
     provideInitialTheme('modern'),
-    provideAnimationsAsync(),
     provideRouter(routes, withEnabledBlockingInitialNavigation()),
   ],
 }).catch((err) => console.error(err));

--- a/apps/e2e/angular-tree-component-storybook/src/main.ts
+++ b/apps/e2e/angular-tree-component-storybook/src/main.ts
@@ -1,6 +1,5 @@
 import { provideZoneChangeDetection } from '@angular/core';
 import { bootstrapApplication } from '@angular/platform-browser';
-import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
 import {
   provideRouter,
   withEnabledBlockingInitialNavigation,
@@ -12,7 +11,6 @@ import { routes } from './app/app.routes';
 bootstrapApplication(AppComponent, {
   providers: [
     provideZoneChangeDetection(),
-    provideAnimationsAsync(),
     provideRouter(routes, withEnabledBlockingInitialNavigation()),
   ],
 }).catch((err) => console.error(err));

--- a/apps/e2e/avatar-storybook/src/main.ts
+++ b/apps/e2e/avatar-storybook/src/main.ts
@@ -1,6 +1,5 @@
 import { provideZoneChangeDetection } from '@angular/core';
 import { bootstrapApplication } from '@angular/platform-browser';
-import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
 import {
   provideRouter,
   withEnabledBlockingInitialNavigation,
@@ -12,7 +11,6 @@ import { routes } from './app/app.routes';
 bootstrapApplication(AppComponent, {
   providers: [
     provideZoneChangeDetection(),
-    provideAnimationsAsync(),
     provideRouter(routes, withEnabledBlockingInitialNavigation()),
   ],
 }).catch((err) => console.error(err));

--- a/apps/e2e/colorpicker-storybook/src/main.ts
+++ b/apps/e2e/colorpicker-storybook/src/main.ts
@@ -1,6 +1,5 @@
 import { provideZoneChangeDetection } from '@angular/core';
 import { bootstrapApplication } from '@angular/platform-browser';
-import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
 import {
   provideRouter,
   withEnabledBlockingInitialNavigation,
@@ -12,7 +11,6 @@ import { routes } from './app/app.routes';
 bootstrapApplication(AppComponent, {
   providers: [
     provideZoneChangeDetection(),
-    provideAnimationsAsync(),
     provideRouter(routes, withEnabledBlockingInitialNavigation()),
   ],
 }).catch((err) => console.error(err));

--- a/apps/e2e/core-storybook/src/main.ts
+++ b/apps/e2e/core-storybook/src/main.ts
@@ -1,6 +1,5 @@
 import { provideZoneChangeDetection } from '@angular/core';
 import { bootstrapApplication } from '@angular/platform-browser';
-import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
 import {
   provideRouter,
   withEnabledBlockingInitialNavigation,
@@ -12,7 +11,6 @@ import { routes } from './app/app.routes';
 bootstrapApplication(AppComponent, {
   providers: [
     provideZoneChangeDetection(),
-    provideAnimationsAsync(),
     provideRouter(routes, withEnabledBlockingInitialNavigation()),
   ],
 }).catch((err) => console.error(err));

--- a/apps/e2e/data-manager-storybook/src/main.ts
+++ b/apps/e2e/data-manager-storybook/src/main.ts
@@ -1,6 +1,5 @@
 import { provideZoneChangeDetection } from '@angular/core';
 import { bootstrapApplication } from '@angular/platform-browser';
-import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
 import {
   provideRouter,
   withEnabledBlockingInitialNavigation,
@@ -12,7 +11,6 @@ import { routes } from './app/app.routes';
 bootstrapApplication(AppComponent, {
   providers: [
     provideZoneChangeDetection(),
-    provideAnimationsAsync(),
     provideRouter(routes, withEnabledBlockingInitialNavigation()),
   ],
 }).catch((err) => console.error(err));

--- a/apps/e2e/datetime-storybook/src/main.ts
+++ b/apps/e2e/datetime-storybook/src/main.ts
@@ -1,6 +1,5 @@
 import { provideZoneChangeDetection } from '@angular/core';
 import { bootstrapApplication } from '@angular/platform-browser';
-import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
 import {
   provideRouter,
   withEnabledBlockingInitialNavigation,
@@ -12,7 +11,6 @@ import { routes } from './app/app.routes';
 bootstrapApplication(AppComponent, {
   providers: [
     provideZoneChangeDetection(),
-    provideAnimationsAsync(),
     provideRouter(routes, withEnabledBlockingInitialNavigation()),
   ],
 }).catch((err) => console.error(err));

--- a/apps/e2e/errors-storybook/src/main.ts
+++ b/apps/e2e/errors-storybook/src/main.ts
@@ -1,6 +1,5 @@
 import { provideZoneChangeDetection } from '@angular/core';
 import { bootstrapApplication } from '@angular/platform-browser';
-import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
 import {
   provideRouter,
   withEnabledBlockingInitialNavigation,
@@ -12,7 +11,6 @@ import { routes } from './app/app.routes';
 bootstrapApplication(AppComponent, {
   providers: [
     provideZoneChangeDetection(),
-    provideAnimationsAsync(),
     provideRouter(routes, withEnabledBlockingInitialNavigation()),
   ],
 }).catch((err) => console.error(err));

--- a/apps/e2e/filter-bar-storybook/src/main.ts
+++ b/apps/e2e/filter-bar-storybook/src/main.ts
@@ -1,6 +1,5 @@
 import { provideZoneChangeDetection } from '@angular/core';
 import { bootstrapApplication } from '@angular/platform-browser';
-import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
 import {
   provideRouter,
   withEnabledBlockingInitialNavigation,
@@ -12,7 +11,6 @@ import { routes } from './app/app.routes';
 bootstrapApplication(AppComponent, {
   providers: [
     provideZoneChangeDetection(),
-    provideAnimationsAsync(),
     provideRouter(routes, withEnabledBlockingInitialNavigation()),
   ],
 }).catch((err) => console.error(err));

--- a/apps/e2e/flyout-storybook/src/main.ts
+++ b/apps/e2e/flyout-storybook/src/main.ts
@@ -1,6 +1,5 @@
 import { provideZoneChangeDetection } from '@angular/core';
 import { bootstrapApplication } from '@angular/platform-browser';
-import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
 import {
   provideRouter,
   withEnabledBlockingInitialNavigation,
@@ -12,7 +11,6 @@ import { routes } from './app/app.routes';
 bootstrapApplication(AppComponent, {
   providers: [
     provideZoneChangeDetection(),
-    provideAnimationsAsync(),
     provideRouter(routes, withEnabledBlockingInitialNavigation()),
   ],
 }).catch((err) => console.error(err));

--- a/apps/e2e/forms-storybook/src/main.ts
+++ b/apps/e2e/forms-storybook/src/main.ts
@@ -1,6 +1,5 @@
 import { provideZoneChangeDetection } from '@angular/core';
 import { bootstrapApplication } from '@angular/platform-browser';
-import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
 import {
   provideRouter,
   withEnabledBlockingInitialNavigation,
@@ -12,7 +11,6 @@ import { routes } from './app/app.routes';
 bootstrapApplication(AppComponent, {
   providers: [
     provideZoneChangeDetection(),
-    provideAnimationsAsync(),
     provideRouter(routes, withEnabledBlockingInitialNavigation()),
   ],
 }).catch((err) => console.error(err));

--- a/apps/e2e/help-inline-storybook/src/main.ts
+++ b/apps/e2e/help-inline-storybook/src/main.ts
@@ -1,6 +1,5 @@
 import { provideZoneChangeDetection } from '@angular/core';
 import { bootstrapApplication } from '@angular/platform-browser';
-import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
 import {
   provideRouter,
   withEnabledBlockingInitialNavigation,
@@ -12,7 +11,6 @@ import { routes } from './app/app.routes';
 bootstrapApplication(AppComponent, {
   providers: [
     provideZoneChangeDetection(),
-    provideAnimationsAsync(),
     provideRouter(routes, withEnabledBlockingInitialNavigation()),
   ],
 }).catch((err) => console.error(err));

--- a/apps/e2e/indicators-storybook/src/main.ts
+++ b/apps/e2e/indicators-storybook/src/main.ts
@@ -1,6 +1,5 @@
 import { provideZoneChangeDetection } from '@angular/core';
 import { bootstrapApplication } from '@angular/platform-browser';
-import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
 import {
   provideRouter,
   withEnabledBlockingInitialNavigation,
@@ -12,7 +11,6 @@ import { routes } from './app/app.routes';
 bootstrapApplication(AppComponent, {
   providers: [
     provideZoneChangeDetection(),
-    provideAnimationsAsync(),
     provideRouter(routes, withEnabledBlockingInitialNavigation()),
   ],
 }).catch((err) => console.error(err));

--- a/apps/e2e/inline-form-storybook/src/main.ts
+++ b/apps/e2e/inline-form-storybook/src/main.ts
@@ -1,6 +1,5 @@
 import { provideZoneChangeDetection } from '@angular/core';
 import { bootstrapApplication } from '@angular/platform-browser';
-import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
 import {
   provideRouter,
   withEnabledBlockingInitialNavigation,
@@ -12,7 +11,6 @@ import { routes } from './app/app.routes';
 bootstrapApplication(AppComponent, {
   providers: [
     provideZoneChangeDetection(),
-    provideAnimationsAsync(),
     provideRouter(routes, withEnabledBlockingInitialNavigation()),
   ],
 }).catch((err) => console.error(err));

--- a/apps/e2e/layout-storybook/src/main.ts
+++ b/apps/e2e/layout-storybook/src/main.ts
@@ -1,6 +1,5 @@
 import { provideZoneChangeDetection } from '@angular/core';
 import { bootstrapApplication } from '@angular/platform-browser';
-import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
 import {
   provideRouter,
   withEnabledBlockingInitialNavigation,
@@ -14,7 +13,6 @@ bootstrapApplication(AppComponent, {
   providers: [
     provideZoneChangeDetection(),
     provideInitialTheme('modern'),
-    provideAnimationsAsync(),
     provideRouter(routes, withEnabledBlockingInitialNavigation()),
   ],
 }).catch((err) => console.error(err));

--- a/apps/e2e/lists-storybook/src/main.ts
+++ b/apps/e2e/lists-storybook/src/main.ts
@@ -1,6 +1,5 @@
 import { provideZoneChangeDetection } from '@angular/core';
 import { bootstrapApplication } from '@angular/platform-browser';
-import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
 import {
   provideRouter,
   withEnabledBlockingInitialNavigation,
@@ -12,7 +11,6 @@ import { routes } from './app/app.routes';
 bootstrapApplication(AppComponent, {
   providers: [
     provideZoneChangeDetection(),
-    provideAnimationsAsync(),
     provideRouter(routes, withEnabledBlockingInitialNavigation()),
   ],
 }).catch((err) => console.error(err));

--- a/apps/e2e/lookup-storybook/src/main.ts
+++ b/apps/e2e/lookup-storybook/src/main.ts
@@ -1,6 +1,5 @@
 import { provideZoneChangeDetection } from '@angular/core';
 import { bootstrapApplication } from '@angular/platform-browser';
-import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
 import {
   provideRouter,
   withEnabledBlockingInitialNavigation,
@@ -12,7 +11,6 @@ import { routes } from './app/app.routes';
 bootstrapApplication(AppComponent, {
   providers: [
     provideZoneChangeDetection(),
-    provideAnimationsAsync(),
     provideRouter(routes, withEnabledBlockingInitialNavigation()),
   ],
 }).catch((err) => console.error(err));

--- a/apps/e2e/modals-storybook/src/main.ts
+++ b/apps/e2e/modals-storybook/src/main.ts
@@ -1,6 +1,5 @@
 import { provideZoneChangeDetection } from '@angular/core';
 import { bootstrapApplication } from '@angular/platform-browser';
-import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
 import {
   provideRouter,
   withEnabledBlockingInitialNavigation,
@@ -12,7 +11,6 @@ import { routes } from './app/app.routes';
 bootstrapApplication(AppComponent, {
   providers: [
     provideZoneChangeDetection(),
-    provideAnimationsAsync(),
     provideRouter(routes, withEnabledBlockingInitialNavigation()),
   ],
 }).catch((err) => console.error(err));

--- a/apps/e2e/navbar-storybook/src/main.ts
+++ b/apps/e2e/navbar-storybook/src/main.ts
@@ -1,6 +1,5 @@
 import { provideZoneChangeDetection } from '@angular/core';
 import { bootstrapApplication } from '@angular/platform-browser';
-import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
 import {
   provideRouter,
   withEnabledBlockingInitialNavigation,
@@ -12,7 +11,6 @@ import { routes } from './app/app.routes';
 bootstrapApplication(AppComponent, {
   providers: [
     provideZoneChangeDetection(),
-    provideAnimationsAsync(),
     provideRouter(routes, withEnabledBlockingInitialNavigation()),
   ],
 }).catch((err) => console.error(err));

--- a/apps/e2e/pages-storybook/src/main.ts
+++ b/apps/e2e/pages-storybook/src/main.ts
@@ -1,6 +1,5 @@
 import { provideZoneChangeDetection } from '@angular/core';
 import { bootstrapApplication } from '@angular/platform-browser';
-import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import {
   provideRouter,
   withComponentInputBinding,
@@ -15,7 +14,6 @@ bootstrapApplication(AppComponent, {
   providers: [
     provideZoneChangeDetection(),
     provideInitialTheme('modern'),
-    provideNoopAnimations(),
     provideRouter(
       routes,
       withEnabledBlockingInitialNavigation(),

--- a/apps/e2e/phone-field-storybook/src/main.ts
+++ b/apps/e2e/phone-field-storybook/src/main.ts
@@ -1,6 +1,5 @@
 import { provideZoneChangeDetection } from '@angular/core';
 import { bootstrapApplication } from '@angular/platform-browser';
-import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
 import {
   provideRouter,
   withEnabledBlockingInitialNavigation,
@@ -12,7 +11,6 @@ import { routes } from './app/app.routes';
 bootstrapApplication(AppComponent, {
   providers: [
     provideZoneChangeDetection(),
-    provideAnimationsAsync(),
     provideRouter(routes, withEnabledBlockingInitialNavigation()),
   ],
 }).catch((err) => console.error(err));

--- a/apps/e2e/popovers-storybook/src/main.ts
+++ b/apps/e2e/popovers-storybook/src/main.ts
@@ -1,6 +1,5 @@
 import { provideZoneChangeDetection } from '@angular/core';
 import { bootstrapApplication } from '@angular/platform-browser';
-import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
 import {
   provideRouter,
   withEnabledBlockingInitialNavigation,
@@ -14,7 +13,6 @@ bootstrapApplication(AppComponent, {
   providers: [
     provideZoneChangeDetection(),
     provideInitialTheme('modern'),
-    provideAnimationsAsync(),
     provideRouter(routes, withEnabledBlockingInitialNavigation()),
   ],
 }).catch((err) => console.error(err));

--- a/apps/e2e/progress-indicator-storybook/src/main.ts
+++ b/apps/e2e/progress-indicator-storybook/src/main.ts
@@ -1,6 +1,5 @@
 import { provideZoneChangeDetection } from '@angular/core';
 import { bootstrapApplication } from '@angular/platform-browser';
-import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
 import {
   provideRouter,
   withEnabledBlockingInitialNavigation,
@@ -12,7 +11,6 @@ import { routes } from './app/app.routes';
 bootstrapApplication(AppComponent, {
   providers: [
     provideZoneChangeDetection(),
-    provideAnimationsAsync(),
     provideRouter(routes, withEnabledBlockingInitialNavigation()),
   ],
 }).catch((err) => console.error(err));

--- a/apps/e2e/split-view-storybook/src/main.ts
+++ b/apps/e2e/split-view-storybook/src/main.ts
@@ -1,6 +1,5 @@
 import { provideZoneChangeDetection } from '@angular/core';
 import { bootstrapApplication } from '@angular/platform-browser';
-import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
 import {
   provideRouter,
   withEnabledBlockingInitialNavigation,
@@ -12,7 +11,6 @@ import { routes } from './app/app.routes';
 bootstrapApplication(AppComponent, {
   providers: [
     provideZoneChangeDetection(),
-    provideAnimationsAsync(),
     provideRouter(routes, withEnabledBlockingInitialNavigation()),
   ],
 }).catch((err) => console.error(err));

--- a/apps/e2e/tabs-storybook/src/main.ts
+++ b/apps/e2e/tabs-storybook/src/main.ts
@@ -1,6 +1,5 @@
 import { provideZoneChangeDetection } from '@angular/core';
 import { bootstrapApplication } from '@angular/platform-browser';
-import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
 import {
   provideRouter,
   withEnabledBlockingInitialNavigation,
@@ -12,7 +11,6 @@ import { routes } from './app/app.routes';
 bootstrapApplication(AppComponent, {
   providers: [
     provideZoneChangeDetection(),
-    provideAnimationsAsync(),
     provideRouter(routes, withEnabledBlockingInitialNavigation()),
   ],
 }).catch((err) => console.error(err));

--- a/apps/e2e/text-editor-storybook/src/main.ts
+++ b/apps/e2e/text-editor-storybook/src/main.ts
@@ -1,6 +1,5 @@
 import { provideZoneChangeDetection } from '@angular/core';
 import { bootstrapApplication } from '@angular/platform-browser';
-import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
 import {
   provideRouter,
   withEnabledBlockingInitialNavigation,
@@ -12,7 +11,6 @@ import { routes } from './app/app.routes';
 bootstrapApplication(AppComponent, {
   providers: [
     provideZoneChangeDetection(),
-    provideAnimationsAsync(),
     provideRouter(routes, withEnabledBlockingInitialNavigation()),
   ],
 }).catch((err) => console.error(err));

--- a/apps/e2e/theme-storybook/src/main.ts
+++ b/apps/e2e/theme-storybook/src/main.ts
@@ -1,6 +1,5 @@
 import { provideZoneChangeDetection } from '@angular/core';
 import { bootstrapApplication } from '@angular/platform-browser';
-import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
 import {
   provideRouter,
   withEnabledBlockingInitialNavigation,
@@ -12,7 +11,6 @@ import { routes } from './app/app.routes';
 bootstrapApplication(AppComponent, {
   providers: [
     provideZoneChangeDetection(),
-    provideAnimationsAsync(),
     provideRouter(routes, withEnabledBlockingInitialNavigation()),
   ],
 }).catch((err) => console.error(err));

--- a/apps/e2e/tiles-storybook/src/main.ts
+++ b/apps/e2e/tiles-storybook/src/main.ts
@@ -1,6 +1,5 @@
 import { provideZoneChangeDetection } from '@angular/core';
 import { bootstrapApplication } from '@angular/platform-browser';
-import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
 import {
   provideRouter,
   withEnabledBlockingInitialNavigation,
@@ -12,7 +11,6 @@ import { routes } from './app/app.routes';
 bootstrapApplication(AppComponent, {
   providers: [
     provideZoneChangeDetection(),
-    provideAnimationsAsync(),
     provideRouter(routes, withEnabledBlockingInitialNavigation()),
   ],
 }).catch((err) => console.error(err));

--- a/apps/e2e/toast-storybook/src/main.ts
+++ b/apps/e2e/toast-storybook/src/main.ts
@@ -1,6 +1,5 @@
 import { provideZoneChangeDetection } from '@angular/core';
 import { bootstrapApplication } from '@angular/platform-browser';
-import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
 import {
   provideRouter,
   withEnabledBlockingInitialNavigation,
@@ -12,7 +11,6 @@ import { routes } from './app/app.routes';
 bootstrapApplication(AppComponent, {
   providers: [
     provideZoneChangeDetection(),
-    provideAnimationsAsync(),
     provideRouter(routes, withEnabledBlockingInitialNavigation()),
   ],
 }).catch((err) => console.error(err));

--- a/apps/integration/src/app/integrations/field-heights/field-heights.component.spec.ts
+++ b/apps/integration/src/app/integrations/field-heights/field-heights.component.spec.ts
@@ -1,6 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { ActivatedRoute } from '@angular/router';
 import { provideRouter } from '@angular/router';
 import { expectAsync } from '@skyux-sdk/testing';
@@ -17,7 +16,7 @@ describe('FieldHeightsComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [FieldHeightsModule, NoopAnimationsModule],
+      imports: [FieldHeightsModule],
       providers: [SkyThemeService, provideRouter([])],
     });
 
@@ -69,7 +68,7 @@ describe('FieldHeightsComponent with disabled route query parameter', () => {
     };
 
     TestBed.configureTestingModule({
-      imports: [FieldHeightsModule, NoopAnimationsModule],
+      imports: [FieldHeightsModule],
       providers: [
         SkyThemeService,
         provideRouter([]),

--- a/apps/integration/src/app/integrations/lookup-in-modal/lookup-in-modal.component.spec.ts
+++ b/apps/integration/src/app/integrations/lookup-in-modal/lookup-in-modal.component.spec.ts
@@ -1,6 +1,5 @@
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { provideRouter } from '@angular/router';
 import { expectAsync } from '@skyux-sdk/testing';
 import { SkyInputBoxHarness } from '@skyux/forms/testing';
@@ -17,7 +16,7 @@ describe('LookupInModalComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [LookupInModalModule, NoopAnimationsModule],
+      imports: [LookupInModalModule],
       providers: [SkyThemeService, provideRouter([])],
     });
 

--- a/apps/integration/src/app/integrations/lookup-in-modal/modal-lookup.component.spec.ts
+++ b/apps/integration/src/app/integrations/lookup-in-modal/modal-lookup.component.spec.ts
@@ -1,6 +1,5 @@
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { provideRouter } from '@angular/router';
 import { expectAsync } from '@skyux-sdk/testing';
 import { SkyInputBoxHarness } from '@skyux/forms/testing';
@@ -16,7 +15,7 @@ describe('ModalLookupComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [LookupInModalModule, NoopAnimationsModule],
+      imports: [LookupInModalModule],
       providers: [SkyThemeService, provideRouter([])],
     });
 

--- a/apps/integration/src/app/integrations/lookup-in-modal/modal-lookup.component.spec.ts
+++ b/apps/integration/src/app/integrations/lookup-in-modal/modal-lookup.component.spec.ts
@@ -2,6 +2,7 @@ import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideRouter } from '@angular/router';
 import { expectAsync } from '@skyux-sdk/testing';
+import { provideNoopSkyAnimations } from '@skyux/core';
 import { SkyInputBoxHarness } from '@skyux/forms/testing';
 import { SkyLookupHarness } from '@skyux/lookup/testing';
 import { SkyModalHarness } from '@skyux/modals/testing';
@@ -16,7 +17,11 @@ describe('ModalLookupComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [LookupInModalModule],
-      providers: [SkyThemeService, provideRouter([])],
+      providers: [
+        SkyThemeService,
+        provideNoopSkyAnimations(),
+        provideRouter([]),
+      ],
     });
 
     fixture = TestBed.createComponent(ModalLookupComponent);

--- a/apps/integration/src/app/integrations/modal-split-view-tile-dashboard/modal-split-view-tile-dashboard.component.spec.ts
+++ b/apps/integration/src/app/integrations/modal-split-view-tile-dashboard/modal-split-view-tile-dashboard.component.spec.ts
@@ -1,6 +1,5 @@
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { expect } from '@skyux-sdk/testing';
 import { SkyWaitService } from '@skyux/indicators';
 import { SkyModalHarness } from '@skyux/modals/testing';
@@ -23,7 +22,7 @@ describe('ModalSplitViewTileDashboardComponent', () => {
     fixture: ComponentFixture<ModalSplitViewTileDashboardComponent>;
   }> {
     TestBed.configureTestingModule({
-      imports: [ModalSplitViewTileDashboardModule, NoopAnimationsModule],
+      imports: [ModalSplitViewTileDashboardModule],
       providers: [
         {
           provide: SkyWaitService,

--- a/apps/integration/src/app/integrations/modal-viewkept-toolbars/modal-viewkept-toolbars.component.spec.ts
+++ b/apps/integration/src/app/integrations/modal-viewkept-toolbars/modal-viewkept-toolbars.component.spec.ts
@@ -5,7 +5,6 @@ import {
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { RendererFactory2 } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterTestingModule } from '@angular/router/testing';
 import { SkyAppTestUtility } from '@skyux-sdk/testing';
 import {
@@ -65,11 +64,7 @@ describe('Modals with viewkept toolbars', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [
-        NoopAnimationsModule,
-        RouterTestingModule,
-        ModalViewkeptToolbarsModule,
-      ],
+      imports: [RouterTestingModule, ModalViewkeptToolbarsModule],
       providers: [
         SkyThemeService,
         provideHttpClient(withInterceptorsFromDi()),

--- a/apps/integration/src/app/integrations/page-data-manager-split-view/page-data-manager-split-view.component.spec.ts
+++ b/apps/integration/src/app/integrations/page-data-manager-split-view/page-data-manager-split-view.component.spec.ts
@@ -1,5 +1,4 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
 import { PageDataManagerSplitViewComponent } from './page-data-manager-split-view.component';
 
@@ -8,9 +7,7 @@ describe('PageDataManagerSplitViewComponent', () => {
   let fixture: ComponentFixture<PageDataManagerSplitViewComponent>;
 
   beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      imports: [NoopAnimationsModule],
-    }).compileComponents();
+    await TestBed.configureTestingModule({}).compileComponents();
 
     fixture = TestBed.createComponent(PageDataManagerSplitViewComponent);
     component = fixture.componentInstance;

--- a/apps/integration/src/app/integrations/toolbar-standard-items/toolbar-standard-items.component.spec.ts
+++ b/apps/integration/src/app/integrations/toolbar-standard-items/toolbar-standard-items.component.spec.ts
@@ -1,5 +1,4 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
 import { ToolbarStandardItemsComponent } from './toolbar-standard-items.component';
 import { ToolbarStandardItemsModule } from './toolbar-standard-items.module';
@@ -21,7 +20,7 @@ describe('Toolbar with standard items', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ToolbarStandardItemsModule, NoopAnimationsModule],
+      imports: [ToolbarStandardItemsModule],
     });
 
     fixture = TestBed.createComponent(ToolbarStandardItemsComponent);

--- a/apps/integration/src/app/integrations/viewkeeper-tabset/viewkeeper-tabset.component.spec.ts
+++ b/apps/integration/src/app/integrations/viewkeeper-tabset/viewkeeper-tabset.component.spec.ts
@@ -1,5 +1,4 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterTestingModule } from '@angular/router/testing';
 
 import { ViewkeeperTabsetComponent } from './viewkeeper-tabset.component';
@@ -29,11 +28,7 @@ describe('Tabset with viewkept elements', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [
-        NoopAnimationsModule,
-        RouterTestingModule,
-        ViewkeeperTabsetModule,
-      ],
+      imports: [RouterTestingModule, ViewkeeperTabsetModule],
     });
 
     fixture = TestBed.createComponent(ViewkeeperTabsetComponent);

--- a/apps/integration/src/main.ts
+++ b/apps/integration/src/main.ts
@@ -4,7 +4,6 @@ import {
 } from '@angular/common/http';
 import { provideZoneChangeDetection } from '@angular/core';
 import { bootstrapApplication } from '@angular/platform-browser';
-import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { provideRouter, withHashLocation } from '@angular/router';
 import { SkyAppAssetsService } from '@skyux/assets';
 import { provideInitialTheme } from '@skyux/theme';
@@ -17,7 +16,6 @@ bootstrapApplication(AppComponent, {
     provideZoneChangeDetection(),
     provideHttpClient(withInterceptorsFromDi()),
     provideInitialTheme('modern'),
-    provideNoopAnimations(),
     provideRouter(routes, withHashLocation()),
     {
       provide: SkyAppAssetsService,

--- a/apps/playground/src/main.ts
+++ b/apps/playground/src/main.ts
@@ -1,6 +1,5 @@
 import { provideZoneChangeDetection } from '@angular/core';
 import { bootstrapApplication } from '@angular/platform-browser';
-import { provideAnimations } from '@angular/platform-browser/animations';
 import {
   provideRouter,
   withComponentInputBinding,
@@ -17,7 +16,6 @@ import { PlaygroundHelpService } from './app/shared/help.service';
 bootstrapApplication(AppComponent, {
   providers: [
     provideZoneChangeDetection(),
-    provideAnimations(),
     provideIconPreview(),
     provideInitialTheme('modern'),
     provideRouter(routes, withHashLocation(), withComponentInputBinding()),

--- a/docs/migrating-deprecated-components/select-field/README.md
+++ b/docs/migrating-deprecated-components/select-field/README.md
@@ -46,7 +46,7 @@
 
 **Required Test Updates:**
 
-- Add `provideNoopAnimations()` to test providers
+- Add `provideNoopSkyAnimations()` (from `@skyux/core`) to test providers
 - Import `SkyLookupModule` + `SkyInputBoxModule` in tests
 - Update single select assertions: `expect(value[0])` instead of `expect(value)`
 
@@ -169,7 +169,7 @@ TestBed.configureTestingModule({
     // ...existing imports
   ],
   providers: [
-    provideNoopAnimations(), // REQUIRED for sky-lookup
+    provideNoopSkyAnimations(), // REQUIRED for sky-lookup
     // ...existing providers
   ],
 });
@@ -491,7 +491,7 @@ imports: [
 
 ```typescript
 TestBed.configureTestingModule({
-  providers: [provideNoopAnimations()], // Required for sky-lookup
+  providers: [provideNoopSkyAnimations()], // Required for sky-lookup
   // ... existing providers
 });
 ```
@@ -546,8 +546,8 @@ expect(component.selectedValues).toEqual(expectedArray);
 
 ### Missing Animation Provider
 
-**Error:** test failure mentions `BrowserAnimationsModule`, `provideAnimations`, `NoopAnimationsModule`, or `provideNoopAnimations`
-**Fix:** Add `provideNoopAnimations()` to test providers
+**Error:** Tests may fail with unexpected timeouts, elements not reaching expected states, or flaky async behavior after migrating to `sky-lookup`.
+**Fix:** Add `provideNoopSkyAnimations()` (from `@skyux/core`) to test providers to suppress CSS animations during tests.
 
 ### Form Control Type Mismatch
 
@@ -675,7 +675,7 @@ TestBed.configureTestingModule({
     SkyLookupModule, // Required for sky-lookup
     // ... other existing imports
   ],
-  providers: [provideNoopAnimations()],
+  providers: [provideNoopSkyAnimations()],
 });
 ```
 
@@ -753,7 +753,7 @@ class MyComponent {
 - [ ] All migrated data bindings use `(observable | async) ?? []`
 - [ ] Form value access updated for migrated single select fields (use `[0]`)
 - [ ] Form initialization uses arrays for migrated single select fields
-- [ ] Tests updated with `provideNoopAnimations()` for sky-lookup
+- [ ] Tests updated with `provideNoopSkyAnimations()` for sky-lookup
 - [ ] Add `SkyInputBoxModule` + `SkyLookupModule` to test imports (avoid CUSTOM_ELEMENTS_SCHEMA errors)
 - [ ] Update label tests to use `SkyInputBoxHarness.getLabelText()` (only for `sky-input-box` cases)
 

--- a/libs/components/action-bars/src/lib/modules/summary-action-bar/fixtures/summary-action-bar-split-view.component.fixture.html
+++ b/libs/components/action-bars/src/lib/modules/summary-action-bar/fixtures/summary-action-bar-split-view.component.fixture.html
@@ -1,7 +1,7 @@
 <sky-split-view-workspace>
   <div class="sky-split-view-workspace-content">Split View Content</div>
-  @if (showBar) {
   <div class="sky-split-view-workspace-footer">
+    @if (showBar) {
     <sky-summary-action-bar id="summary-action-bar">
       <sky-summary-action-bar-actions>
         <sky-summary-action-bar-primary-action>
@@ -59,6 +59,6 @@
         </div>
       </sky-summary-action-bar-summary>
     </sky-summary-action-bar>
+    }
   </div>
-  }
 </sky-split-view-workspace>

--- a/libs/components/action-bars/src/lib/modules/summary-action-bar/fixtures/summary-action-bar.module.fixture.ts
+++ b/libs/components/action-bars/src/lib/modules/summary-action-bar/fixtures/summary-action-bar.module.fixture.ts
@@ -1,6 +1,5 @@
 import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterTestingModule } from '@angular/router/testing';
 import { SkyKeyInfoModule } from '@skyux/indicators';
 import { SkyModalModule } from '@skyux/modals';
@@ -26,7 +25,7 @@ import { SkySummaryActionBarTestComponent } from './summary-action-bar.component
   ],
   imports: [
     BrowserModule,
-    NoopAnimationsModule,
+
     RouterTestingModule,
     SkyKeyInfoModule,
     SkyModalModule,

--- a/libs/components/action-bars/src/lib/modules/summary-action-bar/fixtures/summary-action-bar.module.fixture.ts
+++ b/libs/components/action-bars/src/lib/modules/summary-action-bar/fixtures/summary-action-bar.module.fixture.ts
@@ -25,7 +25,6 @@ import { SkySummaryActionBarTestComponent } from './summary-action-bar.component
   ],
   imports: [
     BrowserModule,
-
     RouterTestingModule,
     SkyKeyInfoModule,
     SkyModalModule,

--- a/libs/components/action-bars/src/lib/modules/summary-action-bar/summary-action-bar-adapter.service.ts
+++ b/libs/components/action-bars/src/lib/modules/summary-action-bar/summary-action-bar-adapter.service.ts
@@ -14,6 +14,8 @@ import { SkySummaryActionBarType } from './types/summary-action-bar-type';
 @Injectable()
 export class SkySummaryActionBarAdapterService {
   #renderer: Renderer2;
+  #splitViewWorkspaceContent: Element | null = null;
+  #splitViewWorkspaceFooter: Element | null = null;
   #windowRef: SkyAppWindowRef;
 
   constructor(rendererFactory: RendererFactory2, windowRef: SkyAppWindowRef) {
@@ -44,10 +46,10 @@ export class SkySummaryActionBarAdapterService {
   public styleSplitViewElementForActionBar(
     summaryActionBarRef: ElementRef,
   ): void {
-    const splitViewWorkspaceContent = document.querySelector(
+    this.#splitViewWorkspaceContent = document.querySelector(
       '.sky-split-view-workspace-content',
     );
-    const splitViewWorkspaceFooter = document.querySelector(
+    this.#splitViewWorkspaceFooter = document.querySelector(
       '.sky-split-view-workspace-footer',
     );
     const actionBarEl = summaryActionBarRef.nativeElement.querySelector(
@@ -56,11 +58,11 @@ export class SkySummaryActionBarAdapterService {
     /* istanbul ignore else */
     if (actionBarEl.style.visibility !== 'hidden') {
       this.#renderer.setStyle(
-        splitViewWorkspaceContent,
+        this.#splitViewWorkspaceContent,
         'padding-bottom',
         '20px',
       );
-      this.#renderer.setStyle(splitViewWorkspaceFooter, 'padding', 0);
+      this.#renderer.setStyle(this.#splitViewWorkspaceFooter, 'padding', 0);
     }
   }
 
@@ -71,17 +73,16 @@ export class SkySummaryActionBarAdapterService {
   }
 
   public revertSplitViewElementStyles(): void {
-    const splitViewWorkspaceContent = document.querySelector(
-      '.sky-split-view-workspace-content',
-    );
-    const splitViewWorkspaceFooter = document.querySelector(
-      '.sky-split-view-workspace-footer',
-    );
-    if (splitViewWorkspaceContent) {
-      this.#renderer.removeStyle(splitViewWorkspaceContent, 'padding-bottom');
+    if (this.#splitViewWorkspaceContent) {
+      this.#renderer.removeStyle(
+        this.#splitViewWorkspaceContent,
+        'padding-bottom',
+      );
+      this.#splitViewWorkspaceContent = null;
     }
-    if (splitViewWorkspaceFooter) {
-      this.#renderer.removeStyle(splitViewWorkspaceFooter, 'padding');
+    if (this.#splitViewWorkspaceFooter) {
+      this.#renderer.removeStyle(this.#splitViewWorkspaceFooter, 'padding');
+      this.#splitViewWorkspaceFooter = null;
     }
   }
 

--- a/libs/components/action-bars/src/lib/modules/summary-action-bar/summary-action-bar-adapter.service.ts
+++ b/libs/components/action-bars/src/lib/modules/summary-action-bar/summary-action-bar-adapter.service.ts
@@ -57,12 +57,17 @@ export class SkySummaryActionBarAdapterService {
     );
     /* istanbul ignore else */
     if (actionBarEl.style.visibility !== 'hidden') {
-      this.#renderer.setStyle(
-        this.#splitViewWorkspaceContent,
-        'padding-bottom',
-        '20px',
-      );
-      this.#renderer.setStyle(this.#splitViewWorkspaceFooter, 'padding', 0);
+      if (this.#splitViewWorkspaceContent) {
+        this.#renderer.setStyle(
+          this.#splitViewWorkspaceContent,
+          'padding-bottom',
+          '20px',
+        );
+      }
+
+      if (this.#splitViewWorkspaceFooter) {
+        this.#renderer.setStyle(this.#splitViewWorkspaceFooter, 'padding', 0);
+      }
     }
   }
 
@@ -80,6 +85,7 @@ export class SkySummaryActionBarAdapterService {
       );
       this.#splitViewWorkspaceContent = null;
     }
+
     if (this.#splitViewWorkspaceFooter) {
       this.#renderer.removeStyle(this.#splitViewWorkspaceFooter, 'padding');
       this.#splitViewWorkspaceFooter = null;

--- a/libs/components/action-bars/testing/src/modules/summary-action-bar/summary-action-bar-harness.spec.ts
+++ b/libs/components/action-bars/testing/src/modules/summary-action-bar/summary-action-bar-harness.spec.ts
@@ -1,7 +1,6 @@
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import {
   SkySummaryActionBarError,
   SkySummaryActionBarModule,
@@ -83,7 +82,7 @@ describe('Summary action harness', () => {
     mediaQuery: SkyMediaQueryTestingController;
   }> {
     TestBed.configureTestingModule({
-      imports: [TestComponent, NoopAnimationsModule],
+      imports: [TestComponent],
       providers: [provideSkyMediaQueryTesting()],
     });
     const fixture = TestBed.createComponent(TestComponent);

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/ag-grid-data-manager-adapter.directive.spec.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/ag-grid-data-manager-adapter.directive.spec.ts
@@ -1,7 +1,6 @@
 import { DebugElement } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { expect } from '@skyux-sdk/testing';
 import {
   SkyMediaQueryTestingController,
@@ -42,11 +41,7 @@ describe('SkyAgGridDataManagerAdapterDirective', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [SkyAgGridDataManagerFixtureComponent],
-      providers: [
-        provideNoopAnimations(),
-        SkyDataManagerService,
-        provideSkyMediaQueryTesting(),
-      ],
+      providers: [SkyDataManagerService, provideSkyMediaQueryTesting()],
     });
 
     agGridDataManagerFixture = TestBed.createComponent(
@@ -749,7 +744,7 @@ describe('SkyAgGridDataManagerAdapterDirective', () => {
 it('should move the horizontal scroll based on enableTopScroll check', async () => {
   TestBed.configureTestingModule({
     imports: [SkyAgGridDataManagerFixtureComponent],
-    providers: [provideNoopAnimations(), SkyDataManagerService],
+    providers: [SkyDataManagerService],
   });
 
   const fixture = TestBed.createComponent(SkyAgGridDataManagerFixtureComponent);
@@ -799,11 +794,7 @@ describe('Read columnOptions from grid API', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [SkyAgGridDataManagerFixtureComponent],
-      providers: [
-        provideNoopAnimations(),
-        SkyDataManagerService,
-        provideSkyMediaQueryTesting(),
-      ],
+      providers: [SkyDataManagerService, provideSkyMediaQueryTesting()],
     });
     fixture = TestBed.createComponent(SkyAgGridDataManagerFixtureComponent);
     dataManagerService = TestBed.inject(SkyDataManagerService);

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/ag-grid-row-delete.directive.spec.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/ag-grid-row-delete.directive.spec.ts
@@ -1,7 +1,6 @@
 import { ElementRef } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { expectAsync } from '@skyux-sdk/testing';
 import {
   SKY_STACKING_CONTEXT,
@@ -24,7 +23,6 @@ describe('SkyAgGridRowDeleteDirective', () => {
     TestBed.configureTestingModule({
       imports: [SkyAgGridRowDeleteFixtureComponent],
       providers: [
-        provideNoopAnimations(),
         {
           provide: SKY_STACKING_CONTEXT,
           useValue: options?.stackingContextZIndex

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/ag-grid-wrapper.component.spec.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/ag-grid-wrapper.component.spec.ts
@@ -4,7 +4,6 @@ import {
   fakeAsync,
   tick,
 } from '@angular/core/testing';
-import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { SkyAppTestUtility, expect, expectAsync } from '@skyux-sdk/testing';
 import {
   SkyTheme,
@@ -70,7 +69,6 @@ describe('SkyAgGridWrapperComponent', () => {
           provide: SkyThemeService,
           useValue: mockThemeSvc,
         },
-        provideNoopAnimations(),
       ],
     });
     gridFixture = TestBed.createComponent(SkyAgGridFixtureComponent);
@@ -572,7 +570,6 @@ describe('SkyAgGridWrapperComponent via fixture', () => {
           provide: SkyThemeService,
           useValue: mockThemeSvc,
         },
-        provideNoopAnimations(),
       ],
     });
   });

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/cell-editors/cell-editor-currency/cell-editor-currency.component.spec.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/cell-editors/cell-editor-currency/cell-editor-currency.component.spec.ts
@@ -4,7 +4,6 @@ import {
   fakeAsync,
   tick,
 } from '@angular/core/testing';
-import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { expect, expectAsync } from '@skyux-sdk/testing';
 
 import {
@@ -36,7 +35,6 @@ describe('SkyCellEditorCurrencyComponent', () => {
     TestBed.configureTestingModule({
       imports: [SkyAgGridMinimalFixtureComponent],
       providers: [
-        provideNoopAnimations(),
         {
           provide: MinimalColumnDefs,
           useValue: [

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/cell-editors/cell-editor-datepicker/cell-editor-datepicker.component.spec.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/cell-editors/cell-editor-datepicker/cell-editor-datepicker.component.spec.ts
@@ -6,7 +6,6 @@ import {
   tick,
 } from '@angular/core/testing';
 import { AbstractControl } from '@angular/forms';
-import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { expect, expectAsync } from '@skyux-sdk/testing';
 import { SkyDatepickerHarness } from '@skyux/datetime/testing';
 import {
@@ -58,7 +57,6 @@ describe('SkyCellEditorDatepickerComponent', () => {
     TestBed.configureTestingModule({
       imports: [SkyAgGridMinimalFixtureComponent],
       providers: [
-        provideNoopAnimations(),
         {
           provide: MinimalColumnDefs,
           useValue: [
@@ -765,7 +763,6 @@ describe('SkyCellEditorDatepickerComponent without theme', () => {
     TestBed.configureTestingModule({
       imports: [SkyAgGridMinimalFixtureComponent],
       providers: [
-        provideNoopAnimations(),
         {
           provide: MinimalColumnDefs,
           useValue: [

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/cell-editors/cell-editor-lookup/cell-editor-lookup.component.spec.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/cell-editors/cell-editor-lookup/cell-editor-lookup.component.spec.ts
@@ -5,7 +5,6 @@ import {
   fakeAsync,
   tick,
 } from '@angular/core/testing';
-import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { SkyAppTestUtility, expect } from '@skyux-sdk/testing';
 import { SkyLookupSelectModeType } from '@skyux/lookup';
 
@@ -45,7 +44,6 @@ describe('SkyAgGridCellEditorLookupComponent', () => {
     };
     TestBed.configureTestingModule({
       providers: [
-        provideNoopAnimations(),
         {
           provide: ElementRef,
           useValue: elementRef,

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/cell-editors/cell-editor-number/cell-editor-number.component.spec.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/cell-editors/cell-editor-number/cell-editor-number.component.spec.ts
@@ -4,7 +4,6 @@ import {
   fakeAsync,
   tick,
 } from '@angular/core/testing';
-import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { expect, expectAsync } from '@skyux-sdk/testing';
 
 import {
@@ -35,7 +34,6 @@ describe('SkyCellEditorNumberComponent', () => {
     TestBed.configureTestingModule({
       imports: [SkyAgGridMinimalFixtureComponent],
       providers: [
-        provideNoopAnimations(),
         {
           provide: MinimalColumnDefs,
           useValue: [

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/cell-editors/cell-editor-text/cell-editor-text.component.spec.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/cell-editors/cell-editor-text/cell-editor-text.component.spec.ts
@@ -4,7 +4,6 @@ import {
   fakeAsync,
   tick,
 } from '@angular/core/testing';
-import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { expect, expectAsync } from '@skyux-sdk/testing';
 
 import {
@@ -36,7 +35,6 @@ describe('SkyCellEditorTextComponent', () => {
     TestBed.configureTestingModule({
       imports: [SkyAgGridMinimalFixtureComponent],
       providers: [
-        provideNoopAnimations(),
         {
           provide: MinimalColumnDefs,
           useValue: [

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/cell-renderers/cell-renderer-currency/cell-renderer-currency-validator.component.spec.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/cell-renderers/cell-renderer-currency/cell-renderer-currency-validator.component.spec.ts
@@ -1,5 +1,4 @@
 import { TestBed } from '@angular/core/testing';
-import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { expect } from '@skyux-sdk/testing';
 
 import { SkyCellRendererCurrencyParams } from '../../types/cell-renderer-currency-params';
@@ -12,9 +11,7 @@ const NOOP = (): void => {
 
 describe('SkyAgGridCellRendererCurrencyValidatorComponent', () => {
   beforeEach(() => {
-    TestBed.configureTestingModule({
-      providers: [provideNoopAnimations()],
-    });
+    TestBed.configureTestingModule({});
   });
 
   it('should create an instance', () => {

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/cell-renderers/cell-renderer-currency/cell-renderer-currency.component.spec.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/cell-renderers/cell-renderer-currency/cell-renderer-currency.component.spec.ts
@@ -4,7 +4,6 @@ import {
   fakeAsync,
   tick,
 } from '@angular/core/testing';
-import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { expect, expectAsync } from '@skyux-sdk/testing';
 import { NumericOptions } from '@skyux/core';
 
@@ -43,7 +42,6 @@ describe('SkyAgGridCellRendererCurrencyComponent', () => {
     TestBed.configureTestingModule({
       imports: [SkyAgGridMinimalFixtureComponent],
       providers: [
-        provideNoopAnimations(),
         {
           provide: MinimalColumnDefs,
           useValue: [

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/cell-renderers/cell-renderer-row-selector/cell-renderer-row-selector.component.spec.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/cell-renderers/cell-renderer-row-selector/cell-renderer-row-selector.component.spec.ts
@@ -1,6 +1,5 @@
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { expect, expectAsync } from '@skyux-sdk/testing';
 import { SkyCheckboxHarness } from '@skyux/forms/testing';
 
@@ -35,7 +34,6 @@ describe('SkyAgGridCellRendererRowSelectorComponent', () => {
     TestBed.configureTestingModule({
       imports: [SkyAgGridMinimalFixtureComponent],
       providers: [
-        provideNoopAnimations(),
         {
           provide: MinimalColumnDefs,
           useValue: [

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/cell-renderers/cell-renderer-validator-tooltip/cell-renderer-validator-tooltip.component.spec.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/cell-renderers/cell-renderer-validator-tooltip/cell-renderer-validator-tooltip.component.spec.ts
@@ -1,5 +1,4 @@
 import { TestBed } from '@angular/core/testing';
-import { provideNoopAnimations } from '@angular/platform-browser/animations';
 
 import { of } from 'rxjs';
 
@@ -13,9 +12,7 @@ const NOOP = (): void => {
 
 describe('SkyAgGridCellRendererValidatorTooltipComponent', () => {
   beforeEach(() => {
-    TestBed.configureTestingModule({
-      providers: [provideNoopAnimations()],
-    });
+    TestBed.configureTestingModule({});
   });
 
   it('should create an instance', () => {

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/cell-validator/ag-grid-cell-validator-tooltip.component.spec.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/cell-validator/ag-grid-cell-validator-tooltip.component.spec.ts
@@ -1,7 +1,6 @@
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { expect } from '@skyux-sdk/testing';
 import { SkyPopoverContentHarness } from '@skyux/popovers/testing';
 
@@ -17,7 +16,6 @@ describe('SkyAgGridCellValidatorTooltipComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [SkyAgGridCellValidatorTooltipFixtureComponent],
-      providers: [provideNoopAnimations()],
     });
     fixture = TestBed.createComponent(
       SkyAgGridCellValidatorTooltipFixtureComponent,

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/column-filters/column-filter-datepicker/column-filter-datepicker.component.spec.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/column-filters/column-filter-datepicker/column-filter-datepicker.component.spec.ts
@@ -1,6 +1,5 @@
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { expectAsync } from '@skyux-sdk/testing';
 import { SkyDatepickerHarness } from '@skyux/datetime/testing';
 
@@ -25,7 +24,6 @@ describe('SkyAgGridDatePickerComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [SkyAgGridColumnFilterDatepickerComponent],
-      providers: [provideNoopAnimations()],
     }).compileComponents();
 
     fixture = TestBed.createComponent(SkyAgGridColumnFilterDatepickerComponent);

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/loading/loading.component.spec.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/loading/loading.component.spec.ts
@@ -1,6 +1,5 @@
 import { TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { provideNoopAnimations } from '@angular/platform-browser/animations';
 
 import { ILoadingOverlayParams } from 'ag-grid-community';
 
@@ -32,7 +31,6 @@ describe('LoadingComponent', () => {
     TestBed.configureTestingModule({
       imports: [SkyAgGridFixtureComponent],
       providers: [
-        provideNoopAnimations(),
         {
           provide: Loading,
           useValue: true,

--- a/libs/components/code-examples/src/lib/modules/data-manager/data-manager/basic/example.component.spec.ts
+++ b/libs/components/code-examples/src/lib/modules/data-manager/data-manager/basic/example.component.spec.ts
@@ -1,7 +1,6 @@
 import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { SkyDataManagerHarness } from '@skyux/data-manager/testing';
 import { SkyRepeaterHarness } from '@skyux/lists/testing';
 
@@ -15,7 +14,6 @@ describe('Data manager basic example', () => {
   }> {
     await TestBed.configureTestingModule({
       imports: [DataManagerBasicExampleComponent],
-      providers: [provideNoopAnimations()],
     }).compileComponents();
 
     const fixture = TestBed.createComponent(DataManagerBasicExampleComponent);

--- a/libs/components/code-examples/src/lib/modules/datetime/date-range-picker/basic/example.component.spec.ts
+++ b/libs/components/code-examples/src/lib/modules/datetime/date-range-picker/basic/example.component.spec.ts
@@ -1,6 +1,5 @@
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { SkyDateRangeCalculatorId } from '@skyux/datetime';
 import { SkyDateRangePickerHarness } from '@skyux/datetime/testing';
 
@@ -28,10 +27,7 @@ describe('Basic date range picker example', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [
-        DatetimeDateRangePickerBasicExampleComponent,
-        NoopAnimationsModule,
-      ],
+      imports: [DatetimeDateRangePickerBasicExampleComponent],
     });
   });
 

--- a/libs/components/code-examples/src/lib/modules/datetime/date-range-picker/help-key/example.component.spec.ts
+++ b/libs/components/code-examples/src/lib/modules/datetime/date-range-picker/help-key/example.component.spec.ts
@@ -1,6 +1,5 @@
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import {
   SkyHelpTestingController,
   SkyHelpTestingModule,
@@ -35,7 +34,7 @@ describe('Basic date range picker example', () => {
     TestBed.configureTestingModule({
       imports: [
         DatetimeDateRangePickerHelpKeyExampleComponent,
-        NoopAnimationsModule,
+
         SkyHelpTestingModule,
       ],
     });

--- a/libs/components/code-examples/src/lib/modules/datetime/date-range-picker/help-key/example.component.spec.ts
+++ b/libs/components/code-examples/src/lib/modules/datetime/date-range-picker/help-key/example.component.spec.ts
@@ -34,7 +34,6 @@ describe('Basic date range picker example', () => {
     TestBed.configureTestingModule({
       imports: [
         DatetimeDateRangePickerHelpKeyExampleComponent,
-
         SkyHelpTestingModule,
       ],
     });

--- a/libs/components/code-examples/src/lib/modules/datetime/datepicker/basic/example.component.spec.ts
+++ b/libs/components/code-examples/src/lib/modules/datetime/datepicker/basic/example.component.spec.ts
@@ -1,6 +1,5 @@
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { SkyDatepickerHarness } from '@skyux/datetime/testing';
 import { SkyInputBoxHarness } from '@skyux/forms/testing';
 
@@ -31,7 +30,7 @@ describe('Basic datepicker example', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [DatetimeDatepickerBasicExampleComponent, NoopAnimationsModule],
+      imports: [DatetimeDatepickerBasicExampleComponent],
     });
   });
 

--- a/libs/components/code-examples/src/lib/modules/datetime/datepicker/fuzzy/example.component.spec.ts
+++ b/libs/components/code-examples/src/lib/modules/datetime/datepicker/fuzzy/example.component.spec.ts
@@ -1,6 +1,5 @@
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { SkyDatepickerHarness } from '@skyux/datetime/testing';
 import { SkyInputBoxHarness } from '@skyux/forms/testing';
 
@@ -31,7 +30,7 @@ describe('Fuzzy datepicker example', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [DatetimeDatepickerFuzzyExampleComponent, NoopAnimationsModule],
+      imports: [DatetimeDatepickerFuzzyExampleComponent],
     });
   });
 

--- a/libs/components/code-examples/src/lib/modules/datetime/timepicker/basic/example.component.spec.ts
+++ b/libs/components/code-examples/src/lib/modules/datetime/timepicker/basic/example.component.spec.ts
@@ -1,6 +1,5 @@
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { SkyTimepickerHarness } from '@skyux/datetime/testing';
 import { SkyInputBoxHarness } from '@skyux/forms/testing';
 
@@ -31,7 +30,7 @@ describe('Basic timepicker example', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [DatetimeTimepickerBasicExampleComponent, NoopAnimationsModule],
+      imports: [DatetimeTimepickerBasicExampleComponent],
     });
   });
 

--- a/libs/components/code-examples/src/lib/modules/forms/checkbox/basic/example.component.spec.ts
+++ b/libs/components/code-examples/src/lib/modules/forms/checkbox/basic/example.component.spec.ts
@@ -1,6 +1,5 @@
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { TestBed } from '@angular/core/testing';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import {
   SkyCheckboxGroupHarness,
   SkyCheckboxHarness,
@@ -45,7 +44,7 @@ describe('Basic checkbox group example', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [NoopAnimationsModule, FormsCheckboxBasicExampleComponent],
+      imports: [FormsCheckboxBasicExampleComponent],
     });
   });
 

--- a/libs/components/code-examples/src/lib/modules/forms/checkbox/help-key/example.component.spec.ts
+++ b/libs/components/code-examples/src/lib/modules/forms/checkbox/help-key/example.component.spec.ts
@@ -1,6 +1,5 @@
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { TestBed } from '@angular/core/testing';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import {
   SkyHelpTestingController,
   SkyHelpTestingModule,
@@ -61,11 +60,7 @@ describe('Basic checkbox group example', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [
-        NoopAnimationsModule,
-        FormsCheckboxHelpKeyExampleComponent,
-        SkyHelpTestingModule,
-      ],
+      imports: [FormsCheckboxHelpKeyExampleComponent, SkyHelpTestingModule],
     });
   });
 

--- a/libs/components/code-examples/src/lib/modules/forms/file-attachment/basic/example.component.spec.ts
+++ b/libs/components/code-examples/src/lib/modules/forms/file-attachment/basic/example.component.spec.ts
@@ -1,6 +1,5 @@
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import {
   SkyFileAttachmentHarness,
   provideSkyFileAttachmentTesting,
@@ -44,7 +43,7 @@ describe('Basic file attachment example', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [FormsFileAttachmentBasicExampleComponent, NoopAnimationsModule],
+      imports: [FormsFileAttachmentBasicExampleComponent],
     });
   });
 

--- a/libs/components/code-examples/src/lib/modules/forms/file-drop/basic/example.component.spec.ts
+++ b/libs/components/code-examples/src/lib/modules/forms/file-drop/basic/example.component.spec.ts
@@ -2,7 +2,6 @@ import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { TestBed } from '@angular/core/testing';
 import { FormControl } from '@angular/forms';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { SkyFileItem, SkyFileLink } from '@skyux/forms';
 import {
   SkyFileDropHarness,
@@ -55,7 +54,7 @@ describe('Basic file drop example', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [FormsFileDropBasicExampleComponent, NoopAnimationsModule],
+      imports: [FormsFileDropBasicExampleComponent],
     });
   });
 

--- a/libs/components/code-examples/src/lib/modules/forms/input-box/basic/example.component.spec.ts
+++ b/libs/components/code-examples/src/lib/modules/forms/input-box/basic/example.component.spec.ts
@@ -1,6 +1,5 @@
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import {
   SkyHelpTestingController,
   SkyHelpTestingModule,
@@ -28,11 +27,7 @@ describe('Basic input box example', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [
-        NoopAnimationsModule,
-        FormsInputBoxBasicExampleComponent,
-        SkyHelpTestingModule,
-      ],
+      imports: [FormsInputBoxBasicExampleComponent, SkyHelpTestingModule],
     });
   });
 

--- a/libs/components/code-examples/src/lib/modules/forms/radio/help-key/example.component.spec.ts
+++ b/libs/components/code-examples/src/lib/modules/forms/radio/help-key/example.component.spec.ts
@@ -1,6 +1,5 @@
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { TestBed } from '@angular/core/testing';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import {
   SkyHelpTestingController,
   SkyHelpTestingModule,
@@ -30,11 +29,7 @@ describe('Basic radio group example', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [
-        NoopAnimationsModule,
-        FormsRadioHelpKeyExampleComponent,
-        SkyHelpTestingModule,
-      ],
+      imports: [FormsRadioHelpKeyExampleComponent, SkyHelpTestingModule],
     });
   });
 

--- a/libs/components/code-examples/src/lib/modules/forms/radio/standard/example.component.spec.ts
+++ b/libs/components/code-examples/src/lib/modules/forms/radio/standard/example.component.spec.ts
@@ -1,6 +1,5 @@
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { TestBed } from '@angular/core/testing';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { SkyRadioGroupHarness } from '@skyux/forms/testing';
 
 import { FormsRadioStandardExampleComponent } from './example.component';
@@ -34,7 +33,7 @@ describe('Basic radio group example', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [NoopAnimationsModule, FormsRadioStandardExampleComponent],
+      imports: [FormsRadioStandardExampleComponent],
     });
   });
 

--- a/libs/components/code-examples/src/lib/modules/forms/selection-box/checkbox/example.component.spec.ts
+++ b/libs/components/code-examples/src/lib/modules/forms/selection-box/checkbox/example.component.spec.ts
@@ -1,6 +1,5 @@
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { TestBed } from '@angular/core/testing';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { SkyIdService } from '@skyux/core';
 import { SkySelectionBoxGridHarness } from '@skyux/forms/testing';
 
@@ -12,7 +11,7 @@ async function setupTest(options: { dataSkyId?: string } = {}): Promise<{
   selectionBoxGridHarness: SkySelectionBoxGridHarness;
 }> {
   await TestBed.configureTestingModule({
-    imports: [FormsSelectionBoxCheckboxExampleComponent, NoopAnimationsModule],
+    imports: [FormsSelectionBoxCheckboxExampleComponent],
   }).compileComponents();
 
   index = 0;

--- a/libs/components/code-examples/src/lib/modules/forms/selection-box/radio/example.component.spec.ts
+++ b/libs/components/code-examples/src/lib/modules/forms/selection-box/radio/example.component.spec.ts
@@ -1,6 +1,5 @@
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { TestBed } from '@angular/core/testing';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { SkyIdService } from '@skyux/core';
 import { SkySelectionBoxGridHarness } from '@skyux/forms/testing';
 
@@ -12,7 +11,7 @@ async function setupTest(options: { dataSkyId?: string } = {}): Promise<{
   selectionBoxGridHarness: SkySelectionBoxGridHarness;
 }> {
   await TestBed.configureTestingModule({
-    imports: [FormsSelectionBoxRadioExampleComponent, NoopAnimationsModule],
+    imports: [FormsSelectionBoxRadioExampleComponent],
   }).compileComponents();
 
   spyOn(TestBed.inject(SkyIdService), 'generateId').and.callFake(

--- a/libs/components/code-examples/src/lib/modules/forms/toggle-switch/basic/example.component.spec.ts
+++ b/libs/components/code-examples/src/lib/modules/forms/toggle-switch/basic/example.component.spec.ts
@@ -1,6 +1,5 @@
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { TestBed } from '@angular/core/testing';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { SkyToggleSwitchHarness } from '@skyux/forms/testing';
 
 import { FormsToggleSwitchBasicExampleComponent } from './example.component';
@@ -27,7 +26,7 @@ describe('Basic toggle switch example', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [NoopAnimationsModule, FormsToggleSwitchBasicExampleComponent],
+      imports: [FormsToggleSwitchBasicExampleComponent],
     });
   });
 

--- a/libs/components/code-examples/src/lib/modules/forms/toggle-switch/help-key/example.component.spec.ts
+++ b/libs/components/code-examples/src/lib/modules/forms/toggle-switch/help-key/example.component.spec.ts
@@ -1,6 +1,5 @@
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { TestBed } from '@angular/core/testing';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import {
   SkyHelpTestingController,
   SkyHelpTestingModule,
@@ -34,11 +33,7 @@ describe('Basic toggle switch example', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [
-        NoopAnimationsModule,
-        FormsToggleSwitchHelpKeyExampleComponent,
-        SkyHelpTestingModule,
-      ],
+      imports: [FormsToggleSwitchHelpKeyExampleComponent, SkyHelpTestingModule],
     });
   });
 

--- a/libs/components/code-examples/src/lib/modules/help-inline/help-key/example.component.spec.ts
+++ b/libs/components/code-examples/src/lib/modules/help-inline/help-key/example.component.spec.ts
@@ -1,6 +1,5 @@
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import {
   SkyHelpTestingController,
   SkyHelpTestingModule,
@@ -31,7 +30,6 @@ describe('Help inline with help key', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [HelpInlineHelpKeyExampleComponent, SkyHelpTestingModule],
-      providers: [provideNoopAnimations()],
     });
   });
 

--- a/libs/components/code-examples/src/lib/modules/help-inline/popover/example.component.spec.ts
+++ b/libs/components/code-examples/src/lib/modules/help-inline/popover/example.component.spec.ts
@@ -1,6 +1,5 @@
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { SkyHelpInlineHarness } from '@skyux/help-inline/testing';
 
 import { HelpInlinePopoverExampleComponent } from './example.component';
@@ -24,7 +23,6 @@ describe('Help inline with popover', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [HelpInlinePopoverExampleComponent],
-      providers: [provideNoopAnimations()],
     });
   });
 

--- a/libs/components/code-examples/src/lib/modules/indicators/key-info/basic/example.component.spec.ts
+++ b/libs/components/code-examples/src/lib/modules/indicators/key-info/basic/example.component.spec.ts
@@ -1,6 +1,5 @@
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { SkyHelpInlineHarness } from '@skyux/help-inline/testing';
 import { SkyKeyInfoHarness } from '@skyux/indicators/testing';
 
@@ -33,7 +32,6 @@ describe('Basic key info', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [IndicatorsKeyInfoBasicExampleComponent],
-      providers: [provideNoopAnimations()],
     });
   });
 

--- a/libs/components/code-examples/src/lib/modules/indicators/key-info/help-key/example.component.spec.ts
+++ b/libs/components/code-examples/src/lib/modules/indicators/key-info/help-key/example.component.spec.ts
@@ -1,6 +1,5 @@
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import {
   SkyHelpTestingController,
   SkyHelpTestingModule,
@@ -39,7 +38,6 @@ describe('Basic key info', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [IndicatorsKeyInfoHelpKeyExampleComponent, SkyHelpTestingModule],
-      providers: [provideNoopAnimations()],
     });
   });
 

--- a/libs/components/code-examples/src/lib/modules/indicators/tokens/basic/example.component.spec.ts
+++ b/libs/components/code-examples/src/lib/modules/indicators/tokens/basic/example.component.spec.ts
@@ -1,6 +1,5 @@
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { SkyToken } from '@skyux/indicators';
 import { SkyTokensHarness } from '@skyux/indicators/testing';
 
@@ -25,7 +24,7 @@ describe('Tokens basic example', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [NoopAnimationsModule, IndicatorsTokensBasicExampleComponent],
+      imports: [IndicatorsTokensBasicExampleComponent],
     });
   });
 

--- a/libs/components/code-examples/src/lib/modules/indicators/tokens/custom/example.component.spec.ts
+++ b/libs/components/code-examples/src/lib/modules/indicators/tokens/custom/example.component.spec.ts
@@ -1,6 +1,5 @@
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { SkyTokensHarness } from '@skyux/indicators/testing';
 
 import { IndicatorsTokensCustomExampleComponent } from './example.component';
@@ -44,7 +43,7 @@ describe('Tokens basic example', () => {
     ];
 
     TestBed.configureTestingModule({
-      imports: [NoopAnimationsModule, IndicatorsTokensCustomExampleComponent],
+      imports: [IndicatorsTokensCustomExampleComponent],
     });
   });
 

--- a/libs/components/code-examples/src/lib/modules/layout/back-to-top/infinite-scroll/example.component.spec.ts
+++ b/libs/components/code-examples/src/lib/modules/layout/back-to-top/infinite-scroll/example.component.spec.ts
@@ -1,6 +1,5 @@
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { TestBed } from '@angular/core/testing';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { SkyAppTestUtility } from '@skyux-sdk/testing';
 import { SkyBackToTopHarness } from '@skyux/layout/testing';
 import { SkyInfiniteScrollHarness } from '@skyux/lists/testing';
@@ -22,10 +21,7 @@ describe('Back to top repeater with infinite scroll example', () => {
 
   it('should set up the component', async () => {
     await TestBed.configureTestingModule({
-      imports: [
-        LayoutBackToTopInfiniteScrollExampleComponent,
-        NoopAnimationsModule,
-      ],
+      imports: [LayoutBackToTopInfiniteScrollExampleComponent],
     }).compileComponents();
 
     const fixture = TestBed.createComponent(

--- a/libs/components/code-examples/src/lib/modules/layout/back-to-top/repeater/example.component.spec.ts
+++ b/libs/components/code-examples/src/lib/modules/layout/back-to-top/repeater/example.component.spec.ts
@@ -1,6 +1,5 @@
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { TestBed } from '@angular/core/testing';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { SkyAppTestUtility } from '@skyux-sdk/testing';
 import { SkyBackToTopHarness } from '@skyux/layout/testing';
 
@@ -21,7 +20,7 @@ describe('Back to top repeater example', () => {
 
   it('should set up the component', async () => {
     await TestBed.configureTestingModule({
-      imports: [LayoutBackToTopRepeaterExampleComponent, NoopAnimationsModule],
+      imports: [LayoutBackToTopRepeaterExampleComponent],
     }).compileComponents();
 
     const fixture = TestBed.createComponent(

--- a/libs/components/code-examples/src/lib/modules/layout/description-list/help-key/example.component.spec.ts
+++ b/libs/components/code-examples/src/lib/modules/layout/description-list/help-key/example.component.spec.ts
@@ -1,6 +1,5 @@
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import {
   SkyHelpTestingController,
   SkyHelpTestingModule,
@@ -19,7 +18,6 @@ describe('Help key description list', () => {
       imports: [
         LayoutDescriptionListHelpKeyExampleComponent,
         SkyHelpTestingModule,
-        NoopAnimationsModule,
       ],
     }).compileComponents();
 

--- a/libs/components/code-examples/src/lib/modules/layout/description-list/horizontal/example.component.spec.ts
+++ b/libs/components/code-examples/src/lib/modules/layout/description-list/horizontal/example.component.spec.ts
@@ -1,6 +1,5 @@
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { SkyHelpTestingModule } from '@skyux/core/testing';
 import { SkyDescriptionListHarness } from '@skyux/layout/testing';
 
@@ -15,7 +14,6 @@ describe('Horizontal description list', () => {
       imports: [
         LayoutDescriptionListHorizontalExampleComponent,
         SkyHelpTestingModule,
-        NoopAnimationsModule,
       ],
     }).compileComponents();
 

--- a/libs/components/code-examples/src/lib/modules/layout/description-list/inline-help/example.component.spec.ts
+++ b/libs/components/code-examples/src/lib/modules/layout/description-list/inline-help/example.component.spec.ts
@@ -1,6 +1,5 @@
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { SkyHelpTestingModule } from '@skyux/core/testing';
 import { SkyDescriptionListHarness } from '@skyux/layout/testing';
 
@@ -15,7 +14,6 @@ describe('Horizontal description list', () => {
       imports: [
         LayoutDescriptionListInlineHelpExampleComponent,
         SkyHelpTestingModule,
-        NoopAnimationsModule,
       ],
     }).compileComponents();
 

--- a/libs/components/code-examples/src/lib/modules/layout/description-list/long-description/example.component.spec.ts
+++ b/libs/components/code-examples/src/lib/modules/layout/description-list/long-description/example.component.spec.ts
@@ -1,6 +1,5 @@
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { SkyHelpTestingModule } from '@skyux/core/testing';
 import { SkyDescriptionListHarness } from '@skyux/layout/testing';
 
@@ -15,7 +14,6 @@ describe('Long description list', () => {
       imports: [
         LayoutDescriptionListLongDescriptionExampleComponent,
         SkyHelpTestingModule,
-        NoopAnimationsModule,
       ],
     }).compileComponents();
 

--- a/libs/components/code-examples/src/lib/modules/layout/description-list/vertical/example.component.spec.ts
+++ b/libs/components/code-examples/src/lib/modules/layout/description-list/vertical/example.component.spec.ts
@@ -1,6 +1,5 @@
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { SkyHelpTestingModule } from '@skyux/core/testing';
 import { SkyDescriptionListHarness } from '@skyux/layout/testing';
 
@@ -15,7 +14,6 @@ describe('Vertical description list', () => {
       imports: [
         LayoutDescriptionListVerticalExampleComponent,
         SkyHelpTestingModule,
-        NoopAnimationsModule,
       ],
     }).compileComponents();
 

--- a/libs/components/code-examples/src/lib/modules/layout/inline-delete/custom/example.component.spec.ts
+++ b/libs/components/code-examples/src/lib/modules/layout/inline-delete/custom/example.component.spec.ts
@@ -1,6 +1,6 @@
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { provideNoopSkyAnimations } from '@skyux/core';
 import { SkyInlineDeleteHarness } from '@skyux/layout/testing';
 
 import { LayoutInlineDeleteCustomExampleComponent } from './example.component';
@@ -11,7 +11,8 @@ describe('Custom component inline delete example', () => {
     fixture: ComponentFixture<LayoutInlineDeleteCustomExampleComponent>;
   }> {
     TestBed.configureTestingModule({
-      imports: [LayoutInlineDeleteCustomExampleComponent, NoopAnimationsModule],
+      imports: [LayoutInlineDeleteCustomExampleComponent],
+      providers: [provideNoopSkyAnimations()],
     });
     const fixture = TestBed.createComponent(
       LayoutInlineDeleteCustomExampleComponent,

--- a/libs/components/code-examples/src/lib/modules/layout/inline-delete/repeater/example.component.spec.ts
+++ b/libs/components/code-examples/src/lib/modules/layout/inline-delete/repeater/example.component.spec.ts
@@ -1,6 +1,6 @@
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { provideNoopSkyAnimations } from '@skyux/core';
 import { SkyInlineDeleteHarness } from '@skyux/layout/testing';
 
 import { LayoutInlineDeleteRepeaterExampleComponent } from './example.component';
@@ -11,10 +11,8 @@ describe('Custom component inline delete example', () => {
     fixture: ComponentFixture<LayoutInlineDeleteRepeaterExampleComponent>;
   }> {
     TestBed.configureTestingModule({
-      imports: [
-        LayoutInlineDeleteRepeaterExampleComponent,
-        NoopAnimationsModule,
-      ],
+      imports: [LayoutInlineDeleteRepeaterExampleComponent],
+      providers: [provideNoopSkyAnimations()],
     });
     const fixture = TestBed.createComponent(
       LayoutInlineDeleteRepeaterExampleComponent,

--- a/libs/components/code-examples/src/lib/modules/lists/filter/inline/example.component.spec.ts
+++ b/libs/components/code-examples/src/lib/modules/lists/filter/inline/example.component.spec.ts
@@ -1,7 +1,6 @@
 import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { SkyCheckboxHarness } from '@skyux/forms/testing';
 import {
   SkyFilterButtonHarness,
@@ -21,7 +20,7 @@ describe('Filter inline example', () => {
     loader: HarnessLoader;
   }> {
     await TestBed.configureTestingModule({
-      imports: [ListsFilterInlineExampleComponent, NoopAnimationsModule],
+      imports: [ListsFilterInlineExampleComponent],
     }).compileComponents();
 
     const fixture = TestBed.createComponent(ListsFilterInlineExampleComponent);

--- a/libs/components/code-examples/src/lib/modules/lists/infinite-scroll/repeater/example.component.spec.ts
+++ b/libs/components/code-examples/src/lib/modules/lists/infinite-scroll/repeater/example.component.spec.ts
@@ -1,6 +1,5 @@
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { TestBed } from '@angular/core/testing';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { SkyInfiniteScrollHarness } from '@skyux/lists/testing';
 
 import { ListsInfiniteScrollRepeaterExampleComponent } from './example.component';
@@ -10,10 +9,7 @@ describe('Infinite scroll example', () => {
     infiniteScrollHarness: SkyInfiniteScrollHarness;
   }> {
     await TestBed.configureTestingModule({
-      imports: [
-        ListsInfiniteScrollRepeaterExampleComponent,
-        NoopAnimationsModule,
-      ],
+      imports: [ListsInfiniteScrollRepeaterExampleComponent],
     }).compileComponents();
 
     const fixture = TestBed.createComponent(

--- a/libs/components/code-examples/src/lib/modules/lists/list-summary/basic/example.component.spec.ts
+++ b/libs/components/code-examples/src/lib/modules/lists/list-summary/basic/example.component.spec.ts
@@ -1,7 +1,6 @@
 import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { expectAsync } from '@skyux-sdk/testing';
 import { SkyListSummaryHarness } from '@skyux/lists/testing';
 
@@ -15,7 +14,6 @@ describe('Lists list summary basic example', () => {
   }> {
     await TestBed.configureTestingModule({
       imports: [ListsListSummaryBasicExampleComponent],
-      providers: [provideNoopAnimations()],
     }).compileComponents();
 
     const fixture = TestBed.createComponent(

--- a/libs/components/code-examples/src/lib/modules/lists/paging/with-content/example.component.spec.ts
+++ b/libs/components/code-examples/src/lib/modules/lists/paging/with-content/example.component.spec.ts
@@ -1,6 +1,5 @@
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { SkyPagingHarness, SkyRepeaterHarness } from '@skyux/lists/testing';
 
 import { ListsPagingWithContentExampleComponent } from './example.component';
@@ -15,7 +14,7 @@ describe('Paging example', () => {
     fixture: ComponentFixture<ListsPagingWithContentExampleComponent>;
   }> {
     await TestBed.configureTestingModule({
-      imports: [ListsPagingWithContentExampleComponent, NoopAnimationsModule],
+      imports: [ListsPagingWithContentExampleComponent],
     }).compileComponents();
 
     const fixture = TestBed.createComponent(

--- a/libs/components/code-examples/src/lib/modules/lists/repeater/inline-form/example.component.spec.ts
+++ b/libs/components/code-examples/src/lib/modules/lists/repeater/inline-form/example.component.spec.ts
@@ -1,6 +1,5 @@
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { SkyRepeaterHarness } from '@skyux/lists/testing';
 
 import { ListsRepeaterInlineFormExampleComponent } from './example.component';
@@ -12,7 +11,7 @@ describe('ListsRepeaterInlineFormExampleComponent', () => {
     repeaterHarness: SkyRepeaterHarness;
   }> {
     await TestBed.configureTestingModule({
-      imports: [ListsRepeaterInlineFormExampleComponent, NoopAnimationsModule],
+      imports: [ListsRepeaterInlineFormExampleComponent],
     }).compileComponents();
 
     const fixture = TestBed.createComponent(

--- a/libs/components/code-examples/src/lib/modules/lists/sort/basic/example.component.spec.ts
+++ b/libs/components/code-examples/src/lib/modules/lists/sort/basic/example.component.spec.ts
@@ -1,6 +1,5 @@
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { SkySortHarness } from '@skyux/lists/testing';
 
 import { ListsSortBasicExampleComponent } from './example.component';
@@ -15,7 +14,7 @@ describe('Sort demo', () => {
     fixture: ComponentFixture<ListsSortBasicExampleComponent>;
   }> {
     await TestBed.configureTestingModule({
-      imports: [ListsSortBasicExampleComponent, NoopAnimationsModule],
+      imports: [ListsSortBasicExampleComponent],
     }).compileComponents();
 
     const fixture = TestBed.createComponent(ListsSortBasicExampleComponent);

--- a/libs/components/code-examples/src/lib/modules/lookup/lookup/add-item/example.component.spec.ts
+++ b/libs/components/code-examples/src/lib/modules/lookup/lookup/add-item/example.component.spec.ts
@@ -1,6 +1,5 @@
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { SkyInputBoxHarness } from '@skyux/forms/testing';
 import { SkyLookupHarness } from '@skyux/lookup/testing';
 
@@ -34,7 +33,7 @@ describe('Lookup asynchronous search example', () => {
     mockSvc = jasmine.createSpyObj<DemoService>('DemoService', ['search']);
 
     TestBed.configureTestingModule({
-      imports: [LookupAddItemExampleComponent, NoopAnimationsModule],
+      imports: [LookupAddItemExampleComponent],
       providers: [
         {
           provide: DemoService,

--- a/libs/components/code-examples/src/lib/modules/lookup/lookup/custom-picker/example.component.spec.ts
+++ b/libs/components/code-examples/src/lib/modules/lookup/lookup/custom-picker/example.component.spec.ts
@@ -1,6 +1,5 @@
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { SkyInputBoxHarness } from '@skyux/forms/testing';
 import { SkyLookupHarness } from '@skyux/lookup/testing';
 
@@ -119,7 +118,7 @@ describe('Lookup custom picker example', () => {
     mockSvc = jasmine.createSpyObj<DemoService>('DemoService', ['search']);
 
     TestBed.configureTestingModule({
-      imports: [LookupCustomPickerExampleComponent, NoopAnimationsModule],
+      imports: [LookupCustomPickerExampleComponent],
       providers: [
         {
           provide: DemoService,

--- a/libs/components/code-examples/src/lib/modules/lookup/lookup/multi-select/example.component.spec.ts
+++ b/libs/components/code-examples/src/lib/modules/lookup/lookup/multi-select/example.component.spec.ts
@@ -1,6 +1,5 @@
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { SkyInputBoxHarness } from '@skyux/forms/testing';
 import { SkyLookupHarness } from '@skyux/lookup/testing';
 
@@ -34,7 +33,7 @@ describe('Lookup multi-select example', () => {
     mockSvc = jasmine.createSpyObj<DemoService>('DemoService', ['search']);
 
     TestBed.configureTestingModule({
-      imports: [LookupMultiSelectExampleComponent, NoopAnimationsModule],
+      imports: [LookupMultiSelectExampleComponent],
       providers: [
         {
           provide: DemoService,

--- a/libs/components/code-examples/src/lib/modules/lookup/lookup/result-templates/example.component.spec.ts
+++ b/libs/components/code-examples/src/lib/modules/lookup/lookup/result-templates/example.component.spec.ts
@@ -1,6 +1,5 @@
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { SkyInputBoxHarness } from '@skyux/forms/testing';
 import { SkyLookupHarness } from '@skyux/lookup/testing';
 
@@ -37,7 +36,7 @@ describe('Lookup result templates example', () => {
     mockSvc = jasmine.createSpyObj<DemoService>('DemoService', ['search']);
 
     TestBed.configureTestingModule({
-      imports: [LookupResultTemplatesExampleComponent, NoopAnimationsModule],
+      imports: [LookupResultTemplatesExampleComponent],
       providers: [
         {
           provide: DemoService,

--- a/libs/components/code-examples/src/lib/modules/lookup/lookup/single-select/example.component.spec.ts
+++ b/libs/components/code-examples/src/lib/modules/lookup/lookup/single-select/example.component.spec.ts
@@ -1,6 +1,5 @@
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { SkyInputBoxHarness } from '@skyux/forms/testing';
 import { SkyLookupHarness } from '@skyux/lookup/testing';
 
@@ -34,7 +33,7 @@ describe('Lookup single-select example', () => {
     mockSvc = jasmine.createSpyObj<DemoService>('DemoService', ['search']);
 
     TestBed.configureTestingModule({
-      imports: [LookupSingleSelectExampleComponent, NoopAnimationsModule],
+      imports: [LookupSingleSelectExampleComponent],
       providers: [
         {
           provide: DemoService,

--- a/libs/components/code-examples/src/lib/modules/lookup/selection-modal/add-item/example.component.spec.ts
+++ b/libs/components/code-examples/src/lib/modules/lookup/selection-modal/add-item/example.component.spec.ts
@@ -1,6 +1,5 @@
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { SkySelectionModalHarness } from '@skyux/lookup/testing';
 
 import { of } from 'rxjs';
@@ -58,10 +57,7 @@ describe('Selection modal example', () => {
     });
 
     TestBed.configureTestingModule({
-      imports: [
-        LookupSelectionModalAddItemExampleComponent,
-        NoopAnimationsModule,
-      ],
+      imports: [LookupSelectionModalAddItemExampleComponent],
       providers: [{ provide: ExampleService, useValue: mockSvc }],
     });
   });

--- a/libs/components/code-examples/src/lib/modules/lookup/selection-modal/basic/example.component.spec.ts
+++ b/libs/components/code-examples/src/lib/modules/lookup/selection-modal/basic/example.component.spec.ts
@@ -1,6 +1,5 @@
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { SkySelectionModalHarness } from '@skyux/lookup/testing';
 
 import { of } from 'rxjs';
@@ -57,10 +56,7 @@ describe('Selection modal example', () => {
     });
 
     TestBed.configureTestingModule({
-      imports: [
-        LookupSelectionModalBasicExampleComponent,
-        NoopAnimationsModule,
-      ],
+      imports: [LookupSelectionModalBasicExampleComponent],
       providers: [{ provide: ExampleService, useValue: mockSvc }],
     });
   });

--- a/libs/components/code-examples/src/lib/modules/modals/modal/basic-with-harness-help-key/example.component.spec.ts
+++ b/libs/components/code-examples/src/lib/modules/modals/modal/basic-with-harness-help-key/example.component.spec.ts
@@ -45,7 +45,6 @@ describe('Basic modal', () => {
     TestBed.configureTestingModule({
       imports: [
         ModalsModalBasicWithHarnessHelpKeyExampleComponent,
-
         SkyHelpTestingModule,
       ],
       providers: [

--- a/libs/components/code-examples/src/lib/modules/modals/modal/basic-with-harness-help-key/example.component.spec.ts
+++ b/libs/components/code-examples/src/lib/modules/modals/modal/basic-with-harness-help-key/example.component.spec.ts
@@ -1,6 +1,5 @@
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import {
   SkyHelpTestingController,
   SkyHelpTestingModule,
@@ -46,7 +45,7 @@ describe('Basic modal', () => {
     TestBed.configureTestingModule({
       imports: [
         ModalsModalBasicWithHarnessHelpKeyExampleComponent,
-        NoopAnimationsModule,
+
         SkyHelpTestingModule,
       ],
       providers: [

--- a/libs/components/code-examples/src/lib/modules/modals/modal/basic-with-harness/example.component.spec.ts
+++ b/libs/components/code-examples/src/lib/modules/modals/modal/basic-with-harness/example.component.spec.ts
@@ -1,6 +1,5 @@
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { SkyWaitService } from '@skyux/indicators';
 import { SkyModalHarness } from '@skyux/modals/testing';
 
@@ -38,10 +37,7 @@ describe('Basic modal', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [
-        ModalsModalBasicWithHarnessExampleComponent,
-        NoopAnimationsModule,
-      ],
+      imports: [ModalsModalBasicWithHarnessExampleComponent],
       providers: [
         {
           provide: SkyWaitService,

--- a/libs/components/code-examples/src/lib/modules/pages/action-hub/settings-modal.component.spec.ts
+++ b/libs/components/code-examples/src/lib/modules/pages/action-hub/settings-modal.component.spec.ts
@@ -1,7 +1,6 @@
 import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { SkyModalHarness } from '@skyux/modals/testing';
 import { SkyActionHubHarness } from '@skyux/pages/testing';
 
@@ -29,7 +28,7 @@ describe('SettingsModalComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [PagesActionHubExampleComponent, NoopAnimationsModule],
+      imports: [PagesActionHubExampleComponent],
       providers: [
         {
           provide: MODAL_TITLE,

--- a/libs/components/code-examples/src/lib/modules/pages/page/data-manager-split-view-fit-layout/example.component.spec.ts
+++ b/libs/components/code-examples/src/lib/modules/pages/page/data-manager-split-view-fit-layout/example.component.spec.ts
@@ -1,7 +1,6 @@
 import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { SkyDataManagerHarness } from '@skyux/data-manager/testing';
 import { SkyInputBoxHarness } from '@skyux/forms/testing';
 import { SkyRepeaterHarness } from '@skyux/lists/testing';
@@ -18,7 +17,6 @@ describe('Data manager with split view in a fit layout page example', () => {
   }> {
     await TestBed.configureTestingModule({
       imports: [PagesPageDataManagerSplitViewFitLayoutExampleComponent],
-      providers: [provideNoopAnimations()],
     }).compileComponents();
 
     const fixture = TestBed.createComponent(

--- a/libs/components/code-examples/src/lib/modules/pages/page/home-page-blocks-layout-demo/example.component.spec.ts
+++ b/libs/components/code-examples/src/lib/modules/pages/page/home-page-blocks-layout-demo/example.component.spec.ts
@@ -1,6 +1,5 @@
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { provideRouter } from '@angular/router';
 import { SkyHelpTestingModule } from '@skyux/core/testing';
 import { SkyPageHarness } from '@skyux/pages/testing';
@@ -27,7 +26,6 @@ describe('Record page blocks layout example', () => {
       imports: [
         PagesPageHomePageBlocksLayoutExampleComponent,
         SkyHelpTestingModule,
-        NoopAnimationsModule,
       ],
       providers: [provideRouter([])],
     });

--- a/libs/components/code-examples/src/lib/modules/pages/page/list-page-list-layout-demo/example.component.spec.ts
+++ b/libs/components/code-examples/src/lib/modules/pages/page/list-page-list-layout-demo/example.component.spec.ts
@@ -1,6 +1,5 @@
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import {
   SkyHelpTestingController,
   SkyHelpTestingModule,
@@ -31,7 +30,6 @@ describe('List page list layout example', () => {
       imports: [
         PagesPageListPageListLayoutExampleComponent,
         SkyHelpTestingModule,
-        NoopAnimationsModule,
       ],
     });
   });

--- a/libs/components/code-examples/src/lib/modules/pages/page/list-page-tabs-layout-demo/example.component.spec.ts
+++ b/libs/components/code-examples/src/lib/modules/pages/page/list-page-tabs-layout-demo/example.component.spec.ts
@@ -1,6 +1,5 @@
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { provideRouter } from '@angular/router';
 import {
   SkyHelpTestingController,
@@ -32,7 +31,6 @@ describe('List page tabs layout example', () => {
       imports: [
         PagesPageListPageTabsLayoutExampleComponent,
         SkyHelpTestingModule,
-        NoopAnimationsModule,
       ],
       providers: [provideRouter([])],
     });

--- a/libs/components/code-examples/src/lib/modules/pages/page/record-page-blocks-layout-demo/example.component.spec.ts
+++ b/libs/components/code-examples/src/lib/modules/pages/page/record-page-blocks-layout-demo/example.component.spec.ts
@@ -1,6 +1,5 @@
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { provideRouter } from '@angular/router';
 import {
   SkyHelpTestingController,
@@ -32,7 +31,6 @@ describe('Record page blocks layout example', () => {
       imports: [
         PagesPageRecordPageBlocksLayoutExampleComponent,
         SkyHelpTestingModule,
-        NoopAnimationsModule,
       ],
       providers: [provideRouter([])],
     });

--- a/libs/components/code-examples/src/lib/modules/pages/page/record-page-tabs-layout-demo/example.component.spec.ts
+++ b/libs/components/code-examples/src/lib/modules/pages/page/record-page-tabs-layout-demo/example.component.spec.ts
@@ -1,6 +1,5 @@
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { provideRouter } from '@angular/router';
 import {
   SkyHelpTestingController,
@@ -32,7 +31,6 @@ describe('Record page tabs layout example', () => {
       imports: [
         PagesPageRecordPageTabsLayoutExampleComponent,
         SkyHelpTestingModule,
-        NoopAnimationsModule,
       ],
       providers: [provideRouter([])],
     });

--- a/libs/components/code-examples/src/lib/modules/pages/page/split-view-page-fit-layout-demo/example.component.spec.ts
+++ b/libs/components/code-examples/src/lib/modules/pages/page/split-view-page-fit-layout-demo/example.component.spec.ts
@@ -1,6 +1,5 @@
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { provideRouter } from '@angular/router';
 import {
   SkyHelpTestingController,
@@ -32,7 +31,6 @@ describe('Split view page fit layout example', () => {
       imports: [
         PagesPageSplitViewPageFitLayoutExampleComponent,
         SkyHelpTestingModule,
-        NoopAnimationsModule,
       ],
       providers: [provideRouter([])],
     });

--- a/libs/components/code-examples/src/lib/modules/phone-field/phone-field/basic/example.component.spec.ts
+++ b/libs/components/code-examples/src/lib/modules/phone-field/phone-field/basic/example.component.spec.ts
@@ -1,6 +1,5 @@
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { SkyInputBoxHarness } from '@skyux/forms/testing';
 import { SkyPhoneFieldCountry } from '@skyux/phone-field';
 import { SkyPhoneFieldHarness } from '@skyux/phone-field/testing';
@@ -39,7 +38,7 @@ describe('Basic phone field example', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [PhoneFieldBasicExampleComponent, NoopAnimationsModule],
+      imports: [PhoneFieldBasicExampleComponent],
     });
   });
 

--- a/libs/components/code-examples/src/lib/modules/tabs/wizard/basic/modal.component.spec.ts
+++ b/libs/components/code-examples/src/lib/modules/tabs/wizard/basic/modal.component.spec.ts
@@ -1,7 +1,6 @@
 import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { provideRouter } from '@angular/router';
 import { provideNoopSkyAnimations } from '@skyux/core';
 import { SkyInputBoxHarness } from '@skyux/forms/testing';
@@ -25,7 +24,7 @@ describe('Wizard tabset demo', () => {
         provideRouter([]),
         SkyModalInstance,
       ],
-      imports: [ModalComponent, NoopAnimationsModule],
+      imports: [ModalComponent],
     }).compileComponents();
 
     const fixture = TestBed.createComponent(ModalComponent);

--- a/libs/components/colorpicker/src/lib/modules/colorpicker/fixtures/colorpicker-fixtures.module.ts
+++ b/libs/components/colorpicker/src/lib/modules/colorpicker/fixtures/colorpicker-fixtures.module.ts
@@ -1,6 +1,5 @@
 import { NgModule } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { SkyHelpTestingModule } from '@skyux/core/testing';
 import { SkyInputBoxModule } from '@skyux/forms';
 
@@ -17,7 +16,6 @@ import { ColorpickerReactiveTestComponent } from './colorpicker-reactive-compone
     SkyColorpickerModule,
     SkyHelpTestingModule,
     SkyInputBoxModule,
-    NoopAnimationsModule,
   ],
 })
 export class SkyColorpickerFixturesModule {}

--- a/libs/components/colorpicker/testing/src/modules/colorpicker/colorpicker-harness.spec.ts
+++ b/libs/components/colorpicker/testing/src/modules/colorpicker/colorpicker-harness.spec.ts
@@ -117,7 +117,6 @@ describe('Colorpicker harness', () => {
       imports: [
         SkyColorpickerModule,
         SkyFormErrorModule,
-
         FormsModule,
         ReactiveFormsModule,
       ],

--- a/libs/components/colorpicker/testing/src/modules/colorpicker/colorpicker-harness.spec.ts
+++ b/libs/components/colorpicker/testing/src/modules/colorpicker/colorpicker-harness.spec.ts
@@ -10,7 +10,6 @@ import {
   ReactiveFormsModule,
   Validators,
 } from '@angular/forms';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { SkyColorpickerModule } from '@skyux/colorpicker';
 import { SkyFormErrorModule } from '@skyux/forms';
 import {
@@ -118,7 +117,7 @@ describe('Colorpicker harness', () => {
       imports: [
         SkyColorpickerModule,
         SkyFormErrorModule,
-        NoopAnimationsModule,
+
         FormsModule,
         ReactiveFormsModule,
       ],

--- a/libs/components/core/src/index.ts
+++ b/libs/components/core/src/index.ts
@@ -15,6 +15,7 @@ export { SkyAffixModule } from './lib/modules/affix/affix.module';
 export { SkyAffixService } from './lib/modules/affix/affix.service';
 export { SkyAffixer } from './lib/modules/affix/affixer';
 
+export { _SkyAnimationEndHandlerDirective } from './lib/modules/animations/shared/animation-handler';
 export { _SkyTransitionEndHandlerDirective } from './lib/modules/animations/shared/transition-handler';
 export { _SkyAnimationSlideComponent } from './lib/modules/animations/slide/slide';
 export { provideNoopSkyAnimations } from './lib/modules/animations/utility/provide-noop-animations';

--- a/libs/components/core/src/lib/modules/animations/shared/animation-handler.spec.ts
+++ b/libs/components/core/src/lib/modules/animations/shared/animation-handler.spec.ts
@@ -7,7 +7,7 @@ import { _SkyAnimationEndHandlerDirective } from './animation-handler';
   hostDirectives: [
     {
       directive: _SkyAnimationEndHandlerDirective,
-      inputs: ['animationTrigger: trigger'],
+      inputs: ['animationTrigger: trigger', 'emitOnAnimateEnter'],
       outputs: ['animationEnd'],
     },
   ],
@@ -195,6 +195,33 @@ describe('SkyAnimationEndHandler', () => {
       await fixture.whenStable();
 
       expect(animationEndEmitted).toBeFalse();
+    });
+
+    it('should emit on initial render when emitOnAnimateEnter is true', async () => {
+      TestBed.configureTestingModule({
+        imports: [TestComponent],
+      });
+
+      const fixture = TestBed.createComponent(TestComponent);
+      fixture.componentRef.setInput('trigger', signal(true));
+      fixture.componentRef.setInput('emitOnAnimateEnter', true);
+      fixture.detectChanges();
+
+      let animationEndEmitted = false;
+
+      const handler = fixture.debugElement.injector.get(
+        _SkyAnimationEndHandlerDirective,
+      );
+
+      handler.animationEnd.subscribe(() => {
+        animationEndEmitted = true;
+      });
+
+      fixture.detectChanges();
+
+      await fixture.whenStable();
+
+      expect(animationEndEmitted).toBeTrue();
     });
   });
 

--- a/libs/components/core/src/lib/modules/animations/shared/animation-handler.ts
+++ b/libs/components/core/src/lib/modules/animations/shared/animation-handler.ts
@@ -2,6 +2,7 @@ import {
   DestroyRef,
   Directive,
   ElementRef,
+  booleanAttribute,
   inject,
   input,
   output,
@@ -26,6 +27,16 @@ import { watchForDisabledCssAnimations } from './utils';
 })
 export class _SkyAnimationEndHandlerDirective {
   /**
+   * When `true` and the host element uses `animate.enter`, the
+   * disabled-animation fallback emits `animationEnd` on the initial
+   * render. Use this when the element's insertion into the DOM is
+   * the animation event.
+   */
+  public readonly emitOnAnimateEnter = input(false, {
+    transform: booleanAttribute,
+  });
+
+  /**
    * Drives animation lifecycle tracking on the host element. When the
    * value changes and the CSS animation is disabled, `animationEnd`
    * emits via a microtask.
@@ -42,6 +53,7 @@ export class _SkyAnimationEndHandlerDirective {
     watchForDisabledCssAnimations({
       destroyRef: inject(DestroyRef),
       elementRef: inject(ElementRef),
+      emitOnAnimateEnter: this.emitOnAnimateEnter,
       emitter: this.animationEnd,
       trigger: this.animationTrigger,
     });

--- a/libs/components/core/src/lib/modules/animations/shared/utils.ts
+++ b/libs/components/core/src/lib/modules/animations/shared/utils.ts
@@ -14,6 +14,9 @@ interface WatchMotionArgs {
   /** A reference to the host element whose computed styles are inspected. */
   elementRef: ElementRef<Element>;
 
+  /** When `true`, the disabled-animation fallback fires on the first effect run instead of skipping it. */
+  emitOnAnimateEnter?: Signal<boolean>;
+
   /** The output emitter to call when CSS motion is disabled. */
   emitter: OutputEmitterRef<void>;
 
@@ -79,7 +82,7 @@ function emitWhenMotionDisabled(
   args: WatchMotionArgs,
   isMotionDisabled: (style: CSSStyleDeclaration) => boolean,
 ): void {
-  const { destroyRef, elementRef, emitter, trigger } = args;
+  const { destroyRef, elementRef, emitOnAnimateEnter, emitter, trigger } = args;
   const el = elementRef.nativeElement;
 
   let destroyed = false;
@@ -91,6 +94,11 @@ function emitWhenMotionDisabled(
 
   effect(() => {
     trigger();
+
+    // On the first run, check if emitOnAnimateEnter opts out of skipping.
+    if (!initialized && emitOnAnimateEnter) {
+      initialized = untracked(() => emitOnAnimateEnter());
+    }
 
     const style = getComputedStyle(el);
     const isRendered = style.display !== 'none';

--- a/libs/components/core/src/lib/modules/animations/shared/utils.ts
+++ b/libs/components/core/src/lib/modules/animations/shared/utils.ts
@@ -75,8 +75,10 @@ export function watchForDisabledCssTransitions(
 
 /**
  * Creates an effect that watches a trigger signal and emits via a microtask
- * when the host element's CSS motion is disabled. Skips the initial effect
- * run and unrendered elements to match native CSS behavior.
+ * when the host element's CSS motion is disabled. By default, skips the
+ * initial effect run to match native CSS behavior. When `emitOnAnimateEnter`
+ * is `true`, the first run is not skipped, allowing emission for elements
+ * that use `animate.enter` (where DOM insertion is the animation event).
  */
 function emitWhenMotionDisabled(
   args: WatchMotionArgs,
@@ -103,8 +105,9 @@ function emitWhenMotionDisabled(
     const style = getComputedStyle(el);
     const isRendered = style.display !== 'none';
 
-    // Skip the first effect run (and unrendered elements) to match native CSS behavior.
-    // Motion events only fire on rendered elements when a property value changes.
+    // By default, skip the first effect run (and unrendered elements) to match
+    // native CSS behavior. When emitOnAnimateEnter is true, the first run is
+    // treated as initialized, allowing emission for enter animations.
     if (initialized && isRendered && untracked(() => isMotionDisabled(style))) {
       // Defer the emit to a microtask so it fires after the current
       // change detection pass, matching real transition timing.

--- a/libs/components/core/testing/src/modules/media-query/media-query-testing.controller.spec.ts
+++ b/libs/components/core/testing/src/modules/media-query/media-query-testing.controller.spec.ts
@@ -1,6 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { provideRouter } from '@angular/router';
 import {
   SkyBreakpoint,
@@ -35,7 +34,7 @@ describe('media-query-testing.controller', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [TestComponent, NoopAnimationsModule],
+      imports: [TestComponent],
       providers: [provideSkyMediaQueryTesting(), provideRouter([])],
     });
   });

--- a/libs/components/data-manager/src/lib/modules/data-manager/fixtures/data-manager.module.fixture.ts
+++ b/libs/components/data-manager/src/lib/modules/data-manager/fixtures/data-manager.module.fixture.ts
@@ -1,5 +1,4 @@
 import { NgModule } from '@angular/core';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { SkyCardModule, SkyToolbarModule } from '@skyux/layout';
 import { SkyRepeaterModule } from '@skyux/lists';
 import { SkyThemeService } from '@skyux/theme';
@@ -12,7 +11,6 @@ import { DataViewRepeaterFixtureComponent } from './data-manager-repeater-view.c
 import { DataManagerFixtureComponent } from './data-manager.component.fixture';
 
 @NgModule({
-  imports: [NoopAnimationsModule],
   declarations: [
     DataViewCardFixtureComponent,
     DataViewRepeaterFixtureComponent,

--- a/libs/components/data-manager/testing/src/modules/data-manager/data-manager-harness.spec.ts
+++ b/libs/components/data-manager/testing/src/modules/data-manager/data-manager-harness.spec.ts
@@ -1,6 +1,5 @@
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
 import { SkyDataManagerColumnPickerHarness } from './data-manager-column-picker-harness';
 import { SkyDataManagerHarness } from './data-manager-harness';
@@ -13,7 +12,7 @@ describe('Data manager harness', () => {
     fixture: ComponentFixture<DataManagerHarnessTestComponent>;
   }> {
     await TestBed.configureTestingModule({
-      imports: [DataManagerHarnessTestComponent, NoopAnimationsModule],
+      imports: [DataManagerHarnessTestComponent],
     }).compileComponents();
 
     const fixture = TestBed.createComponent(DataManagerHarnessTestComponent);

--- a/libs/components/datetime/src/lib/modules/datepicker/fixtures/datepicker.module.fixture.ts
+++ b/libs/components/datetime/src/lib/modules/datepicker/fixtures/datepicker.module.fixture.ts
@@ -1,6 +1,5 @@
 import { NgModule } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { SkyInputBoxModule } from '@skyux/forms';
 import { SkyThemeModule } from '@skyux/theme';
 
@@ -22,7 +21,7 @@ import { DatepickerTestComponent } from './datepicker.component.fixture';
   ],
   imports: [
     SkyDatepickerModule,
-    NoopAnimationsModule,
+
     FormsModule,
     ReactiveFormsModule,
     SkyInputBoxModule,

--- a/libs/components/datetime/src/lib/modules/datepicker/fixtures/datepicker.module.fixture.ts
+++ b/libs/components/datetime/src/lib/modules/datepicker/fixtures/datepicker.module.fixture.ts
@@ -21,7 +21,6 @@ import { DatepickerTestComponent } from './datepicker.component.fixture';
   ],
   imports: [
     SkyDatepickerModule,
-
     FormsModule,
     ReactiveFormsModule,
     SkyInputBoxModule,

--- a/libs/components/datetime/src/lib/modules/datepicker/fixtures/fuzzy-datepicker.module.fixture.ts
+++ b/libs/components/datetime/src/lib/modules/datepicker/fixtures/fuzzy-datepicker.module.fixture.ts
@@ -1,6 +1,5 @@
 import { NgModule } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
 import { SkyDatepickerModule } from '../datepicker.module';
 import { FuzzyDatepickerNoFormatTestComponent } from '../fuzzy/fixtures/fuzzy-datepicker-no-format.component.fixture';
@@ -14,12 +13,7 @@ import { SkyFuzzyDateService } from '../fuzzy/fuzzy-date.service';
     FuzzyDatepickerReactiveTestComponent,
     FuzzyDatepickerTestComponent,
   ],
-  imports: [
-    SkyDatepickerModule,
-    NoopAnimationsModule,
-    FormsModule,
-    ReactiveFormsModule,
-  ],
+  imports: [SkyDatepickerModule, FormsModule, ReactiveFormsModule],
   providers: [SkyFuzzyDateService],
   exports: [
     FuzzyDatepickerNoFormatTestComponent,

--- a/libs/components/datetime/src/lib/modules/datepicker/fuzzy/fixtures/fuzzy-datepicker.module.fixture.ts
+++ b/libs/components/datetime/src/lib/modules/datepicker/fuzzy/fixtures/fuzzy-datepicker.module.fixture.ts
@@ -1,6 +1,5 @@
 import { NgModule } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
 import { SkyDatepickerModule } from '../../datepicker.module';
 import { SkyFuzzyDateService } from '../fuzzy-date.service';
@@ -15,12 +14,7 @@ import { FuzzyDatepickerTestComponent } from './fuzzy-datepicker.component.fixtu
     FuzzyDatepickerReactiveTestComponent,
     FuzzyDatepickerTestComponent,
   ],
-  imports: [
-    SkyDatepickerModule,
-    NoopAnimationsModule,
-    FormsModule,
-    ReactiveFormsModule,
-  ],
+  imports: [SkyDatepickerModule, FormsModule, ReactiveFormsModule],
   providers: [SkyFuzzyDateService],
   exports: [
     FuzzyDatepickerNoFormatTestComponent,

--- a/libs/components/datetime/src/lib/modules/timepicker/timepicker.component.spec.ts
+++ b/libs/components/datetime/src/lib/modules/timepicker/timepicker.component.spec.ts
@@ -12,7 +12,6 @@ import {
   Validators,
 } from '@angular/forms';
 import { By } from '@angular/platform-browser';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { SkyAppTestUtility, expect, expectAsync } from '@skyux-sdk/testing';
 import { SKY_STACKING_CONTEXT } from '@skyux/core';
 import { SkyInputBoxModule } from '@skyux/forms';
@@ -172,7 +171,7 @@ describe('Timepicker', () => {
     beforeEach(() => {
       TestBed.configureTestingModule({
         declarations: [TimepickerTestComponent],
-        imports: [SkyTimepickerModule, NoopAnimationsModule, FormsModule],
+        imports: [SkyTimepickerModule, FormsModule],
         providers: [
           {
             provide: SkyThemeService,
@@ -554,7 +553,7 @@ describe('Timepicker', () => {
       TestBed.configureTestingModule({
         declarations: [TimepickerTestComponent],
         providers: [NgModel],
-        imports: [SkyTimepickerModule, NoopAnimationsModule, FormsModule],
+        imports: [SkyTimepickerModule, FormsModule],
       });
 
       fixture = TestBed.createComponent(TimepickerTestComponent);
@@ -687,12 +686,7 @@ describe('Timepicker', () => {
     beforeEach(() => {
       TestBed.configureTestingModule({
         declarations: [TimepickerReactiveTestComponent],
-        imports: [
-          SkyTimepickerModule,
-          NoopAnimationsModule,
-          FormsModule,
-          ReactiveFormsModule,
-        ],
+        imports: [SkyTimepickerModule, FormsModule, ReactiveFormsModule],
       });
 
       fixture = TestBed.createComponent(TimepickerReactiveTestComponent);

--- a/libs/components/datetime/testing/src/modules/date-range-picker/date-range-picker-harness.spec.ts
+++ b/libs/components/datetime/testing/src/modules/date-range-picker/date-range-picker-harness.spec.ts
@@ -7,7 +7,6 @@ import {
   FormsModule,
   ReactiveFormsModule,
 } from '@angular/forms';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import {
   SkyDateRangeCalculation,
   SkyDateRangeCalculator,
@@ -105,12 +104,7 @@ describe('Date range picker harness', () => {
   }> {
     await TestBed.configureTestingModule({
       declarations: [TestComponent],
-      imports: [
-        FormsModule,
-        ReactiveFormsModule,
-        SkyDateRangePickerModule,
-        NoopAnimationsModule,
-      ],
+      imports: [FormsModule, ReactiveFormsModule, SkyDateRangePickerModule],
     }).compileComponents();
 
     const fixture = TestBed.createComponent(TestComponent);

--- a/libs/components/datetime/testing/src/modules/datepicker/datepicker-harness.spec.ts
+++ b/libs/components/datetime/testing/src/modules/datepicker/datepicker-harness.spec.ts
@@ -8,7 +8,6 @@ import {
   FormsModule,
   ReactiveFormsModule,
 } from '@angular/forms';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { SkyDatepickerModule } from '@skyux/datetime';
 import { SkyInputBoxModule } from '@skyux/forms';
 import { SkyInputBoxHarness } from '@skyux/forms/testing';
@@ -71,7 +70,6 @@ describe('Datepicker harness', () => {
         ReactiveFormsModule,
         SkyDatepickerModule,
         SkyInputBoxModule,
-        NoopAnimationsModule,
       ],
     }).compileComponents();
 

--- a/libs/components/datetime/testing/src/modules/timepicker/timepicker-harness.spec.ts
+++ b/libs/components/datetime/testing/src/modules/timepicker/timepicker-harness.spec.ts
@@ -8,7 +8,6 @@ import {
   FormsModule,
   ReactiveFormsModule,
 } from '@angular/forms';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { SkyTimepickerModule } from '@skyux/datetime';
 import { SkyInputBoxModule } from '@skyux/forms';
 import { SkyInputBoxHarness } from '@skyux/forms/testing';
@@ -66,7 +65,6 @@ describe('Timepicker harness', () => {
         ReactiveFormsModule,
         SkyTimepickerModule,
         SkyInputBoxModule,
-        NoopAnimationsModule,
       ],
     }).compileComponents();
 

--- a/libs/components/docs-tools/src/lib/modules/code-example-viewer/stackblitz.service.spec.ts
+++ b/libs/components/docs-tools/src/lib/modules/code-example-viewer/stackblitz.service.spec.ts
@@ -353,7 +353,6 @@ import {
   makeEnvironmentProviders,
 } from '@angular/core';
 import { bootstrapApplication } from '@angular/platform-browser';
-import { provideAnimations } from '@angular/platform-browser/animations';
 import { SkyHelpService } from '@skyux/core';
 import { provideInitialTheme } from '@skyux/theme';
 import { provideRouter } from '@angular/router';
@@ -375,7 +374,6 @@ function provideExampleHelpService(): EnvironmentProviders {
 
 bootstrapApplication(FooExampleComponent, {
   providers: [
-    provideAnimations(),
     provideInitialTheme('modern'),
     provideHttpClient(),
     provideExampleHelpService(),

--- a/libs/components/docs-tools/src/lib/modules/code-example-viewer/stackblitz.service.ts
+++ b/libs/components/docs-tools/src/lib/modules/code-example-viewer/stackblitz.service.ts
@@ -313,7 +313,6 @@ import {
   makeEnvironmentProviders,
 } from '@angular/core';
 import { bootstrapApplication } from '@angular/platform-browser';
-import { provideAnimations } from '@angular/platform-browser/animations';
 import { SkyHelpService } from '@skyux/core';
 import { provideInitialTheme } from '@skyux/theme';
 import { provideRouter } from '@angular/router';
@@ -335,7 +334,6 @@ function provideExampleHelpService(): EnvironmentProviders {
 
 bootstrapApplication(${config.componentName}, {
   providers: [
-    provideAnimations(),
     provideInitialTheme('modern'),
     provideHttpClient(),
     provideExampleHelpService(),

--- a/libs/components/docs-tools/src/lib/modules/code-snippet/code-snippet-wrapper.component.spec.ts
+++ b/libs/components/docs-tools/src/lib/modules/code-snippet/code-snippet-wrapper.component.spec.ts
@@ -1,6 +1,5 @@
 import { Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { provideNoopAnimations } from '@angular/platform-browser/animations';
 
 import { SkyDocsCodeSnippetWrapperComponent } from './code-snippet-wrapper.component';
 
@@ -49,7 +48,6 @@ describe('SkyDocsCodeSnippetWrapperComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [TestComponent],
-      providers: [provideNoopAnimations()],
     });
   });
 
@@ -158,9 +156,7 @@ describe('SkyDocsCodeSnippetWrapperComponent', () => {
 
   it('should transform boolean string attributes correctly', () => {
     TestBed.resetTestingModule();
-    TestBed.configureTestingModule({
-      providers: [provideNoopAnimations()],
-    });
+    TestBed.configureTestingModule({});
 
     @Component({
       template: `

--- a/libs/components/filter-bar/src/lib/modules/filter-bar/filter-bar.component.spec.ts
+++ b/libs/components/filter-bar/src/lib/modules/filter-bar/filter-bar.component.spec.ts
@@ -1,6 +1,5 @@
 import { StaticProvider } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { SkyFilterState, SkyFilterStateService } from '@skyux/lists';
 import {
   SkySelectionModalInstance,
@@ -67,7 +66,6 @@ describe('Filter bar component', () => {
     );
 
     const providers: StaticProvider[] = [
-      provideNoopAnimations(),
       { provide: SkyConfirmService, useValue: confirmServiceSpy },
       {
         provide: SkySelectionModalService,
@@ -1390,7 +1388,6 @@ describe('Filter bar component', () => {
       await TestBed.configureTestingModule({
         imports: [SkyFilterBarForLoopTestComponent],
         providers: [
-          provideNoopAnimations(),
           {
             provide: SkyConfirmService,
             useValue: jasmine.createSpyObj('SkyConfirmService', ['open']),

--- a/libs/components/filter-bar/testing/src/modules/filter-bar/filter-bar-harness.spec.ts
+++ b/libs/components/filter-bar/testing/src/modules/filter-bar/filter-bar-harness.spec.ts
@@ -1,6 +1,5 @@
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { TestBed } from '@angular/core/testing';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { SkyModalInstance, SkyModalService } from '@skyux/modals';
 
 import { of } from 'rxjs';
@@ -17,7 +16,7 @@ describe('Filter bar test harness', () => {
     filterBarHarness: SkyFilterBarHarness;
   }> {
     await TestBed.configureTestingModule({
-      imports: [FilterBarHarnessTestComponent, NoopAnimationsModule],
+      imports: [FilterBarHarnessTestComponent],
     }).compileComponents();
 
     const fixture = TestBed.createComponent(FilterBarHarnessTestComponent);

--- a/libs/components/forms/src/lib/modules/checkbox/checkbox.component.spec.ts
+++ b/libs/components/forms/src/lib/modules/checkbox/checkbox.component.spec.ts
@@ -17,7 +17,6 @@ import {
   Validators,
 } from '@angular/forms';
 import { By } from '@angular/platform-browser';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { expect, expectAsync } from '@skyux-sdk/testing';
 import { SkyIdService, SkyLogService } from '@skyux/core';
 import {
@@ -338,7 +337,7 @@ describe('Checkbox component', () => {
         FormsModule,
         ReactiveFormsModule,
         SkyCheckboxModule,
-        NoopAnimationsModule,
+
         SkyHelpTestingModule,
       ],
       providers: [NgForm],

--- a/libs/components/forms/src/lib/modules/checkbox/checkbox.component.spec.ts
+++ b/libs/components/forms/src/lib/modules/checkbox/checkbox.component.spec.ts
@@ -337,7 +337,6 @@ describe('Checkbox component', () => {
         FormsModule,
         ReactiveFormsModule,
         SkyCheckboxModule,
-
         SkyHelpTestingModule,
       ],
       providers: [NgForm],

--- a/libs/components/forms/src/lib/modules/file-attachment/file-drop/file-drop.component.spec.ts
+++ b/libs/components/forms/src/lib/modules/file-attachment/file-drop/file-drop.component.spec.ts
@@ -2,7 +2,6 @@ import { Component, DebugElement } from '@angular/core';
 import { ComponentFixture, TestBed, fakeAsync } from '@angular/core/testing';
 import { Validators } from '@angular/forms';
 import { By } from '@angular/platform-browser';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { SkyAppTestUtility, expect, expectAsync } from '@skyux-sdk/testing';
 import { SkyIdService, SkyLiveAnnouncerService } from '@skyux/core';
 import {
@@ -41,7 +40,6 @@ describe('File drop component', () => {
         FileDropContentComponent,
         SkyFileDropModule,
         SkyHelpTestingModule,
-        NoopAnimationsModule,
       ],
     });
 

--- a/libs/components/forms/src/lib/modules/input-box/fixtures/input-box.module.fixture.ts
+++ b/libs/components/forms/src/lib/modules/input-box/fixtures/input-box.module.fixture.ts
@@ -1,6 +1,5 @@
 import { NgModule } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { SkyIdModule } from '@skyux/core';
 import { SkyHelpInlineModule } from '@skyux/help-inline';
 import { SkyIconModule } from '@skyux/icon';
@@ -14,7 +13,6 @@ import { InputBoxFixtureComponent } from './input-box.component.fixture';
 
 @NgModule({
   imports: [
-    NoopAnimationsModule,
     FormsModule,
     ReactiveFormsModule,
     SkyCharacterCounterModule,

--- a/libs/components/forms/testing/src/modules/checkbox/checkbox-group-harness.spec.ts
+++ b/libs/components/forms/testing/src/modules/checkbox/checkbox-group-harness.spec.ts
@@ -1,6 +1,5 @@
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { SkyHelpService } from '@skyux/core';
 import { SkyHelpTestingModule } from '@skyux/core/testing';
 
@@ -12,11 +11,7 @@ async function setupTest(options: { dataSkyId?: string } = {}): Promise<{
   fixture: ComponentFixture<CheckboxHarnessTestComponent>;
 }> {
   await TestBed.configureTestingModule({
-    imports: [
-      CheckboxHarnessTestComponent,
-      SkyHelpTestingModule,
-      NoopAnimationsModule,
-    ],
+    imports: [CheckboxHarnessTestComponent, SkyHelpTestingModule],
   }).compileComponents();
 
   const fixture = TestBed.createComponent(CheckboxHarnessTestComponent);

--- a/libs/components/forms/testing/src/modules/checkbox/checkbox-harness.spec.ts
+++ b/libs/components/forms/testing/src/modules/checkbox/checkbox-harness.spec.ts
@@ -1,7 +1,6 @@
 import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { SkyHelpService } from '@skyux/core';
 import { SkyHelpTestingModule } from '@skyux/core/testing';
 
@@ -16,11 +15,7 @@ async function setupTest(
   loader: HarnessLoader;
 }> {
   await TestBed.configureTestingModule({
-    imports: [
-      CheckboxHarnessTestComponent,
-      SkyHelpTestingModule,
-      NoopAnimationsModule,
-    ],
+    imports: [CheckboxHarnessTestComponent, SkyHelpTestingModule],
   }).compileComponents();
 
   const fixture = TestBed.createComponent(CheckboxHarnessTestComponent);

--- a/libs/components/forms/testing/src/modules/field-group/field-group-harness.spec.ts
+++ b/libs/components/forms/testing/src/modules/field-group/field-group-harness.spec.ts
@@ -1,6 +1,5 @@
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { SkyHelpService } from '@skyux/core';
 import { SkyHelpTestingModule } from '@skyux/core/testing';
 
@@ -12,7 +11,7 @@ async function setupTest(options: { dataSkyId?: string } = {}): Promise<{
   fixture: ComponentFixture<FieldGroupComponent>;
 }> {
   await TestBed.configureTestingModule({
-    imports: [FieldGroupComponent, NoopAnimationsModule, SkyHelpTestingModule],
+    imports: [FieldGroupComponent, SkyHelpTestingModule],
   }).compileComponents();
 
   const fixture = TestBed.createComponent(FieldGroupComponent);

--- a/libs/components/forms/testing/src/modules/file-attachment/file-attachment/file-attachment-harness.spec.ts
+++ b/libs/components/forms/testing/src/modules/file-attachment/file-attachment/file-attachment-harness.spec.ts
@@ -9,7 +9,6 @@ import {
   ReactiveFormsModule,
   Validators,
 } from '@angular/forms';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { SkyFileAttachmentModule, SkyFileItem } from '@skyux/forms';
 import {
   SkyTheme,
@@ -114,7 +113,7 @@ describe('File attachment harness', () => {
     };
 
     await TestBed.configureTestingModule({
-      imports: [TestComponent, NoopAnimationsModule],
+      imports: [TestComponent],
       providers: [
         {
           provide: SkyThemeService,

--- a/libs/components/forms/testing/src/modules/file-attachment/file-drop/file-drop-harness.spec.ts
+++ b/libs/components/forms/testing/src/modules/file-attachment/file-drop/file-drop-harness.spec.ts
@@ -9,7 +9,6 @@ import {
   FormsModule,
   ReactiveFormsModule,
 } from '@angular/forms';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { provideSkyFileReaderTesting } from '@skyux/core/testing';
 import {
   SkyFileDropModule,
@@ -99,7 +98,7 @@ describe('File drop harness', () => {
     loader: HarnessLoader;
   }> {
     await TestBed.configureTestingModule({
-      imports: [TestComponent, NoopAnimationsModule],
+      imports: [TestComponent],
       providers: [provideSkyFileReaderTesting()],
     }).compileComponents();
 

--- a/libs/components/forms/testing/src/modules/input-box/input-box-harness.spec.ts
+++ b/libs/components/forms/testing/src/modules/input-box/input-box-harness.spec.ts
@@ -1,7 +1,6 @@
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { Validators } from '@angular/forms';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { SkyHelpService } from '@skyux/core';
 import { SkyHelpTestingModule } from '@skyux/core/testing';
 import { SkyValidators } from '@skyux/validation';
@@ -21,11 +20,7 @@ describe('Input box harness', () => {
     inputBoxHarness: SkyInputBoxHarness;
   }> {
     await TestBed.configureTestingModule({
-      imports: [
-        NoopAnimationsModule,
-        InputBoxHarnessTestModule,
-        SkyHelpTestingModule,
-      ],
+      imports: [InputBoxHarnessTestModule, SkyHelpTestingModule],
     }).compileComponents();
 
     const fixture = TestBed.createComponent(InputBoxHarnessTestComponent);

--- a/libs/components/forms/testing/src/modules/radio/radio-group-harness.spec.ts
+++ b/libs/components/forms/testing/src/modules/radio/radio-group-harness.spec.ts
@@ -1,6 +1,5 @@
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { SkyHelpService } from '@skyux/core';
 import { SkyHelpTestingModule } from '@skyux/core/testing';
 
@@ -12,11 +11,7 @@ async function setupTest(options: { dataSkyId?: string } = {}): Promise<{
   fixture: ComponentFixture<RadioHarnessTestComponent>;
 }> {
   await TestBed.configureTestingModule({
-    imports: [
-      RadioHarnessTestComponent,
-      SkyHelpTestingModule,
-      NoopAnimationsModule,
-    ],
+    imports: [RadioHarnessTestComponent, SkyHelpTestingModule],
   }).compileComponents();
 
   const fixture = TestBed.createComponent(RadioHarnessTestComponent);

--- a/libs/components/forms/testing/src/modules/radio/radio-harness.spec.ts
+++ b/libs/components/forms/testing/src/modules/radio/radio-harness.spec.ts
@@ -1,7 +1,6 @@
 import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { SkyHelpService } from '@skyux/core';
 import { SkyHelpTestingModule } from '@skyux/core/testing';
 
@@ -16,11 +15,7 @@ async function setupTest(
   loader: HarnessLoader;
 }> {
   await TestBed.configureTestingModule({
-    imports: [
-      RadioHarnessTestComponent,
-      SkyHelpTestingModule,
-      NoopAnimationsModule,
-    ],
+    imports: [RadioHarnessTestComponent, SkyHelpTestingModule],
   }).compileComponents();
 
   const fixture = TestBed.createComponent(RadioHarnessTestComponent);

--- a/libs/components/forms/testing/src/modules/selection-box/selection-box-harness.spec.ts
+++ b/libs/components/forms/testing/src/modules/selection-box/selection-box-harness.spec.ts
@@ -1,6 +1,5 @@
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { TestBed } from '@angular/core/testing';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { SkyIdService } from '@skyux/core';
 
 import { SelectionBoxHarnessTestComponent } from './fixtures/selection-box-harness-test.component';
@@ -12,7 +11,7 @@ async function setupTest(options: { dataSkyId?: string } = {}): Promise<{
   selectionBoxGridHarness: SkySelectionBoxGridHarness;
 }> {
   await TestBed.configureTestingModule({
-    imports: [SelectionBoxHarnessTestComponent, NoopAnimationsModule],
+    imports: [SelectionBoxHarnessTestComponent],
   }).compileComponents();
 
   index = 0;

--- a/libs/components/forms/testing/src/modules/toggle-switch/toggle-switch-harness.spec.ts
+++ b/libs/components/forms/testing/src/modules/toggle-switch/toggle-switch-harness.spec.ts
@@ -1,7 +1,6 @@
 import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { SkyHelpService, SkyIdService } from '@skyux/core';
 import { SkyHelpTestingModule } from '@skyux/core/testing';
 
@@ -19,11 +18,7 @@ async function setupTest(
 }> {
   index = 0;
   await TestBed.configureTestingModule({
-    imports: [
-      ToggleSwitchHarnessTestComponent,
-      SkyHelpTestingModule,
-      NoopAnimationsModule,
-    ],
+    imports: [ToggleSwitchHarnessTestComponent, SkyHelpTestingModule],
   }).compileComponents();
 
   spyOn(TestBed.inject(SkyIdService), 'generateId').and.callFake(

--- a/libs/components/grids/src/lib/modules/grid/fixtures/grid-fixtures.module.ts
+++ b/libs/components/grids/src/lib/modules/grid/fixtures/grid-fixtures.module.ts
@@ -1,6 +1,5 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { SkyUIConfigService } from '@skyux/core';
 import { SkyPopoverModule } from '@skyux/popovers';
 
@@ -26,12 +25,7 @@ import { GridTestComponent } from './grid.component.fixture';
     GridUndefinedTestComponent,
     GridNoHeaderTestComponent,
   ],
-  imports: [
-    CommonModule,
-    SkyGridModule,
-    SkyPopoverModule,
-    NoopAnimationsModule,
-  ],
+  imports: [CommonModule, SkyGridModule, SkyPopoverModule],
   providers: [
     {
       provide: SkyUIConfigService,

--- a/libs/components/help-inline/src/lib/modules/help-inline/help-inline.component.spec.ts
+++ b/libs/components/help-inline/src/lib/modules/help-inline/help-inline.component.spec.ts
@@ -7,7 +7,6 @@ import {
   tick,
 } from '@angular/core/testing';
 import { BrowserModule } from '@angular/platform-browser';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { expect, expectAsync } from '@skyux-sdk/testing';
 import {
   SKY_HELP_GLOBAL_OPTIONS,
@@ -134,7 +133,7 @@ describe('Help inline component', () => {
     }
 
     TestBed.configureTestingModule({
-      imports: [BrowserModule, NoopAnimationsModule, HelpInlineTestComponent],
+      imports: [BrowserModule, HelpInlineTestComponent],
       providers,
     });
 

--- a/libs/components/help-inline/testing/src/modules/help-inline/help-inline-harness.spec.ts
+++ b/libs/components/help-inline/testing/src/modules/help-inline/help-inline-harness.spec.ts
@@ -2,7 +2,6 @@ import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { SkyHelpInlineModule } from '@skyux/help-inline';
 
 import { SkyHelpInlineHarness } from './help-inline-harness';
@@ -58,7 +57,7 @@ describe('Inline help harness', () => {
   }> {
     TestBed.configureTestingModule({
       declarations: [TestComponent],
-      imports: [SkyHelpInlineModule, NoopAnimationsModule],
+      imports: [SkyHelpInlineModule],
     });
 
     const fixture = TestBed.createComponent(TestComponent);

--- a/libs/components/indicators/testing/src/modules/key-info/fixtures/key-info-harness-test.module.ts
+++ b/libs/components/indicators/testing/src/modules/key-info/fixtures/key-info-harness-test.module.ts
@@ -1,12 +1,11 @@
 import { NgModule } from '@angular/core';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { SkyKeyInfoModule } from '@skyux/indicators';
 
 import { KeyInfoHarnessTestComponent } from './key-info-harness-test.component';
 
 @NgModule({
   declarations: [KeyInfoHarnessTestComponent],
-  imports: [SkyKeyInfoModule, NoopAnimationsModule],
+  imports: [SkyKeyInfoModule],
   exports: [KeyInfoHarnessTestComponent],
 })
 export class KeyInfoHarnessTestModule {}

--- a/libs/components/indicators/testing/src/modules/status-indicator/status-indicator-harness.spec.ts
+++ b/libs/components/indicators/testing/src/modules/status-indicator/status-indicator-harness.spec.ts
@@ -1,7 +1,6 @@
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import {
   SkyIndicatorDescriptionType,
   SkyIndicatorIconType,
@@ -49,7 +48,7 @@ describe('Status indicator harness', () => {
     fixture: ComponentFixture<TestComponent>;
   }> {
     await TestBed.configureTestingModule({
-      imports: [TestComponent, NoopAnimationsModule],
+      imports: [TestComponent],
     }).compileComponents();
 
     const fixture = TestBed.createComponent(TestComponent);

--- a/libs/components/inline-form/testing/src/modules/inline-form/inline-form-harness.spec.ts
+++ b/libs/components/inline-form/testing/src/modules/inline-form/inline-form-harness.spec.ts
@@ -1,7 +1,6 @@
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import {
   SkyInlineFormButtonLayout,
   SkyInlineFormConfig,
@@ -46,7 +45,7 @@ describe('Inline form harness', () => {
     fixture: ComponentFixture<TestComponent>;
   }> {
     TestBed.configureTestingModule({
-      imports: [TestComponent, NoopAnimationsModule],
+      imports: [TestComponent],
     });
     const fixture = TestBed.createComponent(TestComponent);
     const loader = TestbedHarnessEnvironment.loader(fixture);

--- a/libs/components/layout/package.json
+++ b/libs/components/layout/package.json
@@ -16,7 +16,6 @@
   },
   "homepage": "https://github.com/blackbaud/skyux#readme",
   "peerDependencies": {
-    "@angular/animations": "^21.2.0",
     "@angular/cdk": "^21.2.0",
     "@angular/common": "^21.2.0",
     "@angular/core": "^21.2.0",

--- a/libs/components/layout/src/lib/modules/card/fixtures/card-fixtures.module.ts
+++ b/libs/components/layout/src/lib/modules/card/fixtures/card-fixtures.module.ts
@@ -1,6 +1,5 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
 import { SkyInlineDeleteModule } from '../../inline-delete/inline-delete.module';
 import { SkyCardModule } from '../card.module';
@@ -9,12 +8,7 @@ import { CardTestComponent } from './card.component.fixture';
 
 @NgModule({
   declarations: [CardTestComponent],
-  imports: [
-    CommonModule,
-    SkyCardModule,
-    SkyInlineDeleteModule,
-    NoopAnimationsModule,
-  ],
+  imports: [CommonModule, SkyCardModule, SkyInlineDeleteModule],
   exports: [CardTestComponent],
 })
 export class SkyCardFixturesModule {}

--- a/libs/components/layout/src/lib/modules/card/fixtures/card.component.fixture.html
+++ b/libs/components/layout/src/lib/modules/card/fixtures/card.component.fixture.html
@@ -1,5 +1,4 @@
 <sky-card
-  [@.disabled]="true"
   [selectable]="showCheckbox"
   [size]="cardSize"
   [(selected)]="cardSelected"

--- a/libs/components/layout/src/lib/modules/inline-delete/fixtures/inline-delete-fixtures.module.ts
+++ b/libs/components/layout/src/lib/modules/inline-delete/fixtures/inline-delete-fixtures.module.ts
@@ -1,5 +1,4 @@
 import { NgModule } from '@angular/core';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
 import { SkyInlineDeleteModule } from '../inline-delete.module';
 
@@ -7,7 +6,7 @@ import { InlineDeleteTestComponent } from './inline-delete.component.fixture';
 
 @NgModule({
   declarations: [InlineDeleteTestComponent],
-  imports: [NoopAnimationsModule, SkyInlineDeleteModule],
+  imports: [SkyInlineDeleteModule],
   exports: [InlineDeleteTestComponent],
 })
 export class SkyInlineDeleteFixturesModule {}

--- a/libs/components/layout/src/lib/modules/inline-delete/fixtures/inline-delete.component.fixture.html
+++ b/libs/components/layout/src/lib/modules/inline-delete/fixtures/inline-delete.component.fixture.html
@@ -1,7 +1,7 @@
 @if (showExtraButtons) {
 <button id="noop-button-1" type="button">Noop Button 1</button>
 }
-<div id="inline-delete-fixture" [@.disabled]="true" [tabIndex]="parentTabIndex">
+<div id="inline-delete-fixture" [tabIndex]="parentTabIndex">
   @if (showCoveredButtons) {
   <button id="covered-button" type="button">Covered Button</button>
   <button id="covered-button-2" type="button">Covered Button 2</button>

--- a/libs/components/layout/src/lib/modules/inline-delete/inline-delete.component.html
+++ b/libs/components/layout/src/lib/modules/inline-delete/inline-delete.component.html
@@ -2,10 +2,10 @@
   class="sky-inline-delete sky-inline-delete-{{ type }}"
   role="alertdialog"
   skyAnimationEndHandler
+  emitOnAnimateEnter
   animate.enter="sky-inline-delete-entering"
   animate.leave="sky-inline-delete-leaving"
   [animationTrigger]="enterAnimationTrigger()"
-  emitOnAnimateEnter
   [attr.aria-describedby]="assistiveTextId"
   [attr.aria-label]="'skyux_inline_delete_confirm_deletion' | skyLibResources"
   (animationEnd)="onAnimationEnd()"

--- a/libs/components/layout/src/lib/modules/inline-delete/inline-delete.component.html
+++ b/libs/components/layout/src/lib/modules/inline-delete/inline-delete.component.html
@@ -5,6 +5,7 @@
   animate.enter="sky-inline-delete-entering"
   animate.leave="sky-inline-delete-leaving"
   [animationTrigger]="enterAnimationTrigger()"
+  emitOnAnimateEnter
   [attr.aria-describedby]="assistiveTextId"
   [attr.aria-label]="'skyux_inline_delete_confirm_deletion' | skyLibResources"
   (animationEnd)="onAnimationEnd()"

--- a/libs/components/layout/src/lib/modules/inline-delete/inline-delete.component.html
+++ b/libs/components/layout/src/lib/modules/inline-delete/inline-delete.component.html
@@ -1,10 +1,13 @@
 <div
   class="sky-inline-delete sky-inline-delete-{{ type }}"
   role="alertdialog"
+  skyAnimationEndHandler
   animate.enter="sky-inline-delete-entering"
   animate.leave="sky-inline-delete-leaving"
+  [animationTrigger]="enterAnimationTrigger()"
   [attr.aria-describedby]="assistiveTextId"
   [attr.aria-label]="'skyux_inline_delete_confirm_deletion' | skyLibResources"
+  (animationEnd)="onAnimationEnd()"
 >
   <span
     class="sky-inline-delete-assistive-text sky-screen-reader-only"

--- a/libs/components/layout/src/lib/modules/inline-delete/inline-delete.component.html
+++ b/libs/components/layout/src/lib/modules/inline-delete/inline-delete.component.html
@@ -1,10 +1,10 @@
 <div
   class="sky-inline-delete sky-inline-delete-{{ type }}"
   role="alertdialog"
-  [@inlineDeleteAnimation]="animationState"
+  animate.enter="sky-inline-delete-entering"
+  animate.leave="sky-inline-delete-leaving"
   [attr.aria-describedby]="assistiveTextId"
   [attr.aria-label]="'skyux_inline_delete_confirm_deletion' | skyLibResources"
-  (@inlineDeleteAnimation.done)="onAnimationDone($event)"
 >
   <span
     class="sky-inline-delete-assistive-text sky-screen-reader-only"

--- a/libs/components/layout/src/lib/modules/inline-delete/inline-delete.component.scss
+++ b/libs/components/layout/src/lib/modules/inline-delete/inline-delete.component.scss
@@ -98,17 +98,21 @@
 }
 
 .sky-inline-delete-entering {
-  animation: sky-inline-delete-enter-overlay 300ms ease-in-out;
+  animation: sky-inline-delete-enter-overlay var(--sky-transition-time-medium)
+    ease-in-out;
 }
 
 .sky-inline-delete-entering .sky-inline-delete-content-animation-container {
-  animation: sky-inline-delete-enter-content 300ms ease-in-out;
+  animation: sky-inline-delete-enter-content var(--sky-transition-time-medium)
+    ease-in-out;
 }
 
 .sky-inline-delete-leaving {
-  animation: sky-inline-delete-leave-overlay 300ms ease-in-out forwards;
+  animation: sky-inline-delete-leave-overlay var(--sky-transition-time-medium)
+    ease-in-out forwards;
 }
 
 .sky-inline-delete-leaving .sky-inline-delete-content-animation-container {
-  animation: sky-inline-delete-leave-content 300ms ease-in-out forwards;
+  animation: sky-inline-delete-leave-content var(--sky-transition-time-medium)
+    ease-in-out forwards;
 }

--- a/libs/components/layout/src/lib/modules/inline-delete/inline-delete.component.scss
+++ b/libs/components/layout/src/lib/modules/inline-delete/inline-delete.component.scss
@@ -60,3 +60,55 @@
 .sky-inline-delete-wait {
   height: 100%;
 }
+
+@keyframes sky-inline-delete-enter-overlay {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes sky-inline-delete-enter-content {
+  from {
+    transform: scale(0);
+  }
+  to {
+    transform: scale(1);
+  }
+}
+
+@keyframes sky-inline-delete-leave-overlay {
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
+  }
+}
+
+@keyframes sky-inline-delete-leave-content {
+  from {
+    transform: scale(1);
+  }
+  to {
+    transform: scale(0);
+  }
+}
+
+.sky-inline-delete-entering {
+  animation: sky-inline-delete-enter-overlay 300ms ease-in-out;
+}
+
+.sky-inline-delete-entering .sky-inline-delete-content-animation-container {
+  animation: sky-inline-delete-enter-content 300ms ease-in-out;
+}
+
+.sky-inline-delete-leaving {
+  animation: sky-inline-delete-leave-overlay 300ms ease-in-out forwards;
+}
+
+.sky-inline-delete-leaving .sky-inline-delete-content-animation-container {
+  animation: sky-inline-delete-leave-content 300ms ease-in-out forwards;
+}

--- a/libs/components/layout/src/lib/modules/inline-delete/inline-delete.component.spec.ts
+++ b/libs/components/layout/src/lib/modules/inline-delete/inline-delete.component.spec.ts
@@ -5,6 +5,7 @@ import {
   tick,
 } from '@angular/core/testing';
 import { SkyAppTestUtility, expect, expectAsync } from '@skyux-sdk/testing';
+import { provideNoopSkyAnimations } from '@skyux/core';
 
 import { SkyInlineDeleteFixturesModule } from './fixtures/inline-delete-fixtures.module';
 import { InlineDeleteTestComponent } from './fixtures/inline-delete.component.fixture';
@@ -18,18 +19,13 @@ describe('Inline delete component', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [SkyInlineDeleteFixturesModule],
+      providers: [provideNoopSkyAnimations()],
     });
 
     fixture = TestBed.createComponent(InlineDeleteTestComponent);
     cmp = fixture.componentInstance;
     el = fixture.nativeElement;
   });
-
-  function simulateAnimationEnd(): void {
-    el.querySelector('.sky-inline-delete').dispatchEvent(
-      new AnimationEvent('animationend', { bubbles: true }),
-    );
-  }
 
   afterEach(fakeAsync(() => {
     cmp.showDelete = false;
@@ -101,7 +97,7 @@ describe('Inline delete component', () => {
   describe('focus handling', () => {
     it('should focus the delete button on load', async () => {
       fixture.detectChanges();
-      simulateAnimationEnd();
+      fixture.detectChanges();
       await fixture.whenStable();
       expect(document.activeElement).toBe(el.querySelector('.sky-btn-danger'));
     });
@@ -109,7 +105,6 @@ describe('Inline delete component', () => {
     it('should skip items that are under the overlay when tabbing forward', fakeAsync(() => {
       fixture.componentInstance.showExtraButtons = true;
       fixture.detectChanges();
-      simulateAnimationEnd();
       tick();
       fixture.detectChanges();
       el.querySelector('#noop-button-1').focus();
@@ -129,7 +124,6 @@ describe('Inline delete component', () => {
     it('should skip items that are under the overlay when tabbing backward', fakeAsync(() => {
       fixture.componentInstance.showExtraButtons = true;
       fixture.detectChanges();
-      simulateAnimationEnd();
       tick();
       el.querySelector('.sky-btn-danger').focus();
       SkyAppTestUtility.fireDomEvent(
@@ -147,7 +141,6 @@ describe('Inline delete component', () => {
 
     it('should wrap around to the next focusable item on the screen when no direct item is found and tabbing backwards', fakeAsync(() => {
       fixture.detectChanges();
-      simulateAnimationEnd();
       tick();
       fixture.detectChanges();
       el.querySelector('.sky-btn-danger').focus();

--- a/libs/components/layout/src/lib/modules/inline-delete/inline-delete.component.spec.ts
+++ b/libs/components/layout/src/lib/modules/inline-delete/inline-delete.component.spec.ts
@@ -25,6 +25,12 @@ describe('Inline delete component', () => {
     el = fixture.nativeElement;
   });
 
+  function simulateAnimationEnd(): void {
+    el.querySelector('.sky-inline-delete').dispatchEvent(
+      new AnimationEvent('animationend', { bubbles: true }),
+    );
+  }
+
   afterEach(fakeAsync(() => {
     cmp.showDelete = false;
     fixture.detectChanges();
@@ -95,6 +101,7 @@ describe('Inline delete component', () => {
   describe('focus handling', () => {
     it('should focus the delete button on load', async () => {
       fixture.detectChanges();
+      simulateAnimationEnd();
       await fixture.whenStable();
       expect(document.activeElement).toBe(el.querySelector('.sky-btn-danger'));
     });
@@ -102,6 +109,7 @@ describe('Inline delete component', () => {
     it('should skip items that are under the overlay when tabbing forward', fakeAsync(() => {
       fixture.componentInstance.showExtraButtons = true;
       fixture.detectChanges();
+      simulateAnimationEnd();
       tick();
       fixture.detectChanges();
       el.querySelector('#noop-button-1').focus();
@@ -121,6 +129,7 @@ describe('Inline delete component', () => {
     it('should skip items that are under the overlay when tabbing backward', fakeAsync(() => {
       fixture.componentInstance.showExtraButtons = true;
       fixture.detectChanges();
+      simulateAnimationEnd();
       tick();
       el.querySelector('.sky-btn-danger').focus();
       SkyAppTestUtility.fireDomEvent(
@@ -138,6 +147,7 @@ describe('Inline delete component', () => {
 
     it('should wrap around to the next focusable item on the screen when no direct item is found and tabbing backwards', fakeAsync(() => {
       fixture.detectChanges();
+      simulateAnimationEnd();
       tick();
       fixture.detectChanges();
       el.querySelector('.sky-btn-danger').focus();

--- a/libs/components/layout/src/lib/modules/inline-delete/inline-delete.component.spec.ts
+++ b/libs/components/layout/src/lib/modules/inline-delete/inline-delete.component.spec.ts
@@ -97,7 +97,6 @@ describe('Inline delete component', () => {
   describe('focus handling', () => {
     it('should focus the delete button on load', async () => {
       fixture.detectChanges();
-      fixture.detectChanges();
       await fixture.whenStable();
       expect(document.activeElement).toBe(el.querySelector('.sky-btn-danger'));
     });

--- a/libs/components/layout/src/lib/modules/inline-delete/inline-delete.component.ts
+++ b/libs/components/layout/src/lib/modules/inline-delete/inline-delete.component.ts
@@ -1,11 +1,11 @@
 import {
+  AfterViewInit,
   ChangeDetectorRef,
   Component,
   ElementRef,
   EventEmitter,
   Input,
   OnDestroy,
-  OnInit,
   Output,
   ViewChild,
   signal,
@@ -27,7 +27,7 @@ let nextId = 0;
   providers: [SkyCoreAdapterService, SkyInlineDeleteAdapterService],
   standalone: false,
 })
-export class SkyInlineDeleteComponent implements OnDestroy, OnInit {
+export class SkyInlineDeleteComponent implements AfterViewInit, OnDestroy {
   /**
    * Whether the deletion is pending.
    * @default false
@@ -49,8 +49,6 @@ export class SkyInlineDeleteComponent implements OnDestroy, OnInit {
 
   public assistiveTextId = `sky-inline-delete-assistive-text-${++nextId}`;
 
-  public enterAnimationTrigger = signal(false);
-
   public type: SkyInlineDeleteType = SkyInlineDeleteType.Standard;
 
   @ViewChild('delete', {
@@ -59,9 +57,12 @@ export class SkyInlineDeleteComponent implements OnDestroy, OnInit {
   })
   public deleteButton: ElementRef | undefined;
 
+  protected readonly enterAnimationTrigger = signal(false);
+
   #adapterService: SkyInlineDeleteAdapterService;
   #changeDetector: ChangeDetectorRef;
   #elRef: ElementRef;
+  #initialized = false;
 
   constructor(
     adapterService: SkyInlineDeleteAdapterService,
@@ -73,27 +74,19 @@ export class SkyInlineDeleteComponent implements OnDestroy, OnInit {
     this.#elRef = elRef;
   }
 
-  /**
-   * @internal
-   */
-  public ngOnInit(): void {
+  public ngAfterViewInit(): void {
     this.enterAnimationTrigger.set(true);
   }
 
-  /**
-   * @internal
-   */
-  public onAnimationEnd(): void {
-    this.deleteButton?.nativeElement.focus();
-    /* istanbul ignore else */
-    if (this.#elRef) {
+  protected onAnimationEnd(): void {
+    if (!this.#initialized) {
+      this.#initialized = true;
       this.#adapterService.setEl(this.#elRef.nativeElement);
     }
+
+    this.deleteButton?.nativeElement.focus();
   }
 
-  /**
-   * @internal
-   */
   public ngOnDestroy(): void {
     this.#adapterService.clearListeners();
     this.cancelTriggered.complete();

--- a/libs/components/layout/src/lib/modules/inline-delete/inline-delete.component.ts
+++ b/libs/components/layout/src/lib/modules/inline-delete/inline-delete.component.ts
@@ -77,9 +77,12 @@ export class SkyInlineDeleteComponent implements OnDestroy {
     if (!this.#initialized) {
       this.#initialized = true;
       this.#adapterService.setEl(this.#elRef.nativeElement);
-    }
 
-    this.deleteButton?.nativeElement.focus();
+      // Defer focus so it runs after the animationend event handler completes.
+      setTimeout(() => {
+        this.deleteButton?.nativeElement.focus();
+      });
+    }
   }
 
   public ngOnDestroy(): void {

--- a/libs/components/layout/src/lib/modules/inline-delete/inline-delete.component.ts
+++ b/libs/components/layout/src/lib/modules/inline-delete/inline-delete.component.ts
@@ -1,5 +1,4 @@
 import {
-  AfterViewInit,
   ChangeDetectorRef,
   Component,
   ElementRef,
@@ -27,7 +26,7 @@ let nextId = 0;
   providers: [SkyCoreAdapterService, SkyInlineDeleteAdapterService],
   standalone: false,
 })
-export class SkyInlineDeleteComponent implements AfterViewInit, OnDestroy {
+export class SkyInlineDeleteComponent implements OnDestroy {
   /**
    * Whether the deletion is pending.
    * @default false
@@ -57,7 +56,7 @@ export class SkyInlineDeleteComponent implements AfterViewInit, OnDestroy {
   })
   public deleteButton: ElementRef | undefined;
 
-  protected readonly enterAnimationTrigger = signal(false);
+  protected readonly enterAnimationTrigger = signal(true);
 
   #adapterService: SkyInlineDeleteAdapterService;
   #changeDetector: ChangeDetectorRef;
@@ -72,10 +71,6 @@ export class SkyInlineDeleteComponent implements AfterViewInit, OnDestroy {
     this.#adapterService = adapterService;
     this.#changeDetector = changeDetector;
     this.#elRef = elRef;
-  }
-
-  public ngAfterViewInit(): void {
-    this.enterAnimationTrigger.set(true);
   }
 
   protected onAnimationEnd(): void {

--- a/libs/components/layout/src/lib/modules/inline-delete/inline-delete.component.ts
+++ b/libs/components/layout/src/lib/modules/inline-delete/inline-delete.component.ts
@@ -1,13 +1,14 @@
 import {
-  AfterViewInit,
   ChangeDetectorRef,
   Component,
   ElementRef,
   EventEmitter,
   Input,
   OnDestroy,
+  OnInit,
   Output,
   ViewChild,
+  signal,
 } from '@angular/core';
 import { SkyCoreAdapterService } from '@skyux/core';
 
@@ -26,7 +27,7 @@ let nextId = 0;
   providers: [SkyCoreAdapterService, SkyInlineDeleteAdapterService],
   standalone: false,
 })
-export class SkyInlineDeleteComponent implements AfterViewInit, OnDestroy {
+export class SkyInlineDeleteComponent implements OnDestroy, OnInit {
   /**
    * Whether the deletion is pending.
    * @default false
@@ -47,6 +48,8 @@ export class SkyInlineDeleteComponent implements AfterViewInit, OnDestroy {
   public deleteTriggered = new EventEmitter<void>();
 
   public assistiveTextId = `sky-inline-delete-assistive-text-${++nextId}`;
+
+  public enterAnimationTrigger = signal(false);
 
   public type: SkyInlineDeleteType = SkyInlineDeleteType.Standard;
 
@@ -73,7 +76,14 @@ export class SkyInlineDeleteComponent implements AfterViewInit, OnDestroy {
   /**
    * @internal
    */
-  public ngAfterViewInit(): void {
+  public ngOnInit(): void {
+    this.enterAnimationTrigger.set(true);
+  }
+
+  /**
+   * @internal
+   */
+  public onAnimationEnd(): void {
     this.deleteButton?.nativeElement.focus();
     /* istanbul ignore else */
     if (this.#elRef) {

--- a/libs/components/layout/src/lib/modules/inline-delete/inline-delete.component.ts
+++ b/libs/components/layout/src/lib/modules/inline-delete/inline-delete.component.ts
@@ -1,20 +1,11 @@
 import {
-  AnimationEvent,
-  animate,
-  group,
-  query,
-  style,
-  transition,
-  trigger,
-} from '@angular/animations';
-import {
+  AfterViewInit,
   ChangeDetectorRef,
   Component,
   ElementRef,
   EventEmitter,
   Input,
   OnDestroy,
-  OnInit,
   Output,
   ViewChild,
 } from '@angular/core';
@@ -32,58 +23,10 @@ let nextId = 0;
   selector: 'sky-inline-delete',
   styleUrls: ['./inline-delete.component.scss'],
   templateUrl: './inline-delete.component.html',
-  animations: [
-    trigger('inlineDeleteAnimation', [
-      transition('* => shown', [
-        style({
-          opacity: 0,
-        }),
-        query(
-          '.sky-inline-delete-content-animation-container',
-          style({ transform: 'scale(0.0)' }),
-        ),
-        group([
-          animate('300ms ease-in-out', style({ opacity: 1 })),
-          query(
-            '.sky-inline-delete-content-animation-container',
-            animate(
-              '300ms ease-in-out',
-              style({
-                transform: 'scale(1)',
-              }),
-            ),
-          ),
-        ]),
-      ]),
-      transition(`shown <=> *`, [
-        query(
-          '.sky-inline-delete-content-animation-container',
-          style({ transform: 'scale(1)' }),
-        ),
-        group([
-          animate(
-            '300ms ease-in-out',
-            style({
-              opacity: 0,
-            }),
-          ),
-          query(
-            '.sky-inline-delete-content-animation-container',
-            animate(
-              '300ms ease-in-out',
-              style({
-                transform: 'scale(0.0)',
-              }),
-            ),
-          ),
-        ]),
-      ]),
-    ]),
-  ],
   providers: [SkyCoreAdapterService, SkyInlineDeleteAdapterService],
   standalone: false,
 })
-export class SkyInlineDeleteComponent implements OnDestroy, OnInit {
+export class SkyInlineDeleteComponent implements AfterViewInit, OnDestroy {
   /**
    * Whether the deletion is pending.
    * @default false
@@ -102,8 +45,6 @@ export class SkyInlineDeleteComponent implements OnDestroy, OnInit {
    */
   @Output()
   public deleteTriggered = new EventEmitter<void>();
-
-  public animationState = 'shown';
 
   public assistiveTextId = `sky-inline-delete-assistive-text-${++nextId}`;
 
@@ -130,15 +71,17 @@ export class SkyInlineDeleteComponent implements OnDestroy, OnInit {
   }
 
   /**
-   * Initialization lifecycle hook
    * @internal
    */
-  public ngOnInit(): void {
-    this.animationState = 'shown';
+  public ngAfterViewInit(): void {
+    this.deleteButton?.nativeElement.focus();
+    /* istanbul ignore else */
+    if (this.#elRef) {
+      this.#adapterService.setEl(this.#elRef.nativeElement);
+    }
   }
 
   /**
-   * Destruction lifecycle hook
    * @internal
    */
   public ngOnDestroy(): void {
@@ -151,7 +94,7 @@ export class SkyInlineDeleteComponent implements OnDestroy, OnInit {
    * @internal
    */
   public onCancelClick(): void {
-    this.animationState = 'hidden';
+    this.cancelTriggered.emit();
   }
 
   /**
@@ -169,22 +112,5 @@ export class SkyInlineDeleteComponent implements OnDestroy, OnInit {
   public setType(type: SkyInlineDeleteType): void {
     this.type = type;
     this.#changeDetector.detectChanges();
-  }
-
-  /**
-   * Handles actions that should be taken after the inline delete animates
-   * @param event The animation event
-   * @internal
-   */
-  public onAnimationDone(event: AnimationEvent): void {
-    if (event.toState === 'hidden') {
-      this.cancelTriggered.emit();
-    } else {
-      this.deleteButton?.nativeElement.focus();
-      /* istanbul ignore else */
-      if (this.#elRef) {
-        this.#adapterService.setEl(this.#elRef.nativeElement);
-      }
-    }
   }
 }

--- a/libs/components/layout/src/lib/modules/inline-delete/inline-delete.module.ts
+++ b/libs/components/layout/src/lib/modules/inline-delete/inline-delete.module.ts
@@ -1,4 +1,5 @@
 import { NgModule } from '@angular/core';
+import { _SkyAnimationEndHandlerDirective } from '@skyux/core';
 import { SkyWaitModule } from '@skyux/indicators';
 
 import { SkyLayoutResourcesModule } from '../shared/sky-layout-resources.module';
@@ -7,7 +8,11 @@ import { SkyInlineDeleteComponent } from './inline-delete.component';
 
 @NgModule({
   declarations: [SkyInlineDeleteComponent],
-  imports: [SkyLayoutResourcesModule, SkyWaitModule],
+  imports: [
+    _SkyAnimationEndHandlerDirective,
+    SkyLayoutResourcesModule,
+    SkyWaitModule,
+  ],
   exports: [SkyInlineDeleteComponent],
 })
 export class SkyInlineDeleteModule {}

--- a/libs/components/layout/src/lib/modules/page-summary/fixtures/page-summary-fixtures.module.ts
+++ b/libs/components/layout/src/lib/modules/page-summary/fixtures/page-summary-fixtures.module.ts
@@ -1,6 +1,5 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
 import { SkyPageSummaryModule } from '../page-summary.module';
 
@@ -8,7 +7,7 @@ import { SkyPageSummaryTestComponent } from './page-summary.component.fixture';
 
 @NgModule({
   declarations: [SkyPageSummaryTestComponent],
-  imports: [CommonModule, NoopAnimationsModule, SkyPageSummaryModule],
+  imports: [CommonModule, SkyPageSummaryModule],
   exports: [SkyPageSummaryTestComponent],
 })
 export class SkyPageSummaryFixturesModule {}

--- a/libs/components/layout/src/lib/modules/page-summary/fixtures/page-summary.component.fixture.html
+++ b/libs/components/layout/src/lib/modules/page-summary/fixtures/page-summary.component.fixture.html
@@ -1,4 +1,4 @@
-<sky-page-summary [@.disabled]="true">
+<sky-page-summary>
   @if (showKeyInfo) {
   <sky-page-summary-key-info>
     <div class="key-info-find-me">Key Info</div>

--- a/libs/components/layout/testing/src/modules/back-to-top/back-to-top-harness.spec.ts
+++ b/libs/components/layout/testing/src/modules/back-to-top/back-to-top-harness.spec.ts
@@ -1,6 +1,5 @@
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { TestBed } from '@angular/core/testing';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { SkyAppTestUtility } from '@skyux-sdk/testing';
 
 import { SkyBackToTopHarness } from './back-to-top-harness';
@@ -9,7 +8,7 @@ import { BackToTopHarnessTestComponent } from './fixtures/back-to-top-harness-te
 describe('BackToTop test harness', () => {
   it('should get the back to top component and click it', async () => {
     await TestBed.configureTestingModule({
-      imports: [BackToTopHarnessTestComponent, NoopAnimationsModule],
+      imports: [BackToTopHarnessTestComponent],
     }).compileComponents();
 
     const fixture = TestBed.createComponent(BackToTopHarnessTestComponent);

--- a/libs/components/layout/testing/src/modules/box/fixtures/box-harness-test.module.ts
+++ b/libs/components/layout/testing/src/modules/box/fixtures/box-harness-test.module.ts
@@ -1,11 +1,10 @@
 import { NgModule } from '@angular/core';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { SkyBoxModule } from '@skyux/layout';
 
 import { BoxHarnessTestComponent } from './box-harness-test.component';
 
 @NgModule({
-  imports: [SkyBoxModule, NoopAnimationsModule],
+  imports: [SkyBoxModule],
   declarations: [BoxHarnessTestComponent],
 })
 export class BoxHarnessTestModule {}

--- a/libs/components/layout/testing/src/modules/description-list/description-list-harness.spec.ts
+++ b/libs/components/layout/testing/src/modules/description-list/description-list-harness.spec.ts
@@ -1,6 +1,5 @@
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { SkyHelpService } from '@skyux/core';
 import { SkyHelpTestingModule } from '@skyux/core/testing';
 
@@ -17,11 +16,7 @@ describe('Description list test harness', () => {
     fixture: ComponentFixture<DescriptionListHarnessTestComponent>;
   }> {
     await TestBed.configureTestingModule({
-      imports: [
-        DescriptionListHarnessTestComponent,
-        SkyHelpTestingModule,
-        NoopAnimationsModule,
-      ],
+      imports: [DescriptionListHarnessTestComponent, SkyHelpTestingModule],
     }).compileComponents();
 
     const fixture = TestBed.createComponent(

--- a/libs/components/layout/testing/src/modules/inline-delete/inline-delete-harness.spec.ts
+++ b/libs/components/layout/testing/src/modules/inline-delete/inline-delete-harness.spec.ts
@@ -1,7 +1,6 @@
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { SkyInlineDeleteModule } from '@skyux/layout';
 
 import { SkyInlineDeleteHarness } from './inline-delete-harness';
@@ -33,7 +32,7 @@ describe('Inline delete harness', () => {
     fixture: ComponentFixture<TestComponent>;
   }> {
     await TestBed.configureTestingModule({
-      imports: [TestComponent, NoopAnimationsModule],
+      imports: [TestComponent],
     });
     const fixture = TestBed.createComponent(TestComponent);
     const loader = TestbedHarnessEnvironment.loader(fixture);

--- a/libs/components/layout/testing/src/modules/inline-delete/inline-delete-harness.spec.ts
+++ b/libs/components/layout/testing/src/modules/inline-delete/inline-delete-harness.spec.ts
@@ -1,6 +1,7 @@
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideNoopSkyAnimations } from '@skyux/core';
 import { SkyInlineDeleteModule } from '@skyux/layout';
 
 import { SkyInlineDeleteHarness } from './inline-delete-harness';
@@ -33,6 +34,7 @@ describe('Inline delete harness', () => {
   }> {
     await TestBed.configureTestingModule({
       imports: [TestComponent],
+      providers: [provideNoopSkyAnimations()],
     });
     const fixture = TestBed.createComponent(TestComponent);
     const loader = TestbedHarnessEnvironment.loader(fixture);

--- a/libs/components/layout/testing/src/modules/toolbar/toolbar-harness.spec.ts
+++ b/libs/components/layout/testing/src/modules/toolbar/toolbar-harness.spec.ts
@@ -1,6 +1,5 @@
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { TestBed } from '@angular/core/testing';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
 import { ToolbarHarnessTestComponent } from './fixtures/toolbar-harness-test.component';
 import { SkyToolbarHarness } from './toolbar-harness';
@@ -14,7 +13,7 @@ describe('Text expand test harness', () => {
     toolbarHarness: SkyToolbarHarness;
   }> {
     await TestBed.configureTestingModule({
-      imports: [ToolbarHarnessTestComponent, NoopAnimationsModule],
+      imports: [ToolbarHarnessTestComponent],
     }).compileComponents();
 
     const fixture = TestBed.createComponent(ToolbarHarnessTestComponent);

--- a/libs/components/list-builder-view-checklist/src/lib/modules/list-view-checklist/list-view-checklist.component.spec.ts
+++ b/libs/components/list-builder-view-checklist/src/lib/modules/list-view-checklist/list-view-checklist.component.spec.ts
@@ -7,7 +7,6 @@ import {
   waitForAsync,
 } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import {
   ListItemsLoadAction,
   ListState,
@@ -183,7 +182,7 @@ describe('List View Checklist Component', () => {
 
       TestBed.configureTestingModule({
         declarations: [ListViewChecklistTestComponent],
-        imports: [NoopAnimationsModule, SkyListViewChecklistModule],
+        imports: [SkyListViewChecklistModule],
         providers: [
           { provide: ListState, useValue: state },
           { provide: ListStateDispatcher, useValue: dispatcher },
@@ -316,7 +315,7 @@ describe('List View Checklist Component', () => {
 
       TestBed.configureTestingModule({
         declarations: [ListViewChecklistEmptyTestComponent],
-        imports: [NoopAnimationsModule, SkyListViewChecklistModule],
+        imports: [SkyListViewChecklistModule],
         providers: [
           { provide: ListState, useValue: state },
           { provide: ListStateDispatcher, useValue: dispatcher },
@@ -387,7 +386,6 @@ describe('List View Checklist Component', () => {
       TestBed.configureTestingModule({
         declarations: [ListViewChecklistPaginationTestComponent],
         imports: [
-          NoopAnimationsModule,
           SkyListModule,
           SkyListToolbarModule,
           SkyListViewChecklistModule,
@@ -455,7 +453,6 @@ describe('List View Checklist Component', () => {
       TestBed.configureTestingModule({
         declarations: [ListViewChecklistToolbarTestComponent],
         imports: [
-          NoopAnimationsModule,
           SkyListModule,
           SkyListToolbarModule,
           SkyListViewChecklistModule,
@@ -797,7 +794,6 @@ describe('List View Checklist Component', () => {
       TestBed.configureTestingModule({
         declarations: [ListViewChecklistToolbarTestComponent],
         imports: [
-          NoopAnimationsModule,
           SkyListModule,
           SkyListToolbarModule,
           SkyListViewChecklistModule,
@@ -846,7 +842,6 @@ describe('List View Checklist Component', () => {
       TestBed.configureTestingModule({
         declarations: [ListViewChecklistToolbarTestComponent],
         imports: [
-          NoopAnimationsModule,
           SkyListModule,
           SkyListToolbarModule,
           SkyListViewChecklistModule,
@@ -935,7 +930,6 @@ describe('List View Checklist Component', () => {
       TestBed.configureTestingModule({
         declarations: [ListViewChecklistToolbarTestComponent],
         imports: [
-          NoopAnimationsModule,
           SkyListModule,
           SkyListToolbarModule,
           SkyListViewChecklistModule,

--- a/libs/components/list-builder-view-checklist/testing/src/legacy/list-view-checklist-fixture.spec.ts
+++ b/libs/components/list-builder-view-checklist/testing/src/legacy/list-view-checklist-fixture.spec.ts
@@ -1,6 +1,5 @@
 import { Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { SkyListModule, SkyListToolbarModule } from '@skyux/list-builder';
 import { SkyListViewChecklistModule } from '@skyux/list-builder-view-checklist';
 
@@ -71,7 +70,6 @@ describe('List view checklist fixture', () => {
     TestBed.configureTestingModule({
       declarations: [TestComponent],
       imports: [
-        NoopAnimationsModule,
         SkyListModule,
         SkyListToolbarModule,
         SkyListViewChecklistModule,

--- a/libs/components/list-builder-view-grids/src/lib/modules/column-selector/column-selector-modal.component.spec.ts
+++ b/libs/components/list-builder-view-grids/src/lib/modules/column-selector/column-selector-modal.component.spec.ts
@@ -4,7 +4,6 @@ import {
   fakeAsync,
   tick,
 } from '@angular/core/testing';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterTestingModule } from '@angular/router/testing';
 import { expect, expectAsync } from '@skyux-sdk/testing';
 import { SkyModalModule } from '@skyux/modals';
@@ -20,12 +19,7 @@ describe('Column selector component', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       declarations: [ColumnSelectorTestComponent],
-      imports: [
-        NoopAnimationsModule,
-        RouterTestingModule,
-        SkyColumnSelectorModule,
-        SkyModalModule,
-      ],
+      imports: [RouterTestingModule, SkyColumnSelectorModule, SkyModalModule],
     });
 
     fixture = TestBed.createComponent(ColumnSelectorTestComponent);

--- a/libs/components/list-builder-view-grids/src/lib/modules/list-column-selector-action/list-column-selector-action.spec.ts
+++ b/libs/components/list-builder-view-grids/src/lib/modules/list-column-selector-action/list-column-selector-action.spec.ts
@@ -8,7 +8,6 @@ import {
   waitForAsync,
 } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterTestingModule } from '@angular/router/testing';
 import { expect, expectAsync } from '@skyux-sdk/testing';
 import { SkyGridModule } from '@skyux/grids';
@@ -98,7 +97,6 @@ describe('List column selector action', () => {
           SkyListSecondaryActionsModule,
           SkyGridModule,
           SkyListViewGridModule,
-          NoopAnimationsModule,
         ],
       }).overrideComponent(SkyListComponent, {
         set: {
@@ -254,7 +252,6 @@ describe('List column selector action', () => {
           SkyListSecondaryActionsModule,
           SkyGridModule,
           SkyListViewGridModule,
-          NoopAnimationsModule,
         ],
       }).overrideComponent(SkyListComponent, {
         set: {

--- a/libs/components/list-builder-view-grids/src/lib/modules/list-view-grid/fixtures/list-view-grid-fixtures.module.ts
+++ b/libs/components/list-builder-view-grids/src/lib/modules/list-view-grid/fixtures/list-view-grid-fixtures.module.ts
@@ -1,6 +1,5 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { SkyGridModule } from '@skyux/grids';
 import { SkyListModule } from '@skyux/list-builder';
 
@@ -18,13 +17,7 @@ import { ListViewGridFixtureComponent } from './list-view-grid.component.fixture
     ListViewGridEmptyTestComponent,
     ListViewGridDynamicTestComponent,
   ],
-  imports: [
-    CommonModule,
-    SkyGridModule,
-    SkyListViewGridModule,
-    SkyListModule,
-    NoopAnimationsModule,
-  ],
+  imports: [CommonModule, SkyGridModule, SkyListViewGridModule, SkyListModule],
   exports: [
     ListViewGridFixtureComponent,
     ListViewGridDisplayTestComponent,

--- a/libs/components/list-builder-view-grids/testing/src/legacy/list-view-grid-fixture.spec.ts
+++ b/libs/components/list-builder-view-grids/testing/src/legacy/list-view-grid-fixture.spec.ts
@@ -1,7 +1,6 @@
 import { Component } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { SkyListModule, SkyListToolbarModule } from '@skyux/list-builder';
 import { SkyListViewGridModule } from '@skyux/list-builder-view-grids';
 
@@ -57,12 +56,7 @@ describe('List view grid fixture', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       declarations: [TestComponent],
-      imports: [
-        SkyListModule,
-        SkyListViewGridModule,
-        SkyListToolbarModule,
-        NoopAnimationsModule,
-      ],
+      imports: [SkyListModule, SkyListViewGridModule, SkyListToolbarModule],
     });
 
     const fixture = TestBed.createComponent(TestComponent);

--- a/libs/components/list-builder/src/lib/modules/list-filters/list-filter-button.component.spec.ts
+++ b/libs/components/list-builder/src/lib/modules/list-filters/list-filter-button.component.spec.ts
@@ -1,5 +1,4 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
 import { skip, take } from 'rxjs/operators';
 
@@ -22,11 +21,7 @@ describe('List filter button', () => {
 
     TestBed.configureTestingModule({
       declarations: [ListFilterButtonTestComponent],
-      imports: [
-        SkyListToolbarModule,
-        SkyListFiltersModule,
-        NoopAnimationsModule,
-      ],
+      imports: [SkyListToolbarModule, SkyListFiltersModule],
       providers: [
         { provide: ListState, useValue: state },
         { provide: ListStateDispatcher, useValue: dispatcher },

--- a/libs/components/list-builder/src/lib/modules/list-filters/list-filter-inline.component.spec.ts
+++ b/libs/components/list-builder/src/lib/modules/list-filters/list-filter-inline.component.spec.ts
@@ -6,7 +6,6 @@ import {
   waitForAsync,
 } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { SkyAppTestUtility, expect } from '@skyux-sdk/testing';
 import { SkyCheckboxModule } from '@skyux/forms';
 
@@ -39,7 +38,6 @@ describe('List inline filters', () => {
         SkyListFiltersModule,
         FormsModule,
         SkyCheckboxModule,
-        NoopAnimationsModule,
       ],
       providers: [
         { provide: ListState, useValue: state },

--- a/libs/components/list-builder/src/lib/modules/list-filters/list-filter-summary.component.spec.ts
+++ b/libs/components/list-builder/src/lib/modules/list-filters/list-filter-summary.component.spec.ts
@@ -1,5 +1,4 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { expect } from '@skyux-sdk/testing';
 
 import { skip, take } from 'rxjs/operators';
@@ -52,11 +51,7 @@ describe('List filter summary', () => {
 
     TestBed.configureTestingModule({
       declarations: [ListFilterSummaryTestComponent],
-      imports: [
-        SkyListToolbarModule,
-        SkyListFiltersModule,
-        NoopAnimationsModule,
-      ],
+      imports: [SkyListToolbarModule, SkyListFiltersModule],
       providers: [
         { provide: ListState, useValue: state },
         { provide: ListStateDispatcher, useValue: dispatcher },

--- a/libs/components/list-builder/src/lib/modules/list-paging/list-paging.component.spec.ts
+++ b/libs/components/list-builder/src/lib/modules/list-paging/list-paging.component.spec.ts
@@ -1,7 +1,6 @@
 import { DebugElement } from '@angular/core';
 import { TestBed, fakeAsync, tick, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { AsyncList, ListItemModel } from '@skyux/list-builder-common';
 
 import { skip, take } from 'rxjs/operators';
@@ -29,7 +28,7 @@ describe('List Paging Component', () => {
 
     TestBed.configureTestingModule({
       declarations: [ListPagingTestComponent],
-      imports: [SkyListPagingModule, NoopAnimationsModule],
+      imports: [SkyListPagingModule],
       providers: [
         { provide: ListState, useValue: state },
         { provide: ListStateDispatcher, useValue: dispatcher },

--- a/libs/components/list-builder/src/lib/modules/list-toolbar/list-secondary-actions/list-secondary-actions.service.spec.ts
+++ b/libs/components/list-builder/src/lib/modules/list-toolbar/list-secondary-actions/list-secondary-actions.service.spec.ts
@@ -1,5 +1,4 @@
 import { TestBed, inject } from '@angular/core/testing';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
 import { SkyListSecondaryAction } from './list-secondary-action';
 import { SkyListSecondaryActionsService } from './list-secondary-actions.service';
@@ -8,7 +7,6 @@ describe('List secondary actions service', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       providers: [SkyListSecondaryActionsService],
-      imports: [NoopAnimationsModule],
     });
   });
 

--- a/libs/components/list-builder/src/lib/modules/list-toolbar/list-secondary-actions/list-secondary-actions.spec.ts
+++ b/libs/components/list-builder/src/lib/modules/list-toolbar/list-secondary-actions/list-secondary-actions.spec.ts
@@ -5,7 +5,6 @@ import {
   tick,
   waitForAsync,
 } from '@angular/core/testing';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { expect } from '@skyux-sdk/testing';
 
 import { SkyListToolbarModule } from '../../list-toolbar/list-toolbar.module';
@@ -28,11 +27,7 @@ describe('List Secondary Actions Component', () => {
 
     TestBed.configureTestingModule({
       declarations: [ListSecondaryActionsTestComponent],
-      imports: [
-        SkyListToolbarModule,
-        SkyListSecondaryActionsModule,
-        NoopAnimationsModule,
-      ],
+      imports: [SkyListToolbarModule, SkyListSecondaryActionsModule],
       providers: [
         { provide: ListState, useValue: state },
         { provide: ListStateDispatcher, useValue: dispatcher },

--- a/libs/components/list-builder/src/lib/modules/list-toolbar/list-toolbar.component.spec.ts
+++ b/libs/components/list-builder/src/lib/modules/list-toolbar/list-toolbar.component.spec.ts
@@ -7,7 +7,6 @@ import {
   waitForAsync,
 } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { expect } from '@skyux-sdk/testing';
 import { ListItemModel } from '@skyux/list-builder-common';
 
@@ -42,7 +41,7 @@ describe('List Toolbar Component', () => {
 
     TestBed.configureTestingModule({
       declarations: [ListToolbarTestComponent],
-      imports: [SkyListToolbarModule, NoopAnimationsModule],
+      imports: [SkyListToolbarModule],
       providers: [
         { provide: ListState, useValue: state },
         { provide: ListStateDispatcher, useValue: dispatcher },

--- a/libs/components/list-builder/src/lib/modules/list/list.component.spec.ts
+++ b/libs/components/list-builder/src/lib/modules/list/list.component.spec.ts
@@ -8,7 +8,6 @@ import {
 } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import {
   ListItemModel,
   ListSortFieldSelectorModel,
@@ -106,7 +105,6 @@ describe('List Component', () => {
             SkyListModule,
             SkyListToolbarModule,
             FormsModule,
-            NoopAnimationsModule,
           ],
           providers: [{ provide: 'items', useValue: items }],
         }).overrideComponent(SkyListComponent, {
@@ -416,7 +414,6 @@ describe('List Component', () => {
             SkyListModule,
             SkyListToolbarModule,
             FormsModule,
-            NoopAnimationsModule,
           ],
           providers: [{ provide: 'items', useValue: items }],
         }).overrideComponent(SkyListComponent, {
@@ -841,7 +838,6 @@ describe('List Component', () => {
             SkyListModule,
             SkyListToolbarModule,
             FormsModule,
-            NoopAnimationsModule,
           ],
           providers: [{ provide: 'items', useValue: items }],
         }).overrideComponent(SkyListComponent, {
@@ -1030,7 +1026,6 @@ describe('List Component', () => {
             SkyListModule,
             SkyListToolbarModule,
             FormsModule,
-            NoopAnimationsModule,
           ],
           providers: [{ provide: 'items', useValue: items }],
         }).overrideComponent(SkyListComponent, {
@@ -1087,7 +1082,6 @@ describe('List Component', () => {
             SkyListModule,
             SkyListToolbarModule,
             FormsModule,
-            NoopAnimationsModule,
           ],
           providers: [
             { provide: 'items', useValue: items },
@@ -1196,7 +1190,6 @@ describe('List Component', () => {
             SkyListModule,
             SkyListToolbarModule,
             FormsModule,
-            NoopAnimationsModule,
           ],
           providers: [
             { provide: 'items', useValue: null },
@@ -1248,7 +1241,6 @@ describe('List Component', () => {
             SkyListModule,
             SkyListToolbarModule,
             FormsModule,
-            NoopAnimationsModule,
           ],
           providers: [
             { provide: 'items', useValue: null },
@@ -1336,7 +1328,6 @@ describe('List Component', () => {
             SkyListModule,
             SkyListToolbarModule,
             FormsModule,
-            NoopAnimationsModule,
           ],
           providers: [{ provide: 'items', useValue: items }],
         }).overrideComponent(SkyListComponent, {

--- a/libs/components/lists/src/lib/modules/repeater/fixtures/repeater-fixtures.module.ts
+++ b/libs/components/lists/src/lib/modules/repeater/fixtures/repeater-fixtures.module.ts
@@ -1,3 +1,4 @@
+import { AsyncPipe } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { SkyDropdownModule } from '@skyux/popovers';
 
@@ -21,7 +22,7 @@ import { RepeaterTestComponent } from './repeater.component.fixture';
     NestedRepeaterTestComponent,
     A11yRepeaterTestComponent,
   ],
-  imports: [SkyDropdownModule, SkyRepeaterModule],
+  imports: [AsyncPipe, SkyDropdownModule, SkyRepeaterModule],
   exports: [
     RepeaterAsyncItemsTestComponent,
     RepeaterInlineFormFixtureComponent,

--- a/libs/components/lists/src/lib/modules/repeater/fixtures/repeater-fixtures.module.ts
+++ b/libs/components/lists/src/lib/modules/repeater/fixtures/repeater-fixtures.module.ts
@@ -1,5 +1,4 @@
 import { NgModule } from '@angular/core';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { SkyDropdownModule } from '@skyux/popovers';
 
 import { SkyRepeaterModule } from '../repeater.module';
@@ -22,7 +21,7 @@ import { RepeaterTestComponent } from './repeater.component.fixture';
     NestedRepeaterTestComponent,
     A11yRepeaterTestComponent,
   ],
-  imports: [NoopAnimationsModule, SkyDropdownModule, SkyRepeaterModule],
+  imports: [SkyDropdownModule, SkyRepeaterModule],
   exports: [
     RepeaterAsyncItemsTestComponent,
     RepeaterInlineFormFixtureComponent,

--- a/libs/components/lists/testing/src/legacy/sort/sort-fixture.spec.ts
+++ b/libs/components/lists/testing/src/legacy/sort/sort-fixture.spec.ts
@@ -1,5 +1,4 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { expect } from '@skyux-sdk/testing';
 import { SkyToolbarModule } from '@skyux/layout';
 import { SkyRepeaterModule, SkySortModule } from '@skyux/lists';
@@ -60,7 +59,6 @@ describe('Sort fixture', () => {
     TestBed.configureTestingModule({
       declarations: [SortFixtureTestComponent],
       imports: [SkyRepeaterModule, SkySortModule, SkyToolbarModule],
-      providers: [provideNoopAnimations()],
     });
 
     fixture = TestBed.createComponent(SortFixtureTestComponent);

--- a/libs/components/lists/testing/src/modules/filter/filter-button-harness.spec.ts
+++ b/libs/components/lists/testing/src/modules/filter/filter-button-harness.spec.ts
@@ -1,7 +1,6 @@
 import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { SkyCheckboxHarness } from '@skyux/forms/testing';
 
 import { SkyFilterButtonHarness } from './filter-button-harness';
@@ -20,7 +19,7 @@ describe('Filter test harness', () => {
     loader: HarnessLoader;
   }> {
     await TestBed.configureTestingModule({
-      imports: [FilterHarnessTestComponent, NoopAnimationsModule],
+      imports: [FilterHarnessTestComponent],
     }).compileComponents();
 
     const fixture = TestBed.createComponent(FilterHarnessTestComponent);

--- a/libs/components/lists/testing/src/modules/list-summary/list-summary-harness.spec.ts
+++ b/libs/components/lists/testing/src/modules/list-summary/list-summary-harness.spec.ts
@@ -2,7 +2,6 @@ import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { SkyListSummaryModule } from '@skyux/lists';
 
 import { SkyListSummaryHarness } from './list-summary-harness';
@@ -56,7 +55,6 @@ async function setupTest(
 ): Promise<void> {
   await TestBed.configureTestingModule({
     imports: [component],
-    providers: [provideNoopAnimations()],
   }).compileComponents();
 
   fixture = TestBed.createComponent(component);

--- a/libs/components/lists/testing/src/modules/paging/paging-harness.spec.ts
+++ b/libs/components/lists/testing/src/modules/paging/paging-harness.spec.ts
@@ -1,6 +1,5 @@
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
 import { PagingHarnessTestComponent } from './fixtures/paging-harness-test.component';
 import { SkyPagingHarness } from './paging-harness';
@@ -17,7 +16,7 @@ describe('Paging test harness', () => {
     fixture: ComponentFixture<PagingHarnessTestComponent>;
   }> {
     await TestBed.configureTestingModule({
-      imports: [PagingHarnessTestComponent, NoopAnimationsModule],
+      imports: [PagingHarnessTestComponent],
     }).compileComponents();
 
     const fixture = TestBed.createComponent(PagingHarnessTestComponent);

--- a/libs/components/lists/testing/src/modules/repeater/fixtures/repeater-harness-test.module.ts
+++ b/libs/components/lists/testing/src/modules/repeater/fixtures/repeater-harness-test.module.ts
@@ -1,5 +1,4 @@
 import { NgModule } from '@angular/core';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { SkyInputBoxModule } from '@skyux/forms';
 import { SkyRepeaterModule } from '@skyux/lists';
 import { SkyDropdownModule } from '@skyux/popovers';
@@ -7,12 +6,7 @@ import { SkyDropdownModule } from '@skyux/popovers';
 import { RepeaterHarnessTestComponent } from './repeater-harness-test.component';
 
 @NgModule({
-  imports: [
-    NoopAnimationsModule,
-    SkyRepeaterModule,
-    SkyInputBoxModule,
-    SkyDropdownModule,
-  ],
+  imports: [SkyRepeaterModule, SkyInputBoxModule, SkyDropdownModule],
   declarations: [RepeaterHarnessTestComponent],
 })
 export class RepeaterHarnessTestModule {}

--- a/libs/components/lists/testing/src/modules/sort/sort-harness.spec.ts
+++ b/libs/components/lists/testing/src/modules/sort/sort-harness.spec.ts
@@ -1,6 +1,5 @@
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
 import { SortHarnessTestComponent } from './fixtures/sort-harness-test.component';
 import { SkySortHarness } from './sort-harness';
@@ -15,7 +14,7 @@ describe('Sort test harness', () => {
     fixture: ComponentFixture<SortHarnessTestComponent>;
   }> {
     await TestBed.configureTestingModule({
-      imports: [SortHarnessTestComponent, NoopAnimationsModule],
+      imports: [SortHarnessTestComponent],
     }).compileComponents();
 
     const fixture = TestBed.createComponent(SortHarnessTestComponent);

--- a/libs/components/lookup/src/lib/modules/lookup/fixtures/lookup-fixtures.module.ts
+++ b/libs/components/lookup/src/lib/modules/lookup/fixtures/lookup-fixtures.module.ts
@@ -1,6 +1,5 @@
 import { NgModule } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterTestingModule } from '@angular/router/testing';
 import { SkyInputBoxModule } from '@skyux/forms';
 import {
@@ -43,7 +42,6 @@ export function themeServiceFactory(): any {
     RouterTestingModule,
     SkyInputBoxModule,
     SkyLookupModule,
-    NoopAnimationsModule,
   ],
   exports: [SkyLookupTestComponent, SkyLookupTemplateTestComponent],
   providers: [

--- a/libs/components/lookup/src/lib/modules/selection-modal/selection-modal.component.spec.ts
+++ b/libs/components/lookup/src/lib/modules/selection-modal/selection-modal.component.spec.ts
@@ -1,5 +1,4 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { expectAsync } from '@skyux-sdk/testing';
 import { SkyLiveAnnouncerService } from '@skyux/core';
 import {
@@ -123,7 +122,6 @@ describe('Selection modal component', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [NoopAnimationsModule],
       providers: [
         SelectionModalFixtureService,
         { provide: SkyModalHostService, useValue: modalHost },

--- a/libs/components/lookup/testing/src/modules/autocomplete/fixtures/autocomplete-harness-test.module.ts
+++ b/libs/components/lookup/testing/src/modules/autocomplete/fixtures/autocomplete-harness-test.module.ts
@@ -1,6 +1,5 @@
 import { NgModule } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { SkyIdModule } from '@skyux/core';
 import { SkyAutocompleteModule } from '@skyux/lookup';
 
@@ -10,7 +9,7 @@ import { AutocompleteHarnessTestComponent } from './autocomplete-harness-test.co
   declarations: [AutocompleteHarnessTestComponent],
   imports: [
     FormsModule,
-    NoopAnimationsModule,
+
     ReactiveFormsModule,
     SkyAutocompleteModule,
     SkyIdModule,

--- a/libs/components/lookup/testing/src/modules/autocomplete/fixtures/autocomplete-harness-test.module.ts
+++ b/libs/components/lookup/testing/src/modules/autocomplete/fixtures/autocomplete-harness-test.module.ts
@@ -9,7 +9,6 @@ import { AutocompleteHarnessTestComponent } from './autocomplete-harness-test.co
   declarations: [AutocompleteHarnessTestComponent],
   imports: [
     FormsModule,
-
     ReactiveFormsModule,
     SkyAutocompleteModule,
     SkyIdModule,

--- a/libs/components/lookup/testing/src/modules/lookup/fixtures/lookup-harness-test.module.ts
+++ b/libs/components/lookup/testing/src/modules/lookup/fixtures/lookup-harness-test.module.ts
@@ -1,6 +1,5 @@
 import { NgModule } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterModule } from '@angular/router';
 import { SkyIdModule } from '@skyux/core';
 import { SkyInputBoxModule } from '@skyux/forms';
@@ -12,7 +11,7 @@ import { LookupHarnessTestComponent } from './lookup-harness-test.component';
   declarations: [LookupHarnessTestComponent],
   imports: [
     FormsModule,
-    NoopAnimationsModule,
+
     ReactiveFormsModule,
     RouterModule,
     SkyIdModule,

--- a/libs/components/lookup/testing/src/modules/lookup/fixtures/lookup-harness-test.module.ts
+++ b/libs/components/lookup/testing/src/modules/lookup/fixtures/lookup-harness-test.module.ts
@@ -11,7 +11,6 @@ import { LookupHarnessTestComponent } from './lookup-harness-test.component';
   declarations: [LookupHarnessTestComponent],
   imports: [
     FormsModule,
-
     ReactiveFormsModule,
     RouterModule,
     SkyIdModule,

--- a/libs/components/lookup/testing/src/modules/selection-modal/fixtures/selection-modal-harness-test.module.ts
+++ b/libs/components/lookup/testing/src/modules/selection-modal/fixtures/selection-modal-harness-test.module.ts
@@ -1,10 +1,8 @@
 import { NgModule } from '@angular/core';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
 import { SelectionModalHarnessTestComponent } from './selection-modal-harness-test.component';
 
 @NgModule({
   declarations: [SelectionModalHarnessTestComponent],
-  imports: [NoopAnimationsModule],
 })
 export class SelectionModalHarnessTestModule {}

--- a/libs/components/modals/testing/src/modules/modal/modal-banner-harness.spec.ts
+++ b/libs/components/modals/testing/src/modules/modal/modal-banner-harness.spec.ts
@@ -8,7 +8,6 @@ import {
   inject,
 } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { SkyModalModule, SkyModalService } from '@skyux/modals';
 
 import { SkyModalBannerHarness } from './modal-banner-harness';
@@ -104,7 +103,7 @@ describe('Modal banner harness', () => {
         NoBannerModalComponent,
         NonMatchingBannerModalComponent,
       ],
-      imports: [NoopAnimationsModule, SkyModalModule],
+      imports: [SkyModalModule],
     }).compileComponents();
 
     fixture = TestBed.createComponent(TestButtonComponent);

--- a/libs/components/modals/testing/src/modules/modal/modal-harness.spec.ts
+++ b/libs/components/modals/testing/src/modules/modal/modal-harness.spec.ts
@@ -2,7 +2,6 @@ import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { Component, Injectable, StaticProvider, inject } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import {
   SkyModalConfigurationInterface,
   SkyModalModule,
@@ -111,7 +110,7 @@ describe('Modal test harness', () => {
         TestKeepWaitingPromptComponent,
         TestSkyIdComponent,
       ],
-      imports: [NoopAnimationsModule, SkyModalModule],
+      imports: [SkyModalModule],
     }).compileComponents();
 
     fixture = TestBed.createComponent(TestButtonComponent);

--- a/libs/components/navbar/testing/src/modules/navbar/navbar-harness.spec.ts
+++ b/libs/components/navbar/testing/src/modules/navbar/navbar-harness.spec.ts
@@ -1,6 +1,5 @@
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { TestBed } from '@angular/core/testing';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
 import { NavbarHarnessTestComponent } from './fixtures/navbar-harness-test.component';
 import { SkyNavbarHarness } from './navbar-harness';
@@ -14,7 +13,7 @@ describe('Navbar test harness', () => {
     navbarHarness: SkyNavbarHarness;
   }> {
     await TestBed.configureTestingModule({
-      imports: [NavbarHarnessTestComponent, NoopAnimationsModule],
+      imports: [NavbarHarnessTestComponent],
     }).compileComponents();
 
     const fixture = TestBed.createComponent(NavbarHarnessTestComponent);

--- a/libs/components/phone-field/package.json
+++ b/libs/components/phone-field/package.json
@@ -20,7 +20,6 @@
     "@angular/common": "^21.2.0",
     "@angular/core": "^21.2.0",
     "@angular/forms": "^21.2.0",
-    "@angular/platform-browser": "^21.2.0",
     "@skyux/core": "0.0.0-PLACEHOLDER",
     "@skyux/forms": "0.0.0-PLACEHOLDER",
     "@skyux/i18n": "0.0.0-PLACEHOLDER",

--- a/libs/components/phone-field/src/lib/modules/phone-field/phone-field.component.spec.ts
+++ b/libs/components/phone-field/src/lib/modules/phone-field/phone-field.component.spec.ts
@@ -6,7 +6,6 @@ import {
 } from '@angular/core/testing';
 import { NgModel, UntypedFormControl } from '@angular/forms';
 import { By } from '@angular/platform-browser';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { SkyAppTestUtility, expect, expectAsync } from '@skyux-sdk/testing';
 
 import { PhoneFieldInputBoxTestComponent } from './fixtures/phone-field-input-box.component.fixture';
@@ -272,7 +271,7 @@ describe('Phone Field Component', () => {
 
     beforeEach(() => {
       TestBed.configureTestingModule({
-        imports: [PhoneFieldTestComponent, NoopAnimationsModule],
+        imports: [PhoneFieldTestComponent],
       });
 
       fixture = TestBed.createComponent(PhoneFieldTestComponent);
@@ -1487,7 +1486,7 @@ describe('Phone Field Component', () => {
 
     beforeEach(() => {
       TestBed.configureTestingModule({
-        imports: [PhoneFieldReactiveTestComponent, NoopAnimationsModule],
+        imports: [PhoneFieldReactiveTestComponent],
       });
 
       fixture = TestBed.createComponent(PhoneFieldReactiveTestComponent);
@@ -2369,7 +2368,7 @@ describe('Phone Field Component', () => {
 
     beforeEach(() => {
       TestBed.configureTestingModule({
-        imports: [PhoneFieldInputBoxTestComponent, NoopAnimationsModule],
+        imports: [PhoneFieldInputBoxTestComponent],
       });
 
       fixture = TestBed.createComponent(PhoneFieldInputBoxTestComponent);

--- a/libs/components/phone-field/testing/src/legacy/phone-field/phone-field-testing.module.ts
+++ b/libs/components/phone-field/testing/src/legacy/phone-field/phone-field-testing.module.ts
@@ -5,11 +5,6 @@ import { SkyPhoneFieldModule } from '@skyux/phone-field';
  * @internal
  */
 @NgModule({
-  exports: [
-    SkyPhoneFieldModule,
-
-    // The noop animations module needs to be loaded last to avoid
-    // subsequent modules adding animations and overriding this.
-  ],
+  exports: [SkyPhoneFieldModule],
 })
 export class SkyPhoneFieldTestingModule {}

--- a/libs/components/phone-field/testing/src/legacy/phone-field/phone-field-testing.module.ts
+++ b/libs/components/phone-field/testing/src/legacy/phone-field/phone-field-testing.module.ts
@@ -1,5 +1,4 @@
 import { NgModule } from '@angular/core';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { SkyPhoneFieldModule } from '@skyux/phone-field';
 
 /**
@@ -11,7 +10,6 @@ import { SkyPhoneFieldModule } from '@skyux/phone-field';
 
     // The noop animations module needs to be loaded last to avoid
     // subsequent modules adding animations and overriding this.
-    NoopAnimationsModule,
   ],
 })
 export class SkyPhoneFieldTestingModule {}

--- a/libs/components/progress-indicator/src/lib/modules/progress-indicator/progress-indicator.component.spec.ts
+++ b/libs/components/progress-indicator/src/lib/modules/progress-indicator/progress-indicator.component.spec.ts
@@ -4,7 +4,6 @@ import {
   fakeAsync,
   tick,
 } from '@angular/core/testing';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { expect, expectAsync } from '@skyux-sdk/testing';
 import {
   SkyHelpTestingController,
@@ -123,11 +122,7 @@ describe('Progress indicator component', () => {
     };
 
     TestBed.configureTestingModule({
-      imports: [
-        SkyProgressIndicatorFixtureModule,
-        SkyHelpTestingModule,
-        NoopAnimationsModule,
-      ],
+      imports: [SkyProgressIndicatorFixtureModule, SkyHelpTestingModule],
       providers: [
         {
           provide: SkyThemeService,

--- a/libs/components/progress-indicator/testing/src/modules/progress-indicator/progress-indicator-harness.spec.ts
+++ b/libs/components/progress-indicator/testing/src/modules/progress-indicator/progress-indicator-harness.spec.ts
@@ -1,7 +1,6 @@
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { SkyProgressIndicatorModule } from '@skyux/progress-indicator';
 
 import { SkyProgressIndicatorHarness } from './progress-indicator-harness';
@@ -61,7 +60,7 @@ describe('Progress indicator test harness', () => {
   }> {
     await TestBed.configureTestingModule({
       declarations: [TestProgressIndicatorComponent],
-      imports: [SkyProgressIndicatorModule, NoopAnimationsModule],
+      imports: [SkyProgressIndicatorModule],
     }).compileComponents();
 
     const fixture = TestBed.createComponent(TestProgressIndicatorComponent);

--- a/libs/components/select-field/src/lib/modules/select-field/select-field.component.spec.ts
+++ b/libs/components/select-field/src/lib/modules/select-field/select-field.component.spec.ts
@@ -5,7 +5,6 @@ import {
   inject,
   tick,
 } from '@angular/core/testing';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { SkyAppTestUtility, expect } from '@skyux-sdk/testing';
 import { SkyModalService } from '@skyux/modals';
 
@@ -132,7 +131,7 @@ describe('Select field component', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [NoopAnimationsModule, SkySelectFieldFixturesModule],
+      imports: [SkySelectFieldFixturesModule],
     });
 
     fixture = TestBed.createComponent(SkySelectFieldTestComponent);

--- a/libs/components/storybook/src/lib/preview-wrapper/preview-wrapper-decorators.ts
+++ b/libs/components/storybook/src/lib/preview-wrapper/preview-wrapper-decorators.ts
@@ -1,4 +1,3 @@
-import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { RouterTestingModule } from '@angular/router/testing';
 import { SkyThemeService } from '@skyux/theme';
 import type { AngularRenderer } from '@storybook/angular';
@@ -26,7 +25,6 @@ export const previewWrapperDecorators: DecoratorFunction<
   applicationConfig({
     providers: [
       provideIconPreview(),
-      provideNoopAnimations(),
       SkyThemeService,
       {
         provide: 'BODY',

--- a/libs/components/tiles/src/lib/modules/tiles/tile-content/tile-content-section.component.spec.ts
+++ b/libs/components/tiles/src/lib/modules/tiles/tile-content/tile-content-section.component.spec.ts
@@ -1,5 +1,4 @@
 import { TestBed } from '@angular/core/testing';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { expect, expectAsync } from '@skyux-sdk/testing';
 import {
   SkyTheme,
@@ -33,7 +32,7 @@ describe('Tile content section component', () => {
 
     TestBed.configureTestingModule({
       declarations: [TileContentSectionTestComponent],
-      imports: [NoopAnimationsModule, SkyTilesModule],
+      imports: [SkyTilesModule],
       providers: [
         {
           provide: SkyThemeService,

--- a/libs/components/tiles/src/lib/modules/tiles/tile-dashboard/tile-dashboard.component.spec.ts
+++ b/libs/components/tiles/src/lib/modules/tiles/tile-dashboard/tile-dashboard.component.spec.ts
@@ -1,7 +1,6 @@
 import { QueryList } from '@angular/core';
 import { TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { expect, expectAsync } from '@skyux-sdk/testing';
 import { SkyUIConfigService } from '@skyux/core';
 import {
@@ -64,7 +63,7 @@ describe('Tile dashboard component', () => {
           useValue: mockThemeSvc,
         },
       ],
-      imports: [NoopAnimationsModule, SkyTileDashboardFixturesModule],
+      imports: [SkyTileDashboardFixturesModule],
     });
   });
 

--- a/libs/components/tiles/src/lib/modules/tiles/tile-dashboard/tile-dashboard.service.spec.ts
+++ b/libs/components/tiles/src/lib/modules/tiles/tile-dashboard/tile-dashboard.service.spec.ts
@@ -8,7 +8,6 @@ import {
   waitForAsync,
 } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { SkyAppTestUtility, expect } from '@skyux-sdk/testing';
 import { SkyUIConfigService } from '@skyux/core';
 import {
@@ -82,11 +81,7 @@ describe('Tile dashboard service', () => {
     };
 
     TestBed.configureTestingModule({
-      imports: [
-        NoopAnimationsModule,
-        SkyTileDashboardFixturesModule,
-        SkyTilesModule,
-      ],
+      imports: [SkyTileDashboardFixturesModule, SkyTilesModule],
       providers: [
         provideSkyMediaQueryTesting(),
         { provide: SkyUIConfigService, useValue: mockUIConfigService },

--- a/libs/components/tiles/src/lib/modules/tiles/tile/tile.component.spec.ts
+++ b/libs/components/tiles/src/lib/modules/tiles/tile/tile.component.spec.ts
@@ -4,7 +4,6 @@ import {
   fakeAsync,
   tick,
 } from '@angular/core/testing';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { expect, expectAsync } from '@skyux-sdk/testing';
 import { SkyLogService } from '@skyux/core';
 import {
@@ -77,7 +76,7 @@ describe('Tile component', () => {
     };
 
     TestBed.configureTestingModule({
-      imports: [NoopAnimationsModule, SkyHelpTestingModule, TileTestComponent],
+      imports: [SkyHelpTestingModule, TileTestComponent],
       providers: [
         {
           provide: SkyThemeService,

--- a/libs/components/tiles/testing/src/modules/tiles/tile-dashboard-harness.spec.ts
+++ b/libs/components/tiles/testing/src/modules/tiles/tile-dashboard-harness.spec.ts
@@ -1,6 +1,5 @@
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { TestBed } from '@angular/core/testing';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import {
   SkyMediaQueryTestingController,
   provideSkyMediaQueryTesting,
@@ -19,7 +18,7 @@ describe('Tile dashboard test harness', () => {
     mediaQueryController: SkyMediaQueryTestingController;
   }> {
     await TestBed.configureTestingModule({
-      imports: [TileDashboardHarnessTestComponent, NoopAnimationsModule],
+      imports: [TileDashboardHarnessTestComponent],
       providers: [provideSkyMediaQueryTesting()],
     }).compileComponents();
 

--- a/libs/components/tiles/testing/src/modules/tiles/tile-harness.spec.ts
+++ b/libs/components/tiles/testing/src/modules/tiles/tile-harness.spec.ts
@@ -1,6 +1,5 @@
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { SkyHelpService } from '@skyux/core';
 import { SkyHelpTestingModule } from '@skyux/core/testing';
 
@@ -13,7 +12,7 @@ describe('Tile test harness', () => {
     fixture: ComponentFixture<Tile1Component>;
   }> {
     await TestBed.configureTestingModule({
-      imports: [Tile1Component, SkyHelpTestingModule, NoopAnimationsModule],
+      imports: [Tile1Component, SkyHelpTestingModule],
     }).compileComponents();
 
     const fixture = TestBed.createComponent(Tile1Component);

--- a/libs/components/toast/src/lib/modules/toast/fixtures/toast-fixtures.module.ts
+++ b/libs/components/toast/src/lib/modules/toast/fixtures/toast-fixtures.module.ts
@@ -1,5 +1,4 @@
 import { NgModule } from '@angular/core';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { SkyLibResourcesService } from '@skyux/i18n';
 
 import { SkyToastModule } from '../toast.module';
@@ -16,7 +15,7 @@ import { SkyToasterTestComponent } from './toaster.component.fixture';
     SkyToasterTestComponent,
     SkyToastWithToasterServiceTestComponent,
   ],
-  imports: [SkyToastModule, NoopAnimationsModule],
+  imports: [SkyToastModule],
   exports: [SkyToastTestComponent, SkyToasterTestComponent],
   providers: [SkyLibResourcesService],
 })


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed animation provider configurations from multiple applications and test environments across the codebase.
  * Simplified animation handling in component testing setup.
  * Updated test guidance documentation to reflect new animation configuration approach.
  * Removed animation-related peer dependencies from package configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->