### PR TITLE
fix(components/phone-field): update format when country changes (#4445)

### DIFF
--- a/libs/components/phone-field/src/lib/modules/phone-field/phone-field-input.directive.ts
+++ b/libs/components/phone-field/src/lib/modules/phone-field/phone-field-input.directive.ts
@@ -127,7 +127,21 @@ export class SkyPhoneFieldInputDirective
 
     this.#phoneFieldComponent?.selectedCountryChange.subscribe(() => {
       const value = this.#adapterSvc?.getInputValue(this.#elRef);
+      const previousValue = this.#getValue();
       this.#setValue(value);
+      const newValue = this.#getValue();
+
+      // When changing the country reformats the existing number (i.e. the
+      // number is formattable for the newly selected country), push the
+      // reformatted value — including its country code — to the form control so
+      // downstream consumers receive a correctly formatted number without the
+      // user having to edit the field again. `#setValue` leaves the value
+      // untouched when it isn't formattable for the new country, so comparing
+      // against the raw input skips that case and leaves validation to flag it.
+      if (newValue !== previousValue && newValue !== value) {
+        this.#notifyChange?.(newValue);
+      }
+
       this.#control?.updateValueAndValidity();
     });
 

--- a/libs/components/phone-field/src/lib/modules/phone-field/phone-field.component.spec.ts
+++ b/libs/components/phone-field/src/lib/modules/phone-field/phone-field.component.spec.ts
@@ -1278,6 +1278,34 @@ describe('Phone Field Component', () => {
         );
       }));
 
+      it('should reapply formatting and country code when the country is changed', fakeAsync(() => {
+        fixture.detectChanges();
+        const inputElement = fixture.debugElement.query(By.css('input'));
+        const ngModel = inputElement.injector.get(NgModel);
+
+        // Non-US tenant.
+        component.defaultCountry = 'au';
+        fixture.detectChanges();
+
+        // Enter a US number while a non-US country is selected.
+        setCountry('France', fixture);
+        component.modelValue = '6675555309';
+        detectChangesAndTick(fixture);
+
+        // Switching to the US reformats the existing number with the +1 country
+        // code and propagates it to the model without re-editing the input.
+        setCountry('United States', fixture);
+
+        validateInputAndModel(
+          '6675555309',
+          '+1 667-555-5309',
+          true,
+          true,
+          ngModel,
+          fixture,
+        );
+      }));
+
       it('should validate correctly after country is changed programmatically', fakeAsync(() => {
         fixture.detectChanges();
         const inputElement = fixture.debugElement.query(By.css('input'));

--- a/libs/components/phone-field/testing/src/modules/phone-field/phone-field-harness.spec.ts
+++ b/libs/components/phone-field/testing/src/modules/phone-field/phone-field-harness.spec.ts
@@ -131,6 +131,39 @@ describe('Phone field harness', () => {
     }
   });
 
+  it('should reapply formatting to an existing number when the country changes', async () => {
+    const { phoneFieldHarness, fixture } = await setupTest({
+      dataSkyId: DATA_SKY_ID,
+    });
+
+    // Non-US tenant.
+    fixture.componentInstance.defaultCountry = 'au';
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    // Select a non-US country and enter a US number in that context.
+    await phoneFieldHarness.selectCountry('France');
+    await (await phoneFieldHarness.getControl()).setValue('8675555309');
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    // Switch to the United States.
+    if (COUNTRY_US.name) {
+      await phoneFieldHarness.selectCountry(COUNTRY_US.name);
+    }
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    // The number is reformatted with the US country code in the model, without
+    // the user re-editing the input (the raw input text is left as typed).
+    expect(fixture.componentInstance.phoneControl?.value).toEqual(
+      '+1 867-555-5309',
+    );
+    await expectAsync(
+      (await phoneFieldHarness.getControl()).getValue(),
+    ).toBeResolvedTo('8675555309');
+  });
+
   it('should not have constructor race condition', async () => {
     // There is some concern that the delayed instantiation of the country field in the fixture's
     // constructor will cause a race condition. We attempt to access the country field as early as


### PR DESCRIPTION
:cherries: Cherry picked from #4445 [fix(components/phone-field): update format when country changes](https://github.com/blackbaud/skyux/pull/4445)

[AB#3926195](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3926195) 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Phone numbers now automatically reformat to match the selected country's format, including the correct country code.

* **Tests**
  * Added test coverage verifying phone number formatting is reapplied when the country selection changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->