### PR TITLE
fix(components/lookup): repopulate input box host when `enableShowMore` changes after init

### DIFF
--- a/libs/components/lookup/src/lib/modules/lookup/lookup.component.html
+++ b/libs/components/lookup/src/lib/modules/lookup/lookup.component.html
@@ -54,7 +54,7 @@
               (keyup)="onTokensKeyUp($event)"
               (tokensChange)="onTokensChange($event)"
               (tokensRendered)="onTokensRendered()"
-              (tokenSelected)="enableShowMore() ? openPicker('') : undefined"
+              (tokenSelected)="onTokenSelected()"
               (focusIndexOverRange)="onTokensFocusIndexOverRange()"
             >
               <textarea

--- a/libs/components/lookup/src/lib/modules/lookup/lookup.component.html
+++ b/libs/components/lookup/src/lib/modules/lookup/lookup.component.html
@@ -18,7 +18,7 @@
       [data]="data"
       [debounceTime]="debounceTime"
       [descriptorProperty]="descriptorProperty"
-      [enableShowMore]="enableShowMore"
+      [enableShowMore]="enableShowMore()"
       [messageStream]="autocompleteController"
       [propertiesToSearch]="propertiesToSearch"
       [search]="searchOrDefault"
@@ -54,7 +54,7 @@
               (keyup)="onTokensKeyUp($event)"
               (tokensChange)="onTokensChange($event)"
               (tokensRendered)="onTokensRendered()"
-              (tokenSelected)="enableShowMore ? openPicker('') : undefined"
+              (tokenSelected)="enableShowMore() ? openPicker('') : undefined"
               (focusIndexOverRange)="onTokensFocusIndexOverRange()"
             >
               <textarea
@@ -95,7 +95,7 @@
             </div>
           }
         </div>
-        @if (!inputBoxHostSvc && enableShowMore) {
+        @if (!inputBoxHostSvc && enableShowMore()) {
           <ng-container *ngTemplateOutlet="showMoreButtonTemplateRef" />
         }
       </div>

--- a/libs/components/lookup/src/lib/modules/lookup/lookup.component.spec.ts
+++ b/libs/components/lookup/src/lib/modules/lookup/lookup.component.spec.ts
@@ -7583,6 +7583,31 @@ describe('Lookup component', function () {
       expect(containerEl).toHaveCssClass('sky-lookup');
     }));
 
+    it('should show and hide the show more search button when `enableShowMore` changes after init', fakeAsync(() => {
+      fixture.detectChanges();
+
+      let searchButton = nativeElement.querySelector(
+        '#my-lookup .sky-input-group-btn .sky-btn',
+      );
+      expect(searchButton).not.toExist();
+
+      component.enableShowMore = true;
+      fixture.detectChanges();
+
+      searchButton = nativeElement.querySelector(
+        '#my-lookup .sky-input-group-btn .sky-btn',
+      );
+      expect(searchButton).toExist();
+
+      component.enableShowMore = false;
+      fixture.detectChanges();
+
+      searchButton = nativeElement.querySelector(
+        '#my-lookup .sky-input-group-btn .sky-btn',
+      );
+      expect(searchButton).not.toExist();
+    }));
+
     it('should unfocus the component if it loses focus', async function () {
       fixture.detectChanges();
 

--- a/libs/components/lookup/src/lib/modules/lookup/lookup.component.ts
+++ b/libs/components/lookup/src/lib/modules/lookup/lookup.component.ts
@@ -140,7 +140,14 @@ export class SkyLookupComponent
    * @default false
    */
   @Input({ transform: booleanAttribute })
-  public enableShowMore = false;
+  public set enableShowMore(value: boolean) {
+    this.#_enableShowMore = value;
+    this.#populateInputBox();
+  }
+
+  public get enableShowMore(): boolean {
+    return this.#_enableShowMore;
+  }
 
   /**
    * Placeholder text to display in the lookup field.
@@ -309,6 +316,7 @@ export class SkyLookupComponent
 
   #_autocompleteInputDirective: SkyAutocompleteInputDirective | undefined;
   #_data: any[] | undefined;
+  #_enableShowMore = false;
   #_selectMode: SkyLookupSelectModeType | undefined;
   #_tokens: SkyToken[] | undefined;
   #_value: any[] | undefined;
@@ -358,12 +366,7 @@ export class SkyLookupComponent
       this.controlId = this.inputBoxHostSvc.controlId;
       this.ariaDescribedBy = this.inputBoxHostSvc.ariaDescribedBy;
 
-      this.inputBoxHostSvc.populate({
-        inputTemplate: this.inputTemplateRef,
-        buttonsTemplate: this.enableShowMore
-          ? this.showMoreButtonTemplateRef
-          : undefined,
-      });
+      this.#populateInputBox();
 
       this.inputBoxHostSvc?.setRequired(this.required);
     } else {
@@ -933,5 +936,16 @@ export class SkyLookupComponent
 
   #pickerModalOpen(): boolean {
     return !!(this.#openNativePicker || this.#openSelectionModal);
+  }
+
+  #populateInputBox(): void {
+    if (this.inputBoxHostSvc && this.inputTemplateRef) {
+      this.inputBoxHostSvc.populate({
+        inputTemplate: this.inputTemplateRef,
+        buttonsTemplate: this.enableShowMore
+          ? this.showMoreButtonTemplateRef
+          : undefined,
+      });
+    }
   }
 }

--- a/libs/components/lookup/src/lib/modules/lookup/lookup.component.ts
+++ b/libs/components/lookup/src/lib/modules/lookup/lookup.component.ts
@@ -440,6 +440,12 @@ export class SkyLookupComponent
     }
   }
 
+  protected onTokenSelected(): void {
+    if (this.enableShowMore()) {
+      this.openPicker('');
+    }
+  }
+
   public onTokensFocusIndexOverRange(): void {
     this.#windowRef.nativeWindow.setTimeout(() => {
       this.#focusInput();

--- a/libs/components/lookup/src/lib/modules/lookup/lookup.component.ts
+++ b/libs/components/lookup/src/lib/modules/lookup/lookup.component.ts
@@ -15,7 +15,9 @@ import {
   ViewChild,
   ViewEncapsulation,
   booleanAttribute,
+  effect,
   inject,
+  input,
 } from '@angular/core';
 import { ControlValueAccessor, NgControl } from '@angular/forms';
 import { SkyAppWindowRef, SkyIdService, SkyLogService } from '@skyux/core';
@@ -139,15 +141,9 @@ export class SkyLookupComponent
    * Whether to enable users to open a picker where they can view all options.
    * @default false
    */
-  @Input({ transform: booleanAttribute })
-  public set enableShowMore(value: boolean) {
-    this.#_enableShowMore = value;
-    this.#populateInputBox();
-  }
-
-  public get enableShowMore(): boolean {
-    return this.#_enableShowMore;
-  }
+  public readonly enableShowMore = input(false, {
+    transform: booleanAttribute,
+  });
 
   /**
    * Placeholder text to display in the lookup field.
@@ -237,7 +233,7 @@ export class SkyLookupComponent
     const value = this.#getValue();
 
     // Collapse the tokens into a single token if the user has selected many options.
-    if (this.enableShowMore && value.length > 5) {
+    if (this.enableShowMore() && value.length > 5) {
       this.#resourcesService
         .getString('skyux_lookup_tokens_summary', value.length.toString())
         .pipe(take(1))
@@ -316,7 +312,6 @@ export class SkyLookupComponent
 
   #_autocompleteInputDirective: SkyAutocompleteInputDirective | undefined;
   #_data: any[] | undefined;
-  #_enableShowMore = false;
   #_selectMode: SkyLookupSelectModeType | undefined;
   #_tokens: SkyToken[] | undefined;
   #_value: any[] | undefined;
@@ -359,6 +354,11 @@ export class SkyLookupComponent
     if (ngControl) {
       ngControl.valueAccessor = this;
     }
+
+    effect(() => {
+      this.enableShowMore();
+      this.#populateInputBox();
+    });
   }
 
   public ngOnInit(): void {
@@ -942,7 +942,7 @@ export class SkyLookupComponent
     if (this.inputBoxHostSvc && this.inputTemplateRef) {
       this.inputBoxHostSvc.populate({
         inputTemplate: this.inputTemplateRef,
-        buttonsTemplate: this.enableShowMore
+        buttonsTemplate: this.enableShowMore()
           ? this.showMoreButtonTemplateRef
           : undefined,
       });


### PR DESCRIPTION
[AB#3924605](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3924605) (part 1 of 2)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a test verifying the lookup component’s "show more" button appears and disappears correctly as the setting changes.

* **Bug Fixes**
  * The "show more" button now updates dynamically when the enable setting is changed, ensuring the UI reflects the current state without requiring a full reinitialize.

* **Refactor**
  * Internal input and initialization logic was reworked to make the show-more behavior reactive and keep the picker/input UI in sync.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->