### PR TITLE
fix: add support for `ng-packagr@21.2.2`

### DIFF
--- a/libs/components/a11y/package.json
+++ b/libs/components/a11y/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@skyux/a11y",
+  "type": "commonjs",
   "version": "0.0.0-PLACEHOLDER",
   "author": "Blackbaud, Inc.",
   "keywords": [

--- a/libs/components/action-bars/package.json
+++ b/libs/components/action-bars/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@skyux/action-bars",
+  "type": "commonjs",
   "version": "0.0.0-PLACEHOLDER",
   "author": "Blackbaud, Inc.",
   "keywords": [

--- a/libs/components/ag-grid/package.json
+++ b/libs/components/ag-grid/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@skyux/ag-grid",
+  "type": "commonjs",
   "version": "0.0.0-PLACEHOLDER",
   "author": "Blackbaud, Inc.",
   "keywords": [

--- a/libs/components/angular-tree-component/package.json
+++ b/libs/components/angular-tree-component/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@skyux/angular-tree-component",
+  "type": "commonjs",
   "version": "0.0.0-PLACEHOLDER",
   "author": "Blackbaud, Inc.",
   "keywords": [

--- a/libs/components/animations/package.json
+++ b/libs/components/animations/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@skyux/animations",
+  "type": "commonjs",
   "version": "0.0.0-PLACEHOLDER",
   "author": "Blackbaud, Inc.",
   "keywords": [

--- a/libs/components/assets/package.json
+++ b/libs/components/assets/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@skyux/assets",
+  "type": "commonjs",
   "version": "0.0.0-PLACEHOLDER",
   "author": "Blackbaud, Inc.",
   "keywords": [

--- a/libs/components/autonumeric/package.json
+++ b/libs/components/autonumeric/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@skyux/autonumeric",
+  "type": "commonjs",
   "version": "0.0.0-PLACEHOLDER",
   "author": "Blackbaud, Inc.",
   "keywords": [

--- a/libs/components/avatar/package.json
+++ b/libs/components/avatar/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@skyux/avatar",
+  "type": "commonjs",
   "version": "0.0.0-PLACEHOLDER",
   "author": "Blackbaud, Inc.",
   "keywords": [

--- a/libs/components/code-examples/package.json
+++ b/libs/components/code-examples/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@skyux/code-examples",
+  "type": "commonjs",
   "version": "0.0.0-PLACEHOLDER",
   "author": "Blackbaud, Inc.",
   "description": "Internal SKY UX use only",

--- a/libs/components/colorpicker/package.json
+++ b/libs/components/colorpicker/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@skyux/colorpicker",
+  "type": "commonjs",
   "version": "0.0.0-PLACEHOLDER",
   "author": "Blackbaud, Inc.",
   "keywords": [

--- a/libs/components/config/package.json
+++ b/libs/components/config/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@skyux/config",
+  "type": "commonjs",
   "version": "0.0.0-PLACEHOLDER",
   "author": "Blackbaud, Inc.",
   "keywords": [

--- a/libs/components/core/package.json
+++ b/libs/components/core/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@skyux/core",
+  "type": "commonjs",
   "version": "0.0.0-PLACEHOLDER",
   "author": "Blackbaud, Inc.",
   "keywords": [

--- a/libs/components/data-manager/package.json
+++ b/libs/components/data-manager/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@skyux/data-manager",
+  "type": "commonjs",
   "version": "0.0.0-PLACEHOLDER",
   "author": "Blackbaud, Inc.",
   "keywords": [

--- a/libs/components/datetime/package.json
+++ b/libs/components/datetime/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@skyux/datetime",
+  "type": "commonjs",
   "version": "0.0.0-PLACEHOLDER",
   "author": "Blackbaud, Inc.",
   "keywords": [

--- a/libs/components/docs-tools/package.json
+++ b/libs/components/docs-tools/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@skyux/docs-tools",
+  "type": "commonjs",
   "version": "0.0.0-PLACEHOLDER",
   "author": "Blackbaud, Inc.",
   "keywords": [

--- a/libs/components/errors/package.json
+++ b/libs/components/errors/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@skyux/errors",
+  "type": "commonjs",
   "version": "0.0.0-PLACEHOLDER",
   "author": "Blackbaud, Inc.",
   "keywords": [

--- a/libs/components/filter-bar/package.json
+++ b/libs/components/filter-bar/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@skyux/filter-bar",
+  "type": "commonjs",
   "version": "0.0.0-PLACEHOLDER",
   "author": "Blackbaud, Inc.",
   "keywords": [

--- a/libs/components/flyout/package.json
+++ b/libs/components/flyout/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@skyux/flyout",
+  "type": "commonjs",
   "version": "0.0.0-PLACEHOLDER",
   "author": "Blackbaud, Inc.",
   "keywords": [

--- a/libs/components/forms/package.json
+++ b/libs/components/forms/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@skyux/forms",
+  "type": "commonjs",
   "version": "0.0.0-PLACEHOLDER",
   "author": "Blackbaud, Inc.",
   "keywords": [

--- a/libs/components/grids/package.json
+++ b/libs/components/grids/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@skyux/grids",
+  "type": "commonjs",
   "version": "0.0.0-PLACEHOLDER",
   "author": "Blackbaud, Inc.",
   "keywords": [

--- a/libs/components/help-inline/package.json
+++ b/libs/components/help-inline/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@skyux/help-inline",
+  "type": "commonjs",
   "version": "0.0.0-PLACEHOLDER",
   "author": "Blackbaud, Inc.",
   "keywords": [

--- a/libs/components/i18n/package.json
+++ b/libs/components/i18n/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@skyux/i18n",
+  "type": "commonjs",
   "version": "0.0.0-PLACEHOLDER",
   "author": "Blackbaud, Inc.",
   "keywords": [

--- a/libs/components/icon/package.json
+++ b/libs/components/icon/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@skyux/icon",
+  "type": "commonjs",
   "version": "0.0.0-PLACEHOLDER",
   "author": "Blackbaud, Inc.",
   "keywords": [

--- a/libs/components/indicators/package.json
+++ b/libs/components/indicators/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@skyux/indicators",
+  "type": "commonjs",
   "version": "0.0.0-PLACEHOLDER",
   "author": "Blackbaud, Inc.",
   "keywords": [

--- a/libs/components/inline-form/package.json
+++ b/libs/components/inline-form/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@skyux/inline-form",
+  "type": "commonjs",
   "version": "0.0.0-PLACEHOLDER",
   "author": "Blackbaud, Inc.",
   "keywords": [

--- a/libs/components/layout/package.json
+++ b/libs/components/layout/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@skyux/layout",
+  "type": "commonjs",
   "version": "0.0.0-PLACEHOLDER",
   "author": "Blackbaud, Inc.",
   "keywords": [

--- a/libs/components/list-builder-common/package.json
+++ b/libs/components/list-builder-common/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@skyux/list-builder-common",
+  "type": "commonjs",
   "version": "0.0.0-PLACEHOLDER",
   "author": "Blackbaud, Inc.",
   "keywords": [

--- a/libs/components/list-builder-view-checklist/package.json
+++ b/libs/components/list-builder-view-checklist/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@skyux/list-builder-view-checklist",
+  "type": "commonjs",
   "version": "0.0.0-PLACEHOLDER",
   "author": "Blackbaud, Inc.",
   "keywords": [

--- a/libs/components/list-builder-view-grids/package.json
+++ b/libs/components/list-builder-view-grids/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@skyux/list-builder-view-grids",
+  "type": "commonjs",
   "version": "0.0.0-PLACEHOLDER",
   "author": "Blackbaud, Inc.",
   "keywords": [

--- a/libs/components/list-builder/package.json
+++ b/libs/components/list-builder/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@skyux/list-builder",
+  "type": "commonjs",
   "version": "0.0.0-PLACEHOLDER",
   "author": "Blackbaud, Inc.",
   "keywords": [

--- a/libs/components/lists/package.json
+++ b/libs/components/lists/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@skyux/lists",
+  "type": "commonjs",
   "version": "0.0.0-PLACEHOLDER",
   "author": "Blackbaud, Inc.",
   "keywords": [

--- a/libs/components/lookup/package.json
+++ b/libs/components/lookup/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@skyux/lookup",
+  "type": "commonjs",
   "version": "0.0.0-PLACEHOLDER",
   "author": "Blackbaud, Inc.",
   "keywords": [

--- a/libs/components/manifest-generator/src/testing/fixtures/example-packages/bar/package.json
+++ b/libs/components/manifest-generator/src/testing/fixtures/example-packages/bar/package.json
@@ -1,3 +1,4 @@
 {
-  "name": "@skyux/bar"
+  "name": "@skyux/bar",
+  "type": "commonjs"
 }

--- a/libs/components/manifest-generator/src/testing/fixtures/example-packages/code-examples/package.json
+++ b/libs/components/manifest-generator/src/testing/fixtures/example-packages/code-examples/package.json
@@ -1,3 +1,4 @@
 {
-  "name": "@skyux/code-examples"
+  "name": "@skyux/code-examples",
+  "type": "commonjs"
 }

--- a/libs/components/manifest-generator/src/testing/fixtures/example-packages/foo/package.json
+++ b/libs/components/manifest-generator/src/testing/fixtures/example-packages/foo/package.json
@@ -1,3 +1,4 @@
 {
-  "name": "@skyux/foo"
+  "name": "@skyux/foo",
+  "type": "commonjs"
 }

--- a/libs/components/manifest-generator/src/testing/fixtures/example-packages/invalid-code-examples/package.json
+++ b/libs/components/manifest-generator/src/testing/fixtures/example-packages/invalid-code-examples/package.json
@@ -1,3 +1,4 @@
 {
-  "name": "@skyux/invalid-code-examples"
+  "name": "@skyux/invalid-code-examples",
+  "type": "commonjs"
 }

--- a/libs/components/manifest-generator/src/testing/fixtures/example-packages/invalid-docs-id/package.json
+++ b/libs/components/manifest-generator/src/testing/fixtures/example-packages/invalid-docs-id/package.json
@@ -1,3 +1,4 @@
 {
-  "name": "@skyux/invalid-docs-id"
+  "name": "@skyux/invalid-docs-id",
+  "type": "commonjs"
 }

--- a/libs/components/manifest-generator/src/testing/fixtures/example-packages/invalid-documentation-json/package.json
+++ b/libs/components/manifest-generator/src/testing/fixtures/example-packages/invalid-documentation-json/package.json
@@ -1,3 +1,4 @@
 {
-  "name": "@skyux/invalid-documentation-json"
+  "name": "@skyux/invalid-documentation-json",
+  "type": "commonjs"
 }

--- a/libs/components/modals/package.json
+++ b/libs/components/modals/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@skyux/modals",
+  "type": "commonjs",
   "version": "0.0.0-PLACEHOLDER",
   "author": "Blackbaud, Inc.",
   "keywords": [

--- a/libs/components/navbar/package.json
+++ b/libs/components/navbar/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@skyux/navbar",
+  "type": "commonjs",
   "version": "0.0.0-PLACEHOLDER",
   "author": "Blackbaud, Inc.",
   "keywords": [

--- a/libs/components/packages/package.json
+++ b/libs/components/packages/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@skyux/packages",
+  "type": "commonjs",
   "version": "0.0.0-PLACEHOLDER",
   "author": "Blackbaud, Inc.",
   "description": "Handles the `ng update` command for SKY UX component libraries.",

--- a/libs/components/pages/package.json
+++ b/libs/components/pages/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@skyux/pages",
+  "type": "commonjs",
   "version": "0.0.0-PLACEHOLDER",
   "author": "Blackbaud, Inc.",
   "keywords": [

--- a/libs/components/phone-field/package.json
+++ b/libs/components/phone-field/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@skyux/phone-field",
+  "type": "commonjs",
   "version": "0.0.0-PLACEHOLDER",
   "author": "Blackbaud, Inc.",
   "keywords": [

--- a/libs/components/popovers/package.json
+++ b/libs/components/popovers/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@skyux/popovers",
+  "type": "commonjs",
   "version": "0.0.0-PLACEHOLDER",
   "author": "Blackbaud, Inc.",
   "keywords": [

--- a/libs/components/progress-indicator/package.json
+++ b/libs/components/progress-indicator/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@skyux/progress-indicator",
+  "type": "commonjs",
   "version": "0.0.0-PLACEHOLDER",
   "author": "Blackbaud, Inc.",
   "keywords": [

--- a/libs/components/router/package.json
+++ b/libs/components/router/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@skyux/router",
+  "type": "commonjs",
   "version": "0.0.0-PLACEHOLDER",
   "author": "Blackbaud, Inc.",
   "keywords": [

--- a/libs/components/select-field/package.json
+++ b/libs/components/select-field/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@skyux/select-field",
+  "type": "commonjs",
   "version": "0.0.0-PLACEHOLDER",
   "author": "Blackbaud, Inc.",
   "keywords": [

--- a/libs/components/split-view/package.json
+++ b/libs/components/split-view/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@skyux/split-view",
+  "type": "commonjs",
   "version": "0.0.0-PLACEHOLDER",
   "author": "Blackbaud, Inc.",
   "keywords": [

--- a/libs/components/storybook/package.json
+++ b/libs/components/storybook/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@skyux/storybook",
+  "type": "commonjs",
   "version": "0.0.1",
   "peerDependencies": {
     "@angular/cdk": "^21.2.0",

--- a/libs/components/tabs/package.json
+++ b/libs/components/tabs/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@skyux/tabs",
+  "type": "commonjs",
   "version": "0.0.0-PLACEHOLDER",
   "author": "Blackbaud, Inc.",
   "keywords": [

--- a/libs/components/text-editor/package.json
+++ b/libs/components/text-editor/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@skyux/text-editor",
+  "type": "commonjs",
   "version": "0.0.0-PLACEHOLDER",
   "author": "Blackbaud, Inc.",
   "keywords": [

--- a/libs/components/theme/package.json
+++ b/libs/components/theme/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@skyux/theme",
+  "type": "commonjs",
   "version": "0.0.0-PLACEHOLDER",
   "author": "Blackbaud, Inc.",
   "keywords": [

--- a/libs/components/tiles/package.json
+++ b/libs/components/tiles/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@skyux/tiles",
+  "type": "commonjs",
   "version": "0.0.0-PLACEHOLDER",
   "author": "Blackbaud, Inc.",
   "keywords": [

--- a/libs/components/toast/package.json
+++ b/libs/components/toast/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@skyux/toast",
+  "type": "commonjs",
   "version": "0.0.0-PLACEHOLDER",
   "author": "Blackbaud, Inc.",
   "keywords": [

--- a/libs/components/validation/package.json
+++ b/libs/components/validation/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@skyux/validation",
+  "type": "commonjs",
   "version": "0.0.0-PLACEHOLDER",
   "author": "Blackbaud, Inc.",
   "keywords": [

--- a/libs/sdk/cypress-commands/package.json
+++ b/libs/sdk/cypress-commands/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@skyux-sdk/cypress-commands",
+  "type": "commonjs",
   "version": "0.0.1",
   "dependencies": {},
   "peerDependencies": {

--- a/libs/sdk/e2e-schematics/package.json
+++ b/libs/sdk/e2e-schematics/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@skyux-sdk/e2e-schematics",
+  "type": "commonjs",
   "version": "1.0.0",
   "peerDependencies": {
     "@angular-devkit/core": "^21.2.0",

--- a/libs/sdk/eslint-config-skyux/package.json
+++ b/libs/sdk/eslint-config-skyux/package.json
@@ -1,5 +1,6 @@
 {
   "name": "eslint-config-skyux",
+  "type": "commonjs",
   "version": "0.0.0-PLACEHOLDER",
   "author": "Blackbaud, Inc.",
   "description": "Recommended ESLint configuration for SKY UX projects",

--- a/libs/sdk/eslint-config/package.json
+++ b/libs/sdk/eslint-config/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@skyux-sdk/eslint-config",
+  "type": "commonjs",
   "version": "0.0.0-PLACEHOLDER",
   "author": "Blackbaud, Inc.",
   "description": "Angular CLI schematics to implement recommended ESLint configuration",

--- a/libs/sdk/eslint-schematics/package.json
+++ b/libs/sdk/eslint-schematics/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@skyux-sdk/eslint-schematics",
+  "type": "commonjs",
   "version": "0.0.0-PLACEHOLDER",
   "author": "Blackbaud, Inc.",
   "description": "SKY UX ESLint schematics for Angular CLI projects",

--- a/libs/sdk/skyux-eslint/package.json
+++ b/libs/sdk/skyux-eslint/package.json
@@ -1,5 +1,6 @@
 {
   "name": "skyux-eslint",
+  "type": "commonjs",
   "version": "0.0.0-PLACEHOLDER",
   "author": "Blackbaud, Inc.",
   "description": "An ESLint plugin for SKY UX projects",

--- a/libs/sdk/stylelint-schematics/package.json
+++ b/libs/sdk/stylelint-schematics/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@skyux-sdk/stylelint-schematics",
+  "type": "commonjs",
   "version": "0.0.0-PLACEHOLDER",
   "author": "Blackbaud, Inc.",
   "description": "Stylelint schematics for SKY UX projects",

--- a/libs/sdk/testing/package.json
+++ b/libs/sdk/testing/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@skyux-sdk/testing",
+  "type": "commonjs",
   "version": "0.0.0-PLACEHOLDER",
   "author": "Blackbaud, Inc.",
   "keywords": [

--- a/libs/sdk/tools/package.json
+++ b/libs/sdk/tools/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@skyux-sdk/tools",
+  "type": "commonjs",
   "generators": "./generators.json",
   "peerDependencies": {
     "@nx/devkit": "^22.5.3"

--- a/package-lock.json
+++ b/package-lock.json
@@ -131,7 +131,7 @@
         "karma-jasmine": "5.1.0",
         "karma-jasmine-html-reporter": "2.2.0",
         "minimist": "1.2.8",
-        "ng-packagr": "21.2.0",
+        "ng-packagr": "21.2.2",
         "nx": "22.5.3",
         "nyc": "17.1.0",
         "prettier": "3.8.1",
@@ -31411,9 +31411,9 @@
       }
     },
     "node_modules/ng-packagr": {
-      "version": "21.2.0",
-      "resolved": "https://registry.npmjs.org/ng-packagr/-/ng-packagr-21.2.0.tgz",
-      "integrity": "sha512-ASlXEboqt+ZgKzNPx3YCr924xqQRFA5qgm77GHf0Fm13hx7gVFYVm6WCdYZyeX/p9NJjFWAL+mIMfhsx2SHKoA==",
+      "version": "21.2.2",
+      "resolved": "https://registry.npmjs.org/ng-packagr/-/ng-packagr-21.2.2.tgz",
+      "integrity": "sha512-VO0y7RU3Ik8E14QdrryVyVbTAyqO2MK9W9GrG4e/4N8+ti+DWiBSQmw0tIhnV67lEjQwCccPA3ZBoIn3B1vJ1Q==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -31434,7 +31434,7 @@
         "ora": "^9.0.0",
         "piscina": "^5.0.0",
         "postcss": "^8.4.47",
-        "rollup-plugin-dts": "^6.2.0",
+        "rollup-plugin-dts": "^6.4.0",
         "rxjs": "^7.8.1",
         "sass": "^1.81.0",
         "tinyglobby": "^0.2.12"

--- a/package.json
+++ b/package.json
@@ -212,7 +212,7 @@
     "karma-jasmine": "5.1.0",
     "karma-jasmine-html-reporter": "2.2.0",
     "minimist": "1.2.8",
-    "ng-packagr": "21.2.0",
+    "ng-packagr": "21.2.2",
     "nx": "22.5.3",
     "nyc": "17.1.0",
     "prettier": "3.8.1",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized module format declarations across component and SDK packages for improved Node.js module resolution.
  * Updated build dependency version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->