### PR TITLE
fix(components/action-bars): cache split view element refs for style cleanup on destroy

### DIFF
--- a/libs/components/action-bars/src/lib/modules/summary-action-bar/fixtures/summary-action-bar-split-view.component.fixture.html
+++ b/libs/components/action-bars/src/lib/modules/summary-action-bar/fixtures/summary-action-bar-split-view.component.fixture.html
@@ -1,7 +1,7 @@
 <sky-split-view-workspace>
   <div class="sky-split-view-workspace-content">Split View Content</div>
-  @if (showBar) {
   <div class="sky-split-view-workspace-footer">
+    @if (showBar) {
     <sky-summary-action-bar id="summary-action-bar">
       <sky-summary-action-bar-actions>
         <sky-summary-action-bar-primary-action>
@@ -59,6 +59,6 @@
         </div>
       </sky-summary-action-bar-summary>
     </sky-summary-action-bar>
+    }
   </div>
-  }
 </sky-split-view-workspace>

--- a/libs/components/action-bars/src/lib/modules/summary-action-bar/fixtures/summary-action-bar.module.fixture.ts
+++ b/libs/components/action-bars/src/lib/modules/summary-action-bar/fixtures/summary-action-bar.module.fixture.ts
@@ -1,6 +1,5 @@
 import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterTestingModule } from '@angular/router/testing';
 import { SkyKeyInfoModule } from '@skyux/indicators';
 import { SkyModalModule } from '@skyux/modals';
@@ -26,7 +25,6 @@ import { SkySummaryActionBarTestComponent } from './summary-action-bar.component
   ],
   imports: [
     BrowserModule,
-    NoopAnimationsModule,
     RouterTestingModule,
     SkyKeyInfoModule,
     SkyModalModule,

--- a/libs/components/action-bars/src/lib/modules/summary-action-bar/summary-action-bar-adapter.service.ts
+++ b/libs/components/action-bars/src/lib/modules/summary-action-bar/summary-action-bar-adapter.service.ts
@@ -73,17 +73,15 @@ export class SkySummaryActionBarAdapterService {
   }
 
   public revertSplitViewElementStyles(): void {
-    if (this.#splitViewWorkspaceContent) {
+    if (this.#splitViewWorkspaceContent?.isConnected) {
       this.#renderer.removeStyle(
         this.#splitViewWorkspaceContent,
         'padding-bottom',
       );
-      this.#splitViewWorkspaceContent = null;
     }
 
-    if (this.#splitViewWorkspaceFooter) {
+    if (this.#splitViewWorkspaceFooter?.isConnected) {
       this.#renderer.removeStyle(this.#splitViewWorkspaceFooter, 'padding');
-      this.#splitViewWorkspaceFooter = null;
     }
   }
 

--- a/libs/components/action-bars/src/lib/modules/summary-action-bar/summary-action-bar-adapter.service.ts
+++ b/libs/components/action-bars/src/lib/modules/summary-action-bar/summary-action-bar-adapter.service.ts
@@ -57,12 +57,17 @@ export class SkySummaryActionBarAdapterService {
     );
     /* istanbul ignore else */
     if (actionBarEl.style.visibility !== 'hidden') {
-      this.#renderer.setStyle(
-        this.#splitViewWorkspaceContent,
-        'padding-bottom',
-        '20px',
-      );
-      this.#renderer.setStyle(this.#splitViewWorkspaceFooter, 'padding', 0);
+      if (this.#splitViewWorkspaceContent) {
+        this.#renderer.setStyle(
+          this.#splitViewWorkspaceContent,
+          'padding-bottom',
+          '20px',
+        );
+      }
+
+      if (this.#splitViewWorkspaceFooter) {
+        this.#renderer.setStyle(this.#splitViewWorkspaceFooter, 'padding', 0);
+      }
     }
   }
 
@@ -73,15 +78,17 @@ export class SkySummaryActionBarAdapterService {
   }
 
   public revertSplitViewElementStyles(): void {
-    if (this.#splitViewWorkspaceContent?.isConnected) {
+    if (this.#splitViewWorkspaceContent) {
       this.#renderer.removeStyle(
         this.#splitViewWorkspaceContent,
         'padding-bottom',
       );
+      this.#splitViewWorkspaceContent = null;
     }
 
-    if (this.#splitViewWorkspaceFooter?.isConnected) {
+    if (this.#splitViewWorkspaceFooter) {
       this.#renderer.removeStyle(this.#splitViewWorkspaceFooter, 'padding');
+      this.#splitViewWorkspaceFooter = null;
     }
   }
 

--- a/libs/components/action-bars/src/lib/modules/summary-action-bar/summary-action-bar-adapter.service.ts
+++ b/libs/components/action-bars/src/lib/modules/summary-action-bar/summary-action-bar-adapter.service.ts
@@ -14,6 +14,8 @@ import { SkySummaryActionBarType } from './types/summary-action-bar-type';
 @Injectable()
 export class SkySummaryActionBarAdapterService {
   #renderer: Renderer2;
+  #splitViewWorkspaceContent: Element | null = null;
+  #splitViewWorkspaceFooter: Element | null = null;
   #windowRef: SkyAppWindowRef;
 
   constructor(rendererFactory: RendererFactory2, windowRef: SkyAppWindowRef) {
@@ -44,10 +46,10 @@ export class SkySummaryActionBarAdapterService {
   public styleSplitViewElementForActionBar(
     summaryActionBarRef: ElementRef,
   ): void {
-    const splitViewWorkspaceContent = document.querySelector(
+    this.#splitViewWorkspaceContent = document.querySelector(
       '.sky-split-view-workspace-content',
     );
-    const splitViewWorkspaceFooter = document.querySelector(
+    this.#splitViewWorkspaceFooter = document.querySelector(
       '.sky-split-view-workspace-footer',
     );
     const actionBarEl = summaryActionBarRef.nativeElement.querySelector(
@@ -56,11 +58,11 @@ export class SkySummaryActionBarAdapterService {
     /* istanbul ignore else */
     if (actionBarEl.style.visibility !== 'hidden') {
       this.#renderer.setStyle(
-        splitViewWorkspaceContent,
+        this.#splitViewWorkspaceContent,
         'padding-bottom',
         '20px',
       );
-      this.#renderer.setStyle(splitViewWorkspaceFooter, 'padding', 0);
+      this.#renderer.setStyle(this.#splitViewWorkspaceFooter, 'padding', 0);
     }
   }
 
@@ -71,17 +73,17 @@ export class SkySummaryActionBarAdapterService {
   }
 
   public revertSplitViewElementStyles(): void {
-    const splitViewWorkspaceContent = document.querySelector(
-      '.sky-split-view-workspace-content',
-    );
-    const splitViewWorkspaceFooter = document.querySelector(
-      '.sky-split-view-workspace-footer',
-    );
-    if (splitViewWorkspaceContent) {
-      this.#renderer.removeStyle(splitViewWorkspaceContent, 'padding-bottom');
+    if (this.#splitViewWorkspaceContent) {
+      this.#renderer.removeStyle(
+        this.#splitViewWorkspaceContent,
+        'padding-bottom',
+      );
+      this.#splitViewWorkspaceContent = null;
     }
-    if (splitViewWorkspaceFooter) {
-      this.#renderer.removeStyle(splitViewWorkspaceFooter, 'padding');
+
+    if (this.#splitViewWorkspaceFooter) {
+      this.#renderer.removeStyle(this.#splitViewWorkspaceFooter, 'padding');
+      this.#splitViewWorkspaceFooter = null;
     }
   }
 


### PR DESCRIPTION
Removing NoopAnimationsModule from the test fixture module changed the renderer pipeline Angular uses during view teardown. With NoopAnimationsModule, Angular's animation-aware renderer kept DOM elements connected long enough for `document.querySelector()` to find them during `ngOnDestroy`. Without it, the standard renderer detaches elements earlier in the destruction sequence, so re-querying the DOM in `revertSplitViewElementStyles()` returned null and the inline styles were never cleaned up.

The fix stores element references when styles are first applied and checks if they are non-null before reverting, so cleanup works regardless of renderer timing. The test fixture was also updated to keep `.sky-split-view-workspace-content` and `.sky-split-view-workspace-footer` outside the `@if` block, matching how the real `sky-split-view component` structures its template.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved action bar adapter to cache DOM element references for better performance and more reliable style handling.
  * Adjusted component fixture rendering so the footer container is always present and the action bar displays conditionally.

* **Chores**
  * Removed an unused animations module from fixture setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->