### PR TITLE
chore: release 14.0.0-alpha.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
 
+## [14.0.0-alpha.13](https://github.com/blackbaud/skyux/compare/14.0.0-alpha.12...14.0.0-alpha.13) (2026-03-23)
+
+
+### Features
+
+* remove deprecated styles, forward new public API ([#4329](https://github.com/blackbaud/skyux/issues/4329)) ([716d80b](https://github.com/blackbaud/skyux/commit/716d80b53101ecb273f15a208539554b793c5db0))
+
 ## [14.0.0-alpha.12](https://github.com/blackbaud/skyux/compare/14.0.0-alpha.11...14.0.0-alpha.12) (2026-03-23)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "skyux",
-  "version": "14.0.0-alpha.12",
+  "version": "14.0.0-alpha.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "skyux",
-      "version": "14.0.0-alpha.12",
+      "version": "14.0.0-alpha.13",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skyux",
-  "version": "14.0.0-alpha.12",
+  "version": "14.0.0-alpha.13",
   "license": "MIT",
   "scripts": {
     "ng": "nx",


### PR DESCRIPTION
## [14.0.0-alpha.13](https://github.com/blackbaud/skyux/compare/14.0.0-alpha.12...14.0.0-alpha.13) (2026-03-23)


### Features

* remove deprecated styles, forward new public API ([#4329](https://github.com/blackbaud/skyux/issues/4329)) ([716d80b](https://github.com/blackbaud/skyux/commit/716d80b53101ecb273f15a208539554b793c5db0))

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * A new public API is now available
* **Deprecations & Removals**
  * Deprecated styles have been removed

<!-- end of auto-generated comment: release notes by coderabbit.ai -->