### PR TITLE
feat(components/pages): adding SkyPageHarness.getHelpKey and a test 

### DIFF
--- a/libs/components/pages/src/lib/modules/page/page.component.ts
+++ b/libs/components/pages/src/lib/modules/page/page.component.ts
@@ -30,6 +30,9 @@ import { SkyPageLayoutType } from './types/page-layout-type';
     provideSkyBreakpointObserver(SkyContainerBreakpointObserver),
   ],
   standalone: false,
+  host: {
+    '[attr.data-sky-help-key]': 'helpKey || null',
+  },
   hostDirectives: [
     {
       directive: SkyLayoutHostDirective,

--- a/libs/components/pages/src/lib/modules/page/page.component.ts
+++ b/libs/components/pages/src/lib/modules/page/page.component.ts
@@ -5,6 +5,7 @@ import {
   OnInit,
   inject,
   input,
+  signal,
 } from '@angular/core';
 import {
   SkyContainerBreakpointObserver,
@@ -31,7 +32,7 @@ import { SkyPageLayoutType } from './types/page-layout-type';
   ],
   standalone: false,
   host: {
-    '[attr.data-sky-help-key]': 'helpKey || null',
+    '[attr.data-sky-help-key]': 'currentHelpKey() || null',
   },
   hostDirectives: [
     {
@@ -55,8 +56,11 @@ export class SkyPageComponent implements OnInit, OnDestroy {
    */
   @Input()
   public set helpKey(value: string | undefined) {
+    this.currentHelpKey.set(value);
     this.#helpSvc?.updateHelp({ pageDefaultHelpKey: value });
   }
+
+  protected readonly currentHelpKey = signal<string | undefined>(undefined);
 
   readonly #themeAdapter = inject(SkyPageThemeAdapterService);
   readonly #helpSvc = inject(SkyHelpService, { optional: true });

--- a/libs/components/pages/testing/src/modules/page/page-harness.spec.ts
+++ b/libs/components/pages/testing/src/modules/page/page-harness.spec.ts
@@ -9,7 +9,11 @@ import { SkyPageHarness } from './page-harness';
 //#region Test component
 @Component({
   selector: 'sky-page-test',
-  template: ` <sky-page data-sky-id="test-page" [layout]="layout">
+  template: ` <sky-page
+    data-sky-id="test-page"
+    [helpKey]="helpKey"
+    [layout]="layout"
+  >
     @if (showPageHeader) {
       <sky-page-header [pageTitle]="pageTitle" />
     }
@@ -17,6 +21,7 @@ import { SkyPageHarness } from './page-harness';
   standalone: false,
 })
 class TestComponent {
+  public helpKey: string | undefined;
   public layout: string | undefined;
   public pageTitle: string | undefined;
   public showPageHeader = true;
@@ -51,6 +56,19 @@ describe('Page harness', () => {
 
     return { harness, fixture, loader };
   }
+
+  it('should return the help key', async () => {
+    const { harness, fixture } = await setupTest({
+      dataSkyId: 'test-page',
+    });
+
+    await expectAsync(harness.getHelpKey()).toBeResolvedTo(null);
+
+    fixture.componentInstance.helpKey = 'test-help-key';
+    fixture.detectChanges();
+
+    await expectAsync(harness.getHelpKey()).toBeResolvedTo('test-help-key');
+  });
 
   it('should return the layout', async () => {
     const { harness, fixture } = await setupTest({

--- a/libs/components/pages/testing/src/modules/page/page-harness.ts
+++ b/libs/components/pages/testing/src/modules/page/page-harness.ts
@@ -30,6 +30,13 @@ export class SkyPageHarness extends SkyComponentHarness {
   }
 
   /**
+   * Gets the help key for the page, or `null` if not set.
+   */
+  public async getHelpKey(): Promise<string | null> {
+    return await (await this.host()).getAttribute('data-sky-help-key');
+  }
+
+  /**
    * Gets the current layout.
    */
   public async getLayout(): Promise<SkyPageLayoutType> {


### PR DESCRIPTION
This change adds a getHelpKey method to SkyPageHarness along with a test for it.

There are a couple of noteworthy decisions made for this PR. 1) An attribute was added to the host of the component for tracking the help key that is set. (This was what copilot thought was a reasonable solution for being able to query this value). 2) The method returns a `Promise<string | null>`. This is similar to what getAttribute returns  on TestElement. That being said, we often return `undefined` so if that is preferred, the code can be easily updated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for setting a help key attribute on the page component that dynamically updates based on input changes.
  * Added testing utility to retrieve the help key value from the page component.

* **Tests**
  * Added test coverage for help key attribute retrieval functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->