### PR TITLE
chore: changelog for 13.16.4 (#4351) 🍒

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 # Changelog
 
 
+## [13.16.4](https://github.com/blackbaud/skyux/compare/13.16.3...13.16.4) (2026-03-31)
+
+
+### Bug Fixes
+
+* **components/forms:** mark file attachment as `touched` on deletion ([#4343](https://github.com/blackbaud/skyux/issues/4343)) ([7f8b13e](https://github.com/blackbaud/skyux/commit/7f8b13e76fb0f1d52a6d74c232c67eae392f7f07)), closes [AB#3695255](https://github.com/AB/issues/3695255)
+
+
+
 ## [14.0.0-beta.0](https://github.com/blackbaud/skyux/compare/14.0.0-alpha.16...14.0.0-beta.0) (2026-03-31)
 
 


### PR DESCRIPTION
:cherries: Cherry picked from #4351 [chore: release 13.16.4](https://github.com/blackbaud/skyux/pull/4351)

[AB#3695255](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3695255) 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * File attachments in forms are now correctly marked as touched when deleted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->