### PR TITLE
fix(components/packages): add dragula dependencies to project-level package.json for library projects

### DIFF
--- a/libs/components/packages/src/schematics/migrations/update-14/remove-dragula/remove-dragula.spec.ts
+++ b/libs/components/packages/src/schematics/migrations/update-14/remove-dragula/remove-dragula.spec.ts
@@ -11,9 +11,9 @@ import { JsonFile } from '../../../utility/json-file';
 const COLLECTION_PATH = path.join(__dirname, '../../../../../migrations.json');
 const SCHEMATIC_NAME = 'remove-dragula';
 
-async function setup(
-  options?: { projectType: 'application' | 'library' },
-): Promise<{
+async function setup(options?: {
+  projectType: 'application' | 'library';
+}): Promise<{
   runSchematic: () => Promise<UnitTestTree>;
   tree: UnitTestTree;
 }> {
@@ -274,9 +274,7 @@ describe('remove-dragula', () => {
         '/projects/my-lib/package.json',
       );
 
-      expect(projectPackageJson.get(['dependencies', 'dragula'])).toBe(
-        '3.7.3',
-      );
+      expect(projectPackageJson.get(['dependencies', 'dragula'])).toBe('3.7.3');
       expect(projectPackageJson.get(['dependencies', 'ng2-dragula'])).toBe(
         '5.1.0',
       );
@@ -323,9 +321,9 @@ describe('remove-dragula', () => {
         '/projects/my-lib/package.json',
       );
 
-      expect(
-        updatedProjectPackageJson.get(['dependencies', 'dragula']),
-      ).toBe('3.0.0');
+      expect(updatedProjectPackageJson.get(['dependencies', 'dragula'])).toBe(
+        '3.0.0',
+      );
       expect(
         updatedProjectPackageJson.get(['dependencies', 'ng2-dragula']),
       ).toBe('2.0.0');

--- a/libs/components/packages/src/schematics/migrations/update-14/remove-dragula/remove-dragula.spec.ts
+++ b/libs/components/packages/src/schematics/migrations/update-14/remove-dragula/remove-dragula.spec.ts
@@ -5,7 +5,7 @@ import {
 
 import path from 'node:path';
 
-import { createTestApp } from '../../../testing/scaffold';
+import { createTestApp, createTestLibrary } from '../../../testing/scaffold';
 import { JsonFile } from '../../../utility/json-file';
 
 const COLLECTION_PATH = path.join(__dirname, '../../../../../migrations.json');
@@ -18,6 +18,21 @@ async function setup(): Promise<{
   const runner = new SchematicTestRunner('migrations', COLLECTION_PATH);
   const tree = await createTestApp(runner, {
     projectName: 'my-app',
+  });
+
+  return {
+    runSchematic: () => runner.runSchematic(SCHEMATIC_NAME, {}, tree),
+    tree,
+  };
+}
+
+async function setupLibrary(): Promise<{
+  runSchematic: () => Promise<UnitTestTree>;
+  tree: UnitTestTree;
+}> {
+  const runner = new SchematicTestRunner('migrations', COLLECTION_PATH);
+  const tree = await createTestLibrary(runner, {
+    projectName: 'my-lib',
   });
 
   return {
@@ -253,6 +268,90 @@ describe('remove-dragula', () => {
           'dom-autoscroller',
         ]),
       ).toBeUndefined();
+    });
+
+    it('should not modify project-level package.json if it does not exist', async () => {
+      const { runSchematic, tree } = await setup();
+
+      tree.create(
+        '/src/app/my-component.ts',
+        `import { DragulaModule } from 'ng2-dragula';`,
+      );
+
+      await expect(runSchematic()).resolves.toBeInstanceOf(UnitTestTree);
+    });
+  });
+
+  describe('when ng2-dragula is used in a library project', () => {
+    it('should add dragula and ng2-dragula to project-level package.json dependencies', async () => {
+      const { runSchematic, tree } = await setupLibrary();
+
+      tree.create(
+        '/projects/my-lib/src/lib/my-component.ts',
+        `import { DragulaModule } from 'ng2-dragula';`,
+      );
+
+      const updatedTree = await runSchematic();
+      const projectPackageJson = new JsonFile(
+        updatedTree,
+        '/projects/my-lib/package.json',
+      );
+
+      expect(projectPackageJson.get(['dependencies', 'dragula'])).toBe(
+        '3.7.3',
+      );
+      expect(projectPackageJson.get(['dependencies', 'ng2-dragula'])).toBe(
+        '5.1.0',
+      );
+    });
+
+    it('should also add dragula dependencies to root package.json', async () => {
+      const { runSchematic, tree } = await setupLibrary();
+
+      tree.create(
+        '/projects/my-lib/src/lib/my-component.ts',
+        `import { DragulaModule } from 'ng2-dragula';`,
+      );
+
+      const updatedTree = await runSchematic();
+      const rootPackageJson = new JsonFile(updatedTree, '/package.json');
+
+      expect(rootPackageJson.get(['devDependencies', '@types/dragula'])).toBe(
+        '2.1.36',
+      );
+      expect(rootPackageJson.get(['dependencies', 'dragula'])).toBe('3.7.3');
+      expect(rootPackageJson.get(['dependencies', 'ng2-dragula'])).toBe(
+        '5.1.0',
+      );
+    });
+
+    it('should not overwrite existing dependencies in project-level package.json', async () => {
+      const { runSchematic, tree } = await setupLibrary();
+
+      tree.create(
+        '/projects/my-lib/src/lib/my-component.ts',
+        `import { DragulaService } from 'ng2-dragula';`,
+      );
+
+      const projectPackageJson = new JsonFile(
+        tree,
+        '/projects/my-lib/package.json',
+      );
+      projectPackageJson.modify(['dependencies', 'dragula'], '3.0.0');
+      projectPackageJson.modify(['dependencies', 'ng2-dragula'], '2.0.0');
+
+      const updatedTree = await runSchematic();
+      const updatedProjectPackageJson = new JsonFile(
+        updatedTree,
+        '/projects/my-lib/package.json',
+      );
+
+      expect(
+        updatedProjectPackageJson.get(['dependencies', 'dragula']),
+      ).toBe('3.0.0');
+      expect(
+        updatedProjectPackageJson.get(['dependencies', 'ng2-dragula']),
+      ).toBe('2.0.0');
     });
   });
 });

--- a/libs/components/packages/src/schematics/migrations/update-14/remove-dragula/remove-dragula.spec.ts
+++ b/libs/components/packages/src/schematics/migrations/update-14/remove-dragula/remove-dragula.spec.ts
@@ -11,29 +11,17 @@ import { JsonFile } from '../../../utility/json-file';
 const COLLECTION_PATH = path.join(__dirname, '../../../../../migrations.json');
 const SCHEMATIC_NAME = 'remove-dragula';
 
-async function setup(): Promise<{
+async function setup(
+  options?: { projectType: 'application' | 'library' },
+): Promise<{
   runSchematic: () => Promise<UnitTestTree>;
   tree: UnitTestTree;
 }> {
   const runner = new SchematicTestRunner('migrations', COLLECTION_PATH);
-  const tree = await createTestApp(runner, {
-    projectName: 'my-app',
-  });
-
-  return {
-    runSchematic: () => runner.runSchematic(SCHEMATIC_NAME, {}, tree),
-    tree,
-  };
-}
-
-async function setupLibrary(): Promise<{
-  runSchematic: () => Promise<UnitTestTree>;
-  tree: UnitTestTree;
-}> {
-  const runner = new SchematicTestRunner('migrations', COLLECTION_PATH);
-  const tree = await createTestLibrary(runner, {
-    projectName: 'my-lib',
-  });
+  const tree =
+    options?.projectType === 'library'
+      ? await createTestLibrary(runner, { projectName: 'my-lib' })
+      : await createTestApp(runner, { projectName: 'my-app' });
 
   return {
     runSchematic: () => runner.runSchematic(SCHEMATIC_NAME, {}, tree),
@@ -273,7 +261,7 @@ describe('remove-dragula', () => {
 
   describe('when ng2-dragula is used in a library project', () => {
     it('should add dragula and ng2-dragula to project-level package.json dependencies', async () => {
-      const { runSchematic, tree } = await setupLibrary();
+      const { runSchematic, tree } = await setup({ projectType: 'library' });
 
       tree.create(
         '/projects/my-lib/src/lib/my-component.ts',
@@ -295,7 +283,7 @@ describe('remove-dragula', () => {
     });
 
     it('should also add dragula dependencies to root package.json', async () => {
-      const { runSchematic, tree } = await setupLibrary();
+      const { runSchematic, tree } = await setup({ projectType: 'library' });
 
       tree.create(
         '/projects/my-lib/src/lib/my-component.ts',
@@ -315,7 +303,7 @@ describe('remove-dragula', () => {
     });
 
     it('should not overwrite existing dependencies in project-level package.json', async () => {
-      const { runSchematic, tree } = await setupLibrary();
+      const { runSchematic, tree } = await setup({ projectType: 'library' });
 
       tree.create(
         '/projects/my-lib/src/lib/my-component.ts',

--- a/libs/components/packages/src/schematics/migrations/update-14/remove-dragula/remove-dragula.spec.ts
+++ b/libs/components/packages/src/schematics/migrations/update-14/remove-dragula/remove-dragula.spec.ts
@@ -269,17 +269,6 @@ describe('remove-dragula', () => {
         ]),
       ).toBeUndefined();
     });
-
-    it('should not modify project-level package.json if it does not exist', async () => {
-      const { runSchematic, tree } = await setup();
-
-      tree.create(
-        '/src/app/my-component.ts',
-        `import { DragulaModule } from 'ng2-dragula';`,
-      );
-
-      await expect(runSchematic()).resolves.toBeInstanceOf(UnitTestTree);
-    });
   });
 
   describe('when ng2-dragula is used in a library project', () => {

--- a/libs/components/packages/src/schematics/migrations/update-14/remove-dragula/remove-dragula.ts
+++ b/libs/components/packages/src/schematics/migrations/update-14/remove-dragula/remove-dragula.ts
@@ -44,14 +44,16 @@ export default function (): Rule {
       );
 
       for (const project of projects) {
-        rules.push(
-          addProjectDependency(project.root, 'dragula', DRAGULA_VERSION),
-          addProjectDependency(
-            project.root,
-            NG2_DRAGULA,
-            NG2_DRAGULA_VERSION,
-          ),
-        );
+        if (project.extensions['projectType'] === 'library') {
+          rules.push(
+            addProjectDependency(project.root, 'dragula', DRAGULA_VERSION),
+            addProjectDependency(
+              project.root,
+              NG2_DRAGULA,
+              NG2_DRAGULA_VERSION,
+            ),
+          );
+        }
       }
     } else {
       rules.push(
@@ -115,11 +117,6 @@ function addProjectDependency(
 ): Rule {
   return (tree: Tree) => {
     const packageJsonPath = normalize(`${projectRoot}/package.json`);
-
-    if (!tree.exists(packageJsonPath)) {
-      return tree;
-    }
-
     const packageJson = new JsonFile(tree, packageJsonPath);
     const existingVersion = packageJson.get(['dependencies', packageName]);
 

--- a/libs/components/packages/src/schematics/migrations/update-14/remove-dragula/remove-dragula.ts
+++ b/libs/components/packages/src/schematics/migrations/update-14/remove-dragula/remove-dragula.ts
@@ -1,3 +1,4 @@
+import { normalize } from '@angular-devkit/core';
 import { Rule, Tree, chain } from '@angular-devkit/schematics';
 import {
   DependencyType,
@@ -6,11 +7,12 @@ import {
   removeDependency,
 } from '@schematics/angular/utility/dependency';
 
-import { isPackageUsed } from '../../../utility/dependencies';
+import { getProjectsUsingPackage } from '../../../utility/dependencies';
 import { JsonFile } from '../../../utility/json-file';
 
 const NG2_DRAGULA = 'ng2-dragula';
 const NG2_DRAGULA_VERSION = '5.1.0';
+const DRAGULA_VERSION = '3.7.3';
 
 /**
  * Remove dragula packages if they are not being used.
@@ -18,15 +20,15 @@ const NG2_DRAGULA_VERSION = '5.1.0';
 export default function (): Rule {
   return async (tree) => {
     const rules: Rule[] = [removeDependency('dom-autoscroller')];
-    const dragulaUsed = await isPackageUsed(tree, NG2_DRAGULA);
+    const projects = await getProjectsUsingPackage(tree, NG2_DRAGULA);
 
-    if (dragulaUsed) {
+    if (projects.length > 0) {
       rules.push(
         addDependency('@types/dragula', '2.1.36', {
           existing: ExistingBehavior.Skip,
           type: DependencyType.Dev,
         }),
-        addDependency('dragula', '3.7.3', {
+        addDependency('dragula', DRAGULA_VERSION, {
           existing: ExistingBehavior.Skip,
           type: DependencyType.Default,
         }),
@@ -40,6 +42,17 @@ export default function (): Rule {
           '@angular/common': '>=21.0.0',
         }),
       );
+
+      for (const project of projects) {
+        rules.push(
+          addProjectDependency(project.root, 'dragula', DRAGULA_VERSION),
+          addProjectDependency(
+            project.root,
+            NG2_DRAGULA,
+            NG2_DRAGULA_VERSION,
+          ),
+        );
+      }
     } else {
       rules.push(
         removeDependency('@types/dragula'),
@@ -92,5 +105,28 @@ function addPackageJsonOverride(
     const packageJsonPath = '/package.json';
     const packageJson = new JsonFile(tree, packageJsonPath);
     packageJson.modify(['overrides', overrideKey], value);
+  };
+}
+
+function addProjectDependency(
+  projectRoot: string,
+  packageName: string,
+  version: string,
+): Rule {
+  return (tree: Tree) => {
+    const packageJsonPath = normalize(`${projectRoot}/package.json`);
+
+    if (!tree.exists(packageJsonPath)) {
+      return tree;
+    }
+
+    const packageJson = new JsonFile(tree, packageJsonPath);
+    const existingVersion = packageJson.get(['dependencies', packageName]);
+
+    if (!existingVersion) {
+      packageJson.modify(['dependencies', packageName], version);
+    }
+
+    return tree;
   };
 }

--- a/libs/components/packages/src/schematics/utility/dependencies.ts
+++ b/libs/components/packages/src/schematics/utility/dependencies.ts
@@ -1,6 +1,6 @@
 import { Tree } from '@angular-devkit/schematics';
-import { ProjectDefinition } from '@schematics/angular/utility';
 import ts from '@schematics/angular/third_party/github.com/Microsoft/TypeScript/lib/typescript';
+import { ProjectDefinition } from '@schematics/angular/utility';
 import { findNodes } from '@schematics/angular/utility/ast-utils';
 import { getWorkspace } from '@schematics/angular/utility/workspace';
 

--- a/libs/components/packages/src/schematics/utility/dependencies.ts
+++ b/libs/components/packages/src/schematics/utility/dependencies.ts
@@ -12,9 +12,18 @@ export async function isPackageUsed(
   tree: Tree,
   packageName: string,
 ): Promise<boolean> {
-  const projects = await getProjectsUsingPackage(tree, packageName);
+  const workspace = await getWorkspace(tree);
 
-  return projects.length > 0;
+  for (const project of workspace.projects.values()) {
+    const sourceRoot = getSourceRoot(project);
+    const found = isPackageFoundInFiles(tree, packageName, sourceRoot);
+
+    if (found) {
+      return true;
+    }
+  }
+
+  return false;
 }
 
 export async function getProjectsUsingPackage(

--- a/libs/components/packages/src/schematics/utility/dependencies.ts
+++ b/libs/components/packages/src/schematics/utility/dependencies.ts
@@ -1,4 +1,5 @@
 import { Tree } from '@angular-devkit/schematics';
+import { ProjectDefinition } from '@schematics/angular/utility';
 import ts from '@schematics/angular/third_party/github.com/Microsoft/TypeScript/lib/typescript';
 import { findNodes } from '@schematics/angular/utility/ast-utils';
 import { getWorkspace } from '@schematics/angular/utility/workspace';
@@ -11,18 +12,27 @@ export async function isPackageUsed(
   tree: Tree,
   packageName: string,
 ): Promise<boolean> {
+  const projects = await getProjectsUsingPackage(tree, packageName);
+
+  return projects.length > 0;
+}
+
+export async function getProjectsUsingPackage(
+  tree: Tree,
+  packageName: string,
+): Promise<ProjectDefinition[]> {
   const workspace = await getWorkspace(tree);
+  const projects: ProjectDefinition[] = [];
 
   for (const project of workspace.projects.values()) {
     const sourceRoot = getSourceRoot(project);
-    const found = isPackageFoundInFiles(tree, packageName, sourceRoot);
 
-    if (found) {
-      return true;
+    if (isPackageFoundInFiles(tree, packageName, sourceRoot)) {
+      projects.push(project);
     }
   }
 
-  return false;
+  return projects;
 }
 
 /**


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Schematic migration now detects which projects use ng2-dragula and applies dependency changes per project, adding missing dragula/ng2-dragula to library projects while preserving existing project versions and ensuring root typings/dependencies are maintained.

* **Tests**
  * Expanded coverage to validate behavior for both application and library projects, including preservation of existing dependency versions and correct per-project additions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->