### PR TITLE
fix(components/theme): replace deprecated `clip` with `clip-path` for `sky-screen-reader-only` CSS class

### DIFF
--- a/libs/components/theme/src/lib/styles/_public-api/_compat/_mixins.scss
+++ b/libs/components/theme/src/lib/styles/_public-api/_compat/_mixins.scss
@@ -163,15 +163,15 @@
 }
 
 @mixin sky-screen-reader-only {
-  width: 0;
-  height: 0;
+  width: 1px;
+  height: 1px;
   padding: 0;
   opacity: 0;
   position: absolute;
   margin: -1px;
   border: 0;
   overflow: hidden;
-  clip: rect(0, 0, 0, 0);
+  clip-path: inset(50%);
   outline: none;
   white-space: nowrap;
 }


### PR DESCRIPTION
`clip` is deprecated https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/clip

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated screen reader hidden text styling technique for improved compatibility and maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->