### PR TITLE
fix(components/packages): standalone schematic unable to read secondary entrypoints

### DIFF
--- a/libs/components/packages/src/schematics/ng-generate/standalone/__snapshots__/standalone.schematic.spec.ts.snap
+++ b/libs/components/packages/src/schematics/ng-generate/standalone/__snapshots__/standalone.schematic.spec.ts.snap
@@ -217,3 +217,17 @@ import { SkyDatePipeModule } from '@skyux/datetime';
     }
     "
 `;
+
+exports[`standalone should resolve types for a subpath export 1`] = `
+"
+    import { Component } from '@angular/core';
+    import { SkyFormsTestingHarness } from '@skyux/forms/testing';
+
+    @Component({
+      selector: 'app-test',
+      template: '<div></div>',
+      imports: [SkyFormsTestingHarness],
+    })
+    export class TestComponent {}
+    "
+`;

--- a/libs/components/packages/src/schematics/ng-generate/standalone/standalone.schematic.spec.ts
+++ b/libs/components/packages/src/schematics/ng-generate/standalone/standalone.schematic.spec.ts
@@ -421,6 +421,78 @@ describe('standalone', () => {
     );
   });
 
+  it('should resolve types for a subpath export', async () => {
+    const { tree } = await setup();
+    tree.create(
+      'node_modules/@skyux/forms/package.json',
+      JSON.stringify({
+        exports: {
+          '.': { types: './index.d.ts' },
+          './testing': { types: './testing/index.d.ts' },
+        },
+      }),
+    );
+    tree.create('node_modules/@skyux/forms/index.d.ts', '');
+    tree.create(
+      'node_modules/@skyux/forms/testing/index.d.ts',
+      /* eslint-disable-next-line @cspell/spellchecker */
+      `import * as i0 from '@angular/core';
+
+declare class SkyFormsTestingHarness {}
+
+declare class SkyFormsTestingModule {
+  static ɵfac: i0.ɵɵFactoryDeclaration<SkyFormsTestingModule, never>;
+  static ɵmod: i0.ɵɵNgModuleDeclaration<SkyFormsTestingModule, never, [typeof SkyFormsTestingHarness], [typeof SkyFormsTestingHarness]>;
+  static ɵinj: i0.ɵɵInjectorDeclaration<SkyFormsTestingModule>;
+}
+
+export { SkyFormsTestingHarness, SkyFormsTestingModule };
+`,
+    );
+    tree.create(
+      'src/app/test.component.ts',
+      `
+    import { Component } from '@angular/core';
+    import { SkyFormsTestingHarness } from '@skyux/forms/testing';
+
+    @Component({
+      selector: 'app-test',
+      template: '<div></div>',
+      imports: [SkyFormsTestingHarness],
+    })
+    export class TestComponent {}
+    `,
+    );
+    await runner.runSchematic('standalone-migration', {}, tree);
+    expect(tree.readText('src/app/test.component.ts')).toMatchSnapshot();
+  });
+
+  it('should throw when a subpath export is not declared in package.json', async () => {
+    const { tree } = await setup();
+    tree.create(
+      'node_modules/@skyux/forms/package.json',
+      JSON.stringify({ exports: { '.': { types: './index.d.ts' } } }),
+    );
+    tree.create('node_modules/@skyux/forms/index.d.ts', '');
+    tree.create(
+      'src/app/test.component.ts',
+      `
+    import { Component } from '@angular/core';
+    import { SkyFormsTestingHarness } from '@skyux/forms/testing';
+
+    @Component({
+      selector: 'app-test',
+      template: '<div></div>',
+      imports: [SkyFormsTestingHarness],
+    })
+    export class TestComponent {}
+    `,
+    );
+    await expect(
+      runner.runSchematic('standalone-migration', {}, tree),
+    ).rejects.toThrow('Unable to read details from @skyux/forms/testing.');
+  });
+
   it('should throw when the types file referenced by package.json is missing', async () => {
     const { tree } = await setup();
     tree.create(

--- a/libs/components/packages/src/schematics/ng-generate/standalone/standalone.schematic.ts
+++ b/libs/components/packages/src/schematics/ng-generate/standalone/standalone.schematic.ts
@@ -141,9 +141,13 @@ function getPackageTypeSourceFile(
   tree: Tree,
   packageName: string,
 ): ts.SourceFile {
+  const [scope, name, ...subpathSegments] = packageName.split('/');
+  const packageRoot = `${scope}/${name}`;
+  const subpath = subpathSegments.join('/');
+  const exportKey = subpath ? `./${subpath}` : '.';
   const packageJson = join(
     normalize('node_modules'),
-    packageName,
+    packageRoot,
     'package.json',
   );
   if (!packageName || !tree.exists(packageJson)) {
@@ -152,9 +156,14 @@ function getPackageTypeSourceFile(
     );
   }
   const packageJsonContent = new JsonFile(tree, packageJson);
-  const typesFile = packageJsonContent.get(['exports', '.', 'types']) as string;
-  const filePath = join(normalize('node_modules'), packageName, typesFile);
-  if (!tree.exists(filePath)) {
+  const typesFile = packageJsonContent.get([
+    'exports',
+    exportKey,
+    'types',
+  ]) as string;
+  const filePath =
+    typesFile && join(normalize('node_modules'), packageRoot, typesFile);
+  if (!filePath || !tree.exists(filePath)) {
     throw new Error(`Unable to read details from ${packageName}.`);
   }
   return parseSourceFile(tree, filePath);


### PR DESCRIPTION
[AB#3984329](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3984329)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved schematic's handling of type declaration resolution for package subpath exports, ensuring proper validation of subpath imports against package configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blackbaud/skyux/pull/4417)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->