### PR TITLE
fix(components/grids): update grid component's sky-checkbox to use labelText

### DIFF
--- a/libs/components/grids/src/lib/modules/grid/grid.component.html
+++ b/libs/components/grids/src/lib/modules/grid/grid.component.html
@@ -156,6 +156,7 @@
                     [labelText]="
                       'skyux_grid_multiselect_select_row' | skyLibResources
                     "
+                    [labelHidden]="true"
                     [(ngModel)]="item.isSelected"
                     (change)="onMultiselectCheckboxChange()"
                   />

--- a/libs/components/grids/src/lib/modules/grid/grid.component.html
+++ b/libs/components/grids/src/lib/modules/grid/grid.component.html
@@ -153,7 +153,7 @@
                   [style.width.px]="minColWidth"
                 >
                   <sky-checkbox
-                    [label]="
+                    [labelText]="
                       'skyux_grid_multiselect_select_row' | skyLibResources
                     "
                     [(ngModel)]="item.isSelected"


### PR DESCRIPTION
[AB#4007153](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/4007153)

Update sky-checkbox to use labelText instead of the deprecated label.  This should fix leaking sky-checkbox label warnings transitively thrown by @skyux/grids usage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the select-row label display for the grid multiselect checkbox so the label now renders consistently.
  * Improved label visibility and accessibility behavior when the row label is configured to be hidden, ensuring screen readers and visual users receive the correct text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->