### PR TITLE
chore: release 14.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### Bug Fixes
 
+* **components/ag-grid:** header checkbox uses correct indeterminate styling when using native multiselect ([#4375](https://github.com/blackbaud/skyux/issues/4375)) ([04d11f7](https://github.com/blackbaud/skyux/commit/04d11f71d1827ab3f87d14e1e1aa65d46aa0b26d))
 * **components/lists:** use correct padding on active toolbar filter button ([#4373](https://github.com/blackbaud/skyux/issues/4373)) ([07974aa](https://github.com/blackbaud/skyux/commit/07974aab12be8d7e17bc6beafda99adf22a1d4a3))
 
 ## [14.0.1](https://github.com/blackbaud/skyux/compare/14.0.0...14.0.1) (2026-04-03)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 
-## [14.0.2](https://github.com/blackbaud/skyux/compare/14.0.1...14.0.2) (2026-04-07)
+## [14.0.2](https://github.com/blackbaud/skyux/compare/14.0.1...14.0.2) (2026-04-08)
 
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 
-## [14.1.0](https://github.com/blackbaud/skyux/compare/14.0.1...14.1.0) (2026-04-16)
+## [14.1.0](https://github.com/blackbaud/skyux/compare/14.0.1...14.1.0) (2026-04-17)
 
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,12 @@
 # Changelog
 
 
-## [14.0.2](https://github.com/blackbaud/skyux/compare/14.0.1...14.0.2) (2026-04-15)
+## [14.1.0](https://github.com/blackbaud/skyux/compare/14.0.1...14.1.0) (2026-04-15)
+
+
+### Features
+
+* **sdk/testing:** implement `ng add` schematic for `@skyux-sdk/testing` package ([#4376](https://github.com/blackbaud/skyux/issues/4376)) ([4db0f98](https://github.com/blackbaud/skyux/commit/4db0f98c91b27261c25c735e3fb202b62f8b9044))
 
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 
-## [14.0.2](https://github.com/blackbaud/skyux/compare/14.0.1...14.0.2) (2026-04-09)
+## [14.0.2](https://github.com/blackbaud/skyux/compare/14.0.1...14.0.2) (2026-04-10)
 
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 
-## [14.0.2](https://github.com/blackbaud/skyux/compare/14.0.1...14.0.2) (2026-04-14)
+## [14.0.2](https://github.com/blackbaud/skyux/compare/14.0.1...14.0.2) (2026-04-15)
 
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 
-## [14.0.2](https://github.com/blackbaud/skyux/compare/14.0.1...14.0.2) (2026-04-11)
+## [14.0.2](https://github.com/blackbaud/skyux/compare/14.0.1...14.0.2) (2026-04-12)
 
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 
-## [14.0.2](https://github.com/blackbaud/skyux/compare/14.0.1...14.0.2) (2026-04-12)
+## [14.0.2](https://github.com/blackbaud/skyux/compare/14.0.1...14.0.2) (2026-04-13)
 
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
 
+## [14.0.2](https://github.com/blackbaud/skyux/compare/14.0.1...14.0.2) (2026-04-07)
+
+
+### Bug Fixes
+
+* **components/lists:** use correct padding on active toolbar filter button ([#4373](https://github.com/blackbaud/skyux/issues/4373)) ([07974aa](https://github.com/blackbaud/skyux/commit/07974aab12be8d7e17bc6beafda99adf22a1d4a3))
+
 ## [14.0.1](https://github.com/blackbaud/skyux/compare/14.0.0...14.0.1) (2026-04-03)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 
-## [14.0.2](https://github.com/blackbaud/skyux/compare/14.0.1...14.0.2) (2026-04-10)
+## [14.0.2](https://github.com/blackbaud/skyux/compare/14.0.1...14.0.2) (2026-04-11)
 
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 
-## [14.1.0](https://github.com/blackbaud/skyux/compare/14.0.1...14.1.0) (2026-04-15)
+## [14.1.0](https://github.com/blackbaud/skyux/compare/14.0.1...14.1.0) (2026-04-16)
 
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Features
 
+* **sdk/testing:** add `toBeAccessible` matcher for vitest assertions ([#4219](https://github.com/blackbaud/skyux/issues/4219)) ([56dedfe](https://github.com/blackbaud/skyux/commit/56dedfe611846fc24f611725c9ee14062131781c))
 * **sdk/testing:** implement `ng add` schematic for `@skyux-sdk/testing` package ([#4376](https://github.com/blackbaud/skyux/issues/4376)) ([4db0f98](https://github.com/blackbaud/skyux/commit/4db0f98c91b27261c25c735e3fb202b62f8b9044))
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 
-## [14.0.2](https://github.com/blackbaud/skyux/compare/14.0.1...14.0.2) (2026-04-13)
+## [14.0.2](https://github.com/blackbaud/skyux/compare/14.0.1...14.0.2) (2026-04-14)
 
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 
-## [14.0.2](https://github.com/blackbaud/skyux/compare/14.0.1...14.0.2) (2026-04-08)
+## [14.0.2](https://github.com/blackbaud/skyux/compare/14.0.1...14.0.2) (2026-04-09)
 
 
 ### Bug Fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "skyux",
-  "version": "14.0.2",
+  "version": "14.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "skyux",
-      "version": "14.0.2",
+      "version": "14.1.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "skyux",
-  "version": "14.0.1",
+  "version": "14.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "skyux",
-      "version": "14.0.1",
+      "version": "14.0.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skyux",
-  "version": "14.0.2",
+  "version": "14.1.0",
   "license": "MIT",
   "scripts": {
     "ng": "nx",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skyux",
-  "version": "14.0.1",
+  "version": "14.0.2",
   "license": "MIT",
   "scripts": {
     "ng": "nx",


### PR DESCRIPTION
## [14.1.0](https://github.com/blackbaud/skyux/compare/14.0.1...14.1.0) (2026-04-17)


### Features

* **sdk/testing:** add `toBeAccessible` matcher for vitest assertions ([#4219](https://github.com/blackbaud/skyux/issues/4219)) ([56dedfe](https://github.com/blackbaud/skyux/commit/56dedfe611846fc24f611725c9ee14062131781c))
* **sdk/testing:** implement `ng add` schematic for `@skyux-sdk/testing` package ([#4376](https://github.com/blackbaud/skyux/issues/4376)) ([4db0f98](https://github.com/blackbaud/skyux/commit/4db0f98c91b27261c25c735e3fb202b62f8b9044))


### Bug Fixes

* **components/ag-grid:** header checkbox uses correct indeterminate styling when using native multiselect ([#4375](https://github.com/blackbaud/skyux/issues/4375)) ([04d11f7](https://github.com/blackbaud/skyux/commit/04d11f71d1827ab3f87d14e1e1aa65d46aa0b26d))
* **components/lists:** use correct padding on active toolbar filter button ([#4373](https://github.com/blackbaud/skyux/issues/4373)) ([07974aa](https://github.com/blackbaud/skyux/commit/07974aab12be8d7e17bc6beafda99adf22a1d4a3))

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added accessibility testing vitest matcher
  * Added schematic for testing SDK setup via `ng add`

* **Bug Fixes**
  * Fixed indeterminate header checkbox styling in ag-grid
  * Fixed padding on active toolbar filter button in lists

<!-- end of auto-generated comment: release notes by coderabbit.ai -->