### PR TITLE
ci: release as 15.0.0-alpha.0

### DIFF
--- a/.versionrc
+++ b/.versionrc
@@ -1,7 +1,7 @@
 {
   "//": "Configuration for https://github.com/absolute-version/commit-and-tag-version",
-  "releaseAs": null,
-  "prerelease": null,
+  "releaseAs": "15.0.0-alpha.0",
+  "prerelease": true,
   "preset": "conventionalcommits",
   "header": "# Changelog\n\n",
   "issuePrefixes": [


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated version configuration to mark the next release as version 15.0.0-alpha.0 with pre-release enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->