### PR TITLE
fix(components/ag-grid): only set currency minDigits and truncate if not set in renderer params

### DIFF
--- a/libs/components/ag-grid/src/lib/modules/ag-grid/cell-renderers/cell-renderer-currency/cell-renderer-currency.component.spec.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/cell-renderers/cell-renderer-currency/cell-renderer-currency.component.spec.ts
@@ -131,6 +131,38 @@ describe('SkyAgGridCellRendererCurrencyComponent', () => {
 
       expect(currencyComponent.skyComponentProperties.format).toBe('currency');
     }));
+
+    it('defaults minDigits to 2 when not specified in skyComponentProperties', () => {
+      currencyComponent.agInit(cellRendererParams as ICellRendererParams);
+
+      expect(currencyComponent.skyComponentProperties.minDigits).toBe(2);
+    });
+
+    it('respects a consumer-specified minDigits in skyComponentProperties', () => {
+      if (cellRendererParams.skyComponentProperties) {
+        cellRendererParams.skyComponentProperties.minDigits = 4;
+      }
+
+      currencyComponent.agInit(cellRendererParams as ICellRendererParams);
+
+      expect(currencyComponent.skyComponentProperties.minDigits).toBe(4);
+    });
+
+    it('defaults truncate to false when not specified in skyComponentProperties', () => {
+      currencyComponent.agInit(cellRendererParams as ICellRendererParams);
+
+      expect(currencyComponent.skyComponentProperties.truncate).toBe(false);
+    });
+
+    it('respects a consumer-specified truncate in skyComponentProperties', () => {
+      if (cellRendererParams.skyComponentProperties) {
+        cellRendererParams.skyComponentProperties.truncate = true;
+      }
+
+      currencyComponent.agInit(cellRendererParams as ICellRendererParams);
+
+      expect(currencyComponent.skyComponentProperties.truncate).toBe(true);
+    });
   });
 
   describe('parameters', () => {

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/cell-renderers/cell-renderer-currency/cell-renderer-currency.component.spec.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/cell-renderers/cell-renderer-currency/cell-renderer-currency.component.spec.ts
@@ -5,14 +5,12 @@ import {
   tick,
 } from '@angular/core/testing';
 import { expect, expectAsync } from '@skyux-sdk/testing';
-import { NumericOptions } from '@skyux/core';
 
 import {
   AgColumn,
   BeanCollection,
   GridApi,
   ICellRenderer,
-  ICellRendererParams,
   RowNode,
 } from 'ag-grid-community';
 
@@ -24,7 +22,6 @@ import {
 import { SkyCellClass } from '../../types/cell-class';
 import { SkyCellRendererCurrencyParams } from '../../types/cell-renderer-currency-params';
 import { SkyCellType } from '../../types/cell-type';
-import { SkyAgGridValidatorProperties } from '../../types/validator-properties';
 
 import { SkyAgGridCellRendererCurrencyComponent } from './cell-renderer-currency.component';
 
@@ -32,11 +29,7 @@ describe('SkyAgGridCellRendererCurrencyComponent', () => {
   let currencyFixture: ComponentFixture<SkyAgGridCellRendererCurrencyComponent>;
   let currencyComponent: SkyAgGridCellRendererCurrencyComponent;
   let currencyNativeElement: HTMLElement;
-  let cellRendererParams: Partial<SkyCellRendererCurrencyParams> & {
-    skyComponentProperties:
-      | (NumericOptions & SkyAgGridValidatorProperties)
-      | undefined;
-  };
+  let cellRendererParams: Partial<SkyCellRendererCurrencyParams>;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -117,7 +110,9 @@ describe('SkyAgGridCellRendererCurrencyComponent', () => {
 
       expect(currencyComponent.value).toBeUndefined();
 
-      currencyComponent.agInit(cellRendererParams as ICellRendererParams);
+      currencyComponent.agInit(
+        cellRendererParams as SkyCellRendererCurrencyParams,
+      );
 
       currencyFixture.detectChanges();
       tick();
@@ -127,13 +122,17 @@ describe('SkyAgGridCellRendererCurrencyComponent', () => {
 
       cellRendererParams.skyComponentProperties = undefined;
       cellRendererParams.column = undefined;
-      currencyComponent.agInit(cellRendererParams as ICellRendererParams);
+      currencyComponent.agInit(
+        cellRendererParams as SkyCellRendererCurrencyParams,
+      );
 
       expect(currencyComponent.skyComponentProperties.format).toBe('currency');
     }));
 
     it('defaults minDigits to 2 when not specified in skyComponentProperties', () => {
-      currencyComponent.agInit(cellRendererParams as ICellRendererParams);
+      currencyComponent.agInit(
+        cellRendererParams as SkyCellRendererCurrencyParams,
+      );
 
       expect(currencyComponent.skyComponentProperties.minDigits).toBe(2);
     });
@@ -143,13 +142,17 @@ describe('SkyAgGridCellRendererCurrencyComponent', () => {
         cellRendererParams.skyComponentProperties.minDigits = 4;
       }
 
-      currencyComponent.agInit(cellRendererParams as ICellRendererParams);
+      currencyComponent.agInit(
+        cellRendererParams as SkyCellRendererCurrencyParams,
+      );
 
       expect(currencyComponent.skyComponentProperties.minDigits).toBe(4);
     });
 
     it('defaults truncate to false when not specified in skyComponentProperties', () => {
-      currencyComponent.agInit(cellRendererParams as ICellRendererParams);
+      currencyComponent.agInit(
+        cellRendererParams as SkyCellRendererCurrencyParams,
+      );
 
       expect(currencyComponent.skyComponentProperties.truncate).toBe(false);
     });
@@ -159,7 +162,9 @@ describe('SkyAgGridCellRendererCurrencyComponent', () => {
         cellRendererParams.skyComponentProperties.truncate = true;
       }
 
-      currencyComponent.agInit(cellRendererParams as ICellRendererParams);
+      currencyComponent.agInit(
+        cellRendererParams as SkyCellRendererCurrencyParams,
+      );
 
       expect(currencyComponent.skyComponentProperties.truncate).toBe(true);
     });
@@ -175,7 +180,8 @@ describe('SkyAgGridCellRendererCurrencyComponent', () => {
 
       expect(currencyComponent.value).toBeUndefined();
 
-      currencyComponent.params = cellRendererParams as ICellRendererParams;
+      currencyComponent.params =
+        cellRendererParams as SkyCellRendererCurrencyParams;
 
       currencyFixture.detectChanges();
       tick();
@@ -188,7 +194,9 @@ describe('SkyAgGridCellRendererCurrencyComponent', () => {
   describe('refresh', () => {
     it('returns false', () => {
       expect(
-        currencyComponent.refresh(cellRendererParams as ICellRendererParams),
+        currencyComponent.refresh(
+          cellRendererParams as SkyCellRendererCurrencyParams,
+        ),
       ).toBe(false);
     });
 
@@ -201,7 +209,9 @@ describe('SkyAgGridCellRendererCurrencyComponent', () => {
 
       expect(currencyComponent.value).toBeUndefined();
 
-      currencyComponent.agInit(cellRendererParams as ICellRendererParams);
+      currencyComponent.agInit(
+        cellRendererParams as SkyCellRendererCurrencyParams,
+      );
 
       currencyFixture.detectChanges();
       tick();
@@ -210,7 +220,9 @@ describe('SkyAgGridCellRendererCurrencyComponent', () => {
       expect(currencyComponent.value).toBe(123);
 
       cellRendererParams.value = 245;
-      currencyComponent.agInit(cellRendererParams as ICellRendererParams);
+      currencyComponent.agInit(
+        cellRendererParams as SkyCellRendererCurrencyParams,
+      );
 
       currencyFixture.detectChanges();
       tick();

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/cell-renderers/cell-renderer-currency/cell-renderer-currency.component.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/cell-renderers/cell-renderer-currency/cell-renderer-currency.component.ts
@@ -48,7 +48,7 @@ export class SkyAgGridCellRendererCurrencyComponent implements ICellRendererAngu
     this.value = params.value;
     this.skyComponentProperties = params.skyComponentProperties || {};
     this.skyComponentProperties.format = 'currency';
-    this.skyComponentProperties.minDigits = 2;
-    this.skyComponentProperties.truncate = false;
+    this.skyComponentProperties.minDigits ??= 2;
+    this.skyComponentProperties.truncate ??= false;
   }
 }

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/types/cell-renderer-currency-params.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/types/cell-renderer-currency-params.ts
@@ -1,12 +1,17 @@
-import { NumericOptions } from '@skyux/core';
+import { SkyNumericOptions } from '@skyux/core';
 
 import { ICellRendererParams } from 'ag-grid-community';
 
 import { SkyAgGridValidatorProperties } from './validator-properties';
 
 /**
- * @internal
+ * Parameters for the currency cell renderer.
  */
 export interface SkyCellRendererCurrencyParams extends ICellRendererParams {
-  skyComponentProperties?: NumericOptions & SkyAgGridValidatorProperties;
+  /**
+   * Options to pass to the `SkyNumericPipe` for formatting the cell value.
+   * `format` is always set to `'currency'`. If not specified, `minDigits` defaults
+   * to `2` and `truncate` defaults to `false`.
+   */
+  skyComponentProperties?: SkyNumericOptions & SkyAgGridValidatorProperties;
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Currency renderer now preserves user-provided formatting settings for minimum decimal digits and truncation instead of unconditionally overwriting them.
* **Documentation**
  * Parameter docs updated to clarify currency formatting behavior and defaults.
* **Tests**
  * Unit tests added to validate default and consumer-overridden formatting behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->