### PR TITLE
fix(components/ag-grid): add keyboard commands for row selection header checkbox

### DIFF
--- a/apps/playground/src/app/components/ag-grid/data-manager-large/data-manager-large.component.html
+++ b/apps/playground/src/app/components/ag-grid/data-manager-large/data-manager-large.component.html
@@ -82,14 +82,14 @@
     </sky-data-manager-toolbar-primary-item>
   </sky-data-manager-toolbar>
   <sky-data-view skyAgGridDataManagerAdapter [viewId]="viewId">
-    @if (isActive$ | async) {
+    @if (isActive()) {
       <sky-ag-grid-wrapper
         skyAgGridRowDelete
-        [compact]="compact"
+        [compact]="gridSettingsValue().compact"
         [(rowDeleteIds)]="rowDeleteIds"
         (rowDeleteConfirm)="deleteConfirm($event)"
       >
-        <ag-grid-angular [gridOptions]="gridOptions" [rowData]="items" />
+        <ag-grid-angular [gridOptions]="gridOptions()" [rowData]="items" />
       </sky-ag-grid-wrapper>
     }
   </sky-data-view>

--- a/apps/playground/src/app/components/ag-grid/data-manager-large/data-manager-large.component.html
+++ b/apps/playground/src/app/components/ag-grid/data-manager-large/data-manager-large.component.html
@@ -44,27 +44,20 @@
           labelText="Delete button"
           labelHidden
         />
-        <sky-radio-group
-          labelText="DOM layout"
+        <sky-checkbox
+          formControlName="showSelect"
+          iconName="checkmark"
+          title="Select checkboxes"
+          labelText="Show select checkboxes"
           labelHidden
-          formControlName="domLayout"
-          class="sky-switch-icon-group"
-        >
-          <sky-radio
-            iconName="square"
-            title="Normal DOM layout"
-            labelText="Normal"
-            labelHidden
-            value="normal"
-          />
-          <sky-radio
-            iconName="arrow-maximize"
-            title="Auto-height DOM layout"
-            labelText="Auto-height"
-            labelHidden
-            value="autoHeight"
-          />
-        </sky-radio-group>
+        />
+        <sky-checkbox
+          formControlName="domLayoutNormal"
+          iconName="arrow-minimize"
+          title="Use normal DOM layout"
+          labelText="Use normal DOM layout"
+          labelHidden
+        />
       </form>
     </sky-data-manager-toolbar-primary-item>
     <sky-data-manager-toolbar-primary-item>

--- a/apps/playground/src/app/components/ag-grid/data-manager-large/data-manager-large.component.ts
+++ b/apps/playground/src/app/components/ag-grid/data-manager-large/data-manager-large.component.ts
@@ -2,15 +2,17 @@ import { CommonModule } from '@angular/common';
 import {
   Component,
   DestroyRef,
-  HostBinding,
   Input,
   OnInit,
+  Signal,
   ViewEncapsulation,
+  computed,
   inject,
   model,
+  signal,
   viewChild,
 } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
 import {
   FormBuilder,
   FormControl,
@@ -41,7 +43,6 @@ import {
   GridOptions,
   ModuleRegistry,
 } from 'ag-grid-community';
-import { BehaviorSubject, debounceTime } from 'rxjs';
 
 import { CustomLinkComponent } from './custom-link/custom-link.component';
 import {
@@ -61,6 +62,17 @@ interface GridSettingsType {
   autoHeightColumns: FormControl<boolean>;
   showSelect: FormControl<boolean>;
   showDelete: FormControl<boolean>;
+}
+
+interface GridSettingsValueType {
+  enableTopScroll: boolean;
+  useColumnGroups: boolean;
+  domLayout: 'normal' | 'autoHeight' | 'print';
+  compact: boolean;
+  wrapText: boolean;
+  autoHeightColumns: boolean;
+  showSelect: boolean;
+  showDelete: boolean;
 }
 
 ModuleRegistry.registerModules([AllCommunityModule]);
@@ -89,17 +101,18 @@ ModuleRegistry.registerModules([AllCommunityModule]);
       useClass: LocalStorageConfigService,
     },
   ],
+  host: {
+    '[class.use-normal-dom-layout]': 'useNormalDomLayout()',
+    '[class.use-auto-height-dom-layout]': 'useAutoHeightDomLayout()',
+  },
 })
 export class DataManagerLargeComponent implements OnInit {
-  @HostBinding('class.use-normal-dom-layout')
-  public get useNormalDomLayout(): boolean {
-    return this.domLayout === 'normal';
-  }
-
-  @HostBinding('class.use-auto-height-dom-layout')
-  public get useAutoHeightDomLayout(): boolean {
-    return this.domLayout === 'autoHeight';
-  }
+  public useNormalDomLayout = computed(
+    () => this.gridOptions().domLayout === 'normal',
+  );
+  public useAutoHeightDomLayout = computed(
+    () => this.gridOptions().domLayout === 'autoHeight',
+  );
 
   @Input()
   public compact = false;
@@ -161,18 +174,20 @@ export class DataManagerLargeComponent implements OnInit {
     ...item,
   }));
   public readonly settingsKey = 'large-test';
-  public gridOptions: GridOptions = {};
-  public readonly isActive$ = new BehaviorSubject(false);
+  public gridOptions: Signal<GridOptions>;
+  public readonly isActive = signal(true);
   public readonly gridSettings: FormGroup<GridSettingsType>;
 
   protected readonly agGrid = viewChild(AgGridAngular);
   protected readonly rowDeleteIds = model<string[]>([]);
+  protected readonly gridSettingsValue: Signal<Partial<GridSettingsValueType>>;
 
   readonly #agGridService = inject(SkyAgGridService);
   readonly #dataManagerService = inject(SkyDataManagerService);
   readonly #destroyRef = inject(DestroyRef);
 
-  constructor(formBuilder: FormBuilder) {
+  constructor() {
+    const formBuilder = inject(FormBuilder);
     this.gridSettings = formBuilder.group<GridSettingsType>({
       enableTopScroll: formBuilder.nonNullable.control(this.enableTopScroll),
       useColumnGroups: formBuilder.nonNullable.control(this.useColumnGroups),
@@ -185,11 +200,67 @@ export class DataManagerLargeComponent implements OnInit {
         this.autoHeightColumns,
       ),
     });
+    this.gridSettingsValue = toSignal(this.gridSettings.valueChanges, {
+      initialValue: this.gridSettings.getRawValue(),
+    });
+    this.gridOptions = computed(() => {
+      const settings = this.gridSettingsValue();
+      return this.#agGridService.getGridOptions({
+        gridOptions: {
+          columnDefs: [
+            ...(settings.showSelect
+              ? [
+                  {
+                    field: 'select',
+                    headerName: 'Select',
+                    headerComponentParams: {
+                      headerHidden: true,
+                    },
+                    type: SkyCellType.RowSelector,
+                  },
+                ]
+              : []),
+            ...(settings.showDelete
+              ? [
+                  {
+                    field: 'delete',
+                    headerName: 'Delete',
+                    headerComponentParams: {
+                      headerHidden: true,
+                    },
+                    cellRenderer: DeleteButtonComponent,
+                  },
+                ]
+              : []),
+            ...(settings.useColumnGroups
+              ? columnDefinitionsGrouped
+              : columnDefinitions.map((col) =>
+                  col.field === 'object_name'
+                    ? { ...col, rowDrag: settings.domLayout === 'normal' }
+                    : col,
+                )),
+          ],
+          columnTypes: {
+            custom_link: {
+              cellRenderer: CustomLinkComponent,
+            },
+          },
+          context: {
+            enableTopScroll: settings.enableTopScroll,
+          },
+          domLayout: settings.domLayout,
+          defaultColDef: {
+            wrapText: settings.wrapText,
+            autoHeight: settings.autoHeightColumns,
+          },
+          rowDragManaged:
+            !settings.useColumnGroups && settings.domLayout === 'normal',
+        },
+      });
+    });
   }
 
   public ngOnInit(): void {
-    this.#applyGridOptions();
-
     this.#dataManagerService.initDataManager({
       activeViewId: this.viewId,
       dataManagerConfig: this.dataManagerConfig,
@@ -218,20 +289,9 @@ export class DataManagerLargeComponent implements OnInit {
     });
 
     this.gridSettings.valueChanges
-      .pipe(takeUntilDestroyed(this.#destroyRef), debounceTime(0))
-      .subscribe((value) => {
-        this.isActive$.next(false);
-        this.enableTopScroll = !!value.enableTopScroll;
-        this.showSelect = !!value.showSelect;
-        this.showDelete = !!value.showDelete;
-        this.useColumnGroups = !!value.useColumnGroups;
-        this.domLayout = value.domLayout ?? 'autoHeight';
-        this.compact = !!value.compact;
-        this.wrapText = !!value.wrapText;
-        this.autoHeightColumns = !!value.autoHeightColumns;
-        this.#applyGridOptions();
-        setTimeout(() => this.isActive$.next(true));
-      });
+      .pipe(takeUntilDestroyed(this.#destroyRef))
+      .subscribe(() => this.#pauseAndShowGrid());
+    this.#pauseAndShowGrid();
   }
 
   public markForDelete(rowId: string): void {
@@ -245,57 +305,8 @@ export class DataManagerLargeComponent implements OnInit {
     this.agGrid().api.setGridOption('rowData', this.items);
   }
 
-  #applyGridOptions(): void {
-    this.gridOptions = this.#agGridService.getGridOptions({
-      gridOptions: {
-        columnDefs: [
-          ...(this.showSelect
-            ? [
-                {
-                  field: 'select',
-                  headerName: 'Select',
-                  headerComponentParams: {
-                    headerHidden: true,
-                  },
-                  type: SkyCellType.RowSelector,
-                },
-              ]
-            : []),
-          ...(this.showDelete
-            ? [
-                {
-                  field: 'delete',
-                  headerName: 'Delete',
-                  headerComponentParams: {
-                    headerHidden: true,
-                  },
-                  cellRenderer: DeleteButtonComponent,
-                },
-              ]
-            : []),
-          ...(this.useColumnGroups
-            ? columnDefinitionsGrouped
-            : columnDefinitions.map((col) =>
-                col.field === 'object_name'
-                  ? { ...col, rowDrag: this.domLayout === 'normal' }
-                  : col,
-              )),
-        ],
-        columnTypes: {
-          custom_link: {
-            cellRenderer: CustomLinkComponent,
-          },
-        },
-        context: {
-          enableTopScroll: this.enableTopScroll,
-        },
-        domLayout: this.domLayout,
-        defaultColDef: {
-          wrapText: this.wrapText,
-          autoHeight: this.autoHeightColumns,
-        },
-        rowDragManaged: !this.useColumnGroups && this.domLayout === 'normal',
-      },
-    });
+  #pauseAndShowGrid(): void {
+    this.isActive.set(false);
+    setTimeout(() => this.isActive.set(true));
   }
 }

--- a/apps/playground/src/app/components/ag-grid/data-manager-large/data-manager-large.component.ts
+++ b/apps/playground/src/app/components/ag-grid/data-manager-large/data-manager-large.component.ts
@@ -1,6 +1,7 @@
 import { CommonModule } from '@angular/common';
 import {
   Component,
+  DestroyRef,
   HostBinding,
   Input,
   OnInit,
@@ -9,6 +10,7 @@ import {
   model,
   viewChild,
 } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import {
   FormBuilder,
   FormControl,
@@ -39,7 +41,7 @@ import {
   GridOptions,
   ModuleRegistry,
 } from 'ag-grid-community';
-import { BehaviorSubject } from 'rxjs';
+import { BehaviorSubject, debounceTime } from 'rxjs';
 
 import { CustomLinkComponent } from './custom-link/custom-link.component';
 import {
@@ -125,6 +127,8 @@ export class DataManagerLargeComponent implements OnInit {
 
   public dataManagerConfig: SkyDataManagerConfig = {};
 
+  public readonly viewId = 'gridView';
+
   public defaultDataState = new SkyDataManagerState({
     filterData: {
       filtersApplied: false,
@@ -132,7 +136,7 @@ export class DataManagerLargeComponent implements OnInit {
     },
     views: [
       {
-        viewId: 'gridView',
+        viewId: this.viewId,
         displayedColumnIds: [
           'select',
           'credit_line',
@@ -151,8 +155,6 @@ export class DataManagerLargeComponent implements OnInit {
     ],
   });
 
-  public readonly viewId = 'gridView';
-
   public dataState: SkyDataManagerState | undefined;
   public items = data.map((item) => ({
     id: item.object_id,
@@ -160,7 +162,7 @@ export class DataManagerLargeComponent implements OnInit {
   }));
   public readonly settingsKey = 'large-test';
   public gridOptions: GridOptions = {};
-  public readonly isActive$ = new BehaviorSubject(true);
+  public readonly isActive$ = new BehaviorSubject(false);
   public readonly gridSettings: FormGroup<GridSettingsType>;
 
   protected readonly agGrid = viewChild(AgGridAngular);
@@ -168,6 +170,7 @@ export class DataManagerLargeComponent implements OnInit {
 
   readonly #agGridService = inject(SkyAgGridService);
   readonly #dataManagerService = inject(SkyDataManagerService);
+  readonly #destroyRef = inject(DestroyRef);
 
   constructor(formBuilder: FormBuilder) {
     this.gridSettings = formBuilder.group<GridSettingsType>({
@@ -185,24 +188,10 @@ export class DataManagerLargeComponent implements OnInit {
   }
 
   public ngOnInit(): void {
-    this.gridSettings.setValue({
-      enableTopScroll: this.enableTopScroll,
-      domLayout: this.domLayout,
-      autoHeightColumns: this.autoHeightColumns,
-      wrapText: this.wrapText,
-      compact: this.compact,
-      showSelect: this.showSelect,
-      showDelete: this.showDelete,
-      useColumnGroups: this.useColumnGroups,
-    });
     this.#applyGridOptions();
 
-    this.#dataManagerService.getActiveViewIdUpdates().subscribe((id) => {
-      this.isActive$.next(id === this.viewId);
-    });
-
     this.#dataManagerService.initDataManager({
-      activeViewId: 'gridView',
+      activeViewId: this.viewId,
       dataManagerConfig: this.dataManagerConfig,
       defaultDataState: this.defaultDataState,
       settingsKey: this.settingsKey,
@@ -228,19 +217,21 @@ export class DataManagerLargeComponent implements OnInit {
       }),
     });
 
-    this.gridSettings.valueChanges.subscribe((value) => {
-      this.isActive$.next(false);
-      this.enableTopScroll = !!value.enableTopScroll;
-      this.showSelect = !!value.showSelect;
-      this.showDelete = !!value.showDelete;
-      this.useColumnGroups = !!value.useColumnGroups;
-      this.domLayout = value.domLayout ?? 'autoHeight';
-      this.compact = !!value.compact;
-      this.wrapText = !!value.wrapText;
-      this.autoHeightColumns = !!value.autoHeightColumns;
-      this.#applyGridOptions();
-      setTimeout(() => this.isActive$.next(true));
-    });
+    this.gridSettings.valueChanges
+      .pipe(takeUntilDestroyed(this.#destroyRef), debounceTime(0))
+      .subscribe((value) => {
+        this.isActive$.next(false);
+        this.enableTopScroll = !!value.enableTopScroll;
+        this.showSelect = !!value.showSelect;
+        this.showDelete = !!value.showDelete;
+        this.useColumnGroups = !!value.useColumnGroups;
+        this.domLayout = value.domLayout ?? 'autoHeight';
+        this.compact = !!value.compact;
+        this.wrapText = !!value.wrapText;
+        this.autoHeightColumns = !!value.autoHeightColumns;
+        this.#applyGridOptions();
+        setTimeout(() => this.isActive$.next(true));
+      });
   }
 
   public markForDelete(rowId: string): void {
@@ -284,12 +275,11 @@ export class DataManagerLargeComponent implements OnInit {
             : []),
           ...(this.useColumnGroups
             ? columnDefinitionsGrouped
-            : columnDefinitions.map((col) => {
-                if (col.field === 'object_name') {
-                  col.rowDrag = this.domLayout === 'normal';
-                }
-                return col;
-              })),
+            : columnDefinitions.map((col) =>
+                col.field === 'object_name'
+                  ? { ...col, rowDrag: this.domLayout === 'normal' }
+                  : col,
+              )),
         ],
         columnTypes: {
           custom_link: {

--- a/apps/playground/src/app/components/ag-grid/data-manager-large/data-manager-large.component.ts
+++ b/apps/playground/src/app/components/ag-grid/data-manager-large/data-manager-large.component.ts
@@ -1,18 +1,17 @@
 import { CommonModule } from '@angular/common';
 import {
   Component,
-  DestroyRef,
-  Input,
-  OnInit,
   Signal,
   ViewEncapsulation,
   computed,
+  effect,
   inject,
+  input,
   model,
   signal,
-  viewChild,
+  untracked,
 } from '@angular/core';
-import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
+import { toSignal } from '@angular/core/rxjs-interop';
 import {
   FormBuilder,
   FormControl,
@@ -37,9 +36,11 @@ import { SkyHelpInlineModule } from '@skyux/help-inline';
 import { SkyIconModule } from '@skyux/icon';
 import { SkyDropdownModule } from '@skyux/popovers';
 
-import { AgGridAngular, AgGridModule } from 'ag-grid-angular';
+import { AgGridModule } from 'ag-grid-angular';
 import {
   AllCommunityModule,
+  ColDef,
+  GridApi,
   GridOptions,
   ModuleRegistry,
 } from 'ag-grid-community';
@@ -56,7 +57,7 @@ import { LocalStorageConfigService } from './local-storage-config.service';
 interface GridSettingsType {
   enableTopScroll: FormControl<boolean>;
   useColumnGroups: FormControl<boolean>;
-  domLayout: FormControl<'normal' | 'autoHeight' | 'print'>;
+  domLayoutNormal: FormControl<boolean>;
   compact: FormControl<boolean>;
   wrapText: FormControl<boolean>;
   autoHeightColumns: FormControl<boolean>;
@@ -67,7 +68,7 @@ interface GridSettingsType {
 interface GridSettingsValueType {
   enableTopScroll: boolean;
   useColumnGroups: boolean;
-  domLayout: 'normal' | 'autoHeight' | 'print';
+  domLayoutNormal: boolean;
   compact: boolean;
   wrapText: boolean;
   autoHeightColumns: boolean;
@@ -106,37 +107,24 @@ ModuleRegistry.registerModules([AllCommunityModule]);
     '[class.use-auto-height-dom-layout]': 'useAutoHeightDomLayout()',
   },
 })
-export class DataManagerLargeComponent implements OnInit {
+export class DataManagerLargeComponent {
+  public readonly autoHeightColumns = input(false);
+  public readonly compact = input(false);
+  public readonly domLayout = input<'normal' | 'autoHeight' | 'print'>(
+    'autoHeight',
+  );
+  public readonly enableTopScroll = input(true);
+  public readonly showDelete = input(false);
+  public readonly showSelect = input(false);
+  public readonly useColumnGroups = input(false);
+  public readonly wrapText = input(false);
+
   public useNormalDomLayout = computed(
     () => this.gridOptions().domLayout === 'normal',
   );
   public useAutoHeightDomLayout = computed(
     () => this.gridOptions().domLayout === 'autoHeight',
   );
-
-  @Input()
-  public compact = false;
-
-  @Input()
-  public domLayout: 'normal' | 'autoHeight' | 'print' = 'autoHeight';
-
-  @Input()
-  public enableTopScroll = true;
-
-  @Input()
-  public useColumnGroups = false;
-
-  @Input()
-  public showSelect = true;
-
-  @Input()
-  public showDelete = false;
-
-  @Input()
-  public wrapText = false;
-
-  @Input()
-  public autoHeightColumns = false;
 
   public dataManagerConfig: SkyDataManagerConfig = {};
 
@@ -178,27 +166,36 @@ export class DataManagerLargeComponent implements OnInit {
   public readonly isActive = signal(true);
   public readonly gridSettings: FormGroup<GridSettingsType>;
 
-  protected readonly agGrid = viewChild(AgGridAngular);
   protected readonly rowDeleteIds = model<string[]>([]);
   protected readonly gridSettingsValue: Signal<Partial<GridSettingsValueType>>;
 
   readonly #agGridService = inject(SkyAgGridService);
   readonly #dataManagerService = inject(SkyDataManagerService);
-  readonly #destroyRef = inject(DestroyRef);
+  readonly #gridApi = signal<GridApi | undefined>(undefined);
 
   constructor() {
     const formBuilder = inject(FormBuilder);
     this.gridSettings = formBuilder.group<GridSettingsType>({
-      enableTopScroll: formBuilder.nonNullable.control(this.enableTopScroll),
-      useColumnGroups: formBuilder.nonNullable.control(this.useColumnGroups),
-      showSelect: formBuilder.nonNullable.control(this.showSelect),
-      showDelete: formBuilder.nonNullable.control(this.showDelete),
-      domLayout: formBuilder.nonNullable.control(this.domLayout),
-      compact: formBuilder.nonNullable.control(this.compact),
-      wrapText: formBuilder.nonNullable.control(this.wrapText),
-      autoHeightColumns: formBuilder.nonNullable.control(
-        this.autoHeightColumns,
-      ),
+      autoHeightColumns: formBuilder.nonNullable.control(false),
+      compact: formBuilder.nonNullable.control(false),
+      domLayoutNormal: formBuilder.nonNullable.control(false),
+      enableTopScroll: formBuilder.nonNullable.control(false),
+      showDelete: formBuilder.nonNullable.control(false),
+      showSelect: formBuilder.nonNullable.control(false),
+      useColumnGroups: formBuilder.nonNullable.control(false),
+      wrapText: formBuilder.nonNullable.control(false),
+    });
+    effect(() => {
+      this.gridSettings.patchValue({
+        autoHeightColumns: this.autoHeightColumns(),
+        compact: this.compact(),
+        domLayoutNormal: this.domLayout() === 'normal',
+        enableTopScroll: this.enableTopScroll(),
+        showDelete: this.showDelete(),
+        showSelect: this.showSelect(),
+        useColumnGroups: this.useColumnGroups(),
+        wrapText: this.wrapText(),
+      });
     });
     this.gridSettingsValue = toSignal(this.gridSettings.valueChanges, {
       initialValue: this.gridSettings.getRawValue(),
@@ -213,11 +210,9 @@ export class DataManagerLargeComponent implements OnInit {
                   {
                     field: 'select',
                     headerName: 'Select',
-                    headerComponentParams: {
-                      headerHidden: true,
-                    },
                     type: SkyCellType.RowSelector,
-                  },
+                    lockVisible: true,
+                  } as ColDef,
                 ]
               : []),
             ...(settings.showDelete
@@ -236,7 +231,7 @@ export class DataManagerLargeComponent implements OnInit {
               ? columnDefinitionsGrouped
               : columnDefinitions.map((col) =>
                   col.field === 'object_name'
-                    ? { ...col, rowDrag: settings.domLayout === 'normal' }
+                    ? { ...col, rowDrag: settings.domLayoutNormal }
                     : col,
                 )),
           ],
@@ -248,19 +243,29 @@ export class DataManagerLargeComponent implements OnInit {
           context: {
             enableTopScroll: settings.enableTopScroll,
           },
-          domLayout: settings.domLayout,
+          domLayout: settings.domLayoutNormal ? 'normal' : 'autoHeight',
           defaultColDef: {
             wrapText: settings.wrapText,
             autoHeight: settings.autoHeightColumns,
           },
-          rowDragManaged:
-            !settings.useColumnGroups && settings.domLayout === 'normal',
+          onGridReady: (ready) => {
+            this.#gridApi.set(ready.api);
+          },
+          onGridPreDestroyed: () => {
+            this.#gridApi.set(undefined);
+          },
+          rowDragManaged: !settings.useColumnGroups && settings.domLayoutNormal,
         },
       });
     });
-  }
+    effect(() => {
+      const api = untracked(() => this.#gridApi());
+      this.gridOptions();
+      if (api) {
+        this.#pauseAndShowGrid();
+      }
+    });
 
-  public ngOnInit(): void {
     this.#dataManagerService.initDataManager({
       activeViewId: this.viewId,
       dataManagerConfig: this.dataManagerConfig,
@@ -274,7 +279,6 @@ export class DataManagerLargeComponent implements OnInit {
       iconName: 'table',
       searchEnabled: false,
       sortEnabled: true,
-      multiselectToolbarEnabled: true,
       columnPickerEnabled: true,
       filterButtonEnabled: true,
       showFilterButtonText: true,
@@ -283,15 +287,10 @@ export class DataManagerLargeComponent implements OnInit {
           id: col.field ?? '',
           label: col.headerName ?? '',
           alwaysDisplayed:
-            this.showSelect && ['select'].includes(col.field ?? ''),
+            this.showSelect() && ['select'].includes(col.field ?? ''),
         };
       }),
     });
-
-    this.gridSettings.valueChanges
-      .pipe(takeUntilDestroyed(this.#destroyRef))
-      .subscribe(() => this.#pauseAndShowGrid());
-    this.#pauseAndShowGrid();
   }
 
   public markForDelete(rowId: string): void {
@@ -302,7 +301,7 @@ export class DataManagerLargeComponent implements OnInit {
 
   protected deleteConfirm($event: SkyAgGridRowDeleteConfirmArgs): void {
     this.items = this.items.filter((item) => item.id !== $event.id);
-    this.agGrid().api.setGridOption('rowData', this.items);
+    this.#gridApi()?.setGridOption('rowData', this.items);
   }
 
   #pauseAndShowGrid(): void {

--- a/apps/playground/src/app/components/ag-grid/data-manager-large/data-manager-large.component.ts
+++ b/apps/playground/src/app/components/ag-grid/data-manager-large/data-manager-large.component.ts
@@ -1,5 +1,6 @@
 import { CommonModule } from '@angular/common';
 import {
+  ChangeDetectionStrategy,
   Component,
   Signal,
   ViewEncapsulation,
@@ -82,6 +83,7 @@ ModuleRegistry.registerModules([AllCommunityModule]);
   selector: 'app-data-manager-large',
   templateUrl: './data-manager-large.component.html',
   styleUrls: ['./data-manager-large.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
   imports: [
     AgGridModule,

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/header/header-row-selector/header-row-selector.component.spec.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/header/header-row-selector/header-row-selector.component.spec.ts
@@ -196,7 +196,7 @@ describe('SkyAgGridHeaderRowSelectorComponent', () => {
     expect(htmlCheckbox?.indeterminate).toBeTrue();
   });
 
-  it('should toggle selection via Enter and Space keypress on the header element', async () => {
+  it('should toggle selection via Enter and Space keydown on the header element', async () => {
     expect(component).toBeTruthy();
     api.getGridOption.and.returnValue({ mode: 'multiRow' });
     const headerEl = document.createElement('div');
@@ -216,13 +216,13 @@ describe('SkyAgGridHeaderRowSelectorComponent', () => {
     const selectEventHandler = api.addEventListener.calls.first().args[1];
 
     // Unchecked + Enter -> selectAll.
-    headerEl.dispatchEvent(new KeyboardEvent('keypress', { key: 'Enter' }));
+    headerEl.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
     expect(api.selectAll).toHaveBeenCalledTimes(1);
     expect(api.deselectAll).not.toHaveBeenCalled();
 
     // Non-target keys are filtered out.
-    headerEl.dispatchEvent(new KeyboardEvent('keypress', { key: 'a' }));
-    headerEl.dispatchEvent(new KeyboardEvent('keypress', { key: 'Tab' }));
+    headerEl.dispatchEvent(new KeyboardEvent('keydown', { key: 'a' }));
+    headerEl.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab' }));
     expect(api.selectAll).toHaveBeenCalledTimes(1);
     expect(api.deselectAll).not.toHaveBeenCalled();
 
@@ -241,10 +241,74 @@ describe('SkyAgGridHeaderRowSelectorComponent', () => {
     fixture.detectChanges();
     await fixture.whenStable();
 
-    // Checked + Space -> deselectAll.
-    headerEl.dispatchEvent(new KeyboardEvent('keypress', { key: ' ' }));
+    // Checked + Space -> deselectAll, and default scrolling is prevented.
+    const spaceEvent = new KeyboardEvent('keydown', {
+      key: ' ',
+      cancelable: true,
+    });
+    headerEl.dispatchEvent(spaceEvent);
+    expect(spaceEvent.defaultPrevented).toBeTrue();
     expect(api.deselectAll).toHaveBeenCalledTimes(1);
     expect(api.selectAll).toHaveBeenCalledTimes(1);
+  });
+
+  it('should ignore auto-repeat keydown events on the header element', async () => {
+    expect(component).toBeTruthy();
+    api.getGridOption.and.returnValue({ mode: 'multiRow' });
+    const headerEl = document.createElement('div');
+    component.agInit({
+      api,
+      displayName: 'test-selected',
+      eGridCell: fixture.nativeElement,
+      eGridHeader: headerEl,
+    } as any);
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    // First press selects.
+    headerEl.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+    expect(api.selectAll).toHaveBeenCalledTimes(1);
+
+    // Held key (repeat=true) is ignored, even for target keys.
+    headerEl.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'Enter', repeat: true }),
+    );
+    headerEl.dispatchEvent(
+      new KeyboardEvent('keydown', { key: ' ', repeat: true }),
+    );
+    expect(api.selectAll).toHaveBeenCalledTimes(1);
+    expect(api.deselectAll).not.toHaveBeenCalled();
+  });
+
+  it('should not stack listeners when agInit is invoked more than once', async () => {
+    expect(component).toBeTruthy();
+    api.getGridOption.and.returnValue({ mode: 'multiRow' });
+    const headerEl = document.createElement('div');
+    const params = {
+      api,
+      displayName: 'test-selected',
+      eGridCell: fixture.nativeElement,
+      eGridHeader: headerEl,
+    } as any;
+
+    // First agInit attaches the keydown listener and two grid-event listeners.
+    component.agInit(params);
+    fixture.detectChanges();
+    await fixture.whenStable();
+    expect(api.addEventListener).toHaveBeenCalledTimes(2);
+    expect(api.removeEventListener).not.toHaveBeenCalled();
+
+    // Second agInit should tear down the first attachment before re-attaching.
+    component.agInit(params);
+    fixture.detectChanges();
+    await fixture.whenStable();
+    expect(api.removeEventListener).toHaveBeenCalledTimes(2);
+    expect(api.addEventListener).toHaveBeenCalledTimes(4);
+
+    // A single Enter keydown should fire selectAll exactly once, not twice.
+    headerEl.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+    expect(api.selectAll).toHaveBeenCalledTimes(1);
+    expect(api.deselectAll).not.toHaveBeenCalled();
   });
 
   it('should hide checkbox for single select', async () => {

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/header/header-row-selector/header-row-selector.component.spec.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/header/header-row-selector/header-row-selector.component.spec.ts
@@ -1,6 +1,5 @@
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-// eslint-disable-next-line @nx/enforce-module-boundaries
 import { SkyCheckboxHarness } from '@skyux/forms/testing';
 
 import {
@@ -195,6 +194,57 @@ describe('SkyAgGridHeaderRowSelectorComponent', () => {
     ).querySelector<HTMLInputElement>('input[type="checkbox"]');
     expect(htmlCheckbox).toBeTruthy();
     expect(htmlCheckbox?.indeterminate).toBeTrue();
+  });
+
+  it('should toggle selection via Enter and Space keypress on the header element', async () => {
+    expect(component).toBeTruthy();
+    api.getGridOption.and.returnValue({ mode: 'multiRow' });
+    const headerEl = document.createElement('div');
+    component.agInit({
+      api,
+      displayName: 'test-selected',
+      eGridCell: fixture.nativeElement,
+      eGridHeader: headerEl,
+    } as any);
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(headerEl.getAttribute('aria-keyshortcuts')).toEqual('Enter Space');
+
+    // Capture the selectionChanged handler so we can flip `checked` on later.
+    expect(api.addEventListener).toHaveBeenCalledTimes(2);
+    const selectEventHandler = api.addEventListener.calls.first().args[1];
+
+    // Unchecked + Enter -> selectAll.
+    headerEl.dispatchEvent(new KeyboardEvent('keypress', { key: 'Enter' }));
+    expect(api.selectAll).toHaveBeenCalledTimes(1);
+    expect(api.deselectAll).not.toHaveBeenCalled();
+
+    // Non-target keys are filtered out.
+    headerEl.dispatchEvent(new KeyboardEvent('keypress', { key: 'a' }));
+    headerEl.dispatchEvent(new KeyboardEvent('keypress', { key: 'Tab' }));
+    expect(api.selectAll).toHaveBeenCalledTimes(1);
+    expect(api.deselectAll).not.toHaveBeenCalled();
+
+    // Flip internal `checked` to true via the selectionChanged event.
+    selectEventHandler({
+      api: api as unknown as GridApi,
+      serverSideState: {},
+      type: 'selectionChanged',
+      source: 'apiSelectAll',
+      selectedNodes: Array.from(Array(10).keys()).map(
+        (i) => ({ id: `id-${i + 1}` }) as IRowNode,
+      ),
+      context: {},
+    } as SelectionChangedEvent);
+    await new Promise((resolve) => setTimeout(resolve, 1));
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    // Checked + Space -> deselectAll.
+    headerEl.dispatchEvent(new KeyboardEvent('keypress', { key: ' ' }));
+    expect(api.deselectAll).toHaveBeenCalledTimes(1);
+    expect(api.selectAll).toHaveBeenCalledTimes(1);
   });
 
   it('should hide checkbox for single select', async () => {

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/header/header-row-selector/header-row-selector.component.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/header/header-row-selector/header-row-selector.component.ts
@@ -8,12 +8,11 @@ import {
   model,
   signal,
 } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { SkyCheckboxChange, SkyCheckboxModule } from '@skyux/forms';
 
 import { IHeaderAngularComp } from 'ag-grid-angular';
 import { GridApi, IHeaderParams } from 'ag-grid-community';
-import { filter, fromEvent } from 'rxjs';
+import { Subscription } from 'rxjs';
 
 import { fromGridEvent } from '../../ag-grid-event-utils';
 
@@ -39,12 +38,18 @@ export class SkyAgGridHeaderRowSelectorComponent implements IHeaderAngularComp {
   });
 
   #api: GridApi<unknown> | undefined;
-  readonly #destroyRef = inject(DestroyRef);
+  #subscriptions = new Subscription();
   readonly #renderer = inject(RendererFactory2).createRenderer(undefined, null);
+
+  constructor() {
+    inject(DestroyRef).onDestroy(() => this.#subscriptions.unsubscribe());
+  }
 
   public agInit(params: IHeaderParams): void {
     this.params.set(params);
     this.#api = params.api;
+    this.#subscriptions.unsubscribe();
+    this.#subscriptions = new Subscription();
 
     // Row selection behavior can only be set when the grid is created.
     // It only changes if the grid is recreated.
@@ -55,9 +60,8 @@ export class SkyAgGridHeaderRowSelectorComponent implements IHeaderAngularComp {
     );
 
     if (this.multiSelect()) {
-      fromGridEvent(params.api, 'selectionChanged')
-        .pipe(takeUntilDestroyed(this.#destroyRef))
-        .subscribe((change): void => {
+      this.#subscriptions.add(
+        fromGridEvent(params.api, 'selectionChanged').subscribe((change) => {
           if (change.source.match(/selectall/i)) {
             // Either select all or clear selection.
             this.indeterminate.set(false);
@@ -66,30 +70,34 @@ export class SkyAgGridHeaderRowSelectorComponent implements IHeaderAngularComp {
             this.indeterminate.set(!!change.selectedNodes?.length);
             this.checked.set(false);
           }
-        });
+        }),
+      );
 
-      fromGridEvent(params.api, 'rowDataUpdated')
-        .pipe(takeUntilDestroyed(this.#destroyRef))
-        .subscribe((): void => {
+      this.#subscriptions.add(
+        fromGridEvent(params.api, 'rowDataUpdated').subscribe(() => {
           this.indeterminate.set(!!this.#api?.getSelectedNodes().length);
           this.checked.set(false);
-        });
+        }),
+      );
 
       const el = params.eGridHeader;
       if (el) {
         this.#renderer.setAttribute(el, 'aria-keyshortcuts', 'Enter Space');
-        fromEvent<KeyboardEvent>(el, 'keypress')
-          .pipe(
-            takeUntilDestroyed(this.#destroyRef),
-            filter((evt) => ['Enter', ' '].includes(evt.key)),
-          )
-          .subscribe((): void => {
+        this.#subscriptions.add(
+          this.#renderer.listen(el, 'keydown', (evt: KeyboardEvent) => {
+            if (!['Enter', ' '].includes(evt.key) || evt.repeat) {
+              return;
+            }
+            if (evt.key === ' ') {
+              evt.preventDefault();
+            }
             if (this.checked()) {
               this.#api?.deselectAll();
             } else {
               this.#api?.selectAll();
             }
-          });
+          }),
+        );
       }
     }
   }

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/header/header-row-selector/header-row-selector.component.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/header/header-row-selector/header-row-selector.component.ts
@@ -2,6 +2,7 @@ import {
   ChangeDetectionStrategy,
   Component,
   DestroyRef,
+  RendererFactory2,
   computed,
   inject,
   model,
@@ -12,6 +13,7 @@ import { SkyCheckboxChange, SkyCheckboxModule } from '@skyux/forms';
 
 import { IHeaderAngularComp } from 'ag-grid-angular';
 import { GridApi, IHeaderParams } from 'ag-grid-community';
+import { filter, fromEvent } from 'rxjs';
 
 import { fromGridEvent } from '../../ag-grid-event-utils';
 
@@ -38,6 +40,7 @@ export class SkyAgGridHeaderRowSelectorComponent implements IHeaderAngularComp {
 
   #api: GridApi<unknown> | undefined;
   readonly #destroyRef = inject(DestroyRef);
+  readonly #renderer = inject(RendererFactory2).createRenderer(undefined, null);
 
   public agInit(params: IHeaderParams): void {
     this.params.set(params);
@@ -71,6 +74,23 @@ export class SkyAgGridHeaderRowSelectorComponent implements IHeaderAngularComp {
           this.indeterminate.set(!!this.#api?.getSelectedNodes().length);
           this.checked.set(false);
         });
+
+      const el = params.eGridHeader;
+      if (el) {
+        this.#renderer.setAttribute(el, 'aria-keyshortcuts', 'Enter Space');
+        fromEvent<KeyboardEvent>(el, 'keypress')
+          .pipe(
+            takeUntilDestroyed(this.#destroyRef),
+            filter((evt) => ['Enter', ' '].includes(evt.key)),
+          )
+          .subscribe((): void => {
+            if (this.checked()) {
+              this.#api?.deselectAll();
+            } else {
+              this.#api?.selectAll();
+            }
+          });
+      }
     }
   }
 


### PR DESCRIPTION
[AB#3963510](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3963510)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Keyboard shortcuts for header row selector: Enter selects all, Space deselects all.

* **Improvements**
  * Toolbar adds options for "Select checkboxes" and "Use normal DOM layout".
  * More predictable reactive updates, cleaner lifecycle handling, and more robust immutable column/view wiring.

* **Behavior Change**
  * Select-column is disabled by default (must be enabled to show).

* **Tests**
  * Added tests covering header row selector keyboard interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->