### PR TITLE
fix(components/packages): standalone schematic unable to read type files

### DIFF
--- a/libs/components/packages/src/schematics/ng-generate/standalone/standalone.schematic.spec.ts
+++ b/libs/components/packages/src/schematics/ng-generate/standalone/standalone.schematic.spec.ts
@@ -73,7 +73,15 @@ describe('standalone', () => {
     const tree = await createTestApp(runner, {
       projectName: 'my-test-app',
     });
+    tree.create(
+      'node_modules/@skyux/datetime/package.json',
+      JSON.stringify({ exports: { '.': { types: './index.d.ts' } } }),
+    );
     tree.create('node_modules/@skyux/datetime/index.d.ts', dateTime);
+    tree.create(
+      'node_modules/@skyux/modals/package.json',
+      JSON.stringify({ exports: { '.': { types: './index.d.ts' } } }),
+    );
     tree.create('node_modules/@skyux/modals/index.d.ts', modals);
 
     return {
@@ -411,6 +419,31 @@ describe('standalone', () => {
     ).rejects.toThrow(
       `Could not find package @skyux/missing -- please run 'npm install'.`,
     );
+  });
+
+  it('should throw when the types file referenced by package.json is missing', async () => {
+    const { tree } = await setup();
+    tree.create(
+      'node_modules/@skyux/broken/package.json',
+      JSON.stringify({ exports: { '.': { types: './missing.d.ts' } } }),
+    );
+    tree.create(
+      'src/app/test.component.ts',
+      `
+    import { Component } from '@angular/core';
+    import { SkyBrokenComponent } from '@skyux/broken';
+
+    @Component({
+      selector: 'app-test',
+      template: '<div></div>',
+      imports: [SkyBrokenComponent],
+    })
+    export class TestComponent {}
+    `,
+    );
+    await expect(
+      runner.runSchematic('standalone-migration', {}, tree),
+    ).rejects.toThrow('Unable to read details from @skyux/broken.');
   });
 
   describe('ngCoreSchematic error handling', () => {

--- a/libs/components/packages/src/schematics/ng-generate/standalone/standalone.schematic.ts
+++ b/libs/components/packages/src/schematics/ng-generate/standalone/standalone.schematic.ts
@@ -29,6 +29,7 @@ import {
   throwError,
 } from 'rxjs';
 
+import { JsonFile } from '../../utility/json-file';
 import {
   isImportedFromPackage,
   parseSourceFile,
@@ -140,11 +141,21 @@ function getPackageTypeSourceFile(
   tree: Tree,
   packageName: string,
 ): ts.SourceFile {
-  const filePath = join(normalize('node_modules'), packageName, 'index.d.ts');
-  if (!packageName || !tree.exists(filePath)) {
+  const packageJson = join(
+    normalize('node_modules'),
+    packageName,
+    'package.json',
+  );
+  if (!packageName || !tree.exists(packageJson)) {
     throw new Error(
       `Could not find package ${packageName} -- please run 'npm install'.`,
     );
+  }
+  const packageJsonContent = new JsonFile(tree, packageJson);
+  const typesFile = packageJsonContent.get(['exports', '.', 'types']) as string;
+  const filePath = join(normalize('node_modules'), packageName, typesFile);
+  if (!tree.exists(filePath)) {
+    throw new Error(`Unable to read details from ${packageName}.`);
   }
   return parseSourceFile(tree, filePath);
 }


### PR DESCRIPTION
[AB#3984329](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3984329)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error detection and reporting when type definition files cannot be found or accessed during package migration
  * Enhanced support for packages that specify types through the package.json exports field

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blackbaud/skyux/pull/4413)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->