### PR TITLE
fix(components/lists): repeater item interactions still work when reorderable is enabled

### DIFF
--- a/libs/components/lists/src/lib/modules/repeater/repeater.component.spec.ts
+++ b/libs/components/lists/src/lib/modules/repeater/repeater.component.spec.ts
@@ -1730,6 +1730,21 @@ describe('Repeater item component', () => {
       flushDropdownTimer();
     }));
 
+    it('should not schedule drag-drop initialization after the component is destroyed', fakeAsync(() => {
+      const fixture = TestBed.createComponent(RepeaterTestComponent);
+      fixture.componentInstance.reorderable = true;
+      fixture.detectChanges();
+      // Intentionally destroy before `tick()` so the pending `setTimeout`
+      // queued in `ngAfterContentInit` fires after destruction. The component
+      // must short-circuit instead of calling `afterNextRender` on a
+      // destroyed injector (which would otherwise throw NG0205).
+      fixture.destroy();
+      expect(() => {
+        tick();
+        flush();
+      }).not.toThrow();
+    }));
+
     it('should rebind DragRefs to grab handles after reorderable toggles back on', fakeAsync(() => {
       const fixture = TestBed.createComponent(RepeaterTestComponent);
       const cmp = fixture.componentInstance;

--- a/libs/components/lists/src/lib/modules/repeater/repeater.component.spec.ts
+++ b/libs/components/lists/src/lib/modules/repeater/repeater.component.spec.ts
@@ -1689,6 +1689,85 @@ describe('Repeater item component', () => {
 
       flushDropdownTimer();
     }));
+
+    it('should bind DragRefs to grab handles so descendant content receives pointer events', fakeAsync(() => {
+      const fixture = TestBed.createComponent(RepeaterTestComponent);
+      fixture.componentInstance.reorderable = true;
+      fixture.detectChanges();
+      tick();
+      fixture.detectChanges();
+      tick();
+
+      const registry = TestBed.inject(DragDropRegistry);
+      const dragRefs = Array.from(
+        (registry as unknown as { _dragInstances: Set<DragRef> })
+          ._dragInstances,
+      );
+
+      expect(dragRefs.length).toBeGreaterThan(0);
+
+      const itemEls: NodeListOf<HTMLElement> =
+        fixture.nativeElement.querySelectorAll('sky-repeater-item');
+
+      // Every enabled DragRef must be bound to its grab handle. Otherwise the
+      // entire item element acts as the drag source and CDK's pointer handler
+      // suppresses focus on descendant focusable content (contenteditable,
+      // inputs, etc.).
+      dragRefs.forEach((dragRef, index) => {
+        const handles = (dragRef as unknown as { _handles: HTMLElement[] })
+          ._handles;
+        const expectedHandle = itemEls[index].querySelector(
+          '.sky-repeater-item-grab-handle',
+        );
+        expect(expectedHandle)
+          .withContext('grab handle present')
+          .not.toBeNull();
+        expect(handles)
+          .withContext('DragRef bound to its grab handle')
+          .toContain(expectedHandle as HTMLElement);
+      });
+
+      flushDropdownTimer();
+    }));
+
+    it('should rebind DragRefs to grab handles after reorderable toggles back on', fakeAsync(() => {
+      const fixture = TestBed.createComponent(RepeaterTestComponent);
+      const cmp = fixture.componentInstance;
+      cmp.reorderable = false;
+      fixture.detectChanges();
+      tick();
+      fixture.detectChanges();
+      tick();
+
+      cmp.reorderable = true;
+      fixture.detectChanges();
+      tick();
+      fixture.detectChanges();
+      tick();
+
+      const registry = TestBed.inject(DragDropRegistry);
+      const dragRefs = Array.from(
+        (registry as unknown as { _dragInstances: Set<DragRef> })
+          ._dragInstances,
+      );
+      const itemEls: NodeListOf<HTMLElement> =
+        fixture.nativeElement.querySelectorAll('sky-repeater-item');
+
+      expect(dragRefs.length).toBe(itemEls.length);
+
+      dragRefs.forEach((dragRef, index) => {
+        const handles = (dragRef as unknown as { _handles: HTMLElement[] })
+          ._handles;
+        const expectedHandle = itemEls[index].querySelector(
+          '.sky-repeater-item-grab-handle',
+        );
+        expect(expectedHandle).not.toBeNull();
+        expect(handles).toContain(expectedHandle as HTMLElement);
+        expect(dragRef.disabled).toBeFalse();
+      });
+
+      flushDropdownTimer();
+    }));
   });
 
   describe('with reorderability', () => {

--- a/libs/components/lists/src/lib/modules/repeater/repeater.component.spec.ts
+++ b/libs/components/lists/src/lib/modules/repeater/repeater.component.spec.ts
@@ -1690,7 +1690,7 @@ describe('Repeater item component', () => {
       flushDropdownTimer();
     }));
 
-    it('should bind DragRefs to grab handles so descendant content receives pointer events', fakeAsync(() => {
+    it('should not intercept pointer events on non-handle descendants of reorderable items', fakeAsync(() => {
       const fixture = TestBed.createComponent(RepeaterTestComponent);
       fixture.componentInstance.reorderable = true;
       fixture.detectChanges();
@@ -1698,33 +1698,38 @@ describe('Repeater item component', () => {
       fixture.detectChanges();
       tick();
 
-      const registry = TestBed.inject(DragDropRegistry);
-      const dragRefs = Array.from(
-        (registry as unknown as { _dragInstances: Set<DragRef> })
-          ._dragInstances,
-      );
-
-      expect(dragRefs.length).toBeGreaterThan(0);
-
       const itemEls: NodeListOf<HTMLElement> =
         fixture.nativeElement.querySelectorAll('sky-repeater-item');
 
-      // Every enabled DragRef must be bound to its grab handle. Otherwise the
-      // entire item element acts as the drag source and CDK's pointer handler
-      // suppresses focus on descendant focusable content (contenteditable,
-      // inputs, etc.).
-      dragRefs.forEach((dragRef, index) => {
-        const handles = (dragRef as unknown as { _handles: HTMLElement[] })
-          ._handles;
-        const expectedHandle = itemEls[index].querySelector(
+      expect(itemEls.length).toBeGreaterThan(0);
+
+      itemEls.forEach((itemEl) => {
+        const handle = itemEl.querySelector<HTMLElement>(
           '.sky-repeater-item-grab-handle',
         );
-        expect(expectedHandle)
-          .withContext('grab handle present')
+        expect(handle)
+          .withContext('grab handle is rendered for reorderable items')
           .not.toBeNull();
-        expect(handles)
-          .withContext('DragRef bound to its grab handle')
-          .toContain(expectedHandle as HTMLElement);
+
+        // A mousedown on a non-handle descendant must not be consumed by CDK's
+        // drag pointer handler. If the entire item element were the drag
+        // source (because the DragRef had no handle bound), CDK would call
+        // preventDefault() here and block focus on focusable content like
+        // contenteditable elements or inputs.
+        const nonHandle = itemEl.querySelector<HTMLElement>(
+          '.sky-repeater-item-title',
+        );
+        expect(nonHandle).not.toBeNull();
+
+        const event = new MouseEvent('mousedown', {
+          bubbles: true,
+          cancelable: true,
+        });
+        nonHandle!.dispatchEvent(event);
+
+        expect(event.defaultPrevented)
+          .withContext('non-handle mousedown is not consumed by CDK drag')
+          .toBeFalse();
       });
 
       flushDropdownTimer();
@@ -1771,14 +1776,32 @@ describe('Repeater item component', () => {
       expect(dragRefs.length).toBe(itemEls.length);
 
       dragRefs.forEach((dragRef, index) => {
-        const handles = (dragRef as unknown as { _handles: HTMLElement[] })
-          ._handles;
-        const expectedHandle = itemEls[index].querySelector(
+        const handle = itemEls[index].querySelector<HTMLElement>(
           '.sky-repeater-item-grab-handle',
         );
-        expect(expectedHandle).not.toBeNull();
-        expect(handles).toContain(expectedHandle as HTMLElement);
+        expect(handle)
+          .withContext('grab handle is rendered after toggle')
+          .not.toBeNull();
+
+        // After toggling reorderable on, the DragRef must be enabled (public
+        // API) and only the grab handle should trigger drag — verified by
+        // confirming a non-handle mousedown is not preventDefault()ed.
         expect(dragRef.disabled).toBeFalse();
+
+        const nonHandle = itemEls[index].querySelector<HTMLElement>(
+          '.sky-repeater-item-title',
+        );
+        expect(nonHandle).not.toBeNull();
+
+        const event = new MouseEvent('mousedown', {
+          bubbles: true,
+          cancelable: true,
+        });
+        nonHandle!.dispatchEvent(event);
+
+        expect(event.defaultPrevented)
+          .withContext('non-handle mousedown is not consumed by CDK drag')
+          .toBeFalse();
       });
 
       flushDropdownTimer();

--- a/libs/components/lists/src/lib/modules/repeater/repeater.component.ts
+++ b/libs/components/lists/src/lib/modules/repeater/repeater.component.ts
@@ -361,14 +361,13 @@ export class SkyRepeaterComponent
       const handleEl = itemEl.querySelector<HTMLElement>(
         '.sky-repeater-item-grab-handle',
       );
-      if (!handleEl) {
-        continue;
-      }
 
       const dragRef = createDragRef(this.#injector, itemEl);
 
-      dragRef.withHandles([handleEl]);
-      dragRef.disabled = !this.reorderable;
+      if (handleEl) {
+        dragRef.withHandles([handleEl]);
+      }
+      dragRef.disabled = !handleEl || !this.reorderable;
 
       dragRef.started.pipe(takeUntil(this.#ngUnsubscribe)).subscribe(() => {
         this.#renderer.addClass(itemEl, 'sky-repeater-item-dragging');

--- a/libs/components/lists/src/lib/modules/repeater/repeater.component.ts
+++ b/libs/components/lists/src/lib/modules/repeater/repeater.component.ts
@@ -126,6 +126,7 @@ export class SkyRepeaterComponent
 
   public role: SkyRepeaterRoleType | undefined;
 
+  #destroyed = false;
   #dropListRef: DropListRef<unknown> | undefined;
   #dragRefs: DragRef<unknown>[] = [];
   #initDragAndDropPending = false;
@@ -263,6 +264,7 @@ export class SkyRepeaterComponent
   }
 
   public ngOnDestroy(): void {
+    this.#destroyed = true;
     this.#ngUnsubscribe.next();
     this.#ngUnsubscribe.complete();
     this.#destroyDragAndDrop();
@@ -305,7 +307,10 @@ export class SkyRepeaterComponent
   }
 
   #scheduleInitializeDragAndDrop(): void {
-    if (this.#initDragAndDropPending) {
+    // Guard against pending `setTimeout` callbacks firing after the component
+    // is destroyed (e.g. during test teardown); `afterNextRender` would throw
+    // NG0205 if invoked with a destroyed injector.
+    if (this.#destroyed || this.#initDragAndDropPending) {
       return;
     }
     this.#initDragAndDropPending = true;
@@ -316,6 +321,10 @@ export class SkyRepeaterComponent
     afterNextRender(
       () => {
         this.#initDragAndDropPending = false;
+        /* istanbul ignore if: defensive guard for destroy racing the render callback */
+        if (this.#destroyed) {
+          return;
+        }
         this.#initializeDragAndDrop();
       },
       { injector: this.#injector },

--- a/libs/components/lists/src/lib/modules/repeater/repeater.component.ts
+++ b/libs/components/lists/src/lib/modules/repeater/repeater.component.ts
@@ -126,9 +126,9 @@ export class SkyRepeaterComponent
 
   public role: SkyRepeaterRoleType | undefined;
 
-  #dragDropReady = false;
   #dropListRef: DropListRef<unknown> | undefined;
   #dragRefs: DragRef<unknown>[] = [];
+  #initDragAndDropPending = false;
   #ngUnsubscribe = new Subject<void>();
   #itemNameWarned = false;
 
@@ -176,11 +176,6 @@ export class SkyRepeaterComponent
     this.#updateForExpandMode();
 
     this.#adapterService.setRepeaterHost(this.#elementRef);
-
-    afterNextRender(() => {
-      this.#initializeDragAndDrop();
-      this.#dragDropReady = true;
-    });
   }
 
   public ngAfterContentInit(): void {
@@ -203,9 +198,7 @@ export class SkyRepeaterComponent
 
           this.#updateReorderability();
 
-          if (this.#dragDropReady) {
-            this.#initializeDragAndDrop();
-          }
+          this.#scheduleInitializeDragAndDrop();
 
           this.#repeaterService.items = this.items.toArray();
         }
@@ -227,6 +220,7 @@ export class SkyRepeaterComponent
       });
 
       this.#updateRole();
+      this.#scheduleInitializeDragAndDrop();
     }, 0);
   }
 
@@ -257,6 +251,12 @@ export class SkyRepeaterComponent
         this.#updateReorderability();
       }
       this.#updateRole();
+      if (!changes['reorderable'].firstChange) {
+        // Initial setup is handled by `ngAfterContentInit` once items are
+        // populated. Re-initialize only on subsequent changes so DragRef
+        // disabled state and handle bindings reflect the new value.
+        this.#scheduleInitializeDragAndDrop();
+      }
 
       this.#changeDetector.markForCheck();
     }
@@ -304,6 +304,24 @@ export class SkyRepeaterComponent
     }
   }
 
+  #scheduleInitializeDragAndDrop(): void {
+    if (this.#initDragAndDropPending) {
+      return;
+    }
+    this.#initDragAndDropPending = true;
+
+    // Defer until after the next render so the child items' grab-handle
+    // buttons (which appear/disappear based on `reorderable`) are in the DOM
+    // before we wire up CDK DragRef handles.
+    afterNextRender(
+      () => {
+        this.#initDragAndDropPending = false;
+        this.#initializeDragAndDrop();
+      },
+      { injector: this.#injector },
+    );
+  }
+
   #initializeDragAndDrop(): void {
     const containerEl: HTMLElement =
       this.#elementRef.nativeElement.querySelector('.sky-repeater');
@@ -334,13 +352,13 @@ export class SkyRepeaterComponent
       const handleEl = itemEl.querySelector<HTMLElement>(
         '.sky-repeater-item-grab-handle',
       );
+      if (!handleEl) {
+        continue;
+      }
 
       const dragRef = createDragRef(this.#injector, itemEl);
 
-      if (handleEl) {
-        dragRef.withHandles([handleEl]);
-      }
-
+      dragRef.withHandles([handleEl]);
       dragRef.disabled = !this.reorderable;
 
       dragRef.started.pipe(takeUntil(this.#ngUnsubscribe)).subscribe(() => {


### PR DESCRIPTION
[AB#3985462](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3985462)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable drag-and-drop reordering for repeater items.
  * Ensured only grab handles initiate dragging; non-handle clicks no longer start drags.
  * Prevented deferred drag-drop setup from running after a component is destroyed.
  * Fixed re-initialization when toggling the reorderable setting.

* **Tests**
  * Added integration and regression tests covering handle binding, safe teardown, and rebind on toggle.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blackbaud/skyux/pull/4423?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->