### PR TITLE
fix(components/i18n): add support for `ng-packagr@21.2.2`

### DIFF
--- a/libs/components/i18n/jasmine.json
+++ b/libs/components/i18n/jasmine.json
@@ -1,4 +1,5 @@
 {
   "spec_dir": "",
-  "spec_files": ["schematics/**/*.spec.ts"]
+  "spec_files": ["schematics/**/*.spec.ts"],
+  "jsLoader": "require"
 }

--- a/libs/components/i18n/package.json
+++ b/libs/components/i18n/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@skyux/i18n",
+  "type": "commonjs",
   "version": "0.0.0-PLACEHOLDER",
   "author": "Blackbaud, Inc.",
   "keywords": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -131,7 +131,7 @@
         "karma-jasmine": "5.1.0",
         "karma-jasmine-html-reporter": "2.2.0",
         "minimist": "1.2.8",
-        "ng-packagr": "21.2.0",
+        "ng-packagr": "21.2.2",
         "nx": "22.5.3",
         "nyc": "17.1.0",
         "prettier": "3.8.1",
@@ -31411,9 +31411,9 @@
       }
     },
     "node_modules/ng-packagr": {
-      "version": "21.2.0",
-      "resolved": "https://registry.npmjs.org/ng-packagr/-/ng-packagr-21.2.0.tgz",
-      "integrity": "sha512-ASlXEboqt+ZgKzNPx3YCr924xqQRFA5qgm77GHf0Fm13hx7gVFYVm6WCdYZyeX/p9NJjFWAL+mIMfhsx2SHKoA==",
+      "version": "21.2.2",
+      "resolved": "https://registry.npmjs.org/ng-packagr/-/ng-packagr-21.2.2.tgz",
+      "integrity": "sha512-VO0y7RU3Ik8E14QdrryVyVbTAyqO2MK9W9GrG4e/4N8+ti+DWiBSQmw0tIhnV67lEjQwCccPA3ZBoIn3B1vJ1Q==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -31434,7 +31434,7 @@
         "ora": "^9.0.0",
         "piscina": "^5.0.0",
         "postcss": "^8.4.47",
-        "rollup-plugin-dts": "^6.2.0",
+        "rollup-plugin-dts": "^6.4.0",
         "rxjs": "^7.8.1",
         "sass": "^1.81.0",
         "tinyglobby": "^0.2.12"

--- a/package.json
+++ b/package.json
@@ -212,7 +212,7 @@
     "karma-jasmine": "5.1.0",
     "karma-jasmine-html-reporter": "2.2.0",
     "minimist": "1.2.8",
-    "ng-packagr": "21.2.0",
+    "ng-packagr": "21.2.2",
     "nx": "22.5.3",
     "nyc": "17.1.0",
     "prettier": "3.8.1",


### PR DESCRIPTION
[AB#3939429](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3939429)

[ng-packagr 21.2.2 sets `type=module` in package.json.](https://github.com/ng-packagr/ng-packagr/releases/tag/21.2.2) This is a breaking change for projects that use `ng-packagr` to build, but ALSO include schematics. Schematics only support CommonJS. Component libraries by themselves can support either CommonJS or ESM.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated build tool dependency to a new patch version.
  * Adjusted package module metadata for CommonJS compatibility.
* **Tests**
  * Updated test runner configuration to use a specific JavaScript loader.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->