### PR TITLE
fix(components/lists): remove dead-code css around disabled sort items

### DIFF
--- a/libs/components/lists/src/lib/modules/sort/sort-item.component.scss
+++ b/libs/components/lists/src/lib/modules/sort/sort-item.component.scss
@@ -100,29 +100,6 @@
           var(--sky-color-border-action-tertiary-focus)
       );
     }
-
-    // NOTE: Not removing these in a minor version out an abundance of caution. However, there is no direct way to trigger these as of 10/14/25.
-    &[disabled] {
-      &,
-      &:hover,
-      &:focus-visible,
-      &:active {
-        box-shadow: inset 0 0 0 var(--sky-border-width-action-disabled)
-          var(--sky-color-border-action-tertiary-disabled);
-        background-color: var(--sky-color-background-action-tertiary-disabled);
-        color: var(--sky-color-text-deemphasized);
-        cursor: not-allowed;
-
-        & button {
-          cursor: not-allowed;
-        }
-
-        &:focus-visible {
-          box-shadow: inset 0 0 0 var(--sky-border-width-action-disabled)
-            var(--sky-color-border-action-tertiary-disabled);
-        }
-      }
-    }
   }
 }
 


### PR DESCRIPTION
[AB#3595137](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3595137)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated disabled state styling for sort items, removing specific visual treatments previously applied to disabled sort components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->