### PR TITLE
fix(components/lists): list summary properly formats values when the numeric value is `0`

### DIFF
--- a/libs/components/lists/src/lib/modules/list-summary/list-summary-item.component.html
+++ b/libs/components/lists/src/lib/modules/list-summary/list-summary-item.component.html
@@ -5,7 +5,7 @@
   [helpPopoverTitle]="helpPopoverTitle()"
 >
   <sky-key-info-value class="sky-font-display-4">
-    @if (numericValue()) {
+    @if (numericValue() !== undefined) {
       {{ numericValue() | skyNumeric: valueFormat() }}
     } @else {
       {{ value() }}

--- a/libs/components/lists/src/lib/modules/list-summary/list-summary-item.component.spec.ts
+++ b/libs/components/lists/src/lib/modules/list-summary/list-summary-item.component.spec.ts
@@ -64,6 +64,16 @@ describe('List summary item component', () => {
     expect(value.nativeElement.textContent.trim()).toBe('0');
   });
 
+  it('should display currency symbol when value is zero', () => {
+    componentRef.setInput('value', 0);
+    componentRef.setInput('labelText', 'Revenue');
+    componentRef.setInput('valueFormat', { format: 'currency' });
+    fixture.detectChanges();
+
+    const value = fixture.debugElement.query(By.css('.sky-key-info-value'));
+    expect(value.nativeElement.textContent.trim()).toBe('$0');
+  });
+
   it('should use horizontal layout', () => {
     componentRef.setInput('value', 100);
     componentRef.setInput('labelText', 'Test Label');


### PR DESCRIPTION
[AB#4002536](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/4002536)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a display issue in the list summary component where zero currency values were not rendering with the appropriate currency symbol.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->