### PR TITLE
fix(components/ag-grid): data manager column picker should not touch ag-grid selection pseudo column

### DIFF
--- a/libs/components/ag-grid/src/lib/modules/ag-grid/ag-grid-data-manager-adapter.directive.spec.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/ag-grid-data-manager-adapter.directive.spec.ts
@@ -204,6 +204,40 @@ describe('SkyAgGridDataManagerAdapterDirective', () => {
     expect(agGridComponent.api.getColumn('name')?.isVisible()).toBeTruthy();
   });
 
+  it('should not hide reserved columns when the data state changes', async () => {
+    await agGridDataManagerFixture.whenStable();
+
+    spyOn(agGridComponent.api, 'getColumnState').and.returnValue([
+      { colId: 'selected', hide: false },
+      { colId: 'name', hide: false },
+      { colId: 'target', hide: false },
+      { colId: 'ag-Grid-SelectionColumn', hide: false },
+    ] as ColumnState[]);
+    const setColumnsVisible = spyOn(agGridComponent.api, 'setColumnsVisible');
+
+    const newDataState = new SkyDataManagerState({
+      views: [
+        {
+          viewId:
+            agGridDataManagerFixtureComponent.initialDataState.views[0].viewId,
+          displayedColumnIds: ['selected', 'name'],
+        },
+      ],
+    });
+    dataManagerService.updateDataState(newDataState, 'unitTest');
+
+    agGridDataManagerFixture.detectChanges();
+    await agGridDataManagerFixture.whenStable();
+
+    // The reserved selection column should be excluded from the columns that
+    // are hidden, even though it is not in the displayed column ids.
+    expect(setColumnsVisible).toHaveBeenCalledWith(['target'], false);
+    expect(setColumnsVisible).not.toHaveBeenCalledWith(
+      jasmine.arrayContaining(['ag-Grid-SelectionColumn']),
+      false,
+    );
+  });
+
   it('should update the data state column widths when columns are removed', async () => {
     const updateDataState = spyOn(
       dataManagerService,

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/ag-grid-data-manager-adapter.directive.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/ag-grid-data-manager-adapter.directive.ts
@@ -40,6 +40,8 @@ function toColumnWidthName(breakpoint: SkyBreakpoint): 'xs' | 'sm' {
   return breakpoint === 'xs' ? 'xs' : 'sm';
 }
 
+const RESERVED_COLUMNS = ['ag-Grid-SelectionColumn'];
+
 /**
  * Connects `SkyAgGridWrapperComponent` with a `SkyDataViewComponent` to control the grid using a `SkyDataManagerService` instance.
  */
@@ -412,7 +414,11 @@ export class SkyAgGridDataManagerAdapterDirective implements OnDestroy {
         const hideColumns = agGrid.api
           .getColumnState()
           .map((col) => col.colId)
-          .filter((colId) => !displayedColumnIds.includes(colId));
+          .filter(
+            (colId) =>
+              !displayedColumnIds.includes(colId) &&
+              !RESERVED_COLUMNS.includes(colId),
+          );
 
         agGrid.api.setColumnsVisible(hideColumns, false);
         agGrid.api.setColumnsVisible(displayedColumnIds, true);


### PR DESCRIPTION
[AB#3942528](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3942528)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where grid selection columns could be inadvertently hidden when reordering or updating displayed columns. Selection columns now remain visible and functional during column management operations, ensuring users can continue to select rows without interruption.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->