### PR TITLE
chore: release 14.3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
 
+## [14.3.4](https://github.com/blackbaud/skyux/compare/14.3.3...14.3.4) (2026-05-14)
+
+
+### Bug Fixes
+
+* **components/lookup:** stop implicit tab selection in empty-search autocomplete ([#4414](https://github.com/blackbaud/skyux/issues/4414)) ([1c997df](https://github.com/blackbaud/skyux/commit/1c997dfeee9c531e6b4ac169866a95b29e2ad049))
+
 ## [14.3.3](https://github.com/blackbaud/skyux/compare/14.3.2...14.3.3) (2026-05-14)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 
-## [14.3.4](https://github.com/blackbaud/skyux/compare/14.3.3...14.3.4) (2026-05-14)
+## [14.3.4](https://github.com/blackbaud/skyux/compare/14.3.3...14.3.4) (2026-05-15)
 
 
 ### Bug Fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "skyux",
-  "version": "14.3.3",
+  "version": "14.3.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "skyux",
-      "version": "14.3.3",
+      "version": "14.3.4",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skyux",
-  "version": "14.3.3",
+  "version": "14.3.4",
   "license": "MIT",
   "scripts": {
     "ng": "nx",


### PR DESCRIPTION
## [14.3.4](https://github.com/blackbaud/skyux/compare/14.3.3...14.3.4) (2026-05-15)


### Bug Fixes

* **components/lookup:** stop implicit tab selection in empty-search autocomplete ([#4414](https://github.com/blackbaud/skyux/issues/4414)) ([1c997df](https://github.com/blackbaud/skyux/commit/1c997dfeee9c531e6b4ac169866a95b29e2ad049))

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed autocomplete behavior to prevent implicit tab selection during empty searches.

* **Chores**
  * Version bumped to 14.3.4.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blackbaud/skyux/pull/4418)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->