### PR TITLE
fix(components/ag-grid): row delete overlay shows when used in the bootstrap component

### DIFF
--- a/libs/components/ag-grid/src/lib/modules/ag-grid/ag-grid-row-delete.directive.spec.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/ag-grid-row-delete.directive.spec.ts
@@ -450,7 +450,6 @@ describe('SkyAgGridRowDeleteDirective', () => {
     const debugElement = fixture.debugElement.query(
       By.directive(SkyAgGridRowDeleteDirective),
     );
-    debugElement.componentInstance.ngAfterViewInit();
     expect(
       TestBed.inject(SkyScrollableHostService)
         .watchScrollableHostClipPathChanges,
@@ -572,6 +571,7 @@ describe('SkyAgGridRowDeleteDirective', () => {
 
     const overlaySvc = TestBed.inject(SkyOverlayService);
     const otherOverlay = overlaySvc.create({});
+    await fixture.whenStable();
     expect(Array.from(document.querySelectorAll('sky-overlay'))).toHaveSize(2);
     fixture.componentRef.hostView.destroy();
     fixture.componentRef.destroy();

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/ag-grid-row-delete.directive.spec.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/ag-grid-row-delete.directive.spec.ts
@@ -1,6 +1,9 @@
-import { ElementRef } from '@angular/core';
+import { provideLocationMocks } from '@angular/common/testing';
+import { Component, ElementRef } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
+import { NavigationStart, Router, provideRouter } from '@angular/router';
+import { RouterTestingHarness } from '@angular/router/testing';
 import { expectAsync } from '@skyux-sdk/testing';
 import {
   SKY_STACKING_CONTEXT,
@@ -13,12 +16,16 @@ import { BehaviorSubject, Observable, of } from 'rxjs';
 import { SkyAgGridRowDeleteDirective } from './ag-grid-row-delete.directive';
 import { SkyAgGridRowDeleteFixtureComponent } from './fixtures/ag-grid-row-delete.component.fixture';
 
+@Component({ standalone: true, template: '' })
+class BlankRouteComponent {}
+
 describe('SkyAgGridRowDeleteDirective', () => {
   let fixture: ComponentFixture<SkyAgGridRowDeleteFixtureComponent>;
 
   function setupTest(options?: {
     stackingContextZIndex?: number;
     hideFirstColumn?: boolean;
+    withRouter?: boolean;
   }): void {
     TestBed.configureTestingModule({
       imports: [SkyAgGridRowDeleteFixtureComponent],
@@ -42,6 +49,14 @@ describe('SkyAgGridRowDeleteDirective', () => {
               .and.returnValue(of('none')),
           },
         },
+        ...(options?.withRouter
+          ? [
+              provideRouter([
+                { path: 'other', component: BlankRouteComponent },
+              ]),
+              provideLocationMocks(),
+            ]
+          : []),
       ],
     });
 
@@ -558,6 +573,38 @@ describe('SkyAgGridRowDeleteDirective', () => {
     expect(inlineDelete1.offsetTop).toEqual(Math.round(row1Rect.top));
     expect(inlineDelete2.offsetLeft).toEqual(Math.round(row2Rect.left));
     expect(inlineDelete2.offsetTop).toEqual(Math.round(row2Rect.top));
+  });
+
+  it('should not close the row delete overlay when navigating to a different route in an app where the router does not wrap the grid', async () => {
+    setupTest({ withRouter: true });
+    await fixture.whenStable();
+
+    fixture.componentInstance.rowDeleteIds = ['0'];
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(document.querySelector('#row-delete-ref-0')).not.toBeNull();
+    expect(document.querySelectorAll('.sky-overlay').length).toBe(1);
+
+    const router = TestBed.inject(Router);
+    const navigationStartSpy = jasmine.createSpy('navigationStart');
+    const sub = router.events.subscribe((event) => {
+      if (event instanceof NavigationStart) {
+        navigationStartSpy();
+      }
+    });
+
+    const harness = await RouterTestingHarness.create();
+    await harness.navigateByUrl('/other');
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(navigationStartSpy).toHaveBeenCalled();
+    expect(document.querySelector('#row-delete-ref-0')).not.toBeNull();
+    expect(document.querySelectorAll('.sky-overlay').length).toBe(1);
+
+    sub.unsubscribe();
   });
 
   it('should not close other overlays', async () => {

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/ag-grid-row-delete.directive.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/ag-grid-row-delete.directive.ts
@@ -1,10 +1,9 @@
 import {
-  AfterContentInit,
-  AfterViewInit,
   Directive,
   ElementRef,
   EnvironmentInjector,
   OnDestroy,
+  afterNextRender,
   contentChild,
   inject,
   linkedSignal,
@@ -52,9 +51,7 @@ import { SkyAgGridRowDeleteConfirmArgs } from './types/ag-grid-row-delete-confir
 @Directive({
   selector: '[skyAgGridRowDelete]',
 })
-export class SkyAgGridRowDeleteDirective
-  implements AfterContentInit, AfterViewInit, OnDestroy
-{
+export class SkyAgGridRowDeleteDirective implements OnDestroy {
   /**
    * The IDs of the data in the rows where the inline delete appears.
    */
@@ -165,56 +162,54 @@ export class SkyAgGridRowDeleteDirective
           (rowIds ?? []).filter((id) => !!evt.api.getRowNode(id)),
         );
       });
-  }
 
-  public ngAfterContentInit(): void {
-    this.#overlay = this.#overlayService.create({
-      enableScroll: true,
-      environmentInjector: this.#environmentInjector,
-      showBackdrop: false,
-      closeOnNavigation: true,
-      enableClose: false,
-      enablePointerEvents: true,
+    afterNextRender(() => {
+      this.#overlay = this.#overlayService.create({
+        enableScroll: true,
+        environmentInjector: this.#environmentInjector,
+        showBackdrop: false,
+        closeOnNavigation: true,
+        enableClose: false,
+        enablePointerEvents: true,
+      });
+
+      this.#overlay.attachComponent(SkyAgGridRowDeleteComponent, [
+        {
+          provide: SKY_AG_GRID_ROW_DELETE_CONTEXT,
+          useValue: this.#rowDeleteSvc,
+        },
+      ]);
+      this.#zIndex
+        .pipe(
+          takeUntil(this.#ngUnsubscribe),
+          takeUntil(this.#overlay.closed),
+          distinctUntilChanged(),
+        )
+        .subscribe((zIndex) => {
+          if (this.#overlay) {
+            this.#overlay.componentRef.instance.zIndex = zIndex.toString(10);
+          }
+        });
+      this.#clipPath
+        .pipe(
+          takeUntil(this.#ngUnsubscribe),
+          takeUntil(this.#overlay.closed),
+          distinctUntilChanged(),
+        )
+        .subscribe((clipPath) => {
+          this.#overlay?.componentRef.instance.updateClipPath(clipPath);
+        });
+
+      this.#scrollableHostService
+        .watchScrollableHostClipPathChanges(
+          this.#elementRef,
+          this.#agGridBodyClipElements.asObservable(),
+        )
+        .pipe(takeUntil(this.#ngUnsubscribe))
+        .subscribe((clipPath) => {
+          this.#clipPath.next(clipPath);
+        });
     });
-
-    this.#overlay.attachComponent(SkyAgGridRowDeleteComponent, [
-      {
-        provide: SKY_AG_GRID_ROW_DELETE_CONTEXT,
-        useValue: this.#rowDeleteSvc,
-      },
-    ]);
-    this.#zIndex
-      .pipe(
-        takeUntil(this.#ngUnsubscribe),
-        takeUntil(this.#overlay.closed),
-        distinctUntilChanged(),
-      )
-      .subscribe((zIndex) => {
-        if (this.#overlay) {
-          this.#overlay.componentRef.instance.zIndex = zIndex.toString(10);
-        }
-      });
-    this.#clipPath
-      .pipe(
-        takeUntil(this.#ngUnsubscribe),
-        takeUntil(this.#overlay.closed),
-        distinctUntilChanged(),
-      )
-      .subscribe((clipPath) => {
-        this.#overlay?.componentRef.instance.updateClipPath(clipPath);
-      });
-  }
-
-  public ngAfterViewInit(): void {
-    this.#scrollableHostService
-      .watchScrollableHostClipPathChanges(
-        this.#elementRef,
-        this.#agGridBodyClipElements.asObservable(),
-      )
-      .pipe(takeUntil(this.#ngUnsubscribe))
-      .subscribe((clipPath) => {
-        this.#clipPath.next(clipPath);
-      });
   }
 
   public ngOnDestroy(): void {

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/ag-grid-row-delete.directive.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/ag-grid-row-delete.directive.ts
@@ -168,7 +168,7 @@ export class SkyAgGridRowDeleteDirective implements OnDestroy {
         enableScroll: true,
         environmentInjector: this.#environmentInjector,
         showBackdrop: false,
-        closeOnNavigation: true,
+        closeOnNavigation: false,
         enableClose: false,
         enablePointerEvents: true,
       });


### PR DESCRIPTION
[AB#3972778](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3972778)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved overlay initialization timing for row-delete overlays, increasing stability and z-index/clip-path reliability.
  * Streamlined teardown so overlays consistently close and subscriptions are cleaned up.

* **Bug Fixes**
  * Overlay no longer unexpectedly closes during navigation in setups where the grid isn't wrapped by the router.
  * Timing-related overlay closing and assertion issues addressed.

* **Tests**
  * Unit tests updated to await stabilization and mirror real render timing.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blackbaud/skyux/pull/4407)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->