### PR TITLE
chore: release 13.17.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Bug Fixes
 
 * **components/toast:** make overflow in the y-axis visible ([#4332](https://github.com/blackbaud/skyux/issues/4332)) ([dd4034f](https://github.com/blackbaud/skyux/commit/dd4034fe1a5748dd00dcbd1a7afbe974635c22c2)), closes [AB#3652195](https://github.com/AB/issues/3652195)
+* **components/toast:** revert make overflow in the y-axis visible ([#4380](https://github.com/blackbaud/skyux/issues/4380)) ([c2faf1b](https://github.com/blackbaud/skyux/commit/c2faf1bb82a5ece17cb7b7c66b7499c78b7df352)), closes [blackbaud/skyux#4332](https://github.com/blackbaud/skyux/issues/4332)
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 # Changelog
 
 
+## [13.17.1](https://github.com/blackbaud/skyux/compare/13.17.0...13.17.1) (2026-04-15)
+
+
+### Bug Fixes
+
+* **components/toast:** make overflow in the y-axis visible ([#4332](https://github.com/blackbaud/skyux/issues/4332)) ([dd4034f](https://github.com/blackbaud/skyux/commit/dd4034fe1a5748dd00dcbd1a7afbe974635c22c2)), closes [AB#3652195](https://github.com/AB/issues/3652195)
+
+
+
 # [13.17.0](https://github.com/blackbaud/skyux/compare/13.16.4...13.17.0) (2026-04-07)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 
-## [13.17.1](https://github.com/blackbaud/skyux/compare/13.17.0...13.17.1) (2026-04-15)
+## [13.17.1](https://github.com/blackbaud/skyux/compare/13.17.0...13.17.1) (2026-05-18)
 
 
 ### Bug Fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "skyux",
-  "version": "13.17.0",
+  "version": "13.17.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "skyux",
-      "version": "13.17.0",
+      "version": "13.17.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skyux",
-  "version": "13.17.0",
+  "version": "13.17.1",
   "license": "MIT",
   "scripts": {
     "ng": "nx",


### PR DESCRIPTION
## [13.17.1](https://github.com/blackbaud/skyux/compare/13.17.0...13.17.1) (2026-05-18)


### Bug Fixes

* **components/toast:** make overflow in the y-axis visible ([#4332](https://github.com/blackbaud/skyux/issues/4332)) ([dd4034f](https://github.com/blackbaud/skyux/commit/dd4034fe1a5748dd00dcbd1a7afbe974635c22c2)), closes [AB#3652195](https://github.com/AB/issues/3652195)
* **components/toast:** revert make overflow in the y-axis visible ([#4380](https://github.com/blackbaud/skyux/issues/4380)) ([c2faf1b](https://github.com/blackbaud/skyux/commit/c2faf1bb82a5ece17cb7b7c66b7499c78b7df352)), closes [blackbaud/skyux#4332](https://github.com/blackbaud/skyux/issues/4332)