### PR TITLE
fix(components/lists): use correct padding on active toolbar filter button

### DIFF
--- a/apps/e2e/layout-storybook/src/app/toolbar/toolbar.component.html
+++ b/apps/e2e/layout-storybook/src/app/toolbar/toolbar.component.html
@@ -25,6 +25,12 @@
     </button>
   </sky-toolbar-item>
   <sky-toolbar-item>
+    <sky-filter-button [showButtonText]="true" />
+  </sky-toolbar-item>
+  <sky-toolbar-item>
+    <sky-filter-button [active]="true" [showButtonText]="true" />
+  </sky-toolbar-item>
+  <sky-toolbar-item>
     <sky-search [debounceTime]="250" />
   </sky-toolbar-item>
   <sky-toolbar-view-actions>

--- a/apps/e2e/layout-storybook/src/app/toolbar/toolbar.module.ts
+++ b/apps/e2e/layout-storybook/src/app/toolbar/toolbar.module.ts
@@ -5,6 +5,7 @@ import { RouterModule, Routes } from '@angular/router';
 import { SkyRadioModule } from '@skyux/forms';
 import { SkyIconModule } from '@skyux/icon';
 import { SkyToolbarModule } from '@skyux/layout';
+import { SkyFilterModule } from '@skyux/lists';
 import { SkySearchModule } from '@skyux/lookup';
 import { SkyThemeModule } from '@skyux/theme';
 
@@ -19,6 +20,7 @@ const routes: Routes = [{ path: '', component: ToolbarComponent }];
     RouterModule.forChild(routes),
     SkyIconModule,
     SkyRadioModule,
+    SkyFilterModule,
     SkySearchModule,
     SkyThemeModule,
     SkyToolbarModule,

--- a/apps/playground/src/app/components/layout/toolbar/toolbar.component.html
+++ b/apps/playground/src/app/components/layout/toolbar/toolbar.component.html
@@ -32,6 +32,12 @@
       </button>
     </sky-toolbar-item>
     <sky-toolbar-item>
+      <sky-filter-button [showButtonText]="true" />
+    </sky-toolbar-item>
+    <sky-toolbar-item>
+      <sky-filter-button [active]="true" [showButtonText]="true" />
+    </sky-toolbar-item>
+    <sky-toolbar-item>
       <sky-search [debounceTime]="250" />
     </sky-toolbar-item>
     <sky-toolbar-view-actions>

--- a/apps/playground/src/app/components/layout/toolbar/toolbar.module.ts
+++ b/apps/playground/src/app/components/layout/toolbar/toolbar.module.ts
@@ -4,6 +4,7 @@ import { SkyViewkeeperModule } from '@skyux/core';
 import { SkyRadioModule } from '@skyux/forms';
 import { SkyIconModule } from '@skyux/icon';
 import { SkyToolbarModule } from '@skyux/layout';
+import { SkyFilterModule } from '@skyux/lists';
 import { SkySearchModule } from '@skyux/lookup';
 
 import { ToolbarRoutingModule } from './toolbar-routing.module';
@@ -18,6 +19,7 @@ import { ToolbarComponent } from './toolbar.component';
     SkySearchModule,
     SkyToolbarModule,
     SkyViewkeeperModule,
+    SkyFilterModule,
     FormsModule,
   ],
 })

--- a/libs/components/layout/src/lib/modules/toolbar/toolbar-item.component.scss
+++ b/libs/components/layout/src/lib/modules/toolbar/toolbar-item.component.scss
@@ -1,4 +1,3 @@
-@use 'libs/components/theme/src/lib/styles/mixins' as mixins;
 @use 'libs/components/theme/src/lib/styles/variables' as *;
 @use 'libs/components/theme/src/lib/styles/compat-tokens-mixins' as compatMixins;
 
@@ -29,11 +28,4 @@
   --sky-comp-override-toolbar-button-elevation-disabled: var(
     --sky-elevation-action-toolbar-disabled
   );
-}
-
-@include mixins.sky-theme-modern {
-  ::ng-deep .sky-btn {
-    padding-left: var(--sky-comp-button-toolbar-space-inset-left);
-    padding-right: var(--sky-comp-button-toolbar-space-inset-right);
-  }
 }

--- a/libs/components/layout/src/lib/modules/toolbar/toolbar.component.scss
+++ b/libs/components/layout/src/lib/modules/toolbar/toolbar.component.scss
@@ -7,6 +7,7 @@
   --sky-override-toolbar-border-top-bottom: #{1px solid
     $sky-border-color-neutral-medium};
   --sky-override-toolbar-container-padding: #{$sky-padding-half $sky-padding 0};
+  --sky-override-toolbar-item-button-horizontal-padding: inherit;
 }
 
 sky-toolbar + :host {
@@ -16,6 +17,15 @@ sky-toolbar + :host {
 }
 
 .sky-toolbar-container {
+  --sky-comp-override-button-padding-right: var(
+    --sky-override-toolbar-item-button-horizontal-padding,
+    var(--sky-comp-button-toolbar-space-inset-right)
+  );
+  --sky-comp-override-button-padding-left: var(
+    --sky-override-toolbar-item-button-horizontal-padding,
+    var(--sky-comp-button-toolbar-space-inset-left)
+  );
+
   min-height: $sky-toolbar-min-height;
   background-color: var(
     --sky-comp-override-list-header-background-color,

--- a/libs/components/lists/src/lib/modules/filter/filter-button.component.scss
+++ b/libs/components/lists/src/lib/modules/filter/filter-button.component.scss
@@ -24,9 +24,15 @@
       var(--sky-color-border-selected);
     color: var(--sky-color-text-selected);
     padding: var(--sky-comp-button-space-inset-top)
-      var(--sky-comp-button-space-inset-right)
+      var(
+        --sky-comp-override-button-padding-right,
+        var(--sky-comp-button-space-inset-right)
+      )
       var(--sky-comp-button-space-inset-bottom)
-      var(--sky-comp-button-space-inset-left);
+      var(
+        --sky-comp-override-button-padding-left,
+        var(--sky-comp-button-space-inset-left)
+      );
 
     sky-icon {
       color: var(--sky-color-icon-selected);

--- a/libs/components/lookup/src/lib/modules/search/search.component.scss
+++ b/libs/components/lookup/src/lib/modules/search/search.component.scss
@@ -90,11 +90,17 @@ sky-search {
     );
     padding-left: var(
       --sky-override-search-mobile-button-horizontal-padding,
-      var(--sky-comp-button-space-inset-left)
+      var(
+        --sky-comp-override-button-padding-left,
+        var(--sky-comp-button-space-inset-left)
+      )
     );
     padding-right: var(
       --sky-override-search-mobile-button-horizontal-padding,
-      var(--sky-comp-button-space-inset-right)
+      var(
+        --sky-comp-override-button-padding-right,
+        var(--sky-comp-button-space-inset-right)
+      )
     );
   }
 

--- a/libs/components/theme/src/lib/styles/themes/modern/_buttons.scss
+++ b/libs/components/theme/src/lib/styles/themes/modern/_buttons.scss
@@ -18,9 +18,15 @@
   .sky-btn-link,
   .sky-btn-borderless {
     padding: var(--sky-comp-button-space-inset-top)
-      var(--sky-comp-button-space-inset-right)
+      var(
+        --sky-comp-override-button-padding-right,
+        var(--sky-comp-button-space-inset-right)
+      )
       var(--sky-comp-button-space-inset-bottom)
-      var(--sky-comp-button-space-inset-left);
+      var(
+        --sky-comp-override-button-padding-left,
+        var(--sky-comp-button-space-inset-left)
+      );
   }
 
   .sky-btn-default,


### PR DESCRIPTION
Also update the toolbar item/button styles to use the comp override token pattern instead of ng-deep

[AB#3897556](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3897556)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Filter buttons added to toolbars, including optional text labels and active-state indication.

* **Style**
  * Improved toolbar and button spacing with new override-aware padding variables for consistent layout and better theming control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->