### PR TITLE
chore: release 13.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 # Changelog
 
 
+# [13.17.0](https://github.com/blackbaud/skyux/compare/13.16.4...13.17.0) (2026-04-07)
+
+
+### Features
+
+* bump design token library ([#4371](https://github.com/blackbaud/skyux/issues/4371)) ([0f53454](https://github.com/blackbaud/skyux/commit/0f534545843327b50e0ebf7560d22d677afa090b)), closes [AB#3652195](https://github.com/AB/issues/3652195)
+
+
+
 ## [13.16.4](https://github.com/blackbaud/skyux/compare/13.16.3...13.16.4) (2026-03-31)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "skyux",
-  "version": "13.16.4",
+  "version": "13.17.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "skyux",
-      "version": "13.16.4",
+      "version": "13.17.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skyux",
-  "version": "13.16.4",
+  "version": "13.17.0",
   "license": "MIT",
   "scripts": {
     "ng": "nx",


### PR DESCRIPTION
# [13.17.0](https://github.com/blackbaud/skyux/compare/13.16.4...13.17.0) (2026-04-07)


### Features

* bump design token library ([#4371](https://github.com/blackbaud/skyux/issues/4371)) ([0f53454](https://github.com/blackbaud/skyux/commit/0f534545843327b50e0ebf7560d22d677afa090b)), closes [AB#3652195](https://github.com/AB/issues/3652195)