### PR TITLE
chore: release 13.16.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 # Changelog
 
 
+## [13.16.3](https://github.com/blackbaud/skyux/compare/13.16.2...13.16.3) (2026-03-24)
+
+
+### Bug Fixes
+
+* **components/ag-grid:** apply minimum height override to column container ([#4333](https://github.com/blackbaud/skyux/issues/4333)) ([95fc062](https://github.com/blackbaud/skyux/commit/95fc062d0c769b64ba7b0da747f2fc6ae974f2cf)), closes [AB#3926782](https://github.com/AB/issues/3926782)
+
+
+
 ## [13.16.2](https://github.com/blackbaud/skyux/compare/13.16.1...13.16.2) (2026-03-17)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "skyux",
-  "version": "13.16.2",
+  "version": "13.16.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "skyux",
-      "version": "13.16.2",
+      "version": "13.16.3",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skyux",
-  "version": "13.16.2",
+  "version": "13.16.3",
   "license": "MIT",
   "scripts": {
     "ng": "nx",


### PR DESCRIPTION
## [13.16.3](https://github.com/blackbaud/skyux/compare/13.16.2...13.16.3) (2026-03-24)


### Bug Fixes

* **components/ag-grid:** apply minimum height override to column container ([#4333](https://github.com/blackbaud/skyux/issues/4333)) ([95fc062](https://github.com/blackbaud/skyux/commit/95fc062d0c769b64ba7b0da747f2fc6ae974f2cf)), closes [AB#3926782](https://github.com/AB/issues/3926782)