### PR TITLE
fix(components/toast): add new token value for last toast when display direction is `NewestOnTop`

### DIFF
--- a/apps/code-examples/src/assets/stack-blitz/package-lock.json
+++ b/apps/code-examples/src/assets/stack-blitz/package-lock.json
@@ -2526,9 +2526,9 @@
       }
     },
     "node_modules/@blackbaud/skyux-design-tokens": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@blackbaud/skyux-design-tokens/-/skyux-design-tokens-4.0.2.tgz",
-      "integrity": "sha512-G6T+iNbPArcGEVYZyv89+noI/NnQjY27kP1gwTDfvnpLmQ5cN4NvzcIKd3JU+RvZ+1nkfZHU7sFI44hpZTQ2eA==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@blackbaud/skyux-design-tokens/-/skyux-design-tokens-4.1.0.tgz",
+      "integrity": "sha512-S5FxAx25OaOORgCC4Lz9cmQHQ8XNC/a/lnO0jUbrBAbJSJV2iSh13OxvevcT90oWaPNhdkEsruUAR3nv/MmAYA==",
       "license": "MIT",
       "engines": {
         "node": ">= 4.2.1",

--- a/libs/components/toast/src/lib/modules/toast/toast.component.scss
+++ b/libs/components/toast/src/lib/modules/toast/toast.component.scss
@@ -259,10 +259,7 @@ sky-toast {
   .sky-toaster-newest-on-top {
     sky-toast:last-child {
       .sky-toast {
-        margin-bottom: var(
-          --sky-override-toast-last-child-margin-bottom,
-          var(--sky-comp-omnibar-toaster-space-inset-bottom)
-        );
+        margin-bottom: var(--sky-comp-omnibar-toaster-space-inset-bottom);
       }
     }
   }

--- a/libs/components/toast/src/lib/modules/toast/toast.component.scss
+++ b/libs/components/toast/src/lib/modules/toast/toast.component.scss
@@ -256,6 +256,17 @@ sky-toast {
 }
 
 .sky-theme-modern {
+  .sky-toaster-newest-on-top {
+    sky-toast:last-child {
+      .sky-toast {
+        margin-bottom: var(
+          --sky-override-toast-last-child-margin-bottom,
+          var(--sky-comp-omnibar-toaster-space-inset-bottom)
+        );
+      }
+    }
+  }
+
   sky-toast {
     .sky-toast-btn-close {
       transition:

--- a/libs/components/toast/src/lib/modules/toast/toaster.component.spec.ts
+++ b/libs/components/toast/src/lib/modules/toast/toaster.component.spec.ts
@@ -327,4 +327,22 @@ describe('Toaster component', () => {
     validateToastMessage(toasts[0], 'Message 1');
     validateToastMessage(toasts[1], 'Message 2');
   }));
+
+  it('should add sky-toaster-newest-on-top class to host when displayDirection is NewestOnTop', fakeAsync(() => {
+    options.displayDirection = SkyToastDisplayDirection.NewestOnTop;
+
+    openMessage();
+
+    const toaster = document.querySelector('sky-toaster');
+    expect(toaster).toHaveCssClass('sky-toaster-newest-on-top');
+  }));
+
+  it('should not add sky-toaster-newest-on-top class to host when displayDirection is OldestOnTop', fakeAsync(() => {
+    options.displayDirection = SkyToastDisplayDirection.OldestOnTop;
+
+    openMessage();
+
+    const toaster = document.querySelector('sky-toaster');
+    expect(toaster).not.toHaveCssClass('sky-toaster-newest-on-top');
+  }));
 });

--- a/libs/components/toast/src/lib/modules/toast/toaster.component.ts
+++ b/libs/components/toast/src/lib/modules/toast/toaster.component.ts
@@ -14,6 +14,7 @@ import {
   ViewContainerRef,
   ViewEncapsulation,
   inject,
+  signal,
 } from '@angular/core';
 import { SKY_STACKING_CONTEXT, SkyDynamicComponentService } from '@skyux/core';
 
@@ -41,6 +42,9 @@ import { SkyToastDisplayDirection } from './types/toast-display-direction';
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
   imports: [CommonModule, SkyToastComponent, SkyToastResourcesModule],
+  host: {
+    '[class.sky-toaster-newest-on-top]': 'isNewestOnTop()',
+  },
 })
 export class SkyToasterComponent implements AfterViewInit, OnDestroy {
   public toastsForDisplay: SkyToast[] | undefined;
@@ -62,6 +66,12 @@ export class SkyToasterComponent implements AfterViewInit, OnDestroy {
   readonly #containerOptions = inject(SkyToastContainerOptions, {
     optional: true,
   });
+
+  protected isNewestOnTop = signal(
+    this.#containerOptions?.displayDirection ===
+      SkyToastDisplayDirection.NewestOnTop,
+  );
+
   readonly #dynamicComponentSvc = inject(SkyDynamicComponentService);
   readonly #domAdapter = inject(SkyToastAdapterService);
   readonly #environmentInjector = inject(EnvironmentInjector);


### PR DESCRIPTION
[AB#3652195](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3652195)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined the spacing and positioning of toast notifications when displaying with newest notifications on top, providing a more polished and organized notification stack experience. Improved vertical alignment enhances visual clarity when multiple notifications are displayed simultaneously.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->