### PR TITLE
chore: release 14.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
 
+## [14.3.3](https://github.com/blackbaud/skyux/compare/14.3.2...14.3.3) (2026-05-13)
+
+
+### Bug Fixes
+
+* **components/code-examples:** restore hard-mode input styling in character count example ([#4415](https://github.com/blackbaud/skyux/issues/4415)) ([722a496](https://github.com/blackbaud/skyux/commit/722a496f0a07f2fc85c28b195eb0b1558fcfe48e))
+
 ## [14.3.2](https://github.com/blackbaud/skyux/compare/14.3.1...14.3.2) (2026-05-13)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 
-## [14.3.3](https://github.com/blackbaud/skyux/compare/14.3.2...14.3.3) (2026-05-13)
+## [14.3.3](https://github.com/blackbaud/skyux/compare/14.3.2...14.3.3) (2026-05-14)
 
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Bug Fixes
 
 * **components/code-examples:** restore hard-mode input styling in character count example ([#4415](https://github.com/blackbaud/skyux/issues/4415)) ([722a496](https://github.com/blackbaud/skyux/commit/722a496f0a07f2fc85c28b195eb0b1558fcfe48e))
+* **components/packages:** standalone schematic unable to read secondary entrypoints ([#4417](https://github.com/blackbaud/skyux/issues/4417)) ([d28bdd4](https://github.com/blackbaud/skyux/commit/d28bdd444604bc417bce9e915b0fb0a446d2addd))
 
 ## [14.3.2](https://github.com/blackbaud/skyux/compare/14.3.1...14.3.2) (2026-05-13)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "skyux",
-  "version": "14.3.2",
+  "version": "14.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "skyux",
-      "version": "14.3.2",
+      "version": "14.3.3",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skyux",
-  "version": "14.3.2",
+  "version": "14.3.3",
   "license": "MIT",
   "scripts": {
     "ng": "nx",


### PR DESCRIPTION
## [14.3.3](https://github.com/blackbaud/skyux/compare/14.3.2...14.3.3) (2026-05-14)


### Bug Fixes

* **components/code-examples:** restore hard-mode input styling in character count example ([#4415](https://github.com/blackbaud/skyux/issues/4415)) ([722a496](https://github.com/blackbaud/skyux/commit/722a496f0a07f2fc85c28b195eb0b1558fcfe48e))
* **components/packages:** standalone schematic unable to read secondary entrypoints ([#4417](https://github.com/blackbaud/skyux/issues/4417)) ([d28bdd4](https://github.com/blackbaud/skyux/commit/d28bdd444604bc417bce9e915b0fb0a446d2addd))

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes - Version 14.3.3

* **Bug Fixes**
  * Restored hard-mode input styling in the character count example.
  * Fixed a standalone schematic failing to read secondary entrypoints.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blackbaud/skyux/pull/4416)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->