### PR TITLE
chore: release 14.0.0-beta.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
 
+## [14.0.0-beta.2](https://github.com/blackbaud/skyux/compare/14.0.0-beta.1...14.0.0-beta.2) (2026-04-01)
+
+
+### Bug Fixes
+
+* **migrations:** add dragula to `allowedNonPeerDependencies` in ng-package.json ([#4357](https://github.com/blackbaud/skyux/issues/4357)) ([cd9c342](https://github.com/blackbaud/skyux/commit/cd9c3421875b28708e6a773b4e896ef1b5c4eab7))
+
 ## [14.0.0-beta.1](https://github.com/blackbaud/skyux/compare/14.0.0-beta.0...14.0.0-beta.1) (2026-04-01)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "skyux",
-  "version": "14.0.0-beta.1",
+  "version": "14.0.0-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "skyux",
-      "version": "14.0.0-beta.1",
+      "version": "14.0.0-beta.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skyux",
-  "version": "14.0.0-beta.1",
+  "version": "14.0.0-beta.2",
   "license": "MIT",
   "scripts": {
     "ng": "nx",


### PR DESCRIPTION
## [14.0.0-beta.2](https://github.com/blackbaud/skyux/compare/14.0.0-beta.1...14.0.0-beta.2) (2026-04-01)


### Bug Fixes

* **migrations:** add dragula to `allowedNonPeerDependencies` in ng-package.json ([#4357](https://github.com/blackbaud/skyux/issues/4357)) ([cd9c342](https://github.com/blackbaud/skyux/commit/cd9c3421875b28708e6a773b4e896ef1b5c4eab7))

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a migrations-related compatibility issue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->