### PR TITLE
fix(components/data-manager): do not render an empty toolbar when filter bar is the only content (#4461)

### DIFF
--- a/libs/components/data-manager/src/lib/modules/data-manager/data-manager-toolbar/data-manager-toolbar.component.html
+++ b/libs/components/data-manager/src/lib/modules/data-manager/data-manager-toolbar/data-manager-toolbar.component.html
@@ -1,92 +1,97 @@
 <div class="sky-data-manager-toolbar">
-  <sky-toolbar [listDescriptor]="dataManagerConfig?.listDescriptor">
-    <sky-toolbar-section>
-      <ng-content select="sky-data-manager-toolbar-primary-item" />
+  @if (hasToolbarContent) {
+    <sky-toolbar [listDescriptor]="dataManagerConfig?.listDescriptor">
+      <sky-toolbar-section>
+        <ng-content select="sky-data-manager-toolbar-primary-item" />
 
-      @if (activeView?.filterButtonEnabled) {
-        <sky-toolbar-item class="sky-data-manager-filter">
-          <sky-filter-button
-            [showButtonText]="activeView?.showFilterButtonText"
-            (filterButtonClick)="filterButtonClicked()"
-          />
-        </sky-toolbar-item>
-      }
-
-      @if (activeView?.sortEnabled) {
-        <sky-toolbar-item class="sky-data-manager-sort">
-          <sky-sort [showButtonText]="activeView?.showSortButtonText">
-            @for (item of dataManagerConfig?.sortOptions; track item.id) {
-              <sky-sort-item
-                [active]="dataState?.activeSortOption?.id === item.id"
-                (itemSelect)="sortSelected(item)"
-              >
-                {{ item.label }}
-              </sky-sort-item>
-            }
-          </sky-sort>
-        </sky-toolbar-item>
-      }
-
-      @if (activeView?.columnPickerEnabled) {
-        <sky-toolbar-item>
-          <button
-            class="sky-btn sky-btn-default sky-col-picker-btn"
-            type="button"
-            [attr.aria-label]="
-              dataManagerConfig?.listDescriptor
-                ? ('skyux_data_manager_columns_button_aria_label'
-                  | skyLibResources: dataManagerConfig?.listDescriptor)
-                : ('skyux_data_manager_columns_button_title' | skyLibResources)
-            "
-            [attr.title]="
-              'skyux_data_manager_columns_button_title' | skyLibResources
-            "
-            (click)="openColumnPicker()"
-          >
-            <sky-icon iconName="layout-column-three" />
-            <span class="sky-column-selector-action-btn-text">
-              {{ 'skyux_data_manager_columns_button_title' | skyLibResources }}
-            </span>
-          </button>
-        </sky-toolbar-item>
-      }
-
-      <ng-content select="sky-data-manager-toolbar-left-item" />
-
-      @if (activeView?.searchEnabled) {
-        <sky-toolbar-item class="sky-data-manager-search">
-          <sky-search
-            [expandMode]="activeView?.searchExpandMode"
-            [placeholderText]="activeView?.searchPlaceholderText"
-            [searchText]="dataState?.searchText"
-            (searchApply)="searchApplied($event)"
-          />
-        </sky-toolbar-item>
-      }
-
-      <sky-toolbar-view-actions>
-        <ng-content select="sky-data-manager-toolbar-right-item" />
-        @if (activeView && views && views.length > 1) {
-          <sky-radio-group
-            class="sky-switch-icon-group"
-            [ariaLabel]="'data view switcher'"
-            [(ngModel)]="activeView.id"
-          >
-            @for (view of views; track view.id) {
-              <sky-radio
-                [attr.aria-label]="view.name"
-                [iconName]="view.iconName"
-                [value]="view.id"
-                [label]="view.name"
-                (change)="onViewChange(view.id)"
-              />
-            }
-          </sky-radio-group>
+        @if (activeView?.filterButtonEnabled) {
+          <sky-toolbar-item class="sky-data-manager-filter">
+            <sky-filter-button
+              [showButtonText]="activeView?.showFilterButtonText"
+              (filterButtonClick)="filterButtonClicked()"
+            />
+          </sky-toolbar-item>
         }
-      </sky-toolbar-view-actions>
-    </sky-toolbar-section>
-    <ng-content select="sky-data-manager-toolbar-section" />
-  </sky-toolbar>
+
+        @if (activeView?.sortEnabled) {
+          <sky-toolbar-item class="sky-data-manager-sort">
+            <sky-sort [showButtonText]="activeView?.showSortButtonText">
+              @for (item of dataManagerConfig?.sortOptions; track item.id) {
+                <sky-sort-item
+                  [active]="dataState?.activeSortOption?.id === item.id"
+                  (itemSelect)="sortSelected(item)"
+                >
+                  {{ item.label }}
+                </sky-sort-item>
+              }
+            </sky-sort>
+          </sky-toolbar-item>
+        }
+
+        @if (activeView?.columnPickerEnabled) {
+          <sky-toolbar-item>
+            <button
+              class="sky-btn sky-btn-default sky-col-picker-btn"
+              type="button"
+              [attr.aria-label]="
+                dataManagerConfig?.listDescriptor
+                  ? ('skyux_data_manager_columns_button_aria_label'
+                    | skyLibResources: dataManagerConfig?.listDescriptor)
+                  : ('skyux_data_manager_columns_button_title'
+                    | skyLibResources)
+              "
+              [attr.title]="
+                'skyux_data_manager_columns_button_title' | skyLibResources
+              "
+              (click)="openColumnPicker()"
+            >
+              <sky-icon iconName="layout-column-three" />
+              <span class="sky-column-selector-action-btn-text">
+                {{
+                  'skyux_data_manager_columns_button_title' | skyLibResources
+                }}
+              </span>
+            </button>
+          </sky-toolbar-item>
+        }
+
+        <ng-content select="sky-data-manager-toolbar-left-item" />
+
+        @if (activeView?.searchEnabled) {
+          <sky-toolbar-item class="sky-data-manager-search">
+            <sky-search
+              [expandMode]="activeView?.searchExpandMode"
+              [placeholderText]="activeView?.searchPlaceholderText"
+              [searchText]="dataState?.searchText"
+              (searchApply)="searchApplied($event)"
+            />
+          </sky-toolbar-item>
+        }
+
+        <sky-toolbar-view-actions>
+          <ng-content select="sky-data-manager-toolbar-right-item" />
+          @if (activeView && views && views.length > 1) {
+            <sky-radio-group
+              class="sky-switch-icon-group"
+              [ariaLabel]="'data view switcher'"
+              [(ngModel)]="activeView.id"
+            >
+              @for (view of views; track view.id) {
+                <sky-radio
+                  [attr.aria-label]="view.name"
+                  [iconName]="view.iconName"
+                  [value]="view.id"
+                  [label]="view.name"
+                  (change)="onViewChange(view.id)"
+                />
+              }
+            </sky-radio-group>
+          }
+        </sky-toolbar-view-actions>
+      </sky-toolbar-section>
+      <ng-content select="sky-data-manager-toolbar-section" />
+    </sky-toolbar>
+  }
 
   <ng-content select="sky-filter-bar" />
   <ng-content select="sky-list-summary" />

--- a/libs/components/data-manager/src/lib/modules/data-manager/data-manager-toolbar/data-manager-toolbar.component.spec.ts
+++ b/libs/components/data-manager/src/lib/modules/data-manager/data-manager-toolbar/data-manager-toolbar.component.spec.ts
@@ -24,6 +24,7 @@ import { SkyDataManagerState } from '../models/data-manager-state';
 import { SkyDataViewConfig } from '../models/data-view-config';
 import { SkyDataViewState } from '../models/data-view-state';
 
+import { SkyDataManagerToolbarPrimaryItemComponent } from './data-manager-toolbar-primary-item.component';
 import { SkyDataManagerToolbarComponent } from './data-manager-toolbar.component';
 
 class MockModalService {
@@ -60,6 +61,21 @@ class MockModalComponent {}
   standalone: false,
 })
 class MockModalLegacyComponent {}
+
+@Component({
+  imports: [
+    SkyDataManagerToolbarComponent,
+    SkyDataManagerToolbarPrimaryItemComponent,
+  ],
+  template: `
+    <sky-data-manager-toolbar>
+      <sky-data-manager-toolbar-primary-item>
+        <button type="button">Primary</button>
+      </sky-data-manager-toolbar-primary-item>
+    </sky-data-manager-toolbar>
+  `,
+})
+class ProjectedContentHostComponent {}
 
 describe('SkyDataManagerToolbarComponent', () => {
   let dataManagerToolbarFixture: ComponentFixture<SkyDataManagerToolbarComponent>;
@@ -183,6 +199,41 @@ describe('SkyDataManagerToolbarComponent', () => {
     expect(primaryButton).toBeVisible();
     expect(leftButton).toBeVisible();
     expect(rightButton).toBeVisible();
+  });
+
+  it('should not render the main toolbar when it has no content', () => {
+    dataManagerToolbarFixture.detectChanges();
+
+    const toolbar = dataManagerToolbarNativeElement.querySelector(
+      'sky-toolbar:not(.sky-data-manager-multiselect-toolbar)',
+    );
+
+    expect(toolbar).toBeNull();
+  });
+
+  it('should render the main toolbar when the active view enables a feature', () => {
+    spyOn(dataManagerService, 'getViewById').and.returnValue({
+      ...(dataManagerToolbarComponent.activeView as SkyDataViewConfig),
+      sortEnabled: true,
+    });
+    dataManagerToolbarFixture.detectChanges();
+
+    const toolbar = dataManagerToolbarNativeElement.querySelector(
+      'sky-toolbar:not(.sky-data-manager-multiselect-toolbar)',
+    );
+
+    expect(toolbar).not.toBeNull();
+  });
+
+  it('should render the main toolbar when only projected content is present', () => {
+    const hostFixture = TestBed.createComponent(ProjectedContentHostComponent);
+    hostFixture.detectChanges();
+
+    const toolbar = hostFixture.nativeElement.querySelector(
+      'sky-toolbar:not(.sky-data-manager-multiselect-toolbar)',
+    );
+
+    expect(toolbar).not.toBeNull();
   });
 
   it('should show a sort button if the data view config has sort enabled', () => {

--- a/libs/components/data-manager/src/lib/modules/data-manager/data-manager-toolbar/data-manager-toolbar.component.ts
+++ b/libs/components/data-manager/src/lib/modules/data-manager/data-manager-toolbar/data-manager-toolbar.component.ts
@@ -4,6 +4,7 @@ import {
   Component,
   OnDestroy,
   OnInit,
+  contentChildren,
   inject,
   isStandalone,
 } from '@angular/core';
@@ -39,6 +40,11 @@ import { SkyDataManagerConfig } from '../models/data-manager-config';
 import { SkyDataManagerSortOption } from '../models/data-manager-sort-option';
 import { SkyDataManagerState } from '../models/data-manager-state';
 import { SkyDataViewConfig } from '../models/data-view-config';
+
+import { SkyDataManagerToolbarLeftItemComponent } from './data-manager-toolbar-left-item.component';
+import { SkyDataManagerToolbarPrimaryItemComponent } from './data-manager-toolbar-primary-item.component';
+import { SkyDataManagerToolbarRightItemComponent } from './data-manager-toolbar-right-item.component';
+import { SkyDataManagerToolbarSectionComponent } from './data-manager-toolbar-section.component';
 
 /**
  * Renders a `sky-toolbar` with the contents specified by the active view's `SkyDataViewConfig`
@@ -102,6 +108,38 @@ export class SkyDataManagerToolbarComponent implements OnDestroy, OnInit {
   }
 
   public onlyShowSelected: boolean | undefined;
+
+  protected readonly primaryItems = contentChildren(
+    SkyDataManagerToolbarPrimaryItemComponent,
+  );
+  protected readonly leftItems = contentChildren(
+    SkyDataManagerToolbarLeftItemComponent,
+  );
+  protected readonly rightItems = contentChildren(
+    SkyDataManagerToolbarRightItemComponent,
+  );
+  protected readonly sections = contentChildren(
+    SkyDataManagerToolbarSectionComponent,
+  );
+
+  /**
+   * Whether the main toolbar has any content to display. Used to avoid
+   * rendering an empty toolbar when the only projected content is a
+   * `sky-filter-bar` or `sky-list-summary`, which render outside the toolbar.
+   */
+  protected get hasToolbarContent(): boolean {
+    return (
+      !!this.activeView?.filterButtonEnabled ||
+      !!this.activeView?.sortEnabled ||
+      !!this.activeView?.columnPickerEnabled ||
+      !!this.activeView?.searchEnabled ||
+      (!!this.activeView && this.views.length > 1) ||
+      this.primaryItems().length > 0 ||
+      this.leftItems().length > 0 ||
+      this.rightItems().length > 0 ||
+      this.sections().length > 0
+    );
+  }
 
   readonly #logger = inject(SkyLogService, { optional: true });
 


### PR DESCRIPTION
:cherries: Cherry picked from #4461 [fix(components/data-manager): do not render an empty toolbar when filter bar is the only content](https://github.com/blackbaud/skyux/pull/4461)

[AB#4018065](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/4018065) 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Data manager toolbar now displays only when it contains relevant content, preventing empty toolbars from appearing unnecessarily.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->