### PR TITLE
chore: use angular parser when formatting HTML files

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -7,6 +7,7 @@
     {
       "files": ["*.html"],
       "options": {
+        "parser": "angular",
         "trailingComma": "none"
       }
     }

--- a/libs/components/action-bars/src/lib/modules/summary-action-bar/fixtures/summary-action-bar-split-view.component.fixture.html
+++ b/libs/components/action-bars/src/lib/modules/summary-action-bar/fixtures/summary-action-bar-split-view.component.fixture.html
@@ -2,63 +2,65 @@
   <div class="sky-split-view-workspace-content">Split View Content</div>
   <div class="sky-split-view-workspace-footer">
     @if (showBar) {
-    <sky-summary-action-bar id="summary-action-bar">
-      <sky-summary-action-bar-actions>
-        <sky-summary-action-bar-primary-action>
-          Primary action
-        </sky-summary-action-bar-primary-action>
-        <sky-summary-action-bar-secondary-actions>
-          Foo
-          <sky-summary-action-bar-secondary-action>
-            Secondary action
-          </sky-summary-action-bar-secondary-action>
-          <sky-summary-action-bar-secondary-action>
-            Secondary action 2
-          </sky-summary-action-bar-secondary-action>
-        </sky-summary-action-bar-secondary-actions>
-        <sky-summary-action-bar-cancel> Cancel </sky-summary-action-bar-cancel>
-      </sky-summary-action-bar-actions>
-      <sky-summary-action-bar-summary>
-        <div>
-          <sky-key-info>
-            <sky-key-info-value>$123.00</sky-key-info-value>
-            <sky-key-info-label>Field 1</sky-key-info-label>
-          </sky-key-info>
-          <sky-key-info>
-            <sky-key-info-value>$456.00</sky-key-info-value>
-            <sky-key-info-label>Field 2</sky-key-info-label>
-          </sky-key-info>
-          <sky-key-info>
-            <sky-key-info-value>18</sky-key-info-value>
-            <sky-key-info-label>Field 3</sky-key-info-label>
-          </sky-key-info>
-          <sky-key-info>
-            <sky-key-info-value>$123.00</sky-key-info-value>
-            <sky-key-info-label>Field 1</sky-key-info-label>
-          </sky-key-info>
-          <sky-key-info>
-            <sky-key-info-value>$456.00</sky-key-info-value>
-            <sky-key-info-label>Field 2</sky-key-info-label>
-          </sky-key-info>
-          <sky-key-info>
-            <sky-key-info-value>18</sky-key-info-value>
-            <sky-key-info-label>Field 3</sky-key-info-label>
-          </sky-key-info>
-          <sky-key-info>
-            <sky-key-info-value>$123.00</sky-key-info-value>
-            <sky-key-info-label>Field 1</sky-key-info-label>
-          </sky-key-info>
-          <sky-key-info>
-            <sky-key-info-value>$456.00</sky-key-info-value>
-            <sky-key-info-label>Field 2</sky-key-info-label>
-          </sky-key-info>
-          <sky-key-info>
-            <sky-key-info-value>18</sky-key-info-value>
-            <sky-key-info-label>Field 3</sky-key-info-label>
-          </sky-key-info>
-        </div>
-      </sky-summary-action-bar-summary>
-    </sky-summary-action-bar>
+      <sky-summary-action-bar id="summary-action-bar">
+        <sky-summary-action-bar-actions>
+          <sky-summary-action-bar-primary-action>
+            Primary action
+          </sky-summary-action-bar-primary-action>
+          <sky-summary-action-bar-secondary-actions>
+            Foo
+            <sky-summary-action-bar-secondary-action>
+              Secondary action
+            </sky-summary-action-bar-secondary-action>
+            <sky-summary-action-bar-secondary-action>
+              Secondary action 2
+            </sky-summary-action-bar-secondary-action>
+          </sky-summary-action-bar-secondary-actions>
+          <sky-summary-action-bar-cancel>
+            Cancel
+          </sky-summary-action-bar-cancel>
+        </sky-summary-action-bar-actions>
+        <sky-summary-action-bar-summary>
+          <div>
+            <sky-key-info>
+              <sky-key-info-value>$123.00</sky-key-info-value>
+              <sky-key-info-label>Field 1</sky-key-info-label>
+            </sky-key-info>
+            <sky-key-info>
+              <sky-key-info-value>$456.00</sky-key-info-value>
+              <sky-key-info-label>Field 2</sky-key-info-label>
+            </sky-key-info>
+            <sky-key-info>
+              <sky-key-info-value>18</sky-key-info-value>
+              <sky-key-info-label>Field 3</sky-key-info-label>
+            </sky-key-info>
+            <sky-key-info>
+              <sky-key-info-value>$123.00</sky-key-info-value>
+              <sky-key-info-label>Field 1</sky-key-info-label>
+            </sky-key-info>
+            <sky-key-info>
+              <sky-key-info-value>$456.00</sky-key-info-value>
+              <sky-key-info-label>Field 2</sky-key-info-label>
+            </sky-key-info>
+            <sky-key-info>
+              <sky-key-info-value>18</sky-key-info-value>
+              <sky-key-info-label>Field 3</sky-key-info-label>
+            </sky-key-info>
+            <sky-key-info>
+              <sky-key-info-value>$123.00</sky-key-info-value>
+              <sky-key-info-label>Field 1</sky-key-info-label>
+            </sky-key-info>
+            <sky-key-info>
+              <sky-key-info-value>$456.00</sky-key-info-value>
+              <sky-key-info-label>Field 2</sky-key-info-label>
+            </sky-key-info>
+            <sky-key-info>
+              <sky-key-info-value>18</sky-key-info-value>
+              <sky-key-info-label>Field 3</sky-key-info-label>
+            </sky-key-info>
+          </div>
+        </sky-summary-action-bar-summary>
+      </sky-summary-action-bar>
     }
   </div>
 </sky-split-view-workspace>

--- a/libs/components/action-bars/src/lib/modules/summary-action-bar/fixtures/summary-action-bar-tabs.component.fixture.html
+++ b/libs/components/action-bars/src/lib/modules/summary-action-bar/fixtures/summary-action-bar-tabs.component.fixture.html
@@ -1,131 +1,133 @@
 <sky-tabset [active]="activeTab">
   <sky-tab tabHeading="Tab 1 ">
     <div>
-      Tab 1 Content @if (showBar1) {
-      <sky-summary-action-bar>
-        <sky-summary-action-bar-actions>
-          <sky-summary-action-bar-primary-action>
-            Primary action 1
-          </sky-summary-action-bar-primary-action>
-          <sky-summary-action-bar-secondary-actions>
-            Foo
-            <sky-summary-action-bar-secondary-action>
-              Secondary action
-            </sky-summary-action-bar-secondary-action>
-            <sky-summary-action-bar-secondary-action>
-              Secondary action 2
-            </sky-summary-action-bar-secondary-action>
-          </sky-summary-action-bar-secondary-actions>
-          <sky-summary-action-bar-cancel>
-            Cancel
-          </sky-summary-action-bar-cancel>
-        </sky-summary-action-bar-actions>
-        <sky-summary-action-bar-summary>
-          <div>
-            <sky-key-info>
-              <sky-key-info-value>$123.00</sky-key-info-value>
-              <sky-key-info-label>Field 1</sky-key-info-label>
-            </sky-key-info>
-            <sky-key-info>
-              <sky-key-info-value>$456.00</sky-key-info-value>
-              <sky-key-info-label>Field 2</sky-key-info-label>
-            </sky-key-info>
-            <sky-key-info>
-              <sky-key-info-value>18</sky-key-info-value>
-              <sky-key-info-label>Field 3</sky-key-info-label>
-            </sky-key-info>
-            <sky-key-info>
-              <sky-key-info-value>$123.00</sky-key-info-value>
-              <sky-key-info-label>Field 1</sky-key-info-label>
-            </sky-key-info>
-            <sky-key-info>
-              <sky-key-info-value>$456.00</sky-key-info-value>
-              <sky-key-info-label>Field 2</sky-key-info-label>
-            </sky-key-info>
-            <sky-key-info>
-              <sky-key-info-value>18</sky-key-info-value>
-              <sky-key-info-label>Field 3</sky-key-info-label>
-            </sky-key-info>
-            <sky-key-info>
-              <sky-key-info-value>$123.00</sky-key-info-value>
-              <sky-key-info-label>Field 1</sky-key-info-label>
-            </sky-key-info>
-            <sky-key-info>
-              <sky-key-info-value>$456.00</sky-key-info-value>
-              <sky-key-info-label>Field 2</sky-key-info-label>
-            </sky-key-info>
-            <sky-key-info>
-              <sky-key-info-value>18</sky-key-info-value>
-              <sky-key-info-label>Field 3</sky-key-info-label>
-            </sky-key-info>
-          </div>
-        </sky-summary-action-bar-summary>
-      </sky-summary-action-bar>
+      Tab 1 Content
+      @if (showBar1) {
+        <sky-summary-action-bar>
+          <sky-summary-action-bar-actions>
+            <sky-summary-action-bar-primary-action>
+              Primary action 1
+            </sky-summary-action-bar-primary-action>
+            <sky-summary-action-bar-secondary-actions>
+              Foo
+              <sky-summary-action-bar-secondary-action>
+                Secondary action
+              </sky-summary-action-bar-secondary-action>
+              <sky-summary-action-bar-secondary-action>
+                Secondary action 2
+              </sky-summary-action-bar-secondary-action>
+            </sky-summary-action-bar-secondary-actions>
+            <sky-summary-action-bar-cancel>
+              Cancel
+            </sky-summary-action-bar-cancel>
+          </sky-summary-action-bar-actions>
+          <sky-summary-action-bar-summary>
+            <div>
+              <sky-key-info>
+                <sky-key-info-value>$123.00</sky-key-info-value>
+                <sky-key-info-label>Field 1</sky-key-info-label>
+              </sky-key-info>
+              <sky-key-info>
+                <sky-key-info-value>$456.00</sky-key-info-value>
+                <sky-key-info-label>Field 2</sky-key-info-label>
+              </sky-key-info>
+              <sky-key-info>
+                <sky-key-info-value>18</sky-key-info-value>
+                <sky-key-info-label>Field 3</sky-key-info-label>
+              </sky-key-info>
+              <sky-key-info>
+                <sky-key-info-value>$123.00</sky-key-info-value>
+                <sky-key-info-label>Field 1</sky-key-info-label>
+              </sky-key-info>
+              <sky-key-info>
+                <sky-key-info-value>$456.00</sky-key-info-value>
+                <sky-key-info-label>Field 2</sky-key-info-label>
+              </sky-key-info>
+              <sky-key-info>
+                <sky-key-info-value>18</sky-key-info-value>
+                <sky-key-info-label>Field 3</sky-key-info-label>
+              </sky-key-info>
+              <sky-key-info>
+                <sky-key-info-value>$123.00</sky-key-info-value>
+                <sky-key-info-label>Field 1</sky-key-info-label>
+              </sky-key-info>
+              <sky-key-info>
+                <sky-key-info-value>$456.00</sky-key-info-value>
+                <sky-key-info-label>Field 2</sky-key-info-label>
+              </sky-key-info>
+              <sky-key-info>
+                <sky-key-info-value>18</sky-key-info-value>
+                <sky-key-info-label>Field 3</sky-key-info-label>
+              </sky-key-info>
+            </div>
+          </sky-summary-action-bar-summary>
+        </sky-summary-action-bar>
       }
     </div>
   </sky-tab>
   <sky-tab tabHeading="Tab 2">
     <div>
-      Tab 2 Content @if (showBar2) {
-      <sky-summary-action-bar>
-        <sky-summary-action-bar-actions>
-          <sky-summary-action-bar-primary-action>
-            Primary action 2
-          </sky-summary-action-bar-primary-action>
-          <sky-summary-action-bar-secondary-actions>
-            Foo
-            <sky-summary-action-bar-secondary-action>
-              Secondary action
-            </sky-summary-action-bar-secondary-action>
-            <sky-summary-action-bar-secondary-action>
-              Secondary action 2
-            </sky-summary-action-bar-secondary-action>
-          </sky-summary-action-bar-secondary-actions>
-          <sky-summary-action-bar-cancel>
-            Cancel
-          </sky-summary-action-bar-cancel>
-        </sky-summary-action-bar-actions>
-        <sky-summary-action-bar-summary>
-          <div>
-            <sky-key-info>
-              <sky-key-info-value>$123.00</sky-key-info-value>
-              <sky-key-info-label>Field 1</sky-key-info-label>
-            </sky-key-info>
-            <sky-key-info>
-              <sky-key-info-value>$456.00</sky-key-info-value>
-              <sky-key-info-label>Field 2</sky-key-info-label>
-            </sky-key-info>
-            <sky-key-info>
-              <sky-key-info-value>18</sky-key-info-value>
-              <sky-key-info-label>Field 3</sky-key-info-label>
-            </sky-key-info>
-            <sky-key-info>
-              <sky-key-info-value>$123.00</sky-key-info-value>
-              <sky-key-info-label>Field 1</sky-key-info-label>
-            </sky-key-info>
-            <sky-key-info>
-              <sky-key-info-value>$456.00</sky-key-info-value>
-              <sky-key-info-label>Field 2</sky-key-info-label>
-            </sky-key-info>
-            <sky-key-info>
-              <sky-key-info-value>18</sky-key-info-value>
-              <sky-key-info-label>Field 3</sky-key-info-label>
-            </sky-key-info>
-            <sky-key-info>
-              <sky-key-info-value>$123.00</sky-key-info-value>
-              <sky-key-info-label>Field 1</sky-key-info-label>
-            </sky-key-info>
-            <sky-key-info>
-              <sky-key-info-value>$456.00</sky-key-info-value>
-              <sky-key-info-label>Field 2</sky-key-info-label>
-            </sky-key-info>
-            <sky-key-info>
-              <sky-key-info-value>18</sky-key-info-value>
-              <sky-key-info-label>Field 3</sky-key-info-label>
-            </sky-key-info>
-          </div>
-        </sky-summary-action-bar-summary>
-      </sky-summary-action-bar>
+      Tab 2 Content
+      @if (showBar2) {
+        <sky-summary-action-bar>
+          <sky-summary-action-bar-actions>
+            <sky-summary-action-bar-primary-action>
+              Primary action 2
+            </sky-summary-action-bar-primary-action>
+            <sky-summary-action-bar-secondary-actions>
+              Foo
+              <sky-summary-action-bar-secondary-action>
+                Secondary action
+              </sky-summary-action-bar-secondary-action>
+              <sky-summary-action-bar-secondary-action>
+                Secondary action 2
+              </sky-summary-action-bar-secondary-action>
+            </sky-summary-action-bar-secondary-actions>
+            <sky-summary-action-bar-cancel>
+              Cancel
+            </sky-summary-action-bar-cancel>
+          </sky-summary-action-bar-actions>
+          <sky-summary-action-bar-summary>
+            <div>
+              <sky-key-info>
+                <sky-key-info-value>$123.00</sky-key-info-value>
+                <sky-key-info-label>Field 1</sky-key-info-label>
+              </sky-key-info>
+              <sky-key-info>
+                <sky-key-info-value>$456.00</sky-key-info-value>
+                <sky-key-info-label>Field 2</sky-key-info-label>
+              </sky-key-info>
+              <sky-key-info>
+                <sky-key-info-value>18</sky-key-info-value>
+                <sky-key-info-label>Field 3</sky-key-info-label>
+              </sky-key-info>
+              <sky-key-info>
+                <sky-key-info-value>$123.00</sky-key-info-value>
+                <sky-key-info-label>Field 1</sky-key-info-label>
+              </sky-key-info>
+              <sky-key-info>
+                <sky-key-info-value>$456.00</sky-key-info-value>
+                <sky-key-info-label>Field 2</sky-key-info-label>
+              </sky-key-info>
+              <sky-key-info>
+                <sky-key-info-value>18</sky-key-info-value>
+                <sky-key-info-label>Field 3</sky-key-info-label>
+              </sky-key-info>
+              <sky-key-info>
+                <sky-key-info-value>$123.00</sky-key-info-value>
+                <sky-key-info-label>Field 1</sky-key-info-label>
+              </sky-key-info>
+              <sky-key-info>
+                <sky-key-info-value>$456.00</sky-key-info-value>
+                <sky-key-info-label>Field 2</sky-key-info-label>
+              </sky-key-info>
+              <sky-key-info>
+                <sky-key-info-value>18</sky-key-info-value>
+                <sky-key-info-label>Field 3</sky-key-info-label>
+              </sky-key-info>
+            </div>
+          </sky-summary-action-bar-summary>
+        </sky-summary-action-bar>
       }
     </div>
   </sky-tab>

--- a/libs/components/action-bars/src/lib/modules/summary-action-bar/fixtures/summary-action-bar.component.fixture.html
+++ b/libs/components/action-bars/src/lib/modules/summary-action-bar/fixtures/summary-action-bar.component.fixture.html
@@ -31,191 +31,192 @@
   Toggle summary
 </button>
 @if (!hideMainActionBar) {
-<sky-summary-action-bar id="summary-action-bar" [formErrors]="formErrors">
-  <sky-summary-action-bar-actions>
-    <sky-summary-action-bar-primary-action
-      [disabled]="disableButtons"
-      (actionClick)="clickHandler()"
-    >
-      Primary action
-    </sky-summary-action-bar-primary-action>
-    <sky-summary-action-bar-secondary-actions>
-      Foo
-      <sky-summary-action-bar-secondary-action
+  <sky-summary-action-bar id="summary-action-bar" [formErrors]="formErrors">
+    <sky-summary-action-bar-actions>
+      <sky-summary-action-bar-primary-action
         [disabled]="disableButtons"
         (actionClick)="clickHandler()"
       >
-        Secondary action
-      </sky-summary-action-bar-secondary-action>
-      <sky-summary-action-bar-secondary-action
+        Primary action
+      </sky-summary-action-bar-primary-action>
+      <sky-summary-action-bar-secondary-actions>
+        Foo
+        <sky-summary-action-bar-secondary-action
+          [disabled]="disableButtons"
+          (actionClick)="clickHandler()"
+        >
+          Secondary action
+        </sky-summary-action-bar-secondary-action>
+        <sky-summary-action-bar-secondary-action
+          [disabled]="disableButtons"
+          (actionClick)="clickHandler()"
+        >
+          Secondary action 2
+        </sky-summary-action-bar-secondary-action>
+        @if (extraActions) {
+          <sky-summary-action-bar-secondary-action
+            [disabled]="disableButtons"
+            (actionClick)="clickHandler()"
+          >
+            Secondary action 3
+          </sky-summary-action-bar-secondary-action>
+          <sky-summary-action-bar-secondary-action
+            [disabled]="disableButtons"
+            (actionClick)="clickHandler()"
+          >
+            Secondary action 4
+          </sky-summary-action-bar-secondary-action>
+          <sky-summary-action-bar-secondary-action
+            [disabled]="disableButtons"
+            (actionClick)="clickHandler()"
+          >
+            Secondary action 5
+          </sky-summary-action-bar-secondary-action>
+        }
+      </sky-summary-action-bar-secondary-actions>
+      <sky-summary-action-bar-cancel
         [disabled]="disableButtons"
         (actionClick)="clickHandler()"
       >
-        Secondary action 2
-      </sky-summary-action-bar-secondary-action>
-      @if (extraActions) {
-      <sky-summary-action-bar-secondary-action
-        [disabled]="disableButtons"
-        (actionClick)="clickHandler()"
-      >
-        Secondary action 3
-      </sky-summary-action-bar-secondary-action>
-      <sky-summary-action-bar-secondary-action
-        [disabled]="disableButtons"
-        (actionClick)="clickHandler()"
-      >
-        Secondary action 4
-      </sky-summary-action-bar-secondary-action>
-      <sky-summary-action-bar-secondary-action
-        [disabled]="disableButtons"
-        (actionClick)="clickHandler()"
-      >
-        Secondary action 5
-      </sky-summary-action-bar-secondary-action>
-      }
-    </sky-summary-action-bar-secondary-actions>
-    <sky-summary-action-bar-cancel
-      [disabled]="disableButtons"
-      (actionClick)="clickHandler()"
-    >
-      Cancel
-    </sky-summary-action-bar-cancel>
-  </sky-summary-action-bar-actions>
-  @if (!noSummary) {
-  <sky-summary-action-bar-summary>
-    @if (!noSummaryContent) {
-    <sky-key-info>
-      <sky-key-info-value>$123.00</sky-key-info-value>
-      <sky-key-info-label>Field 1</sky-key-info-label>
-    </sky-key-info>
-    <sky-key-info>
-      <sky-key-info-value>$456.00</sky-key-info-value>
-      <sky-key-info-label>Field 2</sky-key-info-label>
-    </sky-key-info>
-    <sky-key-info>
-      <sky-key-info-value>18</sky-key-info-value>
-      <sky-key-info-label>Field 3</sky-key-info-label>
-    </sky-key-info>
-    <sky-key-info>
-      <sky-key-info-value>$123.00</sky-key-info-value>
-      <sky-key-info-label>Field 1</sky-key-info-label>
-    </sky-key-info>
-    <sky-key-info>
-      <sky-key-info-value>$456.00</sky-key-info-value>
-      <sky-key-info-label>Field 2</sky-key-info-label>
-    </sky-key-info>
-    <sky-key-info>
-      <sky-key-info-value>18</sky-key-info-value>
-      <sky-key-info-label>Field 3</sky-key-info-label>
-    </sky-key-info>
-    <sky-key-info>
-      <sky-key-info-value>$123.00</sky-key-info-value>
-      <sky-key-info-label>Field 1</sky-key-info-label>
-    </sky-key-info>
-    <sky-key-info>
-      <sky-key-info-value>$456.00</sky-key-info-value>
-      <sky-key-info-label>Field 2</sky-key-info-label>
-    </sky-key-info>
-    <sky-key-info>
-      <sky-key-info-value>18</sky-key-info-value>
-      <sky-key-info-label>Field 3</sky-key-info-label>
-    </sky-key-info>
+        Cancel
+      </sky-summary-action-bar-cancel>
+    </sky-summary-action-bar-actions>
+    @if (!noSummary) {
+      <sky-summary-action-bar-summary>
+        @if (!noSummaryContent) {
+          <sky-key-info>
+            <sky-key-info-value>$123.00</sky-key-info-value>
+            <sky-key-info-label>Field 1</sky-key-info-label>
+          </sky-key-info>
+          <sky-key-info>
+            <sky-key-info-value>$456.00</sky-key-info-value>
+            <sky-key-info-label>Field 2</sky-key-info-label>
+          </sky-key-info>
+          <sky-key-info>
+            <sky-key-info-value>18</sky-key-info-value>
+            <sky-key-info-label>Field 3</sky-key-info-label>
+          </sky-key-info>
+          <sky-key-info>
+            <sky-key-info-value>$123.00</sky-key-info-value>
+            <sky-key-info-label>Field 1</sky-key-info-label>
+          </sky-key-info>
+          <sky-key-info>
+            <sky-key-info-value>$456.00</sky-key-info-value>
+            <sky-key-info-label>Field 2</sky-key-info-label>
+          </sky-key-info>
+          <sky-key-info>
+            <sky-key-info-value>18</sky-key-info-value>
+            <sky-key-info-label>Field 3</sky-key-info-label>
+          </sky-key-info>
+          <sky-key-info>
+            <sky-key-info-value>$123.00</sky-key-info-value>
+            <sky-key-info-label>Field 1</sky-key-info-label>
+          </sky-key-info>
+          <sky-key-info>
+            <sky-key-info-value>$456.00</sky-key-info-value>
+            <sky-key-info-label>Field 2</sky-key-info-label>
+          </sky-key-info>
+          <sky-key-info>
+            <sky-key-info-value>18</sky-key-info-value>
+            <sky-key-info-label>Field 3</sky-key-info-label>
+          </sky-key-info>
+        }
+      </sky-summary-action-bar-summary>
     }
-  </sky-summary-action-bar-summary>
-  }
-</sky-summary-action-bar>
-} @if (showSecondaryActionBar) {
-<sky-summary-action-bar id="summary-action-bar">
-  <sky-summary-action-bar-actions>
-    <sky-summary-action-bar-primary-action
-      [disabled]="disableButtons"
-      (actionClick)="clickHandler()"
-    >
-      Primary action
-    </sky-summary-action-bar-primary-action>
-    <sky-summary-action-bar-secondary-actions>
-      Foo
-      <sky-summary-action-bar-secondary-action
+  </sky-summary-action-bar>
+}
+@if (showSecondaryActionBar) {
+  <sky-summary-action-bar id="summary-action-bar">
+    <sky-summary-action-bar-actions>
+      <sky-summary-action-bar-primary-action
         [disabled]="disableButtons"
         (actionClick)="clickHandler()"
       >
-        Secondary action
-      </sky-summary-action-bar-secondary-action>
-      <sky-summary-action-bar-secondary-action
+        Primary action
+      </sky-summary-action-bar-primary-action>
+      <sky-summary-action-bar-secondary-actions>
+        Foo
+        <sky-summary-action-bar-secondary-action
+          [disabled]="disableButtons"
+          (actionClick)="clickHandler()"
+        >
+          Secondary action
+        </sky-summary-action-bar-secondary-action>
+        <sky-summary-action-bar-secondary-action
+          [disabled]="disableButtons"
+          (actionClick)="clickHandler()"
+        >
+          Secondary action 2
+        </sky-summary-action-bar-secondary-action>
+        @if (extraActions) {
+          <sky-summary-action-bar-secondary-action
+            [disabled]="disableButtons"
+            (actionClick)="clickHandler()"
+          >
+            Secondary action 3
+          </sky-summary-action-bar-secondary-action>
+          <sky-summary-action-bar-secondary-action
+            [disabled]="disableButtons"
+            (actionClick)="clickHandler()"
+          >
+            Secondary action 4
+          </sky-summary-action-bar-secondary-action>
+          <sky-summary-action-bar-secondary-action
+            [disabled]="disableButtons"
+            (actionClick)="clickHandler()"
+          >
+            Secondary action 5
+          </sky-summary-action-bar-secondary-action>
+        }
+      </sky-summary-action-bar-secondary-actions>
+      <sky-summary-action-bar-cancel
         [disabled]="disableButtons"
         (actionClick)="clickHandler()"
       >
-        Secondary action 2
-      </sky-summary-action-bar-secondary-action>
-      @if (extraActions) {
-      <sky-summary-action-bar-secondary-action
-        [disabled]="disableButtons"
-        (actionClick)="clickHandler()"
-      >
-        Secondary action 3
-      </sky-summary-action-bar-secondary-action>
-      <sky-summary-action-bar-secondary-action
-        [disabled]="disableButtons"
-        (actionClick)="clickHandler()"
-      >
-        Secondary action 4
-      </sky-summary-action-bar-secondary-action>
-      <sky-summary-action-bar-secondary-action
-        [disabled]="disableButtons"
-        (actionClick)="clickHandler()"
-      >
-        Secondary action 5
-      </sky-summary-action-bar-secondary-action>
-      }
-    </sky-summary-action-bar-secondary-actions>
-    <sky-summary-action-bar-cancel
-      [disabled]="disableButtons"
-      (actionClick)="clickHandler()"
-    >
-      Cancel
-    </sky-summary-action-bar-cancel>
-  </sky-summary-action-bar-actions>
-  @if (!noSummary) {
-  <sky-summary-action-bar-summary>
-    @if (!noSummaryContent) {
-    <sky-key-info>
-      <sky-key-info-value>$123.00</sky-key-info-value>
-      <sky-key-info-label>Field 1</sky-key-info-label>
-    </sky-key-info>
-    <sky-key-info>
-      <sky-key-info-value>$456.00</sky-key-info-value>
-      <sky-key-info-label>Field 2</sky-key-info-label>
-    </sky-key-info>
-    <sky-key-info>
-      <sky-key-info-value>18</sky-key-info-value>
-      <sky-key-info-label>Field 3</sky-key-info-label>
-    </sky-key-info>
-    <sky-key-info>
-      <sky-key-info-value>$123.00</sky-key-info-value>
-      <sky-key-info-label>Field 1</sky-key-info-label>
-    </sky-key-info>
-    <sky-key-info>
-      <sky-key-info-value>$456.00</sky-key-info-value>
-      <sky-key-info-label>Field 2</sky-key-info-label>
-    </sky-key-info>
-    <sky-key-info>
-      <sky-key-info-value>18</sky-key-info-value>
-      <sky-key-info-label>Field 3</sky-key-info-label>
-    </sky-key-info>
-    <sky-key-info>
-      <sky-key-info-value>$123.00</sky-key-info-value>
-      <sky-key-info-label>Field 1</sky-key-info-label>
-    </sky-key-info>
-    <sky-key-info>
-      <sky-key-info-value>$456.00</sky-key-info-value>
-      <sky-key-info-label>Field 2</sky-key-info-label>
-    </sky-key-info>
-    <sky-key-info>
-      <sky-key-info-value>18</sky-key-info-value>
-      <sky-key-info-label>Field 3</sky-key-info-label>
-    </sky-key-info>
+        Cancel
+      </sky-summary-action-bar-cancel>
+    </sky-summary-action-bar-actions>
+    @if (!noSummary) {
+      <sky-summary-action-bar-summary>
+        @if (!noSummaryContent) {
+          <sky-key-info>
+            <sky-key-info-value>$123.00</sky-key-info-value>
+            <sky-key-info-label>Field 1</sky-key-info-label>
+          </sky-key-info>
+          <sky-key-info>
+            <sky-key-info-value>$456.00</sky-key-info-value>
+            <sky-key-info-label>Field 2</sky-key-info-label>
+          </sky-key-info>
+          <sky-key-info>
+            <sky-key-info-value>18</sky-key-info-value>
+            <sky-key-info-label>Field 3</sky-key-info-label>
+          </sky-key-info>
+          <sky-key-info>
+            <sky-key-info-value>$123.00</sky-key-info-value>
+            <sky-key-info-label>Field 1</sky-key-info-label>
+          </sky-key-info>
+          <sky-key-info>
+            <sky-key-info-value>$456.00</sky-key-info-value>
+            <sky-key-info-label>Field 2</sky-key-info-label>
+          </sky-key-info>
+          <sky-key-info>
+            <sky-key-info-value>18</sky-key-info-value>
+            <sky-key-info-label>Field 3</sky-key-info-label>
+          </sky-key-info>
+          <sky-key-info>
+            <sky-key-info-value>$123.00</sky-key-info-value>
+            <sky-key-info-label>Field 1</sky-key-info-label>
+          </sky-key-info>
+          <sky-key-info>
+            <sky-key-info-value>$456.00</sky-key-info-value>
+            <sky-key-info-label>Field 2</sky-key-info-label>
+          </sky-key-info>
+          <sky-key-info>
+            <sky-key-info-value>18</sky-key-info-value>
+            <sky-key-info-label>Field 3</sky-key-info-label>
+          </sky-key-info>
+        }
+      </sky-summary-action-bar-summary>
     }
-  </sky-summary-action-bar-summary>
-  }
-</sky-summary-action-bar>
+  </sky-summary-action-bar>
 }

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/fixtures/ag-grid-data-manager.component.fixture.html
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/fixtures/ag-grid-data-manager.component.fixture.html
@@ -1,26 +1,27 @@
 <sky-data-manager>
   <sky-data-view skyAgGridDataManagerAdapter [viewId]="viewConfig.id">
     @if (displayFirstGrid) {
-    <sky-ag-grid-wrapper>
-      <ag-grid-angular
-        class="sky-ag-grid-editable"
-        [gridOptions]="gridOptions"
-        [rowData]="gridData"
-      />
-    </sky-ag-grid-wrapper>
-    } @if (displaySecondGrid) {
-    <sky-ag-grid-wrapper>
-      <ag-grid-angular
-        class="sky-ag-grid-editable"
-        [gridOptions]="gridOptions"
-        [rowData]="gridData"
-      />
-    </sky-ag-grid-wrapper>
+      <sky-ag-grid-wrapper>
+        <ag-grid-angular
+          class="sky-ag-grid-editable"
+          [gridOptions]="gridOptions"
+          [rowData]="gridData"
+        />
+      </sky-ag-grid-wrapper>
+    }
+    @if (displaySecondGrid) {
+      <sky-ag-grid-wrapper>
+        <ag-grid-angular
+          class="sky-ag-grid-editable"
+          [gridOptions]="gridOptions"
+          [rowData]="gridData"
+        />
+      </sky-ag-grid-wrapper>
     }
   </sky-data-view>
   @if (displayOtherView) {
-  <sky-data-view viewId="otherView">
-    <p>This is another view. It doesn't do much.</p>
-  </sky-data-view>
+    <sky-data-view viewId="otherView">
+      <p>This is another view. It doesn't do much.</p>
+    </sky-data-view>
   }
 </sky-data-manager>

--- a/libs/components/colorpicker/src/lib/modules/colorpicker/fixtures/colorpicker-reactive-component.fixture.html
+++ b/libs/components/colorpicker/src/lib/modules/colorpicker/fixtures/colorpicker-reactive-component.fixture.html
@@ -14,10 +14,10 @@
       [alphaChannel]="selectedHexType"
     />
     @if (colorControl.errors?.['opaque']) {
-    <sky-form-error
-      errorName="opaque"
-      errorText="Color must have at least 80% opacity."
-    />
+      <sky-form-error
+        errorName="opaque"
+        errorText="Color must have at least 80% opacity."
+      />
     }
   </sky-colorpicker>
   <div class="colorpicker-form-control">
@@ -32,10 +32,10 @@
         [alphaChannel]="selectedHexType"
       />
       @if (colorControl2.errors?.['opaque']) {
-      <sky-form-error
-        errorName="opaque"
-        errorText="Color must have at least 80% opacity."
-      />
+        <sky-form-error
+          errorName="opaque"
+          errorText="Color must have at least 80% opacity."
+        />
       }
     </sky-colorpicker>
   </div>

--- a/libs/components/core/src/lib/modules/dock/fixtures/dock-item.component.fixture.html
+++ b/libs/components/core/src/lib/modules/dock/fixtures/dock-item.component.fixture.html
@@ -1,6 +1,6 @@
 <div
   [ngStyle]="{
-    'height': height ? height + 'px' : 'auto'
+    height: height ? height + 'px' : 'auto'
   }"
 >
   Dock item content.

--- a/libs/components/core/src/lib/modules/numeric/fixtures/numeric.pipe.fixture.html
+++ b/libs/components/core/src/lib/modules/numeric/fixtures/numeric.pipe.fixture.html
@@ -1,4 +1,7 @@
 <p>
-  {{ value | skyNumeric:{ truncate: false, minDigits:2, format: 'currency',
-  locale: locale } }}
+  {{
+    value
+      | skyNumeric
+        : { truncate: false, minDigits: 2, format: 'currency', locale: locale }
+  }}
 </p>

--- a/libs/components/core/src/lib/modules/percent-pipe/fixtures/percent-pipe.component.fixture.html
+++ b/libs/components/core/src/lib/modules/percent-pipe/fixtures/percent-pipe.component.fixture.html
@@ -1,1 +1,1 @@
-{{ numberValue | skyPercent:format:locale }}
+{{ numberValue | skyPercent: format : locale }}

--- a/libs/components/core/src/lib/modules/scroll-shadow/fixtures/scroll-shadow.component.fixture.html
+++ b/libs/components/core/src/lib/modules/scroll-shadow/fixtures/scroll-shadow.component.fixture.html
@@ -2,8 +2,8 @@
   <div
     class="scroll-shadow-test-header"
     [ngStyle]="{
-'box-shadow': scrollShadow?.topShadow ?? 'none'
-}"
+      'box-shadow': scrollShadow?.topShadow ?? 'none'
+    }"
   ></div>
   <div
     class="scroll-shadow-test-body"
@@ -13,14 +13,14 @@
     <span
       class="scroll-shadow-test-content"
       [ngStyle]="{
-    'height.px': height
-  }"
+        'height.px': height
+      }"
     ></span>
   </div>
   <div
     class="scroll-shadow-test-footer"
     [ngStyle]="{
-  'box-shadow': scrollShadow?.bottomShadow ?? 'none'
-}"
+      'box-shadow': scrollShadow?.bottomShadow ?? 'none'
+    }"
   ></div>
 </div>

--- a/libs/components/core/src/lib/modules/scrollable-host/fixtures/scrollable-host.component.fixture.html
+++ b/libs/components/core/src/lib/modules/scrollable-host/fixtures/scrollable-host.component.fixture.html
@@ -4,12 +4,12 @@
     [ngClass]="{
       'scrollable-host': isParentScrollable,
       'display-none': isParentDisplayNoneClass,
-      'positioned': isParentPositioned
+      positioned: isParentPositioned
     }"
     [ngStyle]="{
-      'display': isParentDisplayNoneStyle ? 'none' : undefined,
-      'overflow-y': isParentScrollableStyle ? 'scroll': undefined,
-      'width': isParentPositioned ? positionedParentWidth : undefined
+      display: isParentDisplayNoneStyle ? 'none' : undefined,
+      'overflow-y': isParentScrollableStyle ? 'scroll' : undefined,
+      width: isParentPositioned ? positionedParentWidth : undefined
     }"
     [hidden]="isParentHidden"
   >

--- a/libs/components/data-manager/src/lib/modules/data-manager/fixtures/data-manager-card-view.component.fixture.html
+++ b/libs/components/data-manager/src/lib/modules/data-manager/fixtures/data-manager-card-view.component.fixture.html
@@ -1,10 +1,10 @@
 <sky-data-view [viewId]="viewConfig.id">
   <div style="margin: 10px">
     @for (item of displayedItems; track item) {
-    <sky-card size="small">
-      <sky-card-title>{{item.name}}</sky-card-title>
-      <sky-card-content>{{item.description}}</sky-card-content>
-    </sky-card>
+      <sky-card size="small">
+        <sky-card-title>{{ item.name }}</sky-card-title>
+        <sky-card-content>{{ item.description }}</sky-card-content>
+      </sky-card>
     }
   </div>
 </sky-data-view>

--- a/libs/components/data-manager/src/lib/modules/data-manager/fixtures/data-manager-repeater-view.component.fixture.html
+++ b/libs/components/data-manager/src/lib/modules/data-manager/fixtures/data-manager-repeater-view.component.fixture.html
@@ -1,18 +1,18 @@
 <sky-data-view [viewId]="viewConfig.id">
   @if (isActive) {
-  <sky-repeater expandMode="none">
-    @for (item of displayedItems; track item) {
-    <sky-repeater-item
-      [selectable]="true"
-      [(isSelected)]="item.selected"
-      (isSelectedChange)="onItemSelect($event, item)"
-    >
-      <sky-repeater-item-title> {{item.name}} </sky-repeater-item-title>
-      <sky-repeater-item-content>
-        <div>{{item.description}}</div>
-      </sky-repeater-item-content>
-    </sky-repeater-item>
-    }
-  </sky-repeater>
+    <sky-repeater expandMode="none">
+      @for (item of displayedItems; track item) {
+        <sky-repeater-item
+          [selectable]="true"
+          [(isSelected)]="item.selected"
+          (isSelectedChange)="onItemSelect($event, item)"
+        >
+          <sky-repeater-item-title> {{ item.name }} </sky-repeater-item-title>
+          <sky-repeater-item-content>
+            <div>{{ item.description }}</div>
+          </sky-repeater-item-content>
+        </sky-repeater-item>
+      }
+    </sky-repeater>
   }
 </sky-data-view>

--- a/libs/components/data-manager/src/lib/modules/data-manager/fixtures/data-manager.component.fixture.html
+++ b/libs/components/data-manager/src/lib/modules/data-manager/fixtures/data-manager.component.fixture.html
@@ -6,11 +6,11 @@
       </button>
     </sky-data-manager-toolbar-primary-item>
     @if (activeViewId === 'repeaterView') {
-    <sky-data-manager-toolbar-left-item>
-      <button type="button" class="sky-btn left-test-button">
-        Set search text to "so"
-      </button>
-    </sky-data-manager-toolbar-left-item>
+      <sky-data-manager-toolbar-left-item>
+        <button type="button" class="sky-btn left-test-button">
+          Set search text to "so"
+        </button>
+      </sky-data-manager-toolbar-left-item>
     }
     <sky-data-manager-toolbar-right-item>
       <button type="button" class="sky-btn right-test-button">Expand</button>

--- a/libs/components/datetime/src/lib/modules/date-pipe/fixtures/date-pipe.component.fixture.html
+++ b/libs/components/datetime/src/lib/modules/date-pipe/fixtures/date-pipe.component.fixture.html
@@ -1,1 +1,1 @@
-{{ dateValue | skyDate:format:locale }}
+{{ dateValue | skyDate: format : locale }}

--- a/libs/components/datetime/src/lib/modules/date-pipe/fixtures/fuzzy-date-pipe.component.fixture.html
+++ b/libs/components/datetime/src/lib/modules/date-pipe/fixtures/fuzzy-date-pipe.component.fixture.html
@@ -1,1 +1,1 @@
-{{ dateValue | skyFuzzyDate:format:locale }}
+{{ dateValue | skyFuzzyDate: format : locale }}

--- a/libs/components/datetime/src/lib/modules/date-range-picker/fixtures/date-range-picker.component.fixture.html
+++ b/libs/components/datetime/src/lib/modules/date-range-picker/fixtures/date-range-picker.component.fixture.html
@@ -1,34 +1,34 @@
 <form novalidate [formGroup]="reactiveForm">
   @if (templateDisable === undefined) {
-  <sky-date-range-picker
-    #dateRangePicker
-    formControlName="dateRange"
-    [calculatorIds]="calculatorIds"
-    [dateFormat]="dateFormat"
-    [helpKey]="helpKey"
-    [helpPopoverContent]="helpPopoverContent"
-    [hintText]="hintText"
-    [label]="label"
-    [labelText]="labelText"
-    [required]="required"
-    [stacked]="stacked"
-  >
-    @if (dateRange?.errors?.['customError']) {
-    <sky-form-error
-      errorName="customError"
-      errorText="This is a custom error."
-    />
-    }
-  </sky-date-range-picker>
+    <sky-date-range-picker
+      #dateRangePicker
+      formControlName="dateRange"
+      [calculatorIds]="calculatorIds"
+      [dateFormat]="dateFormat"
+      [helpKey]="helpKey"
+      [helpPopoverContent]="helpPopoverContent"
+      [hintText]="hintText"
+      [label]="label"
+      [labelText]="labelText"
+      [required]="required"
+      [stacked]="stacked"
+    >
+      @if (dateRange?.errors?.['customError']) {
+        <sky-form-error
+          errorName="customError"
+          errorText="This is a custom error."
+        />
+      }
+    </sky-date-range-picker>
   }
 </form>
 
 @if (templateDisable !== undefined) {
-<sky-date-range-picker
-  #dateRangePicker
-  [calculatorIds]="calculatorIds"
-  [dateFormat]="dateFormat"
-  [disabled]="templateDisable"
-  [label]="label"
-/>
+  <sky-date-range-picker
+    #dateRangePicker
+    [calculatorIds]="calculatorIds"
+    [dateFormat]="dateFormat"
+    [disabled]="templateDisable"
+    [label]="label"
+  />
 }

--- a/libs/components/datetime/src/lib/modules/datepicker/fixtures/datepicker.component.fixture.html
+++ b/libs/components/datetime/src/lib/modules/datepicker/fixtures/datepicker.component.fixture.html
@@ -21,5 +21,5 @@
 </sky-datepicker>
 
 @if (showInvalidDirective) {
-<input type="text" skyDatepickerInput />
+  <input type="text" skyDatepickerInput />
 }

--- a/libs/components/datetime/src/lib/modules/datepicker/fuzzy/fixtures/fuzzy-datepicker.component.fixture.html
+++ b/libs/components/datetime/src/lib/modules/datepicker/fuzzy/fixtures/fuzzy-datepicker.component.fixture.html
@@ -18,5 +18,5 @@
 </sky-datepicker>
 
 @if (showInvalidDirective) {
-<input type="text" skyFuzzyDatepickerInput />
+  <input type="text" skyFuzzyDatepickerInput />
 }

--- a/libs/components/flyout/src/lib/modules/flyout/fixtures/flyout-sample.component.fixture.html
+++ b/libs/components/flyout/src/lib/modules/flyout/fixtures/flyout-sample.component.fixture.html
@@ -1,9 +1,12 @@
-{{ data?.name }} @if (data?.showIframe) {
-<iframe src="https://developer.blackbaud.com/skyux/"></iframe>
-} @if (data?.showNormalButton) {
-<button id="normal-button" type="button">Normal Button</button>
-} @if (data?.showAutofocusButton) {
-<button id="autofocus-button" type="button" cdkFocusInitial>
-  Autofocus Button
-</button>
+{{ data?.name }}
+@if (data?.showIframe) {
+  <iframe src="https://developer.blackbaud.com/skyux/"></iframe>
+}
+@if (data?.showNormalButton) {
+  <button id="normal-button" type="button">Normal Button</button>
+}
+@if (data?.showAutofocusButton) {
+  <button id="autofocus-button" type="button" cdkFocusInitial>
+    Autofocus Button
+  </button>
 }

--- a/libs/components/forms/src/lib/modules/character-counter/fixtures/character-count-no-indicator.component.fixture.html
+++ b/libs/components/forms/src/lib/modules/character-counter/fixtures/character-count-no-indicator.component.fixture.html
@@ -20,9 +20,9 @@
     />
 
     @if (firstName.errors?.skyCharacterCounter) {
-    <div class="sky-error-label">
-      Limit First name to {{maxCharacterCount}} characters.
-    </div>
+      <div class="sky-error-label">
+        Limit First name to {{ maxCharacterCount }} characters.
+      </div>
     }
   </form>
 </div>

--- a/libs/components/forms/src/lib/modules/character-counter/fixtures/character-count.component.fixture.html
+++ b/libs/components/forms/src/lib/modules/character-counter/fixtures/character-count.component.fixture.html
@@ -24,9 +24,9 @@
     />
 
     @if (firstName.errors?.skyCharacterCounter) {
-    <div class="sky-error-label">
-      Limit First name to {{maxCharacterCount}} characters.
-    </div>
+      <div class="sky-error-label">
+        Limit First name to {{ maxCharacterCount }} characters.
+      </div>
     }
 
     <div style="display: flex" class="input-count-example-wrapper-last-name">
@@ -53,9 +53,9 @@
     />
 
     @if (lastName.errors?.skyCharacterCounter) {
-    <div class="sky-error-label">
-      Limit Last name to {{maxCharacterCount}} characters.
-    </div>
+      <div class="sky-error-label">
+        Limit Last name to {{ maxCharacterCount }} characters.
+      </div>
     }
   </form>
 </div>

--- a/libs/components/forms/src/lib/modules/file-attachment/file-attachment/fixtures/file-attachment.component.fixture.html
+++ b/libs/components/forms/src/lib/modules/file-attachment/file-attachment/fixtures/file-attachment.component.fixture.html
@@ -12,15 +12,16 @@
     [stacked]="stacked"
   >
     @if (showLabel) {
-    <sky-file-attachment-label>
-      {{ labelElementText }} @if (showInlineHelp) {
-      <sky-help-inline class="sky-control-help" />
-      }
-    </sky-file-attachment-label>
+      <sky-file-attachment-label>
+        {{ labelElementText }}
+        @if (showInlineHelp) {
+          <sky-help-inline class="sky-control-help" />
+        }
+      </sky-file-attachment-label>
     }
   </sky-file-attachment>
 
   @if (attachment?.invalid && attachment?.dirty) {
-  <div class="sky-error-label">Attach a file.</div>
+    <div class="sky-error-label">Attach a file.</div>
   }
 </form>

--- a/libs/components/forms/src/lib/modules/file-attachment/file-drop/fixtures/reactive-file-drop.component.fixture.html
+++ b/libs/components/forms/src/lib/modules/file-attachment/file-drop/fixtures/reactive-file-drop.component.fixture.html
@@ -8,5 +8,5 @@
 </form>
 
 @for (file of fileDrop.value; track file) {
-<sky-file-item [fileItem]="file" (deleteFile)="deleteFile($event)" />
+  <sky-file-item [fileItem]="file" (deleteFile)="deleteFile($event)" />
 }

--- a/libs/components/forms/src/lib/modules/input-box/fixtures/input-box.component.fixture.html
+++ b/libs/components/forms/src/lib/modules/input-box/fixtures/input-box.component.fixture.html
@@ -8,13 +8,13 @@
       [disabled]="basicDisabled"
     />
     @if (hasErrors) {
-    <sky-status-indicator
-      class="sky-control-error"
-      indicatorType="danger"
-      descriptionType="error"
-    >
-      Field is required.
-    </sky-status-indicator>
+      <sky-status-indicator
+        class="sky-control-error"
+        indicatorType="danger"
+        descriptionType="error"
+      >
+        Field is required.
+      </sky-status-indicator>
     }
   </sky-input-box>
 </div>
@@ -31,13 +31,13 @@
       [disabled]="basicDisabled"
     ></textarea>
     @if (hasErrors) {
-    <sky-status-indicator
-      class="sky-control-error"
-      indicatorType="danger"
-      descriptionType="error"
-    >
-      Field is required.
-    </sky-status-indicator>
+      <sky-status-indicator
+        class="sky-control-error"
+        indicatorType="danger"
+        descriptionType="error"
+      >
+        Field is required.
+      </sky-status-indicator>
     }
   </sky-input-box>
 </div>
@@ -59,13 +59,13 @@
       <option>Option 4</option>
     </select>
     @if (hasErrors) {
-    <sky-status-indicator
-      class="sky-control-error"
-      indicatorType="danger"
-      descriptionType="error"
-    >
-      Field is required.
-    </sky-status-indicator>
+      <sky-status-indicator
+        class="sky-control-error"
+        indicatorType="danger"
+        descriptionType="error"
+      >
+        Field is required.
+      </sky-status-indicator>
     }
   </sky-input-box>
 </div>
@@ -76,11 +76,11 @@
       Basic input with inline help
     </label>
     @if (inlineHelpType === 'custom') {
-    <div class="sky-control-help">
-      <button type="button">CUSTOM HELP WIDGET</button>
-    </div>
+      <div class="sky-control-help">
+        <button type="button">CUSTOM HELP WIDGET</button>
+      </div>
     } @else if (inlineHelpType === 'sky') {
-    <sky-help-inline class="sky-control-help" />
+      <sky-help-inline class="sky-control-help" />
     }
     <input #inlineHelp="skyId" class="sky-form-control" skyId />
   </sky-input-box>
@@ -92,11 +92,11 @@
       Textarea with inline help
     </label>
     @if (inlineHelpType === 'custom') {
-    <div class="sky-control-help">
-      <button type="button">CUSTOM HELP WIDGET</button>
-    </div>
+      <div class="sky-control-help">
+        <button type="button">CUSTOM HELP WIDGET</button>
+      </div>
     } @else if (inlineHelpType === 'sky') {
-    <sky-help-inline class="sky-control-help" />
+      <sky-help-inline class="sky-control-help" />
     }
     <textarea
       #textareaInlineHelp="skyId"
@@ -112,11 +112,11 @@
       Select with inline help
     </label>
     @if (inlineHelpType === 'custom') {
-    <div class="sky-control-help">
-      <button type="button">CUSTOM HELP WIDGET</button>
-    </div>
+      <div class="sky-control-help">
+        <button type="button">CUSTOM HELP WIDGET</button>
+      </div>
     } @else if (inlineHelpType === 'sky') {
-    <sky-help-inline class="sky-control-help" />
+      <sky-help-inline class="sky-control-help" />
     }
     <select #selectInlineHelp="skyId" class="sky-form-control" skyId>
       <option>Option 1</option>
@@ -303,7 +303,7 @@
       With character count
     </label>
     @if (characterCountHelp) {
-    <sky-help-inline class="sky-control-help" />
+      <sky-help-inline class="sky-control-help" />
     }
     <sky-character-counter-indicator #characterCount />
     <input
@@ -323,7 +323,7 @@
       With character count
     </label>
     @if (characterCountHelp) {
-    <sky-help-inline class="sky-control-help" />
+      <sky-help-inline class="sky-control-help" />
     }
     <sky-character-counter-indicator #characterCount />
     <textarea
@@ -343,7 +343,7 @@
       With character count
     </label>
     @if (characterCountHelp) {
-    <sky-help-inline class="sky-control-help" />
+      <sky-help-inline class="sky-control-help" />
     }
     <sky-character-counter-indicator #characterCount />
     <select
@@ -430,37 +430,41 @@
       type="text"
     />
     @if (a11yInsetIconLeft) {
-    <div class="sky-input-group-icon sky-input-box-icon-inset-left">
-      <sky-icon class="test-icon-inset=left" iconName="search" iconSize="l" />
-    </div>
-    } @if (a11yInsetIcon) {
-    <div class="sky-input-group-icon sky-input-box-icon-inset">
-      <sky-icon class="test-icon-inset" iconName="search" iconSize="l" />
-    </div>
-    } @if (a11yButtonLeft) {
-    <div class="sky-input-group-btn sky-input-box-btn-left">
-      <button
-        aria-label="Left button"
-        class="sky-btn sky-btn-default test-button-left"
-        type="button"
-      ></button>
-    </div>
-    } @if (a11yInsetButton) {
-    <div class="sky-input-group-btn sky-input-box-btn-inset">
-      <button
-        aria-label="Inset button"
-        class="sky-btn sky-btn-default test-button-inset"
-        type="button"
-      ></button>
-    </div>
-    } @if (a11yNormalButton) {
-    <div class="sky-input-group-btn">
-      <button
-        aria-label="Normal button"
-        class="sky-btn sky-btn-default test-button"
-        type="button"
-      ></button>
-    </div>
+      <div class="sky-input-group-icon sky-input-box-icon-inset-left">
+        <sky-icon class="test-icon-inset=left" iconName="search" iconSize="l" />
+      </div>
+    }
+    @if (a11yInsetIcon) {
+      <div class="sky-input-group-icon sky-input-box-icon-inset">
+        <sky-icon class="test-icon-inset" iconName="search" iconSize="l" />
+      </div>
+    }
+    @if (a11yButtonLeft) {
+      <div class="sky-input-group-btn sky-input-box-btn-left">
+        <button
+          aria-label="Left button"
+          class="sky-btn sky-btn-default test-button-left"
+          type="button"
+        ></button>
+      </div>
+    }
+    @if (a11yInsetButton) {
+      <div class="sky-input-group-btn sky-input-box-btn-inset">
+        <button
+          aria-label="Inset button"
+          class="sky-btn sky-btn-default test-button-inset"
+          type="button"
+        ></button>
+      </div>
+    }
+    @if (a11yNormalButton) {
+      <div class="sky-input-group-btn">
+        <button
+          aria-label="Normal button"
+          class="sky-btn sky-btn-default test-button"
+          type="button"
+        ></button>
+      </div>
     }
   </sky-input-box>
 </div>
@@ -477,37 +481,41 @@
       type="text"
     ></textarea>
     @if (a11yInsetIconLeft) {
-    <div class="sky-input-group-icon sky-input-box-icon-inset-left">
-      <sky-icon class="test-icon-inset=left" iconName="search" iconSize="l" />
-    </div>
-    } @if (a11yInsetIcon) {
-    <div class="sky-input-group-icon sky-input-box-icon-inset">
-      <sky-icon class="test-icon-inset" iconName="search" iconSize="l" />
-    </div>
-    } @if (a11yButtonLeft) {
-    <div class="sky-input-group-btn sky-input-box-btn-left">
-      <button
-        aria-label="Left button"
-        class="sky-btn sky-btn-default test-button-left"
-        type="button"
-      ></button>
-    </div>
-    } @if (a11yInsetButton) {
-    <div class="sky-input-group-btn sky-input-box-btn-inset">
-      <button
-        aria-label="Inset button"
-        class="sky-btn sky-btn-default test-button-inset"
-        type="button"
-      ></button>
-    </div>
-    } @if (a11yNormalButton) {
-    <div class="sky-input-group-btn">
-      <button
-        aria-label="Normal button"
-        class="sky-btn sky-btn-default test-button"
-        type="button"
-      ></button>
-    </div>
+      <div class="sky-input-group-icon sky-input-box-icon-inset-left">
+        <sky-icon class="test-icon-inset=left" iconName="search" iconSize="l" />
+      </div>
+    }
+    @if (a11yInsetIcon) {
+      <div class="sky-input-group-icon sky-input-box-icon-inset">
+        <sky-icon class="test-icon-inset" iconName="search" iconSize="l" />
+      </div>
+    }
+    @if (a11yButtonLeft) {
+      <div class="sky-input-group-btn sky-input-box-btn-left">
+        <button
+          aria-label="Left button"
+          class="sky-btn sky-btn-default test-button-left"
+          type="button"
+        ></button>
+      </div>
+    }
+    @if (a11yInsetButton) {
+      <div class="sky-input-group-btn sky-input-box-btn-inset">
+        <button
+          aria-label="Inset button"
+          class="sky-btn sky-btn-default test-button-inset"
+          type="button"
+        ></button>
+      </div>
+    }
+    @if (a11yNormalButton) {
+      <div class="sky-input-group-btn">
+        <button
+          aria-label="Normal button"
+          class="sky-btn sky-btn-default test-button"
+          type="button"
+        ></button>
+      </div>
     }
   </sky-input-box>
 </div>
@@ -529,37 +537,41 @@
       <option>Option 4</option>
     </select>
     @if (a11yInsetIconLeft) {
-    <div class="sky-input-group-icon sky-input-box-icon-inset-left">
-      <sky-icon class="test-icon-inset=left" iconName="search" iconSize="l" />
-    </div>
-    } @if (a11yInsetIcon) {
-    <div class="sky-input-group-icon sky-input-box-icon-inset">
-      <sky-icon class="test-icon-inset" iconName="search" iconSize="l" />
-    </div>
-    } @if (a11yButtonLeft) {
-    <div class="sky-input-group-btn sky-input-box-btn-left">
-      <button
-        aria-label="Left button"
-        class="sky-btn sky-btn-default test-button-left"
-        type="button"
-      ></button>
-    </div>
-    } @if (a11yInsetButton) {
-    <div class="sky-input-group-btn sky-input-box-btn-inset">
-      <button
-        aria-label="Inset button"
-        class="sky-btn sky-btn-default test-button-inset"
-        type="button"
-      ></button>
-    </div>
-    } @if (a11yNormalButton) {
-    <div class="sky-input-group-btn">
-      <button
-        aria-label="Normal button"
-        class="sky-btn sky-btn-default test-button"
-        type="button"
-      ></button>
-    </div>
+      <div class="sky-input-group-icon sky-input-box-icon-inset-left">
+        <sky-icon class="test-icon-inset=left" iconName="search" iconSize="l" />
+      </div>
+    }
+    @if (a11yInsetIcon) {
+      <div class="sky-input-group-icon sky-input-box-icon-inset">
+        <sky-icon class="test-icon-inset" iconName="search" iconSize="l" />
+      </div>
+    }
+    @if (a11yButtonLeft) {
+      <div class="sky-input-group-btn sky-input-box-btn-left">
+        <button
+          aria-label="Left button"
+          class="sky-btn sky-btn-default test-button-left"
+          type="button"
+        ></button>
+      </div>
+    }
+    @if (a11yInsetButton) {
+      <div class="sky-input-group-btn sky-input-box-btn-inset">
+        <button
+          aria-label="Inset button"
+          class="sky-btn sky-btn-default test-button-inset"
+          type="button"
+        ></button>
+      </div>
+    }
+    @if (a11yNormalButton) {
+      <div class="sky-input-group-btn">
+        <button
+          aria-label="Normal button"
+          class="sky-btn sky-btn-default test-button"
+          type="button"
+        ></button>
+      </div>
     }
   </sky-input-box>
 </div>

--- a/libs/components/forms/src/lib/modules/radio/fixtures/radio-group-reactive.component.fixture.html
+++ b/libs/components/forms/src/lib/modules/radio/fixtures/radio-group-reactive.component.fixture.html
@@ -1,38 +1,42 @@
 <form [formGroup]="radioForm">
   @if (showRadioGroup) {
-  <sky-radio-group
-    class="form-group radio"
-    formControlName="radioGroup"
-    [ariaLabel]="ariaLabel"
-    [ariaLabelledBy]="ariaLabelledBy"
-    [headingHidden]="headingHidden"
-    [headingLevel]="headingLevel"
-    [headingStyle]="headingStyle"
-    [headingText]="headingText"
-    [helpKey]="helpKey"
-    [helpPopoverContent]="helpPopoverContent"
-    [hintText]="hintText"
-    [name]="groupName"
-    [required]="required"
-    [tabIndex]="tabIndex"
-    [stacked]="stacked"
-  >
-    <legend id="radio-group-label">Reactive Radio button options:</legend>
-    <ul class="sky-theme-list-unstyled">
-      @for (value of options; track value) {
-      <li>
-        <sky-radio [disabled]="value.disabled" [id]="value.id" [value]="value">
-          <sky-radio-label> Option {{ value.name }} </sky-radio-label>
-        </sky-radio>
-      </li>
+    <sky-radio-group
+      class="form-group radio"
+      formControlName="radioGroup"
+      [ariaLabel]="ariaLabel"
+      [ariaLabelledBy]="ariaLabelledBy"
+      [headingHidden]="headingHidden"
+      [headingLevel]="headingLevel"
+      [headingStyle]="headingStyle"
+      [headingText]="headingText"
+      [helpKey]="helpKey"
+      [helpPopoverContent]="helpPopoverContent"
+      [hintText]="hintText"
+      [name]="groupName"
+      [required]="required"
+      [tabIndex]="tabIndex"
+      [stacked]="stacked"
+    >
+      <legend id="radio-group-label">Reactive Radio button options:</legend>
+      <ul class="sky-theme-list-unstyled">
+        @for (value of options; track value) {
+          <li>
+            <sky-radio
+              [disabled]="value.disabled"
+              [id]="value.id"
+              [value]="value"
+            >
+              <sky-radio-label> Option {{ value.name }} </sky-radio-label>
+            </sky-radio>
+          </li>
+        }
+      </ul>
+      @if (radioControl?.errors?.['incorrectOption']) {
+        <sky-form-error
+          errorName="incorrectOption"
+          errorText="This option is incorrect."
+        />
       }
-    </ul>
-    @if (radioControl?.errors?.['incorrectOption']) {
-    <sky-form-error
-      errorName="incorrectOption"
-      errorText="This option is incorrect."
-    />
-    }
-  </sky-radio-group>
+    </sky-radio-group>
   }
 </form>

--- a/libs/components/forms/src/lib/modules/selection-box/fixtures/selection-box-grid.component.fixture.html
+++ b/libs/components/forms/src/lib/modules/selection-box/fixtures/selection-box-grid.component.fixture.html
@@ -1,33 +1,33 @@
 @if (render) {
-<sky-selection-box-grid [alignItems]="alignItems">
-  <sky-selection-box [control]="checkbox1">
-    <sky-selection-box-header id="header1">
-      header one
-    </sky-selection-box-header>
-    <sky-selection-box-description>
-      <div [style.height]="firstBoxHeight">
-        Set height on me to make the other selection boxes grow!
-      </div>
-    </sky-selection-box-description>
-    <sky-checkbox #checkbox1 [labelledBy]="'header1'" />
-  </sky-selection-box>
-  <sky-selection-box [control]="checkbox2">
-    <sky-selection-box-header id="header2">
-      header two
-    </sky-selection-box-header>
-    <sky-selection-box-description>
-      description two
-    </sky-selection-box-description>
-    <sky-checkbox #checkbox2 [labelledBy]="'header2'" />
-  </sky-selection-box>
-  <sky-selection-box [control]="checkbox3">
-    <sky-selection-box-header id="header3">
-      header three
-    </sky-selection-box-header>
-    <sky-selection-box-description>
-      {{ dynamicDescription }}
-    </sky-selection-box-description>
-    <sky-checkbox #checkbox3 [labelledBy]="'header3'" />
-  </sky-selection-box>
-</sky-selection-box-grid>
+  <sky-selection-box-grid [alignItems]="alignItems">
+    <sky-selection-box [control]="checkbox1">
+      <sky-selection-box-header id="header1">
+        header one
+      </sky-selection-box-header>
+      <sky-selection-box-description>
+        <div [style.height]="firstBoxHeight">
+          Set height on me to make the other selection boxes grow!
+        </div>
+      </sky-selection-box-description>
+      <sky-checkbox #checkbox1 [labelledBy]="'header1'" />
+    </sky-selection-box>
+    <sky-selection-box [control]="checkbox2">
+      <sky-selection-box-header id="header2">
+        header two
+      </sky-selection-box-header>
+      <sky-selection-box-description>
+        description two
+      </sky-selection-box-description>
+      <sky-checkbox #checkbox2 [labelledBy]="'header2'" />
+    </sky-selection-box>
+    <sky-selection-box [control]="checkbox3">
+      <sky-selection-box-header id="header3">
+        header three
+      </sky-selection-box-header>
+      <sky-selection-box-description>
+        {{ dynamicDescription }}
+      </sky-selection-box-description>
+      <sky-checkbox #checkbox3 [labelledBy]="'header3'" />
+    </sky-selection-box>
+  </sky-selection-box-grid>
 }

--- a/libs/components/forms/src/lib/modules/selection-box/fixtures/selection-box.component.fixture.html
+++ b/libs/components/forms/src/lib/modules/selection-box/fixtures/selection-box.component.fixture.html
@@ -1,35 +1,41 @@
 <div id="radioSelectionBoxes">
   <sky-radio-group ariaLabel="Test options" value="red">
     @for (item of radioArray; track item) {
-    <sky-selection-box [control]="radio">
-      <sky-icon iconSize="l" [iconName]="item.iconName" />
-      <sky-selection-box-header #radioHeaderId="skyId" skyId>
-        {{ item.header }}
-      </sky-selection-box-header>
-      <sky-radio #radio [labelledBy]="radioHeaderId.id" [value]="item.name" />
-    </sky-selection-box>
+      <sky-selection-box [control]="radio">
+        <sky-icon iconSize="l" [iconName]="item.iconName" />
+        <sky-selection-box-header #radioHeaderId="skyId" skyId>
+          {{ item.header }}
+        </sky-selection-box-header>
+        <sky-radio #radio [labelledBy]="radioHeaderId.id" [value]="item.name" />
+      </sky-selection-box>
     }
   </sky-radio-group>
 </div>
 
 <div id="checkboxSelectionBoxes">
   <form [formGroup]="myForm">
-    @for (aControl of selectionBoxFormArray.controls; track aControl; let i =
-    $index) {
-    <sky-selection-box [control]="checkbox">
-      <sky-icon iconSize="l" [iconName]="checkboxSelectionBoxes[i].iconName" />
-      <sky-selection-box-header #checkboxHeaderId="skyId" skyId>
-        {{ checkboxSelectionBoxes[i].header }}
-      </sky-selection-box-header>
-      <sky-selection-box-description>
-        {{ checkboxSelectionBoxes[i].description }}
-      </sky-selection-box-description>
-      <sky-checkbox
-        #checkbox
-        [formControl]="aControl"
-        [labelledBy]="checkboxHeaderId.id"
-      />
-    </sky-selection-box>
+    @for (
+      aControl of selectionBoxFormArray.controls;
+      track aControl;
+      let i = $index
+    ) {
+      <sky-selection-box [control]="checkbox">
+        <sky-icon
+          iconSize="l"
+          [iconName]="checkboxSelectionBoxes[i].iconName"
+        />
+        <sky-selection-box-header #checkboxHeaderId="skyId" skyId>
+          {{ checkboxSelectionBoxes[i].header }}
+        </sky-selection-box-header>
+        <sky-selection-box-description>
+          {{ checkboxSelectionBoxes[i].description }}
+        </sky-selection-box-description>
+        <sky-checkbox
+          #checkbox
+          [formControl]="aControl"
+          [labelledBy]="checkboxHeaderId.id"
+        />
+      </sky-selection-box>
     }
   </form>
 </div>

--- a/libs/components/forms/src/lib/modules/toggle-switch/fixtures/toggle-switch-on-push.component.fixture.html
+++ b/libs/components/forms/src/lib/modules/toggle-switch/fixtures/toggle-switch-on-push.component.fixture.html
@@ -1,5 +1,5 @@
 <sky-toggle-switch ariaLabel="Sample ARIA label" [(ngModel)]="isChecked">
   @if (showLabel) {
-  <sky-toggle-switch-label> Sample async label </sky-toggle-switch-label>
+    <sky-toggle-switch-label> Sample async label </sky-toggle-switch-label>
   }
 </sky-toggle-switch>

--- a/libs/components/forms/src/lib/modules/toggle-switch/fixtures/toggle-switch.component.fixture.html
+++ b/libs/components/forms/src/lib/modules/toggle-switch/fixtures/toggle-switch.component.fixture.html
@@ -11,12 +11,13 @@
   (toggleChange)="checkChanged($event)"
 >
   @if (showLabel) {
-  <sky-toggle-switch-label>{{ buttonLabel }}</sky-toggle-switch-label>
-  } @if (showInlineHelp) {
-  <sky-help-inline class="sky-control-help" />
+    <sky-toggle-switch-label>{{ buttonLabel }}</sky-toggle-switch-label>
+  }
+  @if (showInlineHelp) {
+    <sky-help-inline class="sky-control-help" />
   }
 </sky-toggle-switch>
 
 @if (multiple) {
-<sky-toggle-switch> Option 2 </sky-toggle-switch>
+  <sky-toggle-switch> Option 2 </sky-toggle-switch>
 }

--- a/libs/components/grids/src/lib/modules/grid/fixtures/grid-dynamic.component.fixture.html
+++ b/libs/components/grids/src/lib/modules/grid/fixtures/grid-dynamic.component.fixture.html
@@ -1,5 +1,8 @@
 <sky-grid [data]="data">
   @for (gridColumn of gridColumns; track gridColumn) {
-  <sky-grid-column [field]="gridColumn.field" [heading]="gridColumn.heading" />
+    <sky-grid-column
+      [field]="gridColumn.field"
+      [heading]="gridColumn.heading"
+    />
   }
 </sky-grid>

--- a/libs/components/grids/src/lib/modules/grid/fixtures/grid-empty.component.fixture.html
+++ b/libs/components/grids/src/lib/modules/grid/fixtures/grid-empty.component.fixture.html
@@ -5,6 +5,6 @@
   [selectedColumnIds]="selectedColumnIds"
   [settingsKey]="settingsKey"
 />
-<ng-template #defaultCellTemplate let-row="row" let-value="value"
-  >{{value}}</ng-template
->
+<ng-template #defaultCellTemplate let-row="row" let-value="value">{{
+  value
+}}</ng-template>

--- a/libs/components/grids/src/lib/modules/grid/fixtures/grid-interactive.component.fixture.html
+++ b/libs/components/grids/src/lib/modules/grid/fixtures/grid-interactive.component.fixture.html
@@ -12,9 +12,9 @@
 </sky-grid>
 
 <ng-template #template1 let-value="value">
-  <a href="http://www.example.com"> {{value}} </a>
+  <a href="http://www.example.com"> {{ value }} </a>
 </ng-template>
 
 <ng-template #template2 let-value="value">
-  <button type="button">{{value}}</button>
+  <button type="button">{{ value }}</button>
 </ng-template>

--- a/libs/components/grids/src/lib/modules/grid/fixtures/grid.component.fixture.html
+++ b/libs/components/grids/src/lib/modules/grid/fixtures/grid.component.fixture.html
@@ -33,7 +33,7 @@
     [isSortable]="false"
     [search]="searchFunction"
   >
-    <ng-template let-row="row"> {{row?.column2}} </ng-template>
+    <ng-template let-row="row"> {{ row?.column2 }} </ng-template>
   </sky-grid-column>
   <sky-grid-column
     id="column3"
@@ -44,12 +44,12 @@
     [width]="dynamicWidth || allColumnWidth"
   />
   @if (showNaNColumn) {
-  <sky-grid-column
-    id="column7"
-    field="column1"
-    heading="Column9"
-    [width]="NaN"
-  />
+    <sky-grid-column
+      id="column7"
+      field="column1"
+      heading="Column9"
+      [width]="NaN"
+    />
   }
   <sky-grid-column
     id="column4"
@@ -73,12 +73,12 @@
     [width]="allColumnWidth"
   />
   @if (showWideColumn) {
-  <sky-grid-column
-    id="column6"
-    field="column1"
-    heading="Column8"
-    [width]="50000"
-  />
+    <sky-grid-column
+      id="column6"
+      field="column1"
+      heading="Column8"
+      [width]="50000"
+    />
   }
 </sky-grid>
 
@@ -87,7 +87,7 @@
 <sky-popover #column4Help> Help content for column 4. </sky-popover>
 
 <ng-template #template1 let-value="value">
-  <div class="sky-test-custom-template">{{value}}</div>
+  <div class="sky-test-custom-template">{{ value }}</div>
 </ng-template>
 
 <button

--- a/libs/components/indicators/src/lib/modules/status-indicator/fixtures/status-indicator.component.fixture.html
+++ b/libs/components/indicators/src/lib/modules/status-indicator/fixtures/status-indicator.component.fixture.html
@@ -4,8 +4,9 @@
   [descriptionType]="descriptionType"
   [indicatorType]="indicatorType"
 >
-  Indicator text @if (showHelp) {
-  <span class="sky-control-help">Help inline</span>
+  Indicator text
+  @if (showHelp) {
+    <span class="sky-control-help">Help inline</span>
   }
 </sky-status-indicator>
 <sky-status-indicator
@@ -13,7 +14,8 @@
   [customDescription]="customDescription"
   [descriptionType]="descriptionType"
 >
-  Indicator text @if (showHelp) {
-  <span class="sky-control-help">Help inline</span>
+  Indicator text
+  @if (showHelp) {
+    <span class="sky-control-help">Help inline</span>
   }
 </sky-status-indicator>

--- a/libs/components/indicators/src/lib/modules/text-highlight/fixtures/text-highlight.component.fixture.html
+++ b/libs/components/indicators/src/lib/modules/text-highlight/fixtures/text-highlight.component.fixture.html
@@ -1,56 +1,55 @@
 @if (!childElementsTest) {
+  <input
+    aria-label="noop"
+    class="sky-input-search-term"
+    type="text"
+    [(ngModel)]="searchTerm"
+  />
 
-<input
-  aria-label="noop"
-  class="sky-input-search-term"
-  type="text"
-  [(ngModel)]="searchTerm"
-/>
+  <input
+    aria-label="noop"
+    class="sky-test-checkbox"
+    type="checkbox"
+    [(ngModel)]="showAdditionalContent"
+  />
 
-<input
-  aria-label="noop"
-  class="sky-test-checkbox"
-  type="checkbox"
-  [(ngModel)]="showAdditionalContent"
-/>
-
-<div class="sky-test-div-container" [skyHighlight]="searchTerm">
-  {{innerText1}} @if (showAdditionalContent) {
-  <div>{{innerText2}}</div>
-  }
-</div>
-
+  <div class="sky-test-div-container" [skyHighlight]="searchTerm">
+    {{ innerText1 }}
+    @if (showAdditionalContent) {
+      <div>{{ innerText2 }}</div>
+    }
+  </div>
 } @else {
-<div class="sky-test-child-elements" [skyHighlight]="searchTerm">
-  <span>a</span>
-  <span>a</span>
-  <span>a</span>
-  <span>a</span>
-  <span>a</span>
-  <span>a</span>
-  <span>a</span>
-  <span>a</span>
-  <span>a</span>
-  <span>a</span>
-  <span>a</span>
-  <span>a</span>
-  <span>a</span>
-  <span>a</span>
-  <span>a</span>
-  <span>a</span>
-  <span>a</span>
-  <span>a</span>
-  <span>a</span>
-  <span>a</span>
-  <span>a</span>
-  <span>a</span>
-  <span>a</span>
-  <span>a</span>
-  <span>a</span>
-  <span>a</span>
-  <span>a</span>
-  <span>a</span>
-  <span>a</span>
-  <span>a.</span>
-</div>
+  <div class="sky-test-child-elements" [skyHighlight]="searchTerm">
+    <span>a</span>
+    <span>a</span>
+    <span>a</span>
+    <span>a</span>
+    <span>a</span>
+    <span>a</span>
+    <span>a</span>
+    <span>a</span>
+    <span>a</span>
+    <span>a</span>
+    <span>a</span>
+    <span>a</span>
+    <span>a</span>
+    <span>a</span>
+    <span>a</span>
+    <span>a</span>
+    <span>a</span>
+    <span>a</span>
+    <span>a</span>
+    <span>a</span>
+    <span>a</span>
+    <span>a</span>
+    <span>a</span>
+    <span>a</span>
+    <span>a</span>
+    <span>a</span>
+    <span>a</span>
+    <span>a</span>
+    <span>a</span>
+    <span>a.</span>
+  </div>
 }

--- a/libs/components/indicators/src/lib/modules/tokens/fixtures/tokens.component.fixture.html
+++ b/libs/components/indicators/src/lib/modules/tokens/fixtures/tokens.component.fixture.html
@@ -12,15 +12,16 @@
   (tokenSelected)="onTokenSelected($event)"
   (tokensRendered)="onTokensRendered()"
 >
-  @if (innerContent === 'text') { INNER CONTENT } @else if (innerContent ===
-  'form-control') {
-  <label>
-    Label
-    <input type="text" />
-  </label>
+  @if (innerContent === 'text') {
+    INNER CONTENT
+  } @else if (innerContent === 'form-control') {
+    <label>
+      Label
+      <input type="text" />
+    </label>
   }
 </sky-tokens>
 
 @if (includeSingleToken) {
-<sky-token [ariaLabel]="ariaLabel" />
+  <sky-token [ariaLabel]="ariaLabel" />
 }

--- a/libs/components/indicators/src/lib/modules/wait/fixtures/wait.component.fixture.html
+++ b/libs/components/indicators/src/lib/modules/wait/fixtures/wait.component.fixture.html
@@ -1,31 +1,32 @@
 @if (showMenuOverlay) {
-<div
-  class="menu-overlay"
-  style="
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100vw;
-    height: 100vh;
-    background-color: oklch(44% 40% 303deg / 30%);
-    z-index: 1000;
-  "
->
-  Menu overlay
-</div>
-} @if (showAnchor0) {
-<button
-  class="sky-btn sky-btn-default"
-  href="/"
-  id="anchor-0"
-  type="button"
-  [ngStyle]="{
-    'display': anchor0Display,
-    'visibility': anchor0Visibility
-  }"
->
-  Anchor tag 0
-</button>
+  <div
+    class="menu-overlay"
+    style="
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 100vw;
+      height: 100vh;
+      background-color: oklch(44% 40% 303deg / 30%);
+      z-index: 1000;
+    "
+  >
+    Menu overlay
+  </div>
+}
+@if (showAnchor0) {
+  <button
+    class="sky-btn sky-btn-default"
+    href="/"
+    id="anchor-0"
+    type="button"
+    [ngStyle]="{
+      display: anchor0Display,
+      visibility: anchor0Visibility
+    }"
+  >
+    Anchor tag 0
+  </button>
 }
 <button class="sky-btn sky-btn-default" href="/" id="anchor-1" type="button">
   Anchor tag 1
@@ -44,18 +45,18 @@
 </div>
 <div>
   @if (showAnchor2) {
-  <button
-    class="sky-btn sky-btn-default"
-    href="/"
-    id="anchor-2"
-    type="button"
-    [ngStyle]="{
-      'display': anchor2Display,
-      'visibility': anchor2Visibility
-    }"
-  >
-    Anchor tag 2
-  </button>
+    <button
+      class="sky-btn sky-btn-default"
+      href="/"
+      id="anchor-2"
+      type="button"
+      [ngStyle]="{
+        display: anchor2Display,
+        visibility: anchor2Visibility
+      }"
+    >
+      Anchor tag 2
+    </button>
   }
   <sky-wait
     [isFullPage]="false"

--- a/libs/components/inline-form/src/lib/modules/inline-form/fixtures/inline-form.fixture.html
+++ b/libs/components/inline-form/src/lib/modules/inline-form/fixtures/inline-form.fixture.html
@@ -21,15 +21,15 @@
 
 <!-- The following forms are for testing autocomplete behavior on init. -->
 @if (showFormWithOutAutocomplete) {
-<sky-inline-form
-  [config]="config"
-  [showForm]="showForm"
-  [template]="formWithOutAutocomplete"
-  (close)="onClose($event)"
->
-  <p>Something</p>
-  <p>Something else</p>
-</sky-inline-form>
+  <sky-inline-form
+    [config]="config"
+    [showForm]="showForm"
+    [template]="formWithOutAutocomplete"
+    (close)="onClose($event)"
+  >
+    <p>Something</p>
+    <p>Something else</p>
+  </sky-inline-form>
 }
 
 <ng-template #formWithOutAutocomplete>
@@ -44,15 +44,15 @@
 </ng-template>
 
 @if (showFormWithAutocomplete) {
-<sky-inline-form
-  [config]="config"
-  [showForm]="showForm"
-  [template]="formWithAutocomplete"
-  (close)="onClose($event)"
->
-  <p>Something</p>
-  <p>Something else</p>
-</sky-inline-form>
+  <sky-inline-form
+    [config]="config"
+    [showForm]="showForm"
+    [template]="formWithAutocomplete"
+    (close)="onClose($event)"
+  >
+    <p>Something</p>
+    <p>Something else</p>
+  </sky-inline-form>
 }
 <ng-template #formWithAutocomplete>
   <div class="sky-form-group">
@@ -66,12 +66,12 @@
 </ng-template>
 
 @if (showFormWithHiddenElements) {
-<sky-inline-form
-  [config]="config"
-  [showForm]="showForm"
-  [template]="formWithHiddenElements"
-  (close)="onClose($event)"
-/>
+  <sky-inline-form
+    [config]="config"
+    [showForm]="showForm"
+    [template]="formWithHiddenElements"
+    (close)="onClose($event)"
+  />
 }
 <ng-template #formWithHiddenElements>
   <div class="sky-form-group">
@@ -90,14 +90,14 @@
 </ng-template>
 
 @if (showFormWithNoElements) {
-<sky-inline-form
-  [config]="config"
-  [showForm]="showForm"
-  [template]="formWithNoElements"
->
-  <p>Something</p>
-  <p>Something else</p>
-</sky-inline-form>
+  <sky-inline-form
+    [config]="config"
+    [showForm]="showForm"
+    [template]="formWithNoElements"
+  >
+    <p>Something</p>
+    <p>Something else</p>
+  </sky-inline-form>
 }
 <ng-template #formWithNoElements>
   <p>This form is empty!</p>

--- a/libs/components/layout/src/lib/modules/action-button/fixtures/action-button-ngfor.component.fixture.html
+++ b/libs/components/layout/src/lib/modules/action-button/fixtures/action-button-ngfor.component.fixture.html
@@ -1,8 +1,10 @@
 <sky-action-button-container>
   @for (item of items; track item) {
-  <sky-action-button>
-    <sky-action-button-header> {{ item.header }} </sky-action-button-header>
-    <sky-action-button-details> {{ item.details }} </sky-action-button-details>
-  </sky-action-button>
+    <sky-action-button>
+      <sky-action-button-header> {{ item.header }} </sky-action-button-header>
+      <sky-action-button-details>
+        {{ item.details }}
+      </sky-action-button-details>
+    </sky-action-button>
   }
 </sky-action-button-container>

--- a/libs/components/layout/src/lib/modules/back-to-top/fixtures/back-to-top.component.fixture.html
+++ b/libs/components/layout/src/lib/modules/back-to-top/fixtures/back-to-top.component.fixture.html
@@ -2,7 +2,10 @@
   id="back-to-top-parent"
   style="width: 400px; margin: 0 auto"
   [attr.hidden]="hideParent ? true : undefined"
-  [ngStyle]="{'height': height + 'px', 'overflow': scrollableParent ? 'auto' : null}"
+  [ngStyle]="{
+    height: height + 'px',
+    overflow: scrollableParent ? 'auto' : null
+  }"
 >
   <p
     id="back-to-top-target"

--- a/libs/components/layout/src/lib/modules/box/fixtures/box.component.fixture.html
+++ b/libs/components/layout/src/lib/modules/box/fixtures/box.component.fixture.html
@@ -11,9 +11,9 @@
   [helpPopoverTitle]="helpPopoverTitle"
 >
   @if (showHeader) {
-  <sky-box-header>
-    <h2 class="sky-font-heading-2" id="my-header">Header</h2>
-  </sky-box-header>
+    <sky-box-header>
+      <h2 class="sky-font-heading-2" id="my-header">Header</h2>
+    </sky-box-header>
   }
   <sky-box-controls>
     <button class="sky-btn sky-btn-default sky-btn-icon" type="button">

--- a/libs/components/layout/src/lib/modules/card/fixtures/card.component.fixture.html
+++ b/libs/components/layout/src/lib/modules/card/fixtures/card.component.fixture.html
@@ -4,14 +4,15 @@
   [(selected)]="cardSelected"
 >
   @if (showTitle) {
-  <sky-card-title> Title </sky-card-title>
+    <sky-card-title> Title </sky-card-title>
   }
   <sky-card-content> Content </sky-card-content>
   @if (showActions) {
-  <sky-card-actions>
-    <button type="button" class="btn btn-default">Button</button>
-  </sky-card-actions>
-  } @if (showDelete) {
-  <sky-inline-delete />
+    <sky-card-actions>
+      <button type="button" class="btn btn-default">Button</button>
+    </sky-card-actions>
+  }
+  @if (showDelete) {
+    <sky-inline-delete />
   }
 </sky-card>

--- a/libs/components/layout/src/lib/modules/definition-list/fixtures/definition-list.component.fixture.html
+++ b/libs/components/layout/src/lib/modules/definition-list/fixtures/definition-list.component.fixture.html
@@ -4,10 +4,14 @@
       Personal information
     </sky-definition-list-heading>
     @for (item of personalInfo; track item) {
-    <sky-definition-list-content>
-      <sky-definition-list-label> {{item.label}} </sky-definition-list-label>
-      <sky-definition-list-value> {{item.value}} </sky-definition-list-value>
-    </sky-definition-list-content>
+      <sky-definition-list-content>
+        <sky-definition-list-label>
+          {{ item.label }}
+        </sky-definition-list-label>
+        <sky-definition-list-value>
+          {{ item.value }}
+        </sky-definition-list-value>
+      </sky-definition-list-content>
     }
   </sky-definition-list>
 </div>
@@ -17,10 +21,14 @@
       System information
     </sky-definition-list-heading>
     @for (item of systemInfo; track item) {
-    <sky-definition-list-content>
-      <sky-definition-list-label> {{item.label}} </sky-definition-list-label>
-      <sky-definition-list-value> {{item.value}} </sky-definition-list-value>
-    </sky-definition-list-content>
+      <sky-definition-list-content>
+        <sky-definition-list-label>
+          {{ item.label }}
+        </sky-definition-list-label>
+        <sky-definition-list-value>
+          {{ item.value }}
+        </sky-definition-list-value>
+      </sky-definition-list-content>
     }
   </sky-definition-list>
 </div>

--- a/libs/components/layout/src/lib/modules/description-list/fixtures/description-list.component.fixture.html
+++ b/libs/components/layout/src/lib/modules/description-list/fixtures/description-list.component.fixture.html
@@ -1,51 +1,51 @@
 <div class="sky-description-list-test-1">
   <sky-description-list [listItemWidth]="listItemWidth" [mode]="mode">
     @for (item of personalInfo; track item) {
-    <sky-description-list-content>
-      <sky-description-list-term> {{item.term}} </sky-description-list-term>
-      <sky-description-list-description>
-        {{item.description}}
-      </sky-description-list-description>
-    </sky-description-list-content>
+      <sky-description-list-content>
+        <sky-description-list-term> {{ item.term }} </sky-description-list-term>
+        <sky-description-list-description>
+          {{ item.description }}
+        </sky-description-list-description>
+      </sky-description-list-content>
     }
   </sky-description-list>
 </div>
 <div class="sky-description-list-test-2">
   <sky-description-list defaultDescription="No information found">
     @for (item of systemInfo; track item) {
-    <sky-description-list-content>
-      <sky-description-list-term> {{item.term}} </sky-description-list-term>
-      <sky-description-list-description>
-        {{item.description}}
-      </sky-description-list-description>
-    </sky-description-list-content>
+      <sky-description-list-content>
+        <sky-description-list-term> {{ item.term }} </sky-description-list-term>
+        <sky-description-list-description>
+          {{ item.description }}
+        </sky-description-list-description>
+      </sky-description-list-content>
     }
   </sky-description-list>
 </div>
 <div class="sky-description-list-test-3">
   <sky-description-list defaultDescription="Not yet loaded">
     @for (item of asyncInfo; track item) {
-    <sky-description-list-content>
-      <sky-description-list-term> {{item.term}} </sky-description-list-term>
-      <sky-description-list-description>
-        {{item.description | async}}
-      </sky-description-list-description>
-    </sky-description-list-content>
+      <sky-description-list-content>
+        <sky-description-list-term> {{ item.term }} </sky-description-list-term>
+        <sky-description-list-description>
+          {{ item.description | async }}
+        </sky-description-list-description>
+      </sky-description-list-content>
     }
   </sky-description-list>
 </div>
 <div class="sky-description-list-test-4">
   <sky-description-list>
     @for (item of personalInfo; track item) {
-    <sky-description-list-content>
-      <sky-description-list-term>
-        {{item.term}}
-        <span class="sky-control-help">Help inline</span>
-      </sky-description-list-term>
-      <sky-description-list-description>
-        {{item.description}}
-      </sky-description-list-description>
-    </sky-description-list-content>
+      <sky-description-list-content>
+        <sky-description-list-term>
+          {{ item.term }}
+          <span class="sky-control-help">Help inline</span>
+        </sky-description-list-term>
+        <sky-description-list-description>
+          {{ item.description }}
+        </sky-description-list-description>
+      </sky-description-list-content>
     }
   </sky-description-list>
 </div>

--- a/libs/components/layout/src/lib/modules/inline-delete/fixtures/inline-delete.component.fixture.html
+++ b/libs/components/layout/src/lib/modules/inline-delete/fixtures/inline-delete.component.fixture.html
@@ -1,19 +1,20 @@
 @if (showExtraButtons) {
-<button id="noop-button-1" type="button">Noop Button 1</button>
+  <button id="noop-button-1" type="button">Noop Button 1</button>
 }
 <div id="inline-delete-fixture" [tabIndex]="parentTabIndex">
   @if (showCoveredButtons) {
-  <button id="covered-button" type="button">Covered Button</button>
-  <button id="covered-button-2" type="button">Covered Button 2</button>
-  } @if (showDelete) {
-  <sky-inline-delete
-    [pending]="pending"
-    (cancelTriggered)="onCancelTriggered()"
-    (deleteTriggered)="onDeleteTriggered()"
-  />
+    <button id="covered-button" type="button">Covered Button</button>
+    <button id="covered-button-2" type="button">Covered Button 2</button>
+  }
+  @if (showDelete) {
+    <sky-inline-delete
+      [pending]="pending"
+      (cancelTriggered)="onCancelTriggered()"
+      (deleteTriggered)="onDeleteTriggered()"
+    />
   }
 </div>
 <button id="hidden-button" type="button">Hidden Button</button>
 @if (showExtraButtons) {
-<button id="noop-button-2" type="button">Noop Button 2</button>
+  <button id="noop-button-2" type="button">Noop Button 2</button>
 }

--- a/libs/components/layout/src/lib/modules/page-summary/fixtures/page-summary.component.fixture.html
+++ b/libs/components/layout/src/lib/modules/page-summary/fixtures/page-summary.component.fixture.html
@@ -1,7 +1,7 @@
 <sky-page-summary>
   @if (showKeyInfo) {
-  <sky-page-summary-key-info>
-    <div class="key-info-find-me">Key Info</div>
-  </sky-page-summary-key-info>
+    <sky-page-summary-key-info>
+      <div class="key-info-find-me">Key Info</div>
+    </sky-page-summary-key-info>
   }
 </sky-page-summary>

--- a/libs/components/list-builder-view-grids/src/lib/modules/list-view-grid/fixtures/list-view-grid-display.component.fixture.html
+++ b/libs/components/list-builder-view-grids/src/lib/modules/list-view-grid/fixtures/list-view-grid-display.component.fixture.html
@@ -5,7 +5,7 @@
 >
   <sky-grid-column field="column1" heading="Column1" [locked]="true" />
   <sky-grid-column field="column2" heading="Column2" [width]="150">
-    <ng-template let-row="row">{{row.column2}}</ng-template>
+    <ng-template let-row="row">{{ row.column2 }}</ng-template>
   </sky-grid-column>
   <sky-grid-column
     id="column3"
@@ -25,6 +25,6 @@
   <sky-grid-column id="hiddenCol2" field="column1" heading="Column7" />
 </sky-list-view-grid>
 
-<ng-template #template1 let-value="value"> {{value}} </ng-template>
+<ng-template #template1 let-value="value"> {{ value }} </ng-template>
 
 <ng-template #template2> Testing </ng-template>

--- a/libs/components/list-builder-view-grids/src/lib/modules/list-view-grid/fixtures/list-view-grid-dynamic.component.fixture.html
+++ b/libs/components/list-builder-view-grids/src/lib/modules/list-view-grid/fixtures/list-view-grid-dynamic.component.fixture.html
@@ -1,10 +1,10 @@
 <sky-list [data]="data">
   <sky-list-view-grid fit="scroll" [name]="gridview">
     @for (gridColumn of gridColumns; track gridColumn) {
-    <sky-grid-column
-      [field]="gridColumn.field"
-      [heading]="gridColumn.heading"
-    />
+      <sky-grid-column
+        [field]="gridColumn.field"
+        [heading]="gridColumn.heading"
+      />
     }
   </sky-list-view-grid>
 </sky-list>

--- a/libs/components/list-builder-view-grids/src/lib/modules/list-view-grid/fixtures/list-view-grid.component.fixture.html
+++ b/libs/components/list-builder-view-grids/src/lib/modules/list-view-grid/fixtures/list-view-grid.component.fixture.html
@@ -22,7 +22,7 @@
   />
 
   <sky-grid-column field="column2" heading="Column2" [width]="150">
-    <ng-template let-row="row"> {{row.column2}} </ng-template>
+    <ng-template let-row="row"> {{ row.column2 }} </ng-template>
   </sky-grid-column>
 
   <sky-grid-column
@@ -42,10 +42,10 @@
   <sky-grid-column id="hiddenCol2" field="column1" heading="Column7" />
 
   @if (showNgIfCol) {
-  <sky-grid-column id="ngIfCol" field="column1" heading="Column8" />
+    <sky-grid-column id="ngIfCol" field="column1" heading="Column8" />
   }
 </sky-list-view-grid>
 
-<ng-template #template1 let-value="value"> {{value}} </ng-template>
+<ng-template #template1 let-value="value"> {{ value }} </ng-template>
 
 <ng-template #toolbarItem> Custom </ng-template>

--- a/libs/components/list-builder/src/lib/modules/list-toolbar/fixtures/list-toolbar.component.fixture.html
+++ b/libs/components/list-builder/src/lib/modules/list-toolbar/fixtures/list-toolbar.component.fixture.html
@@ -7,9 +7,9 @@
   [toolbarType]="toolbarType"
 >
   @if (showCustomItem1) {
-  <sky-list-toolbar-item id="custom-item" location="right" [index]="2">
-    <ng-template>Custom Item</ng-template>
-  </sky-list-toolbar-item>
+    <sky-list-toolbar-item id="custom-item" location="right" [index]="2">
+      <ng-template>Custom Item</ng-template>
+    </sky-list-toolbar-item>
   }
   <sky-list-toolbar-item id="custom-item-test2" location="right">
     <ng-template>Custom Item 2</ng-template>

--- a/libs/components/list-builder/src/lib/modules/list-toolbar/list-secondary-actions/fixtures/list-secondary-actions.component.fixture.html
+++ b/libs/components/list-builder/src/lib/modules/list-toolbar/list-secondary-actions/fixtures/list-secondary-actions.component.fixture.html
@@ -1,9 +1,9 @@
 <sky-list-toolbar>
   <sky-list-secondary-actions>
     @if (showOption) {
-    <sky-list-secondary-action>
-      <button type="button">Option</button>
-    </sky-list-secondary-action>
+      <sky-list-secondary-action>
+        <button type="button">Option</button>
+      </sky-list-secondary-action>
     }
   </sky-list-secondary-actions>
 </sky-list-toolbar>

--- a/libs/components/list-builder/src/lib/modules/list/fixtures/list-view-test.component.fixture.html
+++ b/libs/components/list-builder/src/lib/modules/list/fixtures/list-view-test.component.fixture.html
@@ -1,9 +1,9 @@
 @for (item of items; track item) {
-<div class="list-view-test-item">
-  <span class="list-view-test-item-id">{{ item.id }}</span>
-  <span class="list-view-test-item-column1">{{ item.data.column1 }}</span>
-  <span class="list-view-test-item-column2">{{ item.data.column2 }}</span>
-  <span class="list-view-test-item-column3">{{ item.data.column3 }}</span>
-  <span class="list-view-test-item-column4">{{ item.data.column4 }}</span>
-</div>
+  <div class="list-view-test-item">
+    <span class="list-view-test-item-id">{{ item.id }}</span>
+    <span class="list-view-test-item-column1">{{ item.data.column1 }}</span>
+    <span class="list-view-test-item-column2">{{ item.data.column2 }}</span>
+    <span class="list-view-test-item-column3">{{ item.data.column3 }}</span>
+    <span class="list-view-test-item-column4">{{ item.data.column4 }}</span>
+  </div>
 }

--- a/libs/components/lists/src/lib/modules/filter/fixtures/filter-summary.component.fixture.html
+++ b/libs/components/lists/src/lib/modules/filter/fixtures/filter-summary.component.fixture.html
@@ -1,11 +1,11 @@
 <sky-filter-summary>
   @for (item of appliedFilters; track item; let i = $index) {
-  <sky-filter-summary-item
-    [dismissible]="item.dismissible"
-    (dismiss)="onDismiss(i)"
-    (itemClick)="filterButtonClicked()"
-  >
-    {{item.label}}
-  </sky-filter-summary-item>
+    <sky-filter-summary-item
+      [dismissible]="item.dismissible"
+      (dismiss)="onDismiss(i)"
+      (itemClick)="filterButtonClicked()"
+    >
+      {{ item.label }}
+    </sky-filter-summary-item>
   }
 </sky-filter-summary>

--- a/libs/components/lists/src/lib/modules/infinite-scroll/fixtures/infinite-scroll.component.fixture.html
+++ b/libs/components/lists/src/lib/modules/infinite-scroll/fixtures/infinite-scroll.component.fixture.html
@@ -1,7 +1,7 @@
 <div #wrapper>
   <ul>
     @for (item of items; track item) {
-    <li>{{ item.name }}</li>
+      <li>{{ item.name }}</li>
     }
   </ul>
 

--- a/libs/components/lists/src/lib/modules/repeater/fixtures/a11y-repeater.component.fixture.html
+++ b/libs/components/lists/src/lib/modules/repeater/fixtures/a11y-repeater.component.fixture.html
@@ -4,25 +4,29 @@
   [(activeIndex)]="activeIndex"
 >
   @for (item of items; track item) {
-  <sky-repeater-item
-    [selectable]="item.selectable"
-    [disabled]="item.disabled"
-    [isExpanded]="item.expanded"
-    [isSelected]="item.selected"
-    [reorderable]="item.reorderable ?? reorderable"
-    [tag]="item.tag"
-  >
-    @if (item.context) {
-    <sky-repeater-item-context-menu>
-      <sky-dropdown buttonType="context-menu">
-        <sky-dropdown-button />
-      </sky-dropdown>
-    </sky-repeater-item-context-menu>
-    } @if (item.title) {
-    <sky-repeater-item-title> {{ item.title }} </sky-repeater-item-title>
-    } @if (item.message) {
-    <sky-repeater-item-content> {{ item.message }} </sky-repeater-item-content>
-    }
-  </sky-repeater-item>
+    <sky-repeater-item
+      [selectable]="item.selectable"
+      [disabled]="item.disabled"
+      [isExpanded]="item.expanded"
+      [isSelected]="item.selected"
+      [reorderable]="item.reorderable ?? reorderable"
+      [tag]="item.tag"
+    >
+      @if (item.context) {
+        <sky-repeater-item-context-menu>
+          <sky-dropdown buttonType="context-menu">
+            <sky-dropdown-button />
+          </sky-dropdown>
+        </sky-repeater-item-context-menu>
+      }
+      @if (item.title) {
+        <sky-repeater-item-title> {{ item.title }} </sky-repeater-item-title>
+      }
+      @if (item.message) {
+        <sky-repeater-item-content>
+          {{ item.message }}
+        </sky-repeater-item-content>
+      }
+    </sky-repeater-item>
   }
 </sky-repeater>

--- a/libs/components/lists/src/lib/modules/repeater/fixtures/repeater.component.fixture.html
+++ b/libs/components/lists/src/lib/modules/repeater/fixtures/repeater.component.fixture.html
@@ -1,131 +1,135 @@
 @if (!showRepeaterWithActiveIndex && !showRepeaterWithNgFor) {
-<sky-repeater
-  [expandMode]="expandMode"
-  [reorderable]="reorderable"
-  (orderChange)="onOrderChange($event)"
->
-  <sky-repeater-item
-    [disabled]="disableFirstItem"
-    [itemName]="showItemName ? 'Item 1' : undefined"
-    [selectable]="selectable"
-    [tag]="'item1'"
-    (collapse)="onCollapse()"
-    (expand)="onExpand()"
-    (isSelectedChange)="onIsSelectedChange($event)"
+  <sky-repeater
+    [expandMode]="expandMode"
+    [reorderable]="reorderable"
+    (orderChange)="onOrderChange($event)"
   >
-    @if (showContextMenu) {
-    <sky-repeater-item-context-menu>
-      <sky-dropdown buttonType="context-menu">
-        <sky-dropdown-menu>
-          <sky-dropdown-item>
-            <button type="button">Option 1</button>
-          </sky-dropdown-item>
-        </sky-dropdown-menu>
-      </sky-dropdown>
-    </sky-repeater-item-context-menu>
+    <sky-repeater-item
+      [disabled]="disableFirstItem"
+      [itemName]="showItemName ? 'Item 1' : undefined"
+      [selectable]="selectable"
+      [tag]="'item1'"
+      (collapse)="onCollapse()"
+      (expand)="onExpand()"
+      (isSelectedChange)="onIsSelectedChange($event)"
+    >
+      @if (showContextMenu) {
+        <sky-repeater-item-context-menu>
+          <sky-dropdown buttonType="context-menu">
+            <sky-dropdown-menu>
+              <sky-dropdown-item>
+                <button type="button">Option 1</button>
+              </sky-dropdown-item>
+            </sky-dropdown-menu>
+          </sky-dropdown>
+        </sky-repeater-item-context-menu>
+      }
+      <sky-repeater-item-title>Title 1</sky-repeater-item-title>
+      <sky-repeater-item-content>
+        <a href="/"> link 1 </a>
+        Content 1
+        <a href="/"> link 2 </a>
+        <label for="inputField">Field</label>
+        <input type="text" id="inputField" />
+      </sky-repeater-item-content>
+    </sky-repeater-item>
+    <sky-repeater-item
+      [itemName]="showItemName ? 'Item 2' : undefined"
+      [tag]="'item2'"
+      [selectable]="selectable"
+    >
+      @if (showContextMenu) {
+        <sky-repeater-item-context-menu>
+          <sky-dropdown buttonType="context-menu">
+            <sky-dropdown-menu>
+              <sky-dropdown-item>
+                <button type="button">Option 1</button>
+              </sky-dropdown-item>
+            </sky-dropdown-menu>
+          </sky-dropdown>
+        </sky-repeater-item-context-menu>
+      }
+      <sky-repeater-item-title> Title 2 </sky-repeater-item-title>
+      <sky-repeater-item-content> Content 2 </sky-repeater-item-content>
+    </sky-repeater-item>
+    @if (!removeLastItem) {
+      <sky-repeater-item
+        [itemName]="showItemName ? 'Item 3' : undefined"
+        [isExpanded]="lastItemExpanded"
+        [selectable]="selectable"
+        [tag]="'item3'"
+        [(isSelected)]="lastItemSelected"
+      >
+        @if (showContextMenu) {
+          <sky-repeater-item-context-menu>
+            <sky-dropdown buttonType="context-menu">
+              <sky-dropdown-menu>
+                <sky-dropdown-item>
+                  <button type="button">Option 1</button>
+                </sky-dropdown-item>
+              </sky-dropdown-menu>
+            </sky-dropdown>
+          </sky-repeater-item-context-menu>
+        }
+        <sky-repeater-item-title> Title 3 </sky-repeater-item-title>
+        <sky-repeater-item-content> Content 3 </sky-repeater-item-content>
+      </sky-repeater-item>
     }
-    <sky-repeater-item-title>Title 1</sky-repeater-item-title>
-    <sky-repeater-item-content>
-      <a href="/"> link 1 </a>
-      Content 1
-      <a href="/"> link 2 </a>
-      <label for="inputField">Field</label>
-      <input type="text" id="inputField" />
-    </sky-repeater-item-content>
-  </sky-repeater-item>
-  <sky-repeater-item
-    [itemName]="showItemName ? 'Item 2' : undefined"
-    [tag]="'item2'"
-    [selectable]="selectable"
+    @if (showItemWithNoContent) {
+      <sky-repeater-item>
+        <sky-repeater-item-title> No Content </sky-repeater-item-title>
+        @if (showDynamicContent) {
+          <sky-repeater-item-content> Content 3 </sky-repeater-item-content>
+        }
+      </sky-repeater-item>
+    }
+    @if (showItemWithNoTitle) {
+      <sky-repeater-item>
+        @if (showContextMenu) {
+          <sky-repeater-item-context-menu>
+            <sky-dropdown buttonType="context-menu">
+              <sky-dropdown-menu>
+                <sky-dropdown-item>
+                  <button type="button">Option 1</button>
+                </sky-dropdown-item>
+              </sky-dropdown-menu>
+            </sky-dropdown>
+          </sky-repeater-item-context-menu>
+        }
+        <sky-repeater-item-content>
+          Content with no title
+        </sky-repeater-item-content>
+      </sky-repeater-item>
+    }
+  </sky-repeater>
+}
+@if (showRepeaterWithActiveIndex) {
+  <sky-repeater
+    [expandMode]="expandMode"
+    [reorderable]="reorderable"
+    [(activeIndex)]="activeIndex"
   >
-    @if (showContextMenu) {
-    <sky-repeater-item-context-menu>
-      <sky-dropdown buttonType="context-menu">
-        <sky-dropdown-menu>
-          <sky-dropdown-item>
-            <button type="button">Option 1</button>
-          </sky-dropdown-item>
-        </sky-dropdown-menu>
-      </sky-dropdown>
-    </sky-repeater-item-context-menu>
+    <sky-repeater-item [disabled]="disableFirstItem">
+      <sky-repeater-item-title> Title 1 </sky-repeater-item-title>
+    </sky-repeater-item>
+    <sky-repeater-item>
+      <sky-repeater-item-title> Title 2 </sky-repeater-item-title>
+    </sky-repeater-item>
+    <sky-repeater-item>
+      <sky-repeater-item-title> Title 3 </sky-repeater-item-title>
+    </sky-repeater-item>
+  </sky-repeater>
+}
+@if (showRepeaterWithNgFor) {
+  <sky-repeater [reorderable]="reorderable">
+    @for (item of items; track item) {
+      <sky-repeater-item
+        [tag]="item.id"
+        [disabled]="item.id === 'item1' && disableFirstItem"
+        [selectable]="selectable"
+      >
+        <sky-repeater-item-title> {{ item.title }} </sky-repeater-item-title>
+      </sky-repeater-item>
     }
-    <sky-repeater-item-title> Title 2 </sky-repeater-item-title>
-    <sky-repeater-item-content> Content 2 </sky-repeater-item-content>
-  </sky-repeater-item>
-  @if (!removeLastItem) {
-  <sky-repeater-item
-    [itemName]="showItemName ? 'Item 3' : undefined"
-    [isExpanded]="lastItemExpanded"
-    [selectable]="selectable"
-    [tag]="'item3'"
-    [(isSelected)]="lastItemSelected"
-  >
-    @if (showContextMenu) {
-    <sky-repeater-item-context-menu>
-      <sky-dropdown buttonType="context-menu">
-        <sky-dropdown-menu>
-          <sky-dropdown-item>
-            <button type="button">Option 1</button>
-          </sky-dropdown-item>
-        </sky-dropdown-menu>
-      </sky-dropdown>
-    </sky-repeater-item-context-menu>
-    }
-    <sky-repeater-item-title> Title 3 </sky-repeater-item-title>
-    <sky-repeater-item-content> Content 3 </sky-repeater-item-content>
-  </sky-repeater-item>
-  } @if (showItemWithNoContent) {
-  <sky-repeater-item>
-    <sky-repeater-item-title> No Content </sky-repeater-item-title>
-    @if (showDynamicContent) {
-    <sky-repeater-item-content> Content 3 </sky-repeater-item-content>
-    }
-  </sky-repeater-item>
-  } @if (showItemWithNoTitle) {
-  <sky-repeater-item>
-    @if (showContextMenu) {
-    <sky-repeater-item-context-menu>
-      <sky-dropdown buttonType="context-menu">
-        <sky-dropdown-menu>
-          <sky-dropdown-item>
-            <button type="button">Option 1</button>
-          </sky-dropdown-item>
-        </sky-dropdown-menu>
-      </sky-dropdown>
-    </sky-repeater-item-context-menu>
-    }
-    <sky-repeater-item-content>
-      Content with no title
-    </sky-repeater-item-content>
-  </sky-repeater-item>
-  }
-</sky-repeater>
-} @if (showRepeaterWithActiveIndex) {
-<sky-repeater
-  [expandMode]="expandMode"
-  [reorderable]="reorderable"
-  [(activeIndex)]="activeIndex"
->
-  <sky-repeater-item [disabled]="disableFirstItem">
-    <sky-repeater-item-title> Title 1 </sky-repeater-item-title>
-  </sky-repeater-item>
-  <sky-repeater-item>
-    <sky-repeater-item-title> Title 2 </sky-repeater-item-title>
-  </sky-repeater-item>
-  <sky-repeater-item>
-    <sky-repeater-item-title> Title 3 </sky-repeater-item-title>
-  </sky-repeater-item>
-</sky-repeater>
-} @if (showRepeaterWithNgFor) {
-<sky-repeater [reorderable]="reorderable">
-  @for (item of items; track item) {
-  <sky-repeater-item
-    [tag]="item.id"
-    [disabled]="item.id === 'item1' && disableFirstItem"
-    [selectable]="selectable"
-  >
-    <sky-repeater-item-title> {{ item.title }} </sky-repeater-item-title>
-  </sky-repeater-item>
-  }
-</sky-repeater>
+  </sky-repeater>
 }

--- a/libs/components/lists/src/lib/modules/sort/fixtures/sort.component.fixture.html
+++ b/libs/components/lists/src/lib/modules/sort/fixtures/sort.component.fixture.html
@@ -1,10 +1,10 @@
 <sky-sort [ariaLabel]="ariaLabel" [showButtonText]="showButtonText">
   @for (item of sortOptions; track item) {
-  <sky-sort-item
-    [active]="initialState === item.id"
-    (itemSelect)="sortItems(item)"
-  >
-    {{item.label}}
-  </sky-sort-item>
+    <sky-sort-item
+      [active]="initialState === item.id"
+      (itemSelect)="sortItems(item)"
+    >
+      {{ item.label }}
+    </sky-sort-item>
   }
 </sky-sort>

--- a/libs/components/lists/testing/src/legacy/sort/fixtures/sort-fixture.component.fixture.html
+++ b/libs/components/lists/testing/src/legacy/sort/fixtures/sort-fixture.component.fixture.html
@@ -2,27 +2,27 @@
   <sky-toolbar-item>
     <sky-sort data-sky-id="test-sort-fixture" [showButtonText]="true">
       @for (item of sortOptions; track item) {
-      <sky-sort-item
-        [active]="initialState === item.id"
-        (itemSelect)="sortItems(item)"
-      >
-        {{item.label}}
-      </sky-sort-item>
+        <sky-sort-item
+          [active]="initialState === item.id"
+          (itemSelect)="sortItems(item)"
+        >
+          {{ item.label }}
+        </sky-sort-item>
       }
     </sky-sort>
   </sky-toolbar-item>
 </sky-toolbar>
 <sky-repeater expandMode="none">
   @for (item of sortedItems; track item.title) {
-  <sky-repeater-item>
-    <sky-repeater-item-title> {{item.title}} </sky-repeater-item-title>
-    <sky-repeater-item-content>
-      <div style="display: flex; justify-content: space-between">
-        <div>Assigned to {{item.assignee}}</div>
-        <div>Created {{item.date | date}}</div>
-      </div>
-      <div>{{item.note}}</div>
-    </sky-repeater-item-content>
-  </sky-repeater-item>
+    <sky-repeater-item>
+      <sky-repeater-item-title> {{ item.title }} </sky-repeater-item-title>
+      <sky-repeater-item-content>
+        <div style="display: flex; justify-content: space-between">
+          <div>Assigned to {{ item.assignee }}</div>
+          <div>Created {{ item.date | date }}</div>
+        </div>
+        <div>{{ item.note }}</div>
+      </sky-repeater-item-content>
+    </sky-repeater-item>
   }
 </sky-repeater>

--- a/libs/components/lookup/src/lib/modules/autocomplete/fixtures/autocomplete.component.fixture.html
+++ b/libs/components/lookup/src/lib/modules/autocomplete/fixtures/autocomplete.component.fixture.html
@@ -28,15 +28,15 @@
     (showMoreClick)="onShowMoreClick()"
   >
     @if (!hideInput) {
-    <input
-      id="my-autocomplete-input"
-      name="favoriteColor"
-      skyAutocomplete
-      type="text"
-      [autocompleteAttribute]="autocompleteAttribute"
-      [disabled]="disabled"
-      [(ngModel)]="model.favoriteColor"
-    />
+      <input
+        id="my-autocomplete-input"
+        name="favoriteColor"
+        skyAutocomplete
+        type="text"
+        [autocompleteAttribute]="autocompleteAttribute"
+        [disabled]="disabled"
+        [(ngModel)]="model.favoriteColor"
+      />
     }
   </sky-autocomplete>
 </form>
@@ -70,15 +70,15 @@
     (showMoreClick)="onShowMoreClick()"
   >
     @if (!hideInput) {
-    <input
-      id="my-async-autocomplete-input"
-      name="favoriteColor"
-      skyAutocomplete
-      type="text"
-      [autocompleteAttribute]="autocompleteAttribute"
-      [disabled]="disabled"
-      [(ngModel)]="model.favoriteColor"
-    />
+      <input
+        id="my-async-autocomplete-input"
+        name="favoriteColor"
+        skyAutocomplete
+        type="text"
+        [autocompleteAttribute]="autocompleteAttribute"
+        [disabled]="disabled"
+        [(ngModel)]="model.favoriteColor"
+      />
     }
   </sky-autocomplete>
 </form>

--- a/libs/components/modals/src/lib/modules/modal/fixtures/modal.component.fixture.html
+++ b/libs/components/modals/src/lib/modules/modal/fixtures/modal.component.fixture.html
@@ -8,19 +8,23 @@
   <sky-modal-header>Test</sky-modal-header>
   <sky-modal-content>
     <div class="modal-fixture-content">
-      Content @if (longContent) { @for (number of [0,1,2,3,4,5,6,7]; track
-      number) { Lorem ipsum pellentesque habitant morbi tristique senectus et
-      netus et malesuada fames ac turpis egestas. Vestibulum tortor quam,
-      feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit
-      amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat
-      eleifend leo. Quisque sit amet est et sapien ullamcorper pharetra.
-      Vestibulum erat wisi, condimentum sed, commodo vitae, ornare sit amet,
-      wisi. Aenean fermentum, elit eget tincidunt condimentum, eros ipsum rutrum
-      orci, sagittis tempus lacus enim ac dui. Donec non enim in turpis pulvinar
-      facilisis. Ut felis. Praesent dapibus, neque id cursus faucibus, tortor
-      neque egestas augue, eu vulputate magna eros eu erat. Aliquam erat
-      volutpat. Nam dui mi, tincidunt quis, accumsan porttitor, facilisis
-      luctus, metus } }
+      Content
+      @if (longContent) {
+        @for (number of [0, 1, 2, 3, 4, 5, 6, 7]; track number) {
+          Lorem ipsum pellentesque habitant morbi tristique senectus et netus et
+          malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat
+          vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet
+          quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat
+          eleifend leo. Quisque sit amet est et sapien ullamcorper pharetra.
+          Vestibulum erat wisi, condimentum sed, commodo vitae, ornare sit amet,
+          wisi. Aenean fermentum, elit eget tincidunt condimentum, eros ipsum
+          rutrum orci, sagittis tempus lacus enim ac dui. Donec non enim in
+          turpis pulvinar facilisis. Ut felis. Praesent dapibus, neque id cursus
+          faucibus, tortor neque egestas augue, eu vulputate magna eros eu erat.
+          Aliquam erat volutpat. Nam dui mi, tincidunt quis, accumsan porttitor,
+          facilisis luctus, metus
+        }
+      }
     </div>
   </sky-modal-content>
 </sky-modal>

--- a/libs/components/phone-field/src/lib/modules/phone-field/fixtures/phone-field-reactive.component.fixture.html
+++ b/libs/components/phone-field/src/lib/modules/phone-field/fixtures/phone-field-reactive.component.fixture.html
@@ -1,23 +1,24 @@
 <form [formGroup]="phoneForm">
   <label for="phone-field-reactive-input">Reactive phone field</label>
   @if (showPhoneField) {
-  <sky-phone-field
-    [allowExtensions]="allowExtensions"
-    [defaultCountry]="defaultCountry"
-    [returnFormat]="returnFormat"
-    [supportedCountryISOs]="supportedCountryISOs"
-    [(selectedCountry)]="selectedCountry"
-  >
-    <input
-      id="phone-field-reactive-input"
-      formControlName="phone"
-      skyPhoneFieldInput
-      [skyPhoneFieldNoValidate]="noValidate"
-    />
-  </sky-phone-field>
-  } @if (showInvalidDirective) {
-  <div>
-    <input type="text" skyPhoneFieldInput />
-  </div>
+    <sky-phone-field
+      [allowExtensions]="allowExtensions"
+      [defaultCountry]="defaultCountry"
+      [returnFormat]="returnFormat"
+      [supportedCountryISOs]="supportedCountryISOs"
+      [(selectedCountry)]="selectedCountry"
+    >
+      <input
+        id="phone-field-reactive-input"
+        formControlName="phone"
+        skyPhoneFieldInput
+        [skyPhoneFieldNoValidate]="noValidate"
+      />
+    </sky-phone-field>
+  }
+  @if (showInvalidDirective) {
+    <div>
+      <input type="text" skyPhoneFieldInput />
+    </div>
   }
 </form>

--- a/libs/components/phone-field/src/lib/modules/phone-field/fixtures/phone-field.component.fixture.html
+++ b/libs/components/phone-field/src/lib/modules/phone-field/fixtures/phone-field.component.fixture.html
@@ -17,8 +17,8 @@
   </sky-phone-field>
 
   @if (showInvalidDirective) {
-  <div>
-    <input type="text" skyPhoneFieldInput />
-  </div>
+    <div>
+      <input type="text" skyPhoneFieldInput />
+    </div>
   }
 </div>

--- a/libs/components/popovers/src/lib/modules/dropdown/fixtures/dropdown.component.fixture.html
+++ b/libs/components/popovers/src/lib/modules/dropdown/fixtures/dropdown.component.fixture.html
@@ -1,71 +1,73 @@
-@if (show) { @if (useCustomTrigger) {
-<sky-dropdown
-  #dropdownRef
-  [buttonStyle]="buttonStyle"
-  [buttonType]="buttonType"
-  [disabled]="disabled"
-  [horizontalAlignment]="horizontalAlignment"
-  [label]="label"
-  [messageStream]="messageStream"
-  [title]="title"
-  [trigger]="trigger"
->
-  <button class="custom-trigger" skyDropdownTrigger type="button">
-    Custom trigger
-  </button>
-
-  <sky-dropdown-menu
-    #dropdownMenuRef
-    [ariaLabelledBy]="menuAriaLabelledBy"
-    [ariaRole]="menuAriaRole"
-    [useNativeFocus]="useNativeFocus"
-    (menuChanges)="onMenuChanges($event)"
-  >
-    @for (item of items; track item) {
-    <sky-dropdown-item [ariaRole]="itemAriaRole">
-      <button
-        type="button"
-        [attr.disabled]="item.disabled ? '' : null"
-        (click)="onItemClick(item.name)"
-      >
-        {{ item.name }}
+@if (show) {
+  @if (useCustomTrigger) {
+    <sky-dropdown
+      #dropdownRef
+      [buttonStyle]="buttonStyle"
+      [buttonType]="buttonType"
+      [disabled]="disabled"
+      [horizontalAlignment]="horizontalAlignment"
+      [label]="label"
+      [messageStream]="messageStream"
+      [title]="title"
+      [trigger]="trigger"
+    >
+      <button class="custom-trigger" skyDropdownTrigger type="button">
+        Custom trigger
       </button>
-    </sky-dropdown-item>
-    }
-  </sky-dropdown-menu>
-</sky-dropdown>
 
-} @else {<sky-dropdown
-  #dropdownRef
-  [buttonStyle]="buttonStyle"
-  [buttonType]="buttonType"
-  [disabled]="disabled"
-  [horizontalAlignment]="horizontalAlignment"
-  [label]="label"
-  [messageStream]="messageStream"
-  [title]="title"
-  [trigger]="trigger"
->
-  <sky-dropdown-button> Show dropdown </sky-dropdown-button>
-
-  <sky-dropdown-menu
-    #dropdownMenuRef
-    [ariaLabelledBy]="menuAriaLabelledBy"
-    [ariaRole]="menuAriaRole"
-    [useNativeFocus]="useNativeFocus"
-    (menuChanges)="onMenuChanges($event)"
-  >
-    @for (item of items; track item) {
-    <sky-dropdown-item [ariaRole]="itemAriaRole">
-      <button
-        type="button"
-        [attr.disabled]="item.disabled ? '' : null"
-        (click)="onItemClick(item.name)"
+      <sky-dropdown-menu
+        #dropdownMenuRef
+        [ariaLabelledBy]="menuAriaLabelledBy"
+        [ariaRole]="menuAriaRole"
+        [useNativeFocus]="useNativeFocus"
+        (menuChanges)="onMenuChanges($event)"
       >
-        {{ item.name }}
-      </button>
-    </sky-dropdown-item>
-    }
-  </sky-dropdown-menu>
-</sky-dropdown>
-} }
+        @for (item of items; track item) {
+          <sky-dropdown-item [ariaRole]="itemAriaRole">
+            <button
+              type="button"
+              [attr.disabled]="item.disabled ? '' : null"
+              (click)="onItemClick(item.name)"
+            >
+              {{ item.name }}
+            </button>
+          </sky-dropdown-item>
+        }
+      </sky-dropdown-menu>
+    </sky-dropdown>
+  } @else {
+    <sky-dropdown
+      #dropdownRef
+      [buttonStyle]="buttonStyle"
+      [buttonType]="buttonType"
+      [disabled]="disabled"
+      [horizontalAlignment]="horizontalAlignment"
+      [label]="label"
+      [messageStream]="messageStream"
+      [title]="title"
+      [trigger]="trigger"
+    >
+      <sky-dropdown-button> Show dropdown </sky-dropdown-button>
+
+      <sky-dropdown-menu
+        #dropdownMenuRef
+        [ariaLabelledBy]="menuAriaLabelledBy"
+        [ariaRole]="menuAriaRole"
+        [useNativeFocus]="useNativeFocus"
+        (menuChanges)="onMenuChanges($event)"
+      >
+        @for (item of items; track item) {
+          <sky-dropdown-item [ariaRole]="itemAriaRole">
+            <button
+              type="button"
+              [attr.disabled]="item.disabled ? '' : null"
+              (click)="onItemClick(item.name)"
+            >
+              {{ item.name }}
+            </button>
+          </sky-dropdown-item>
+        }
+      </sky-dropdown-menu>
+    </sky-dropdown>
+  }
+}

--- a/libs/components/popovers/src/lib/modules/popover/fixtures/popover.component.fixture.html
+++ b/libs/components/popovers/src/lib/modules/popover/fixtures/popover.component.fixture.html
@@ -31,9 +31,10 @@
     (popoverOpened)="onPopoverOpened()"
   >
     <div [style.height.px]="height ? height : null">
-      Popover content. @if (showFocusableChildren) {
-      <input type="text" />
-      <button type="button">Button</button>
+      Popover content.
+      @if (showFocusableChildren) {
+        <input type="text" />
+        <button type="button">Button</button>
       }
     </div>
   </sky-popover>

--- a/libs/components/progress-indicator/src/lib/modules/progress-indicator/fixtures/progress-indicator.component.fixture.html
+++ b/libs/components/progress-indicator/src/lib/modules/progress-indicator/fixtures/progress-indicator.component.fixture.html
@@ -26,21 +26,21 @@
   </sky-progress-indicator-item>
 
   @if (showFourthItem) {
-  <sky-progress-indicator-item title="Do the fourth thing">
-    Waterfall content 4
-  </sky-progress-indicator-item>
+    <sky-progress-indicator-item title="Do the fourth thing">
+      Waterfall content 4
+    </sky-progress-indicator-item>
   }
 
   <!-- Legacy reset button within a progress indicator -->
   @if (!showIsolatedLegacyResetButton) {
-  <sky-progress-indicator-reset-button
-    #legacyResetButton
-    [disabled]="disabled"
-    [progressIndicator]="progressIndicator"
-    (resetClick)="onResetClick()"
-  >
-    Reset (legacy)
-  </sky-progress-indicator-reset-button>
+    <sky-progress-indicator-reset-button
+      #legacyResetButton
+      [disabled]="disabled"
+      [progressIndicator]="progressIndicator"
+      (resetClick)="onResetClick()"
+    >
+      Reset (legacy)
+    </sky-progress-indicator-reset-button>
   }
 
   <!-- Nav button within a progress indicator -->
@@ -53,32 +53,32 @@
 
 <!-- Legacy reset button outside a progress indicator -->
 @if (showIsolatedLegacyResetButton) {
-<sky-progress-indicator-reset-button
-  #legacyIsolatedResetButton
-  [progressIndicator]="progressIndicator"
-  (resetClick)="onResetClick()"
->
-  Reset (legacy)
-</sky-progress-indicator-reset-button>
+  <sky-progress-indicator-reset-button
+    #legacyIsolatedResetButton
+    [progressIndicator]="progressIndicator"
+    (resetClick)="onResetClick()"
+  >
+    Reset (legacy)
+  </sky-progress-indicator-reset-button>
 }
 
 <!-- Nav buttons outside a progress indicator -->
 @if (showNavButtons) {
-<div class="progress-indicator-fixture-external-nav-buttons">
-  <sky-progress-indicator-nav-button
-    #defaultNavButton
-    [progressIndicator]="defaultNavButtonProgressIndicatorRef"
-  />
+  <div class="progress-indicator-fixture-external-nav-buttons">
+    <sky-progress-indicator-nav-button
+      #defaultNavButton
+      [progressIndicator]="defaultNavButtonProgressIndicatorRef"
+    />
 
-  @for (buttonConfig of buttonConfigs; track buttonConfig) {
-  <sky-progress-indicator-nav-button
-    [buttonText]="buttonConfig.text"
-    [buttonType]="buttonConfig.type"
-    [disabled]="disabled"
-    [progressIndicator]="progressIndicator"
-  />
-  }
-</div>
+    @for (buttonConfig of buttonConfigs; track buttonConfig) {
+      <sky-progress-indicator-nav-button
+        [buttonText]="buttonConfig.text"
+        [buttonType]="buttonConfig.type"
+        [disabled]="disabled"
+        [progressIndicator]="progressIndicator"
+      />
+    }
+  </div>
 }
 
 <!-- Empty progress indicator container -->

--- a/libs/components/split-view/src/lib/modules/split-view/fixtures/split-view.fixture.html
+++ b/libs/components/split-view/src/lib/modules/split-view/fixtures/split-view.fixture.html
@@ -1,5 +1,5 @@
 @if (lowerSplitView) {
-<div style="height: 100px"></div>
+  <div style="height: 100px"></div>
 }
 <sky-split-view
   [backButtonText]="backButtonText"
@@ -10,7 +10,7 @@
   <sky-split-view-drawer [ariaLabel]="ariaLabelForDrawer" [width]="width">
     <ul>
       @for (item of items; track item) {
-      <li>{{ item.name }}</li>
+        <li>{{ item.name }}</li>
       }
     </ul>
   </sky-split-view-drawer>
@@ -28,37 +28,37 @@
         <input name="secondInput" type="text" id="sky-test-second-input" />
       </label>
       @if (showIframe) {
-      <iframe src="https://developer.blackbaud.com/skyux/"></iframe>
+        <iframe src="https://developer.blackbaud.com/skyux/"></iframe>
       }
       <ul>
         @for (item of additionalItems; track item) {
-        <li>{{ item }}</li>
+          <li>{{ item }}</li>
         }
       </ul>
     </sky-split-view-workspace-content>
   </sky-split-view-workspace>
 </sky-split-view>
 @if (showActionBar) {
-<sky-summary-action-bar>
-  <sky-summary-action-bar-actions>
-    <sky-summary-action-bar-primary-action>
-      Primary action
-    </sky-summary-action-bar-primary-action>
-    <sky-summary-action-bar-secondary-actions>
-      Foo
-      <sky-summary-action-bar-secondary-action>
-        Secondary action
-      </sky-summary-action-bar-secondary-action>
-      <sky-summary-action-bar-secondary-action>
-        Secondary action 2
-      </sky-summary-action-bar-secondary-action>
-    </sky-summary-action-bar-secondary-actions>
-    <sky-summary-action-bar-cancel> Cancel </sky-summary-action-bar-cancel>
-  </sky-summary-action-bar-actions>
-  <sky-summary-action-bar-summary>
-    <div>
-      <p>Test</p>
-    </div>
-  </sky-summary-action-bar-summary>
-</sky-summary-action-bar>
+  <sky-summary-action-bar>
+    <sky-summary-action-bar-actions>
+      <sky-summary-action-bar-primary-action>
+        Primary action
+      </sky-summary-action-bar-primary-action>
+      <sky-summary-action-bar-secondary-actions>
+        Foo
+        <sky-summary-action-bar-secondary-action>
+          Secondary action
+        </sky-summary-action-bar-secondary-action>
+        <sky-summary-action-bar-secondary-action>
+          Secondary action 2
+        </sky-summary-action-bar-secondary-action>
+      </sky-summary-action-bar-secondary-actions>
+      <sky-summary-action-bar-cancel> Cancel </sky-summary-action-bar-cancel>
+    </sky-summary-action-bar-actions>
+    <sky-summary-action-bar-summary>
+      <div>
+        <p>Test</p>
+      </div>
+    </sky-summary-action-bar-summary>
+  </sky-summary-action-bar>
 }

--- a/libs/components/tabs/src/lib/modules/tabs/fixtures/tabset-active.component.fixture.html
+++ b/libs/components/tabs/src/lib/modules/tabs/fixtures/tabset-active.component.fixture.html
@@ -1,21 +1,24 @@
-<div [ngStyle]="{'max-width.px': tabMaxWidth}">
+<div [ngStyle]="{ 'max-width.px': tabMaxWidth }">
   <sky-tabset [active]="activeIndex" (activeChange)="tabChanged($event)">
     @if (tab1Available) {
-    <sky-tab [tabHeading]="tab1Heading">
-      <div class="tabset-test-content-1">{{tab1Content}}</div>
-    </sky-tab>
-    } @if (tab2Available) {
-    <sky-tab [tabHeading]="tab2Heading">
-      <div class="tabset-test-content-2">{{tab2Content}}</div>
-    </sky-tab>
-    } @if (tab3Available) {
-    <sky-tab tabIndexValue="something" [tabHeading]="tab3Heading">
-      <div class="tabset-test-content-3">{{tab3Content}}</div>
-    </sky-tab>
-    } @if (tab4Available) {
-    <sky-tab [tabHeading]="tab4Heading">
-      <div class="tabset-test-content-4">{{tab4Content}}</div>
-    </sky-tab>
+      <sky-tab [tabHeading]="tab1Heading">
+        <div class="tabset-test-content-1">{{ tab1Content }}</div>
+      </sky-tab>
+    }
+    @if (tab2Available) {
+      <sky-tab [tabHeading]="tab2Heading">
+        <div class="tabset-test-content-2">{{ tab2Content }}</div>
+      </sky-tab>
+    }
+    @if (tab3Available) {
+      <sky-tab tabIndexValue="something" [tabHeading]="tab3Heading">
+        <div class="tabset-test-content-3">{{ tab3Content }}</div>
+      </sky-tab>
+    }
+    @if (tab4Available) {
+      <sky-tab [tabHeading]="tab4Heading">
+        <div class="tabset-test-content-4">{{ tab4Content }}</div>
+      </sky-tab>
     }
   </sky-tabset>
 </div>

--- a/libs/components/tabs/src/lib/modules/tabs/fixtures/tabset-loop.component.fixture.html
+++ b/libs/components/tabs/src/lib/modules/tabs/fixtures/tabset-loop.component.fixture.html
@@ -3,12 +3,12 @@
   (tabIndexesChange)="onTabIndexesChange($event)"
 >
   @for (tab of tabArray; track tab.tabHeading) {
-  <sky-tab
-    [active]="tab.active"
-    [tabIndexValue]="tab.tabIndex"
-    [tabHeading]="tab.tabHeading"
-  >
-    {{ tab.tabContent }}
-  </sky-tab>
+    <sky-tab
+      [active]="tab.active"
+      [tabIndexValue]="tab.tabIndex"
+      [tabHeading]="tab.tabHeading"
+    >
+      {{ tab.tabContent }}
+    </sky-tab>
   }
 </sky-tabset>

--- a/libs/components/tabs/src/lib/modules/tabs/fixtures/tabset-permalinks.component.fixture.html
+++ b/libs/components/tabs/src/lib/modules/tabs/fixtures/tabset-permalinks.component.fixture.html
@@ -1,15 +1,15 @@
 @if (showIt) {
-<sky-tabset
-  [active]="activeIndex"
-  [permalinkId]="permalinkId"
-  (activeChange)="onActiveChange($event)"
->
-  <sky-tab tabHeading="A.P.I." />
-  <sky-tab
-    tabHeading="Design & Guidelines"
-    [disabled]="secondTabDisabled"
-    [permalinkValue]="permalinkValue"
-  />
-  <sky-tabset tabHeading="Questions?" />
-</sky-tabset>
+  <sky-tabset
+    [active]="activeIndex"
+    [permalinkId]="permalinkId"
+    (activeChange)="onActiveChange($event)"
+  >
+    <sky-tab tabHeading="A.P.I." />
+    <sky-tab
+      tabHeading="Design & Guidelines"
+      [disabled]="secondTabDisabled"
+      [permalinkValue]="permalinkValue"
+    />
+    <sky-tabset tabHeading="Questions?" />
+  </sky-tabset>
 }

--- a/libs/components/tabs/src/lib/modules/tabs/fixtures/tabset.component.fixture.html
+++ b/libs/components/tabs/src/lib/modules/tabs/fixtures/tabset.component.fixture.html
@@ -1,32 +1,33 @@
-<div [ngStyle]="{'max-width.px': tabMaxWidth}">
+<div [ngStyle]="{ 'max-width.px': tabMaxWidth }">
   <sky-tabset
     [ariaLabel]="ariaLabel"
     [ariaLabelledBy]="ariaLabelledBy"
     [tabStyle]="tabStyle"
   >
     <sky-tab [tabHeading]="tab1Heading" [active]="activeTab === 0">
-      <div class="tabset-test-content-1">{{tab1Content}}</div>
+      <div class="tabset-test-content-1">{{ tab1Content }}</div>
     </sky-tab>
     @if (tab2Available) {
-    <sky-tab
-      layout="fit"
-      [tabHeading]="tab2Heading"
-      [active]="activeTab === 1"
-      [disabled]="tab2Disabled"
-      (close)="closeTab2()"
-    >
-      <div class="tabset-test-content-2">{{tab2Content}}</div>
-    </sky-tab>
-    } @if (tab3Available) {
-    <sky-tab
-      [layout]="tab3Layout"
-      [tabHeading]="tab3Heading"
-      [tabHeaderCount]="tab3HeaderCount"
-      [tabIndexValue]="3"
-      [active]="activeTab === 2"
-    >
-      <div class="tabset-test-content-3">{{tab3Content}}</div>
-    </sky-tab>
+      <sky-tab
+        layout="fit"
+        [tabHeading]="tab2Heading"
+        [active]="activeTab === 1"
+        [disabled]="tab2Disabled"
+        (close)="closeTab2()"
+      >
+        <div class="tabset-test-content-2">{{ tab2Content }}</div>
+      </sky-tab>
+    }
+    @if (tab3Available) {
+      <sky-tab
+        [layout]="tab3Layout"
+        [tabHeading]="tab3Heading"
+        [tabHeaderCount]="tab3HeaderCount"
+        [tabIndexValue]="3"
+        [active]="activeTab === 2"
+      >
+        <div class="tabset-test-content-3">{{ tab3Content }}</div>
+      </sky-tab>
     }
   </sky-tabset>
 </div>

--- a/libs/components/tabs/src/lib/modules/vertical-tabset/fixtures/vertical-tabset-ngfor.component.fixture.html
+++ b/libs/components/tabs/src/lib/modules/vertical-tabset/fixtures/vertical-tabset-ngfor.component.fixture.html
@@ -3,8 +3,8 @@
   (activeChange)="onActiveChange($event)"
 >
   @for (tab of tabs; track tab) {
-  <sky-vertical-tab [tabHeading]="tab.heading">
-    {{ tab.content }}
-  </sky-vertical-tab>
+    <sky-vertical-tab [tabHeading]="tab.heading">
+      {{ tab.content }}
+    </sky-vertical-tab>
   }
 </sky-vertical-tabset>

--- a/libs/components/tabs/src/lib/modules/vertical-tabset/fixtures/vertical-tabset.component.fixture.html
+++ b/libs/components/tabs/src/lib/modules/vertical-tabset/fixtures/vertical-tabset.component.fixture.html
@@ -17,267 +17,287 @@
         [tabHeaderCount]="5"
         [tabId]="tab1Id"
       >
-        Group 1 Tab 1 content @if (showScrollable) {
-        <div>
-          <p>
-            Lorem ipsum pellentesque habitant morbi tristique senectus et netus
-            et malesuada fames ac turpis egestas. Vestibulum tortor quam,
-            feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu
-            libero sit amet quam egestas semper. Aenean ultricies mi vitae est.
-            Mauris placerat eleifend leo. Quisque sit amet est et sapien
-            ullamcorper pharetra. Vestibulum erat wisi, condimentum sed, commodo
-            vitae, ornare sit amet, wisi. Aenean fermentum, elit eget tincidunt
-            condimentum, eros ipsum rutrum orci, sagittis tempus lacus enim ac
-            dui. Donec non enim in turpis pulvinar facilisis. Ut felis. Praesent
-            dapibus, neque id cursus faucibus, tortor neque egestas augue, eu
-            vulputate magna eros eu erat. Aliquam erat volutpat. Nam dui mi,
-            tincidunt quis, accumsan porttitor, facilisis luctus, metus
-          </p>
-          <p>
-            Lorem ipsum pellentesque habitant morbi tristique senectus et netus
-            et malesuada fames ac turpis egestas. Vestibulum tortor quam,
-            feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu
-            libero sit amet quam egestas semper. Aenean ultricies mi vitae est.
-            Mauris placerat eleifend leo. Quisque sit amet est et sapien
-            ullamcorper pharetra. Vestibulum erat wisi, condimentum sed, commodo
-            vitae, ornare sit amet, wisi. Aenean fermentum, elit eget tincidunt
-            condimentum, eros ipsum rutrum orci, sagittis tempus lacus enim ac
-            dui. Donec non enim in turpis pulvinar facilisis. Ut felis. Praesent
-            dapibus, neque id cursus faucibus, tortor neque egestas augue, eu
-            vulputate magna eros eu erat. Aliquam erat volutpat. Nam dui mi,
-            tincidunt quis, accumsan porttitor, facilisis luctus, metus
-          </p>
-          <p>
-            Lorem ipsum pellentesque habitant morbi tristique senectus et netus
-            et malesuada fames ac turpis egestas. Vestibulum tortor quam,
-            feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu
-            libero sit amet quam egestas semper. Aenean ultricies mi vitae est.
-            Mauris placerat eleifend leo. Quisque sit amet est et sapien
-            ullamcorper pharetra. Vestibulum erat wisi, condimentum sed, commodo
-            vitae, ornare sit amet, wisi. Aenean fermentum, elit eget tincidunt
-            condimentum, eros ipsum rutrum orci, sagittis tempus lacus enim ac
-            dui. Donec non enim in turpis pulvinar facilisis. Ut felis. Praesent
-            dapibus, neque id cursus faucibus, tortor neque egestas augue, eu
-            vulputate magna eros eu erat. Aliquam erat volutpat. Nam dui mi,
-            tincidunt quis, accumsan porttitor, facilisis luctus, metus
-          </p>
-          <p>
-            Lorem ipsum pellentesque habitant morbi tristique senectus et netus
-            et malesuada fames ac turpis egestas. Vestibulum tortor quam,
-            feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu
-            libero sit amet quam egestas semper. Aenean ultricies mi vitae est.
-            Mauris placerat eleifend leo. Quisque sit amet est et sapien
-            ullamcorper pharetra. Vestibulum erat wisi, condimentum sed, commodo
-            vitae, ornare sit amet, wisi. Aenean fermentum, elit eget tincidunt
-            condimentum, eros ipsum rutrum orci, sagittis tempus lacus enim ac
-            dui. Donec non enim in turpis pulvinar facilisis. Ut felis. Praesent
-            dapibus, neque id cursus faucibus, tortor neque egestas augue, eu
-            vulputate magna eros eu erat. Aliquam erat volutpat. Nam dui mi,
-            tincidunt quis, accumsan porttitor, facilisis luctus, metus
-          </p>
-          <p>
-            Lorem ipsum pellentesque habitant morbi tristique senectus et netus
-            et malesuada fames ac turpis egestas. Vestibulum tortor quam,
-            feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu
-            libero sit amet quam egestas semper. Aenean ultricies mi vitae est.
-            Mauris placerat eleifend leo. Quisque sit amet est et sapien
-            ullamcorper pharetra. Vestibulum erat wisi, condimentum sed, commodo
-            vitae, ornare sit amet, wisi. Aenean fermentum, elit eget tincidunt
-            condimentum, eros ipsum rutrum orci, sagittis tempus lacus enim ac
-            dui. Donec non enim in turpis pulvinar facilisis. Ut felis. Praesent
-            dapibus, neque id cursus faucibus, tortor neque egestas augue, eu
-            vulputate magna eros eu erat. Aliquam erat volutpat. Nam dui mi,
-            tincidunt quis, accumsan porttitor, facilisis luctus, metus
-          </p>
-          <p>
-            Lorem ipsum pellentesque habitant morbi tristique senectus et netus
-            et malesuada fames ac turpis egestas. Vestibulum tortor quam,
-            feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu
-            libero sit amet quam egestas semper. Aenean ultricies mi vitae est.
-            Mauris placerat eleifend leo. Quisque sit amet est et sapien
-            ullamcorper pharetra. Vestibulum erat wisi, condimentum sed, commodo
-            vitae, ornare sit amet, wisi. Aenean fermentum, elit eget tincidunt
-            condimentum, eros ipsum rutrum orci, sagittis tempus lacus enim ac
-            dui. Donec non enim in turpis pulvinar facilisis. Ut felis. Praesent
-            dapibus, neque id cursus faucibus, tortor neque egestas augue, eu
-            vulputate magna eros eu erat. Aliquam erat volutpat. Nam dui mi,
-            tincidunt quis, accumsan porttitor, facilisis luctus, metus
-          </p>
-          <p>
-            Lorem ipsum pellentesque habitant morbi tristique senectus et netus
-            et malesuada fames ac turpis egestas. Vestibulum tortor quam,
-            feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu
-            libero sit amet quam egestas semper. Aenean ultricies mi vitae est.
-            Mauris placerat eleifend leo. Quisque sit amet est et sapien
-            ullamcorper pharetra. Vestibulum erat wisi, condimentum sed, commodo
-            vitae, ornare sit amet, wisi. Aenean fermentum, elit eget tincidunt
-            condimentum, eros ipsum rutrum orci, sagittis tempus lacus enim ac
-            dui. Donec non enim in turpis pulvinar facilisis. Ut felis. Praesent
-            dapibus, neque id cursus faucibus, tortor neque egestas augue, eu
-            vulputate magna eros eu erat. Aliquam erat volutpat. Nam dui mi,
-            tincidunt quis, accumsan porttitor, facilisis luctus, metus
-          </p>
-          <p>
-            Lorem ipsum pellentesque habitant morbi tristique senectus et netus
-            et malesuada fames ac turpis egestas. Vestibulum tortor quam,
-            feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu
-            libero sit amet quam egestas semper. Aenean ultricies mi vitae est.
-            Mauris placerat eleifend leo. Quisque sit amet est et sapien
-            ullamcorper pharetra. Vestibulum erat wisi, condimentum sed, commodo
-            vitae, ornare sit amet, wisi. Aenean fermentum, elit eget tincidunt
-            condimentum, eros ipsum rutrum orci, sagittis tempus lacus enim ac
-            dui. Donec non enim in turpis pulvinar facilisis. Ut felis. Praesent
-            dapibus, neque id cursus faucibus, tortor neque egestas augue, eu
-            vulputate magna eros eu erat. Aliquam erat volutpat. Nam dui mi,
-            tincidunt quis, accumsan porttitor, facilisis luctus, metus
-          </p>
-          <p>
-            Lorem ipsum pellentesque habitant morbi tristique senectus et netus
-            et malesuada fames ac turpis egestas. Vestibulum tortor quam,
-            feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu
-            libero sit amet quam egestas semper. Aenean ultricies mi vitae est.
-            Mauris placerat eleifend leo. Quisque sit amet est et sapien
-            ullamcorper pharetra. Vestibulum erat wisi, condimentum sed, commodo
-            vitae, ornare sit amet, wisi. Aenean fermentum, elit eget tincidunt
-            condimentum, eros ipsum rutrum orci, sagittis tempus lacus enim ac
-            dui. Donec non enim in turpis pulvinar facilisis. Ut felis. Praesent
-            dapibus, neque id cursus faucibus, tortor neque egestas augue, eu
-            vulputate magna eros eu erat. Aliquam erat volutpat. Nam dui mi,
-            tincidunt quis, accumsan porttitor, facilisis luctus, metus
-          </p>
-        </div>
+        Group 1 Tab 1 content
+        @if (showScrollable) {
+          <div>
+            <p>
+              Lorem ipsum pellentesque habitant morbi tristique senectus et
+              netus et malesuada fames ac turpis egestas. Vestibulum tortor
+              quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec
+              eu libero sit amet quam egestas semper. Aenean ultricies mi vitae
+              est. Mauris placerat eleifend leo. Quisque sit amet est et sapien
+              ullamcorper pharetra. Vestibulum erat wisi, condimentum sed,
+              commodo vitae, ornare sit amet, wisi. Aenean fermentum, elit eget
+              tincidunt condimentum, eros ipsum rutrum orci, sagittis tempus
+              lacus enim ac dui. Donec non enim in turpis pulvinar facilisis. Ut
+              felis. Praesent dapibus, neque id cursus faucibus, tortor neque
+              egestas augue, eu vulputate magna eros eu erat. Aliquam erat
+              volutpat. Nam dui mi, tincidunt quis, accumsan porttitor,
+              facilisis luctus, metus
+            </p>
+            <p>
+              Lorem ipsum pellentesque habitant morbi tristique senectus et
+              netus et malesuada fames ac turpis egestas. Vestibulum tortor
+              quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec
+              eu libero sit amet quam egestas semper. Aenean ultricies mi vitae
+              est. Mauris placerat eleifend leo. Quisque sit amet est et sapien
+              ullamcorper pharetra. Vestibulum erat wisi, condimentum sed,
+              commodo vitae, ornare sit amet, wisi. Aenean fermentum, elit eget
+              tincidunt condimentum, eros ipsum rutrum orci, sagittis tempus
+              lacus enim ac dui. Donec non enim in turpis pulvinar facilisis. Ut
+              felis. Praesent dapibus, neque id cursus faucibus, tortor neque
+              egestas augue, eu vulputate magna eros eu erat. Aliquam erat
+              volutpat. Nam dui mi, tincidunt quis, accumsan porttitor,
+              facilisis luctus, metus
+            </p>
+            <p>
+              Lorem ipsum pellentesque habitant morbi tristique senectus et
+              netus et malesuada fames ac turpis egestas. Vestibulum tortor
+              quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec
+              eu libero sit amet quam egestas semper. Aenean ultricies mi vitae
+              est. Mauris placerat eleifend leo. Quisque sit amet est et sapien
+              ullamcorper pharetra. Vestibulum erat wisi, condimentum sed,
+              commodo vitae, ornare sit amet, wisi. Aenean fermentum, elit eget
+              tincidunt condimentum, eros ipsum rutrum orci, sagittis tempus
+              lacus enim ac dui. Donec non enim in turpis pulvinar facilisis. Ut
+              felis. Praesent dapibus, neque id cursus faucibus, tortor neque
+              egestas augue, eu vulputate magna eros eu erat. Aliquam erat
+              volutpat. Nam dui mi, tincidunt quis, accumsan porttitor,
+              facilisis luctus, metus
+            </p>
+            <p>
+              Lorem ipsum pellentesque habitant morbi tristique senectus et
+              netus et malesuada fames ac turpis egestas. Vestibulum tortor
+              quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec
+              eu libero sit amet quam egestas semper. Aenean ultricies mi vitae
+              est. Mauris placerat eleifend leo. Quisque sit amet est et sapien
+              ullamcorper pharetra. Vestibulum erat wisi, condimentum sed,
+              commodo vitae, ornare sit amet, wisi. Aenean fermentum, elit eget
+              tincidunt condimentum, eros ipsum rutrum orci, sagittis tempus
+              lacus enim ac dui. Donec non enim in turpis pulvinar facilisis. Ut
+              felis. Praesent dapibus, neque id cursus faucibus, tortor neque
+              egestas augue, eu vulputate magna eros eu erat. Aliquam erat
+              volutpat. Nam dui mi, tincidunt quis, accumsan porttitor,
+              facilisis luctus, metus
+            </p>
+            <p>
+              Lorem ipsum pellentesque habitant morbi tristique senectus et
+              netus et malesuada fames ac turpis egestas. Vestibulum tortor
+              quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec
+              eu libero sit amet quam egestas semper. Aenean ultricies mi vitae
+              est. Mauris placerat eleifend leo. Quisque sit amet est et sapien
+              ullamcorper pharetra. Vestibulum erat wisi, condimentum sed,
+              commodo vitae, ornare sit amet, wisi. Aenean fermentum, elit eget
+              tincidunt condimentum, eros ipsum rutrum orci, sagittis tempus
+              lacus enim ac dui. Donec non enim in turpis pulvinar facilisis. Ut
+              felis. Praesent dapibus, neque id cursus faucibus, tortor neque
+              egestas augue, eu vulputate magna eros eu erat. Aliquam erat
+              volutpat. Nam dui mi, tincidunt quis, accumsan porttitor,
+              facilisis luctus, metus
+            </p>
+            <p>
+              Lorem ipsum pellentesque habitant morbi tristique senectus et
+              netus et malesuada fames ac turpis egestas. Vestibulum tortor
+              quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec
+              eu libero sit amet quam egestas semper. Aenean ultricies mi vitae
+              est. Mauris placerat eleifend leo. Quisque sit amet est et sapien
+              ullamcorper pharetra. Vestibulum erat wisi, condimentum sed,
+              commodo vitae, ornare sit amet, wisi. Aenean fermentum, elit eget
+              tincidunt condimentum, eros ipsum rutrum orci, sagittis tempus
+              lacus enim ac dui. Donec non enim in turpis pulvinar facilisis. Ut
+              felis. Praesent dapibus, neque id cursus faucibus, tortor neque
+              egestas augue, eu vulputate magna eros eu erat. Aliquam erat
+              volutpat. Nam dui mi, tincidunt quis, accumsan porttitor,
+              facilisis luctus, metus
+            </p>
+            <p>
+              Lorem ipsum pellentesque habitant morbi tristique senectus et
+              netus et malesuada fames ac turpis egestas. Vestibulum tortor
+              quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec
+              eu libero sit amet quam egestas semper. Aenean ultricies mi vitae
+              est. Mauris placerat eleifend leo. Quisque sit amet est et sapien
+              ullamcorper pharetra. Vestibulum erat wisi, condimentum sed,
+              commodo vitae, ornare sit amet, wisi. Aenean fermentum, elit eget
+              tincidunt condimentum, eros ipsum rutrum orci, sagittis tempus
+              lacus enim ac dui. Donec non enim in turpis pulvinar facilisis. Ut
+              felis. Praesent dapibus, neque id cursus faucibus, tortor neque
+              egestas augue, eu vulputate magna eros eu erat. Aliquam erat
+              volutpat. Nam dui mi, tincidunt quis, accumsan porttitor,
+              facilisis luctus, metus
+            </p>
+            <p>
+              Lorem ipsum pellentesque habitant morbi tristique senectus et
+              netus et malesuada fames ac turpis egestas. Vestibulum tortor
+              quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec
+              eu libero sit amet quam egestas semper. Aenean ultricies mi vitae
+              est. Mauris placerat eleifend leo. Quisque sit amet est et sapien
+              ullamcorper pharetra. Vestibulum erat wisi, condimentum sed,
+              commodo vitae, ornare sit amet, wisi. Aenean fermentum, elit eget
+              tincidunt condimentum, eros ipsum rutrum orci, sagittis tempus
+              lacus enim ac dui. Donec non enim in turpis pulvinar facilisis. Ut
+              felis. Praesent dapibus, neque id cursus faucibus, tortor neque
+              egestas augue, eu vulputate magna eros eu erat. Aliquam erat
+              volutpat. Nam dui mi, tincidunt quis, accumsan porttitor,
+              facilisis luctus, metus
+            </p>
+            <p>
+              Lorem ipsum pellentesque habitant morbi tristique senectus et
+              netus et malesuada fames ac turpis egestas. Vestibulum tortor
+              quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec
+              eu libero sit amet quam egestas semper. Aenean ultricies mi vitae
+              est. Mauris placerat eleifend leo. Quisque sit amet est et sapien
+              ullamcorper pharetra. Vestibulum erat wisi, condimentum sed,
+              commodo vitae, ornare sit amet, wisi. Aenean fermentum, elit eget
+              tincidunt condimentum, eros ipsum rutrum orci, sagittis tempus
+              lacus enim ac dui. Donec non enim in turpis pulvinar facilisis. Ut
+              felis. Praesent dapibus, neque id cursus faucibus, tortor neque
+              egestas augue, eu vulputate magna eros eu erat. Aliquam erat
+              volutpat. Nam dui mi, tincidunt quis, accumsan porttitor,
+              facilisis luctus, metus
+            </p>
+          </div>
         }
       </sky-vertical-tab>
       <sky-vertical-tab tabHeading="Group 1 Tab 2">
-        Group 1 Tab 2 content @if (showScrollable) {
-        <div id="some-div">
-          <p>
-            Lorem ipsum p habitant morbi tristique senectus et netus et
-            malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat
-            vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit
-            amet quam egestas semper. Aenean ultricies mi vitae est. Mauris
-            placerat eleifend leo. Quisque sit amet est et sapien ullamcorper
-            pharetra. Vestibulum erat wisi, condimentum sed, commodo vitae,
-            ornare sit amet, wisi. Aenean fermentum, elit eget tincidunt
-            condimentum, eros ipsum rutrum orci, sagittis tempus lacus enim ac
-            dui. Donec non enim in turpis pulvinar facilisis. Ut felis. Praesent
-            dapibus, neque id cursus faucibus, tortor neque egestas augue, eu
-            vulputate magna eros eu erat. Aliquam erat volutpat. Nam dui mi,
-            tincidunt quis, accumsan porttitor, facilisis luctus, metus
-          </p>
-          <p>
-            Lorem ipsum p habitant morbi tristique senectus et netus et
-            malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat
-            vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit
-            amet quam egestas semper. Aenean ultricies mi vitae est. Mauris
-            placerat eleifend leo. Quisque sit amet est et sapien ullamcorper
-            pharetra. Vestibulum erat wisi, condimentum sed, commodo vitae,
-            ornare sit amet, wisi. Aenean fermentum, elit eget tincidunt
-            condimentum, eros ipsum rutrum orci, sagittis tempus lacus enim ac
-            dui. Donec non enim in turpis pulvinar facilisis. Ut felis. Praesent
-            dapibus, neque id cursus faucibus, tortor neque egestas augue, eu
-            vulputate magna eros eu erat. Aliquam erat volutpat. Nam dui mi,
-            tincidunt quis, accumsan porttitor, facilisis luctus, metus
-          </p>
-          <p>
-            Lorem ipsum p habitant morbi tristique senectus et netus et
-            malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat
-            vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit
-            amet quam egestas semper. Aenean ultricies mi vitae est. Mauris
-            placerat eleifend leo. Quisque sit amet est et sapien ullamcorper
-            pharetra. Vestibulum erat wisi, condimentum sed, commodo vitae,
-            ornare sit amet, wisi. Aenean fermentum, elit eget tincidunt
-            condimentum, eros ipsum rutrum orci, sagittis tempus lacus enim ac
-            dui. Donec non enim in turpis pulvinar facilisis. Ut felis. Praesent
-            dapibus, neque id cursus faucibus, tortor neque egestas augue, eu
-            vulputate magna eros eu erat. Aliquam erat volutpat. Nam dui mi,
-            tincidunt quis, accumsan porttitor, facilisis luctus, metus
-          </p>
-          <p>
-            Lorem ipsum p habitant morbi tristique senectus et netus et
-            malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat
-            vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit
-            amet quam egestas semper. Aenean ultricies mi vitae est. Mauris
-            placerat eleifend leo. Quisque sit amet est et sapien ullamcorper
-            pharetra. Vestibulum erat wisi, condimentum sed, commodo vitae,
-            ornare sit amet, wisi. Aenean fermentum, elit eget tincidunt
-            condimentum, eros ipsum rutrum orci, sagittis tempus lacus enim ac
-            dui. Donec non enim in turpis pulvinar facilisis. Ut felis. Praesent
-            dapibus, neque id cursus faucibus, tortor neque egestas augue, eu
-            vulputate magna eros eu erat. Aliquam erat volutpat. Nam dui mi,
-            tincidunt quis, accumsan porttitor, facilisis luctus, metus
-          </p>
-          <p>
-            Lorem ipsum p habitant morbi tristique senectus et netus et
-            malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat
-            vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit
-            amet quam egestas semper. Aenean ultricies mi vitae est. Mauris
-            placerat eleifend leo. Quisque sit amet est et sapien ullamcorper
-            pharetra. Vestibulum erat wisi, condimentum sed, commodo vitae,
-            ornare sit amet, wisi. Aenean fermentum, elit eget tincidunt
-            condimentum, eros ipsum rutrum orci, sagittis tempus lacus enim ac
-            dui. Donec non enim in turpis pulvinar facilisis. Ut felis. Praesent
-            dapibus, neque id cursus faucibus, tortor neque egestas augue, eu
-            vulputate magna eros eu erat. Aliquam erat volutpat. Nam dui mi,
-            tincidunt quis, accumsan porttitor, facilisis luctus, metus
-          </p>
-          <p>
-            Lorem ipsum p habitant morbi tristique senectus et netus et
-            malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat
-            vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit
-            amet quam egestas semper. Aenean ultricies mi vitae est. Mauris
-            placerat eleifend leo. Quisque sit amet est et sapien ullamcorper
-            pharetra. Vestibulum erat wisi, condimentum sed, commodo vitae,
-            ornare sit amet, wisi. Aenean fermentum, elit eget tincidunt
-            condimentum, eros ipsum rutrum orci, sagittis tempus lacus enim ac
-            dui. Donec non enim in turpis pulvinar facilisis. Ut felis. Praesent
-            dapibus, neque id cursus faucibus, tortor neque egestas augue, eu
-            vulputate magna eros eu erat. Aliquam erat volutpat. Nam dui mi,
-            tincidunt quis, accumsan porttitor, facilisis luctus, metus
-          </p>
-          <p>
-            Lorem ipsum p habitant morbi tristique senectus et netus et
-            malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat
-            vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit
-            amet quam egestas semper. Aenean ultricies mi vitae est. Mauris
-            placerat eleifend leo. Quisque sit amet est et sapien ullamcorper
-            pharetra. Vestibulum erat wisi, condimentum sed, commodo vitae,
-            ornare sit amet, wisi. Aenean fermentum, elit eget tincidunt
-            condimentum, eros ipsum rutrum orci, sagittis tempus lacus enim ac
-            dui. Donec non enim in turpis pulvinar facilisis. Ut felis. Praesent
-            dapibus, neque id cursus faucibus, tortor neque egestas augue, eu
-            vulputate magna eros eu erat. Aliquam erat volutpat. Nam dui mi,
-            tincidunt quis, accumsan porttitor, facilisis luctus, metus
-          </p>
-          <p>
-            Lorem ipsum p habitant morbi tristique senectus et netus et
-            malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat
-            vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit
-            amet quam egestas semper. Aenean ultricies mi vitae est. Mauris
-            placerat eleifend leo. Quisque sit amet est et sapien ullamcorper
-            pharetra. Vestibulum erat wisi, condimentum sed, commodo vitae,
-            ornare sit amet, wisi. Aenean fermentum, elit eget tincidunt
-            condimentum, eros ipsum rutrum orci, sagittis tempus lacus enim ac
-            dui. Donec non enim in turpis pulvinar facilisis. Ut felis. Praesent
-            dapibus, neque id cursus faucibus, tortor neque egestas augue, eu
-            vulputate magna eros eu erat. Aliquam erat volutpat. Nam dui mi,
-            tincidunt quis, accumsan porttitor, facilisis luctus, metus
-          </p>
-          <p>
-            Lorem ipsum p habitant morbi tristique senectus et netus et
-            malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat
-            vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit
-            amet quam egestas semper. Aenean ultricies mi vitae est. Mauris
-            placerat eleifend leo. Quisque sit amet est et sapien ullamcorper
-            pharetra. Vestibulum erat wisi, condimentum sed, commodo vitae,
-            ornare sit amet, wisi. Aenean fermentum, elit eget tincidunt
-            condimentum, eros ipsum rutrum orci, sagittis tempus lacus enim ac
-            dui. Donec non enim in turpis pulvinar facilisis. Ut felis. Praesent
-            dapibus, neque id cursus faucibus, tortor neque egestas augue, eu
-            vulputate magna eros eu erat. Aliquam erat volutpat. Nam dui mi,
-            tincidunt quis, accumsan porttitor, facilisis luctus, metus
-          </p>
-        </div>
+        Group 1 Tab 2 content
+        @if (showScrollable) {
+          <div id="some-div">
+            <p>
+              Lorem ipsum p habitant morbi tristique senectus et netus et
+              malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat
+              vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit
+              amet quam egestas semper. Aenean ultricies mi vitae est. Mauris
+              placerat eleifend leo. Quisque sit amet est et sapien ullamcorper
+              pharetra. Vestibulum erat wisi, condimentum sed, commodo vitae,
+              ornare sit amet, wisi. Aenean fermentum, elit eget tincidunt
+              condimentum, eros ipsum rutrum orci, sagittis tempus lacus enim ac
+              dui. Donec non enim in turpis pulvinar facilisis. Ut felis.
+              Praesent dapibus, neque id cursus faucibus, tortor neque egestas
+              augue, eu vulputate magna eros eu erat. Aliquam erat volutpat. Nam
+              dui mi, tincidunt quis, accumsan porttitor, facilisis luctus,
+              metus
+            </p>
+            <p>
+              Lorem ipsum p habitant morbi tristique senectus et netus et
+              malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat
+              vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit
+              amet quam egestas semper. Aenean ultricies mi vitae est. Mauris
+              placerat eleifend leo. Quisque sit amet est et sapien ullamcorper
+              pharetra. Vestibulum erat wisi, condimentum sed, commodo vitae,
+              ornare sit amet, wisi. Aenean fermentum, elit eget tincidunt
+              condimentum, eros ipsum rutrum orci, sagittis tempus lacus enim ac
+              dui. Donec non enim in turpis pulvinar facilisis. Ut felis.
+              Praesent dapibus, neque id cursus faucibus, tortor neque egestas
+              augue, eu vulputate magna eros eu erat. Aliquam erat volutpat. Nam
+              dui mi, tincidunt quis, accumsan porttitor, facilisis luctus,
+              metus
+            </p>
+            <p>
+              Lorem ipsum p habitant morbi tristique senectus et netus et
+              malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat
+              vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit
+              amet quam egestas semper. Aenean ultricies mi vitae est. Mauris
+              placerat eleifend leo. Quisque sit amet est et sapien ullamcorper
+              pharetra. Vestibulum erat wisi, condimentum sed, commodo vitae,
+              ornare sit amet, wisi. Aenean fermentum, elit eget tincidunt
+              condimentum, eros ipsum rutrum orci, sagittis tempus lacus enim ac
+              dui. Donec non enim in turpis pulvinar facilisis. Ut felis.
+              Praesent dapibus, neque id cursus faucibus, tortor neque egestas
+              augue, eu vulputate magna eros eu erat. Aliquam erat volutpat. Nam
+              dui mi, tincidunt quis, accumsan porttitor, facilisis luctus,
+              metus
+            </p>
+            <p>
+              Lorem ipsum p habitant morbi tristique senectus et netus et
+              malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat
+              vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit
+              amet quam egestas semper. Aenean ultricies mi vitae est. Mauris
+              placerat eleifend leo. Quisque sit amet est et sapien ullamcorper
+              pharetra. Vestibulum erat wisi, condimentum sed, commodo vitae,
+              ornare sit amet, wisi. Aenean fermentum, elit eget tincidunt
+              condimentum, eros ipsum rutrum orci, sagittis tempus lacus enim ac
+              dui. Donec non enim in turpis pulvinar facilisis. Ut felis.
+              Praesent dapibus, neque id cursus faucibus, tortor neque egestas
+              augue, eu vulputate magna eros eu erat. Aliquam erat volutpat. Nam
+              dui mi, tincidunt quis, accumsan porttitor, facilisis luctus,
+              metus
+            </p>
+            <p>
+              Lorem ipsum p habitant morbi tristique senectus et netus et
+              malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat
+              vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit
+              amet quam egestas semper. Aenean ultricies mi vitae est. Mauris
+              placerat eleifend leo. Quisque sit amet est et sapien ullamcorper
+              pharetra. Vestibulum erat wisi, condimentum sed, commodo vitae,
+              ornare sit amet, wisi. Aenean fermentum, elit eget tincidunt
+              condimentum, eros ipsum rutrum orci, sagittis tempus lacus enim ac
+              dui. Donec non enim in turpis pulvinar facilisis. Ut felis.
+              Praesent dapibus, neque id cursus faucibus, tortor neque egestas
+              augue, eu vulputate magna eros eu erat. Aliquam erat volutpat. Nam
+              dui mi, tincidunt quis, accumsan porttitor, facilisis luctus,
+              metus
+            </p>
+            <p>
+              Lorem ipsum p habitant morbi tristique senectus et netus et
+              malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat
+              vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit
+              amet quam egestas semper. Aenean ultricies mi vitae est. Mauris
+              placerat eleifend leo. Quisque sit amet est et sapien ullamcorper
+              pharetra. Vestibulum erat wisi, condimentum sed, commodo vitae,
+              ornare sit amet, wisi. Aenean fermentum, elit eget tincidunt
+              condimentum, eros ipsum rutrum orci, sagittis tempus lacus enim ac
+              dui. Donec non enim in turpis pulvinar facilisis. Ut felis.
+              Praesent dapibus, neque id cursus faucibus, tortor neque egestas
+              augue, eu vulputate magna eros eu erat. Aliquam erat volutpat. Nam
+              dui mi, tincidunt quis, accumsan porttitor, facilisis luctus,
+              metus
+            </p>
+            <p>
+              Lorem ipsum p habitant morbi tristique senectus et netus et
+              malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat
+              vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit
+              amet quam egestas semper. Aenean ultricies mi vitae est. Mauris
+              placerat eleifend leo. Quisque sit amet est et sapien ullamcorper
+              pharetra. Vestibulum erat wisi, condimentum sed, commodo vitae,
+              ornare sit amet, wisi. Aenean fermentum, elit eget tincidunt
+              condimentum, eros ipsum rutrum orci, sagittis tempus lacus enim ac
+              dui. Donec non enim in turpis pulvinar facilisis. Ut felis.
+              Praesent dapibus, neque id cursus faucibus, tortor neque egestas
+              augue, eu vulputate magna eros eu erat. Aliquam erat volutpat. Nam
+              dui mi, tincidunt quis, accumsan porttitor, facilisis luctus,
+              metus
+            </p>
+            <p>
+              Lorem ipsum p habitant morbi tristique senectus et netus et
+              malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat
+              vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit
+              amet quam egestas semper. Aenean ultricies mi vitae est. Mauris
+              placerat eleifend leo. Quisque sit amet est et sapien ullamcorper
+              pharetra. Vestibulum erat wisi, condimentum sed, commodo vitae,
+              ornare sit amet, wisi. Aenean fermentum, elit eget tincidunt
+              condimentum, eros ipsum rutrum orci, sagittis tempus lacus enim ac
+              dui. Donec non enim in turpis pulvinar facilisis. Ut felis.
+              Praesent dapibus, neque id cursus faucibus, tortor neque egestas
+              augue, eu vulputate magna eros eu erat. Aliquam erat volutpat. Nam
+              dui mi, tincidunt quis, accumsan porttitor, facilisis luctus,
+              metus
+            </p>
+            <p>
+              Lorem ipsum p habitant morbi tristique senectus et netus et
+              malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat
+              vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit
+              amet quam egestas semper. Aenean ultricies mi vitae est. Mauris
+              placerat eleifend leo. Quisque sit amet est et sapien ullamcorper
+              pharetra. Vestibulum erat wisi, condimentum sed, commodo vitae,
+              ornare sit amet, wisi. Aenean fermentum, elit eget tincidunt
+              condimentum, eros ipsum rutrum orci, sagittis tempus lacus enim ac
+              dui. Donec non enim in turpis pulvinar facilisis. Ut felis.
+              Praesent dapibus, neque id cursus faucibus, tortor neque egestas
+              augue, eu vulputate magna eros eu erat. Aliquam erat volutpat. Nam
+              dui mi, tincidunt quis, accumsan porttitor, facilisis luctus,
+              metus
+            </p>
+          </div>
         }
       </sky-vertical-tab>
     </sky-vertical-tabset-group>

--- a/libs/components/toast/src/lib/modules/toast/fixtures/toast.component.fixture.html
+++ b/libs/components/toast/src/lib/modules/toast/fixtures/toast.component.fixture.html
@@ -1,15 +1,13 @@
 @if (toastType !== undefined) {
-<sky-toast
-  [autoClose]="autoClose"
-  [toastType]="toastType"
-  (closed)="onClosed()"
->
-  Inner content here...
-</sky-toast>
+  <sky-toast
+    [autoClose]="autoClose"
+    [toastType]="toastType"
+    (closed)="onClosed()"
+  >
+    Inner content here...
+  </sky-toast>
 } @else {
-
-<sky-toast [autoClose]="autoClose" (closed)="onClosed()">
-  Inner content here...
-</sky-toast>
-
+  <sky-toast [autoClose]="autoClose" (closed)="onClosed()">
+    Inner content here...
+  </sky-toast>
 }

--- a/libs/components/validation/src/lib/modules/email-validation/fixtures/email-validation.component.fixture.html
+++ b/libs/components/validation/src/lib/modules/email-validation/fixtures/email-validation.component.fixture.html
@@ -4,10 +4,10 @@
     <input #email="ngModel" skyEmailValidation [(ngModel)]="emailValidator" />
   </label>
   @if (email.errors?.skyEmail && (email.dirty || email.touched)) {
-  <div class="sky-error-label">
-    <div [hidden]="!email.errors.skyEmail.invalid">
-      Please enter valid email with format joe&#64;abc.com
+    <div class="sky-error-label">
+      <div [hidden]="!email.errors.skyEmail.invalid">
+        Please enter valid email with format joe&#64;abc.com
+      </div>
     </div>
-  </div>
   }
 </div>

--- a/libs/components/validation/src/lib/modules/url-validation/fixtures/url-validation-ruleset.component.fixture.html
+++ b/libs/components/validation/src/lib/modules/url-validation/fixtures/url-validation-ruleset.component.fixture.html
@@ -8,10 +8,10 @@
     />
   </label>
   @if (url.errors?.skyUrl && (url.dirty || url.touched)) {
-  <div class="sky-error-label">
-    <div [hidden]="!url.errors.skyUrl.invalid">
-      Please enter valid url with format http(s)://site.domain
+    <div class="sky-error-label">
+      <div [hidden]="!url.errors.skyUrl.invalid">
+        Please enter valid url with format http(s)://site.domain
+      </div>
     </div>
-  </div>
   }
 </div>

--- a/libs/components/validation/src/lib/modules/url-validation/fixtures/url-validation.component.fixture.html
+++ b/libs/components/validation/src/lib/modules/url-validation/fixtures/url-validation.component.fixture.html
@@ -4,10 +4,10 @@
     <input #url="ngModel" skyUrlValidation [(ngModel)]="urlValidator" />
   </label>
   @if (url.errors?.skyUrl && (url.dirty || url.touched)) {
-  <div class="sky-error-label">
-    <div [hidden]="!url.errors.skyUrl.invalid">
-      Please enter valid url with format http(s)://site.domain
+    <div class="sky-error-label">
+      <div [hidden]="!url.errors.skyUrl.invalid">
+        Please enter valid url with format http(s)://site.domain
+      </div>
     </div>
-  </div>
   }
 </div>


### PR DESCRIPTION
By default, prettier uses the "angular" parser for `*.component.html` files. It uses the default "html" parser for all other HTML files. This is problematic for our `*.component.fixture.html` files, and for new HTML files that follow Angular's updated file naming guidelines. 

This is a known issue with prettier: https://github.com/prettier/prettier/issues/18871

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Standardized code formatting across component templates, including template syntax, indentation, spacing in expressions, and object literal formatting for improved consistency and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->