### PR TITLE
chore: release 14.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
 
+## [14.3.0](https://github.com/blackbaud/skyux/compare/14.2.2...14.3.0) (2026-04-29)
+
+
+### Features
+
+* **sdk/testing:** duplicate jasmine matchers for vitest ([#4385](https://github.com/blackbaud/skyux/issues/4385)) ([b66a41f](https://github.com/blackbaud/skyux/commit/b66a41f73963d0fdf057c37ae293f1d49c36a424))
+
 ## [14.2.2](https://github.com/blackbaud/skyux/compare/14.2.1...14.2.2) (2026-04-24)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 
-## [14.3.0](https://github.com/blackbaud/skyux/compare/14.2.2...14.3.0) (2026-04-29)
+## [14.3.0](https://github.com/blackbaud/skyux/compare/14.2.2...14.3.0) (2026-04-30)
 
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 
-## [14.3.0](https://github.com/blackbaud/skyux/compare/14.2.2...14.3.0) (2026-05-01)
+## [14.3.0](https://github.com/blackbaud/skyux/compare/14.2.2...14.3.0) (2026-05-02)
 
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 
-## [14.3.0](https://github.com/blackbaud/skyux/compare/14.2.2...14.3.0) (2026-04-30)
+## [14.3.0](https://github.com/blackbaud/skyux/compare/14.2.2...14.3.0) (2026-05-01)
 
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 
-## [14.3.0](https://github.com/blackbaud/skyux/compare/14.2.2...14.3.0) (2026-05-02)
+## [14.3.0](https://github.com/blackbaud/skyux/compare/14.2.2...14.3.0) (2026-05-03)
 
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 
-## [14.3.0](https://github.com/blackbaud/skyux/compare/14.2.2...14.3.0) (2026-05-04)
+## [14.3.0](https://github.com/blackbaud/skyux/compare/14.2.2...14.3.0) (2026-05-05)
 
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 
-## [14.3.0](https://github.com/blackbaud/skyux/compare/14.2.2...14.3.0) (2026-05-03)
+## [14.3.0](https://github.com/blackbaud/skyux/compare/14.2.2...14.3.0) (2026-05-04)
 
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@
 
 * **sdk/testing:** duplicate jasmine matchers for vitest ([#4385](https://github.com/blackbaud/skyux/issues/4385)) ([b66a41f](https://github.com/blackbaud/skyux/commit/b66a41f73963d0fdf057c37ae293f1d49c36a424))
 
+
+### Bug Fixes
+
+* **components/ag-grid:** add keyboard commands for row selection header checkbox ([#4403](https://github.com/blackbaud/skyux/issues/4403)) ([8d6ddbf](https://github.com/blackbaud/skyux/commit/8d6ddbf6e868b5c664e350a0b96315d8961572f3)), closes [AB#3963510](https://dev.azure.com/blackbaud/Products/_workitems/edit/3963510)
+
 ## [14.2.2](https://github.com/blackbaud/skyux/compare/14.2.1...14.2.2) (2026-04-24)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "skyux",
-  "version": "14.2.2",
+  "version": "14.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "skyux",
-      "version": "14.2.2",
+      "version": "14.3.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skyux",
-  "version": "14.2.2",
+  "version": "14.3.0",
   "license": "MIT",
   "scripts": {
     "ng": "nx",


### PR DESCRIPTION
## [14.3.0](https://github.com/blackbaud/skyux/compare/14.2.2...14.3.0) (2026-05-05)


### Features

* **sdk/testing:** duplicate jasmine matchers for vitest ([#4385](https://github.com/blackbaud/skyux/issues/4385)) ([b66a41f](https://github.com/blackbaud/skyux/commit/b66a41f73963d0fdf057c37ae293f1d49c36a424))


### Bug Fixes

* **components/ag-grid:** add keyboard commands for row selection header checkbox ([#4403](https://github.com/blackbaud/skyux/issues/4403)) ([8d6ddbf](https://github.com/blackbaud/skyux/commit/8d6ddbf6e868b5c664e350a0b96315d8961572f3)), closes [AB#3963510](https://dev.azure.com/blackbaud/Products/_workitems/edit/3963510)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added vitest-compatible testing matchers for SDK support

* **Bug Fixes**
  * Fixed keyboard command functionality in ag-grid row selection header checkbox

**Version**: 14.3.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->