### PR TITLE
fix(migrations): add dragula to `allowedNonPeerDependencies` in ng-package.json

### DIFF
--- a/libs/components/packages/src/schematics/migrations/update-14/remove-dragula/remove-dragula.spec.ts
+++ b/libs/components/packages/src/schematics/migrations/update-14/remove-dragula/remove-dragula.spec.ts
@@ -328,5 +328,55 @@ describe('remove-dragula', () => {
         updatedProjectPackageJson.get(['dependencies', 'ng2-dragula']),
       ).toBe('2.0.0');
     });
+
+    it('should add dragula and ng2-dragula to allowedNonPeerDependencies in ng-package.json', async () => {
+      const { runSchematic, tree } = await setup({ projectType: 'library' });
+
+      tree.create(
+        '/projects/my-lib/src/lib/my-component.ts',
+        `import { DragulaModule } from 'ng2-dragula';`,
+      );
+
+      const updatedTree = await runSchematic();
+      const ngPackageJson = new JsonFile(
+        updatedTree,
+        '/projects/my-lib/ng-package.json',
+      );
+
+      const allowed = ngPackageJson.get([
+        'allowedNonPeerDependencies',
+      ]) as string[];
+
+      expect(allowed).toContain('dragula');
+      expect(allowed).toContain('ng2-dragula');
+    });
+
+    it('should not duplicate entries in allowedNonPeerDependencies', async () => {
+      const { runSchematic, tree } = await setup({ projectType: 'library' });
+
+      tree.create(
+        '/projects/my-lib/src/lib/my-component.ts',
+        `import { DragulaModule } from 'ng2-dragula';`,
+      );
+
+      const ngPackageJson = new JsonFile(
+        tree,
+        '/projects/my-lib/ng-package.json',
+      );
+      ngPackageJson.modify(['allowedNonPeerDependencies'], ['dragula']);
+
+      const updatedTree = await runSchematic();
+      const updatedNgPackageJson = new JsonFile(
+        updatedTree,
+        '/projects/my-lib/ng-package.json',
+      );
+
+      const allowed = updatedNgPackageJson.get([
+        'allowedNonPeerDependencies',
+      ]) as string[];
+
+      expect(allowed.filter((dep) => dep === 'dragula')).toHaveLength(1);
+      expect(allowed).toContain('ng2-dragula');
+    });
   });
 });

--- a/libs/components/packages/src/schematics/migrations/update-14/remove-dragula/remove-dragula.spec.ts
+++ b/libs/components/packages/src/schematics/migrations/update-14/remove-dragula/remove-dragula.spec.ts
@@ -378,5 +378,18 @@ describe('remove-dragula', () => {
       expect(allowed.filter((dep) => dep === 'dragula')).toHaveLength(1);
       expect(allowed).toContain('ng2-dragula');
     });
+
+    it('should skip allowedNonPeerDependencies if ng-package.json does not exist', async () => {
+      const { runSchematic, tree } = await setup({ projectType: 'library' });
+
+      tree.create(
+        '/projects/my-lib/src/lib/my-component.ts',
+        `import { DragulaModule } from 'ng2-dragula';`,
+      );
+
+      tree.delete('/projects/my-lib/ng-package.json');
+
+      await expect(runSchematic()).resolves.toBeInstanceOf(UnitTestTree);
+    });
   });
 });

--- a/libs/components/packages/src/schematics/migrations/update-14/remove-dragula/remove-dragula.ts
+++ b/libs/components/packages/src/schematics/migrations/update-14/remove-dragula/remove-dragula.ts
@@ -136,8 +136,12 @@ function addAllowedNonPeerDependency(
 ): Rule {
   return (tree: Tree) => {
     const ngPackagePath = normalize(`${projectRoot}/ng-package.json`);
-    const ngPackageJson = new JsonFile(tree, ngPackagePath);
 
+    if (!tree.exists(ngPackagePath)) {
+      return tree;
+    }
+
+    const ngPackageJson = new JsonFile(tree, ngPackagePath);
     const allowed =
       (ngPackageJson.get(['allowedNonPeerDependencies']) as string[]) ?? [];
 

--- a/libs/components/packages/src/schematics/migrations/update-14/remove-dragula/remove-dragula.ts
+++ b/libs/components/packages/src/schematics/migrations/update-14/remove-dragula/remove-dragula.ts
@@ -52,6 +52,8 @@ export default function (): Rule {
               NG2_DRAGULA,
               NG2_DRAGULA_VERSION,
             ),
+            addAllowedNonPeerDependency(project.root, 'dragula'),
+            addAllowedNonPeerDependency(project.root, NG2_DRAGULA),
           );
         }
       }
@@ -122,6 +124,28 @@ function addProjectDependency(
 
     if (!existingVersion) {
       packageJson.modify(['dependencies', packageName], version);
+    }
+
+    return tree;
+  };
+}
+
+function addAllowedNonPeerDependency(
+  projectRoot: string,
+  packageName: string,
+): Rule {
+  return (tree: Tree) => {
+    const ngPackagePath = normalize(`${projectRoot}/ng-package.json`);
+    const ngPackageJson = new JsonFile(tree, ngPackagePath);
+
+    const allowed =
+      (ngPackageJson.get(['allowedNonPeerDependencies']) as string[]) ?? [];
+
+    if (!allowed.includes(packageName)) {
+      ngPackageJson.modify(
+        ['allowedNonPeerDependencies'],
+        [...allowed, packageName],
+      );
     }
 
     return tree;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Migration updated to update library package build config by ensuring both dragula and ng2-dragula are listed in allowed non-peer dependencies (creates the list if missing, avoids duplicates).

* **Tests**
  * Added tests covering library-specific migration: adds required entries, remains idempotent when entries exist, and succeeds if library build config is absent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->