### PR TITLE
chore: release 14.0.0-beta.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
 
+## [14.0.0-beta.0](https://github.com/blackbaud/skyux/compare/14.0.0-alpha.16...14.0.0-beta.0) (2026-03-31)
+
+
+### Bug Fixes
+
+* **components/packages:** `replace-deprecated-css-vars-and-classes` should not modify SCSS variables ([#4348](https://github.com/blackbaud/skyux/issues/4348)) ([c9f95e7](https://github.com/blackbaud/skyux/commit/c9f95e7ca4354eb695770c7b8d47dfcfbf3c8a48))
+
 ## [14.0.0-alpha.16](https://github.com/blackbaud/skyux/compare/14.0.0-alpha.15...14.0.0-alpha.16) (2026-03-27)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "skyux",
-  "version": "14.0.0-alpha.16",
+  "version": "14.0.0-beta.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "skyux",
-      "version": "14.0.0-alpha.16",
+      "version": "14.0.0-beta.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skyux",
-  "version": "14.0.0-alpha.16",
+  "version": "14.0.0-beta.0",
   "license": "MIT",
   "scripts": {
     "ng": "nx",


### PR DESCRIPTION
## [14.0.0-beta.0](https://github.com/blackbaud/skyux/compare/14.0.0-alpha.16...14.0.0-beta.0) (2026-03-31)


### Bug Fixes

* **components/packages:** `replace-deprecated-css-vars-and-classes` should not modify SCSS variables ([#4348](https://github.com/blackbaud/skyux/issues/4348)) ([c9f95e7](https://github.com/blackbaud/skyux/commit/c9f95e7ca4354eb695770c7b8d47dfcfbf3c8a48))

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of deprecated CSS variables and classes to properly preserve SCSS variables during migration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->