### PR TITLE
fix(components/i18n): update library resources schematic to only include message property

### DIFF
--- a/libs/components/i18n/schematics/ng-generate/lib-resources-module/lib-resources-module.schematic.spec.ts
+++ b/libs/components/i18n/schematics/ng-generate/lib-resources-module/lib-resources-module.schematic.spec.ts
@@ -88,6 +88,41 @@ export class MyLibResourcesModule {}
 `);
   });
 
+  it('should only include the `message` property in the generated resources', async () => {
+    tree.overwrite(
+      defaultResourcesJsonPath,
+      JSON.stringify({
+        only_message: {
+          message: 'A message with no extra properties.',
+        },
+        simple: {
+          _description: 'A simple description.',
+          message: 'A simple message.',
+        },
+        single_placeholder: {
+          _description: 'A description with placeholders.',
+          message: 'A templated message {0}',
+          _0: 'Some placeholder description',
+        },
+        many_placeholders: {
+          _description: 'A description with many placeholders.',
+          message: '{0} has {1} items remaining out of {2}.',
+          _0: 'The name of the user',
+          _1: 'The number of items remaining',
+          _2: 'The total number of items',
+        }
+      }),
+    );
+
+    const updatedTree = await runSchematic();
+
+    const moduleContents = readRequiredFile(updatedTree, resourcesModulePath);
+
+    expect(moduleContents).toContain(
+      `'EN-US': {"only_message":{"message":"A message with no extra properties."},"simple":{"message":"A simple message."},"single_placeholder":{"message":"A templated message {0}"},"many_placeholders":{"message":"{0} has {1} items remaining out of {2}."}}`,
+    );
+  });
+
   it('should create a default resources file if none exists', async () => {
     tree.delete(defaultResourcesJsonPath);
 

--- a/libs/components/i18n/schematics/ng-generate/lib-resources-module/lib-resources-module.schematic.spec.ts
+++ b/libs/components/i18n/schematics/ng-generate/lib-resources-module/lib-resources-module.schematic.spec.ts
@@ -110,7 +110,7 @@ export class MyLibResourcesModule {}
           _0: 'The name of the user',
           _1: 'The number of items remaining',
           _2: 'The total number of items',
-        }
+        },
       }),
     );
 

--- a/libs/components/i18n/schematics/ng-generate/lib-resources-module/lib-resources-module.schematic.ts
+++ b/libs/components/i18n/schematics/ng-generate/lib-resources-module/lib-resources-module.schematic.ts
@@ -58,7 +58,7 @@ function getResources(tree: Tree, project: ProjectDefinition): string {
     );
 
     Object.keys(contents).forEach((key) => {
-      delete contents[key]._description;
+      contents[key] = { message: contents[key].message };
     });
 
     resourcesVar += `\n  '${localeId}': ${JSON.stringify(contents)},`;


### PR DESCRIPTION
Update the library i18n schematic to only care about the a resource's `message` property when generating the library resource module.

This gives libraries the ability to document placeholder fields - `{0}`, `{1}`, ect - with dedicated properties - `_{0}: ''`, `_{1}: ''`, ect - which SPAs already allow. 

<img width="1214" height="267" alt="image" src="https://github.com/user-attachments/assets/80ada996-8d2a-4eec-ba40-0afc7417df5a" />

[AB#3971960](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3971960)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a test to ensure generated i18n resources include only the intended message property for each entry.

* **Bug Fixes**
  * Corrected i18n resource transformation so localized resources are formatted with message properties only.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->