### PR TITLE
fix: update design tokens to include elevation deprecated variables

### DIFF
--- a/libs/components/packages/package.json
+++ b/libs/components/packages/package.json
@@ -105,7 +105,7 @@
     "@angular/core": "^21.2.0"
   },
   "dependencies": {
-    "@blackbaud/skyux-design-tokens": "6.0.0",
+    "@blackbaud/skyux-design-tokens": "6.0.1",
     "fs-extra": "11.3.4",
     "jsonc-parser": "3.3.1",
     "parse5": "7.3.0",

--- a/libs/components/theme/package.json
+++ b/libs/components/theme/package.json
@@ -20,7 +20,7 @@
     "@angular/core": "^21.2.0"
   },
   "dependencies": {
-    "@blackbaud/skyux-design-tokens": "6.0.0",
+    "@blackbaud/skyux-design-tokens": "6.0.1",
     "fontfaceobserver": "2.3.0",
     "tslib": "^2.8.1"
   },

--- a/libs/sdk/skyux-eslint/package.json
+++ b/libs/sdk/skyux-eslint/package.json
@@ -33,7 +33,7 @@
     "@typescript-eslint/utils": "^8.56.1"
   },
   "dependencies": {
-    "@blackbaud/skyux-design-tokens": "6.0.0",
+    "@blackbaud/skyux-design-tokens": "6.0.1",
     "@skyux-sdk/eslint-schematics": "0.0.0-PLACEHOLDER",
     "@skyux/manifest": "0.0.0-PLACEHOLDER",
     "tslib": "^2.8.1"

--- a/libs/sdk/skyux-stylelint/package.json
+++ b/libs/sdk/skyux-stylelint/package.json
@@ -23,7 +23,7 @@
     "stylelint": "^17.1.0"
   },
   "dependencies": {
-    "@blackbaud/skyux-design-tokens": "6.0.0",
+    "@blackbaud/skyux-design-tokens": "6.0.1",
     "tslib": "^2.8.1"
   },
   "type": "module",

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@angular/platform-browser-dynamic": "21.2.0",
         "@angular/router": "21.2.0",
         "@blackbaud/angular-tree-component": "1.0.0",
-        "@blackbaud/skyux-design-tokens": "6.0.0",
+        "@blackbaud/skyux-design-tokens": "6.0.1",
         "@eslint/js": "9.39.3",
         "@nx/angular": "22.5.3",
         "@skyux/icons": "10.4.0",
@@ -3127,9 +3127,9 @@
       }
     },
     "node_modules/@blackbaud/skyux-design-tokens": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@blackbaud/skyux-design-tokens/-/skyux-design-tokens-6.0.0.tgz",
-      "integrity": "sha512-GCSULgqo+8D86wHAXEgiI9vHPQiP3/mggXUtIMwUA+RTo/ijldErwFdZNGfYrTGWnLm5VvUomAUG6g+fJRON7w==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@blackbaud/skyux-design-tokens/-/skyux-design-tokens-6.0.1.tgz",
+      "integrity": "sha512-UohZLM+IhpbYJ6BbfgpDHm0hTdC8FaXOJK81iHD7E2mxvW2Frkx8Dvo10GJRIsh2xeUzhI1jtdo9THPQTgSdrQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 4.2.1",

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "@angular/platform-browser-dynamic": "21.2.0",
     "@angular/router": "21.2.0",
     "@blackbaud/angular-tree-component": "1.0.0",
-    "@blackbaud/skyux-design-tokens": "6.0.0",
+    "@blackbaud/skyux-design-tokens": "6.0.1",
     "@eslint/js": "9.39.3",
     "@nx/angular": "22.5.3",
     "@skyux/icons": "10.4.0",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Updated core design tokens library to version 6.0.1 across all packages to incorporate the latest stability improvements and patches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->