### PR TITLE
fix(components/ag-grid): header checkbox uses correct indeterminate styling when using native multiselect

### DIFF
--- a/apps/e2e/ag-grid-storybook-e2e/src/e2e/ag-grid-native-multiselect.component.cy.ts
+++ b/apps/e2e/ag-grid-storybook-e2e/src/e2e/ag-grid-native-multiselect.component.cy.ts
@@ -8,7 +8,7 @@ describe('ag-grid-native-multiselect', () => {
         : [false];
       compactOptions.forEach((compact) => {
         it(`should render native multiselect checkbox states in ${theme}${compact ? '-compact' : ''} theme`, () => {
-          cy.viewport(1024, 1000).visit(
+          cy.viewport(1024, 2000).visit(
             // eslint-disable-next-line @cspell/spellchecker
             `/iframe.html?globals=theme:${theme}&id=ag-grid-native-multiselectcomponent--ag-grid-native-multiselect${compact ? '-compact' : ''}`,
           );
@@ -21,6 +21,7 @@ describe('ag-grid-native-multiselect', () => {
             {
               overwrite: true,
               disableTimersAndAnimations: true,
+              capture: 'fullPage',
             },
           );
         });

--- a/apps/e2e/ag-grid-storybook-e2e/src/e2e/ag-grid-native-multiselect.component.cy.ts
+++ b/apps/e2e/ag-grid-storybook-e2e/src/e2e/ag-grid-native-multiselect.component.cy.ts
@@ -1,0 +1,30 @@
+import { E2eVariations } from '@skyux-sdk/e2e-schematics';
+
+describe('ag-grid-native-multiselect', () => {
+  E2eVariations.forEachTheme((theme) => {
+    describe(`in ${theme} theme`, () => {
+      const compactOptions = theme.startsWith('modern')
+        ? [false, true]
+        : [false];
+      compactOptions.forEach((compact) => {
+        it(`should render native multiselect checkbox states in ${theme}${compact ? '-compact' : ''} theme`, () => {
+          cy.viewport(1024, 1000).visit(
+            // eslint-disable-next-line @cspell/spellchecker
+            `/iframe.html?globals=theme:${theme}&id=ag-grid-native-multiselectcomponent--ag-grid-native-multiselect${compact ? '-compact' : ''}`,
+          );
+
+          cy.skyReady('app-ag-grid-multiselect', ['#ready']);
+
+          cy.get('#storybook-root').skyVisualTest(
+            // eslint-disable-next-line @cspell/spellchecker
+            `aggridnativemultiselectcomponent-aggridnativemultiselect--${theme}${compact ? '-compact' : ''}`,
+            {
+              overwrite: true,
+              disableTimersAndAnimations: true,
+            },
+          );
+        });
+      });
+    });
+  });
+});

--- a/apps/e2e/ag-grid-storybook/src/app/ag-grid-native-multiselect/ag-grid-native-multiselect.component.html
+++ b/apps/e2e/ag-grid-storybook/src/app/ag-grid-native-multiselect/ag-grid-native-multiselect.component.html
@@ -1,0 +1,24 @@
+<h1>AG Grid Native Multiselect</h1>
+
+<ng-template #gridTemplate>
+  @for (dataSet of dataSets; track dataSet.id) {
+    <h2>{{ dataSet.label }}</h2>
+    <sky-ag-grid-wrapper [attr.id]="dataSet.id" [compact]="compact">
+      <ag-grid-angular [gridOptions]="gridOptions[dataSet.id]" />
+    </sky-ag-grid-wrapper>
+  }
+</ng-template>
+
+@if (isActive$ | async) {
+  <ng-container *ngTemplateOutlet="gridTemplate" />
+} @else {
+  @if (skyTheme) {
+    <div [skyTheme]="skyTheme">
+      <ng-container *ngTemplateOutlet="gridTemplate" />
+    </div>
+  }
+}
+
+@if (ready | async) {
+  <span id="ready"></span>
+}

--- a/apps/e2e/ag-grid-storybook/src/app/ag-grid-native-multiselect/ag-grid-native-multiselect.component.stories.ts
+++ b/apps/e2e/ag-grid-storybook/src/app/ag-grid-native-multiselect/ag-grid-native-multiselect.component.stories.ts
@@ -1,0 +1,18 @@
+import type { Meta, StoryObj } from '@storybook/angular';
+
+import { AgGridMultiselectComponent } from './ag-grid-native-multiselect.component';
+
+export default {
+  id: 'ag-grid-native-multiselectcomponent',
+  title: 'Components/Ag Grid Native Multiselect',
+  component: AgGridMultiselectComponent,
+} as Meta<AgGridMultiselectComponent>;
+type Story = StoryObj<AgGridMultiselectComponent>;
+
+export const AgGridNativeMultiselect: Story = {};
+AgGridNativeMultiselect.args = {};
+
+export const AgGridNativeMultiselectCompact: Story = {};
+AgGridNativeMultiselectCompact.args = {
+  compact: true,
+};

--- a/apps/e2e/ag-grid-storybook/src/app/ag-grid-native-multiselect/ag-grid-native-multiselect.component.ts
+++ b/apps/e2e/ag-grid-storybook/src/app/ag-grid-native-multiselect/ag-grid-native-multiselect.component.ts
@@ -1,0 +1,168 @@
+import { AsyncPipe, NgTemplateOutlet } from '@angular/common';
+import {
+  AfterViewInit,
+  ChangeDetectorRef,
+  Component,
+  Input,
+  OnDestroy,
+  OnInit,
+  ViewEncapsulation,
+  inject,
+} from '@angular/core';
+import { SkyAgGridModule, SkyAgGridService } from '@skyux/ag-grid';
+import {
+  SkyTheme,
+  SkyThemeMode,
+  SkyThemeModule,
+  SkyThemeService,
+  SkyThemeSettings,
+} from '@skyux/theme';
+
+import { AgGridAngular } from 'ag-grid-angular';
+import {
+  AllCommunityModule,
+  ColDef,
+  GridOptions,
+  ModuleRegistry,
+  RowSelectionOptions,
+} from 'ag-grid-community';
+import { BehaviorSubject, Observable, Subscription, combineLatest } from 'rxjs';
+import { delay, filter, map } from 'rxjs/operators';
+
+ModuleRegistry.registerModules([AllCommunityModule]);
+
+interface DemoRow {
+  id: string;
+  name: string;
+  age: number;
+  department: string;
+}
+
+const DEMO_DATA: DemoRow[] = [
+  { id: '1', name: 'Billy Bob', age: 55, department: 'Customer Support' },
+  { id: '2', name: 'Jane Deere', age: 33, department: 'Engineering' },
+  { id: '3', name: 'John Doe', age: 38, department: 'Sales' },
+  { id: '4', name: 'Sarah Smith', age: 28, department: 'Marketing' },
+  { id: '5', name: 'Tom Jones', age: 45, department: 'Engineering' },
+];
+
+const COLUMN_DEFS: ColDef[] = [
+  { field: 'name', headerName: 'Name' },
+  { field: 'age', headerName: 'Age', maxWidth: 80 },
+  { field: 'department', headerName: 'Department' },
+];
+
+const ROW_SELECTION: RowSelectionOptions = {
+  mode: 'multiRow',
+  checkboxes: true,
+  headerCheckbox: true,
+  selectAll: 'filtered',
+};
+
+@Component({
+  imports: [
+    AgGridAngular,
+    AsyncPipe,
+    NgTemplateOutlet,
+    SkyAgGridModule,
+    SkyThemeModule,
+  ],
+  selector: 'app-ag-grid-multiselect',
+  templateUrl: './ag-grid-native-multiselect.component.html',
+  encapsulation: ViewEncapsulation.None,
+})
+export class AgGridMultiselectComponent
+  implements AfterViewInit, OnInit, OnDestroy
+{
+  @Input() public compact = false;
+
+  public readonly dataSets = [
+    {
+      id: 'unchecked',
+      label: 'Unchecked',
+      initialState: undefined,
+    },
+    {
+      id: 'indeterminate',
+      label: 'Indeterminate',
+      initialState: { rowSelection: ['1', '2'] },
+    },
+    {
+      id: 'checked',
+      label: 'All checked',
+      initialState: { rowSelection: ['1', '2', '3', '4', '5'] },
+    },
+  ];
+
+  public gridOptions: Record<string, GridOptions> = {};
+  public readonly isActive$ = new BehaviorSubject(true);
+  public readonly ready = new BehaviorSubject(false);
+  public skyTheme: SkyThemeSettings | undefined;
+
+  readonly #agGridService = inject(SkyAgGridService);
+  readonly #changeDetectorRef = inject(ChangeDetectorRef);
+  readonly #gridsReady = new Map<string, Observable<boolean>>();
+  readonly #ngUnsubscribe = new Subscription();
+  readonly #themeSvc = inject(SkyThemeService);
+
+  public ngOnInit(): void {
+    this.dataSets.forEach((dataSet) =>
+      this.#gridsReady.set(dataSet.id, new BehaviorSubject(false)),
+    );
+    this.#gridsReady.set(
+      'theme',
+      this.#themeSvc.settingsChange.pipe(map(() => true)),
+    );
+    this.#ngUnsubscribe.add(
+      this.#themeSvc.settingsChange.subscribe((settings) => {
+        this.skyTheme = settings.currentSettings;
+        this.isActive$.next(true);
+        this.#changeDetectorRef.markForCheck();
+      }),
+    );
+    this.dataSets.forEach((dataSet) => {
+      this.gridOptions[dataSet.id] = this.#agGridService.getGridOptions({
+        gridOptions: {
+          columnDefs: COLUMN_DEFS,
+          domLayout: 'autoHeight',
+          getRowId: (params) => params.data.id,
+          initialState: dataSet.initialState,
+          rowData: DEMO_DATA,
+          rowSelection: ROW_SELECTION,
+          suppressColumnVirtualisation: true,
+          suppressHorizontalScroll: true,
+          onFirstDataRendered: () => {
+            (this.#gridsReady.get(dataSet.id) as BehaviorSubject<boolean>).next(
+              true,
+            );
+          },
+        },
+      });
+    });
+  }
+
+  public ngAfterViewInit(): void {
+    this.#ngUnsubscribe.add(
+      combineLatest(Array.from(this.#gridsReady.values()))
+        .pipe(
+          filter((gridsReady) => gridsReady.every((ready) => ready)),
+          delay(1000),
+        )
+        .subscribe(() => this.ready.next(true)),
+    );
+    if (!this.skyTheme) {
+      this.#themeSvc.setTheme(
+        new SkyThemeSettings(
+          SkyTheme.presets.default,
+          SkyThemeMode.presets.light,
+        ),
+      );
+    } else {
+      this.isActive$.next(true);
+    }
+  }
+
+  public ngOnDestroy(): void {
+    this.#ngUnsubscribe.unsubscribe();
+  }
+}

--- a/apps/e2e/ag-grid-storybook/src/app/app.routes.ts
+++ b/apps/e2e/ag-grid-storybook/src/app/app.routes.ts
@@ -2,6 +2,13 @@ import { Route } from '@angular/router';
 
 export const routes: Route[] = [
   {
+    path: 'ag-grid-native-multiselect',
+    loadComponent: () =>
+      import('./ag-grid-native-multiselect/ag-grid-native-multiselect.component').then(
+        (m) => m.AgGridMultiselectComponent,
+      ),
+  },
+  {
     path: 'ag-grid-widgets',
     loadComponent: () =>
       import('./ag-grid-widgets/ag-grid-widgets.component').then(

--- a/apps/playground/src/app/components/ag-grid/ag-grid-routing.module.ts
+++ b/apps/playground/src/app/components/ag-grid/ag-grid-routing.module.ts
@@ -44,6 +44,11 @@ const routes: Routes = [
     loadChildren: () => import('./lookup-focus/lookup-focus-routes'),
   },
   {
+    path: 'native-multiselect',
+    loadChildren: () =>
+      import('./native-multiselect/native-multiselect-routes'),
+  },
+  {
     path: 'readonly-grid',
     loadChildren: () =>
       import('./readonly-grid/readonly-grid.module').then(

--- a/apps/playground/src/app/components/ag-grid/native-multiselect/native-multiselect-routes.ts
+++ b/apps/playground/src/app/components/ag-grid/native-multiselect/native-multiselect-routes.ts
@@ -1,0 +1,17 @@
+import { ComponentRouteInfo } from '../../../shared/component-info/component-route-info';
+
+import { NativeMultiselectComponent } from './native-multiselect.component';
+
+const routes: ComponentRouteInfo[] = [
+  {
+    path: '',
+    component: NativeMultiselectComponent,
+    data: {
+      name: 'AG Grid (native multiselect)',
+      library: 'ag-grid',
+      icon: 'table',
+    },
+  },
+];
+
+export default routes;

--- a/apps/playground/src/app/components/ag-grid/native-multiselect/native-multiselect.component.html
+++ b/apps/playground/src/app/components/ag-grid/native-multiselect/native-multiselect.component.html
@@ -1,0 +1,5 @@
+<h1 class="sky-margin-stacked-default">Native ag-grid multiselect</h1>
+
+<sky-ag-grid-wrapper>
+  <ag-grid-angular [gridOptions]="gridOptions" />
+</sky-ag-grid-wrapper>

--- a/apps/playground/src/app/components/ag-grid/native-multiselect/native-multiselect.component.ts
+++ b/apps/playground/src/app/components/ag-grid/native-multiselect/native-multiselect.component.ts
@@ -1,0 +1,71 @@
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { SkyAgGridModule, SkyAgGridService, SkyCellType } from '@skyux/ag-grid';
+
+import { AgGridModule } from 'ag-grid-angular';
+import {
+  AllCommunityModule,
+  GridOptions,
+  ModuleRegistry,
+  RowSelectionOptions,
+} from 'ag-grid-community';
+
+ModuleRegistry.registerModules([AllCommunityModule]);
+
+interface DemoRow {
+  name: string;
+  age: number;
+  department: string;
+}
+
+const DEMO_DATA: DemoRow[] = [
+  { name: 'Billy Bob', age: 55, department: 'Customer Support' },
+  { name: 'Jane Deere', age: 33, department: 'Engineering' },
+  { name: 'John Doe', age: 38, department: 'Sales' },
+  { name: 'Sarah Smith', age: 28, department: 'Marketing' },
+  { name: 'Tom Jones', age: 45, department: 'Engineering' },
+];
+
+/**
+ * Playground for ADO #3944470 — native ag-grid headerCheckbox indeterminate state.
+ *
+ * Steps to reproduce the bug:
+ * 1. Check one or two (but not all) row checkboxes.
+ * 2. The header checkbox should appear shaded/indeterminate but shows empty instead.
+ */
+@Component({
+  selector: 'app-native-multiselect',
+  templateUrl: './native-multiselect.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [AgGridModule, SkyAgGridModule],
+})
+export class NativeMultiselectComponent {
+  protected readonly gridOptions: GridOptions;
+
+  readonly #agGridSvc = inject(SkyAgGridService);
+
+  constructor() {
+    const rowSelection: RowSelectionOptions = {
+      mode: 'multiRow',
+      checkboxes: true,
+      headerCheckbox: true,
+      selectAll: 'filtered',
+    };
+
+    this.gridOptions = this.#agGridSvc.getGridOptions({
+      gridOptions: {
+        rowData: DEMO_DATA,
+        rowSelection,
+        columnDefs: [
+          { field: 'name', headerName: 'Name' },
+          {
+            field: 'age',
+            headerName: 'Age',
+            type: SkyCellType.Number,
+            maxWidth: 80,
+          },
+          { field: 'department', headerName: 'Department' },
+        ],
+      },
+    });
+  }
+}

--- a/libs/components/ag-grid/src/lib/styles/_base.scss
+++ b/libs/components/ag-grid/src/lib/styles/_base.scss
@@ -76,7 +76,8 @@
     );
     --ag-focus-shadow: none;
 
-    .ag-checked {
+    .ag-checked,
+    .ag-indeterminate {
       background: var(
         --sky-override-ag-grid-checkbox-checked-background-color,
         var(--sky-color-background-selected-switch-base)

--- a/libs/components/ag-grid/src/lib/styles/ag-grid-theme.ts
+++ b/libs/components/ag-grid/src/lib/styles/ag-grid-theme.ts
@@ -23,7 +23,13 @@ const defaultsForAllThemes: Partial<ThemeDefaultParams> = {
   checkboxCheckedShapeColor:
     'var(--sky-override-switch-checked-color, var(--sky-color-icon-inverse, var(--sky-text-color-default)))',
   checkboxIndeterminateBackgroundColor:
-    'var(--sky-override-switch-checked-color, var(--sky-color-icon-inverse, transparent))',
+    'var(--sky-override-switch-checked-color, var(--sky-color-background-selected-switch-base))',
+  checkboxIndeterminateBorderColor: { ref: 'checkboxCheckedBorderColor' },
+  checkboxIndeterminateShapeColor:
+    'var(--sky-override-switch-checked-color, var(--sky-color-icon-inverse, var(--sky-text-color-default)))',
+  checkboxIndeterminateShapeImage: {
+    svg: `<svg width="16" height="16" fill="none" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="M2 4.5A2.5 2.5 0 0 1 4.5 2h7A2.5 2.5 0 0 1 14 4.5v7a2.5 2.5 0 0 1-2.5 2.5h-7A2.5 2.5 0 0 1 2 11.5v-7Z" fill="#212121"/></svg>`,
+  },
   checkboxUncheckedBackgroundColor:
     'var(--sky-override-ag-grid-checkbox-unchecked-background-color, var(--sky-color-background-input-base))',
   checkboxUncheckedBorderColor: `var(


### PR DESCRIPTION
## Problem

When using ag-grid's native row selection (\`rowSelection: { mode: 'multiRow', checkboxes: true, headerCheckbox: true }\`), the header checkbox did not display the indeterminate (partly-selected) state correctly. Instead of showing a shaded/filled indicator, the checkbox appeared empty.

This affected only the native ag-grid multiselect path. The SKY UX custom \`SkyCellType.RowSelector\` column type was unaffected because it renders \`<sky-checkbox>\` directly via an Angular component.

### Root Cause

Three issues in the ag-grid theme configuration:

1. **\`ag-grid-theme.ts\`** — \`checkboxIndeterminateBackgroundColor\` was resolving to \`--sky-color-icon-inverse\` (white on light backgrounds) via an incorrect CSS variable chain, making the indeterminate state invisible.

2. **\`_base.scss\`** — The \`.ag-checked\` override rule inside \`.ag-checkbox\` was not extended to cover \`.ag-indeterminate\`, so the indeterminate state had no background color override applied.

3. **\`ag-grid-theme.ts\`** — The \`checkboxIndeterminateShapeImage\`, \`checkboxIndeterminateShapeColor\`, and \`checkboxIndeterminateBorderColor\` theme params were not set, causing ag-grid to render a horizontal dash line for the indeterminate state instead of the solid square used by \`sky-checkbox\`.

## Changes

### \`libs/components/ag-grid/src/lib/styles/_base.scss\`
- Extended the \`.ag-checked\` background override to also apply to \`.ag-indeterminate\` using a combined CSS selector.

### \`libs/components/ag-grid/src/lib/styles/ag-grid-theme.ts\`
- Fixed \`checkboxIndeterminateBackgroundColor\` to use \`--sky-color-background-selected-switch-base\` (the correct brand/selected color).
- Added \`checkboxIndeterminateBorderColor\` — references \`checkboxCheckedBorderColor\` to match the checked state border.
- Added \`checkboxIndeterminateShapeColor\` — uses the same inverse color chain as \`checkboxCheckedShapeColor\` (white icon on colored background).
- Added \`checkboxIndeterminateShapeImage\` — uses the \`sky-i-square-16-solid\` SVG path (a solid rounded square), matching the icon that \`sky-checkbox\` uses for its indeterminate state.

## Testing

- Added a Storybook component (\`ag-grid-native-multiselect\`) in the ag-grid storybook app with three grids showing all three checkbox states: fully unchecked, indeterminate (2 of 5 rows selected), and fully checked.
- Added a Cypress visual regression test (\`ag-grid-native-multiselect.component.cy.ts\`) that runs across all themes and compact variants.
- Added a playground page (\`/components/ag-grid/native-multiselect\`) for manual verification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added AG Grid native multiselect component with multi-row checkbox selection and header checkbox support.
  * New playground demo and Storybook stories for the native multiselect, including a compact variant.

* **Bug Fixes**
  * Improved indeterminate checkbox styling across AG Grid themes.

* **Tests**
  * Added E2E visual tests covering multiselect across themes and compact modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->