### PR TITLE
fix(components/tabs): fit layout tabs should not shift with hidden tabs (#4471)

### DIFF
--- a/apps/e2e/tabs-storybook-e2e/src/e2e/fit-layout.component.cy.ts
+++ b/apps/e2e/tabs-storybook-e2e/src/e2e/fit-layout.component.cy.ts
@@ -1,0 +1,25 @@
+import { E2eVariations } from '@skyux-sdk/e2e-schematics';
+
+describe('tabs fit layout', () => {
+  E2eVariations.forEachTheme((theme) => {
+    describe(`in ${theme} theme`, () => {
+      beforeEach(() =>
+        cy.visit(
+          `/iframe.html?globals=theme:${theme}&id=fit-layoutcomponent--fit-layout`,
+        ),
+      );
+
+      it('should render the tabs using fit layout', () => {
+        cy.skyReady('app-fit-layout').should('exist').should('be.visible');
+        cy.get('sky-tab-button:nth-child(2) [role="tab"]').click();
+        cy.get('sky-tab:nth-of-type(2) [role="tabpanel"] .placeholder')
+          .should('exist')
+          .should('be.visible');
+        cy.window().screenshot(`fit-layout-${theme}`);
+        cy.window().percySnapshot(`fit-layout-${theme}`, {
+          widths: E2eVariations.DISPLAY_WIDTHS,
+        });
+      });
+    });
+  });
+});

--- a/apps/e2e/tabs-storybook/src/app/app.routes.ts
+++ b/apps/e2e/tabs-storybook/src/app/app.routes.ts
@@ -2,6 +2,10 @@ import { Route } from '@angular/router';
 
 export const routes: Route[] = [
   {
+    path: 'fit-layout',
+    loadComponent: () => import('./fit-layout/fit-layout.component'),
+  },
+  {
     path: 'wizard',
     loadChildren: () =>
       import('./wizard/wizard.module').then((m) => m.WizardModule),

--- a/apps/e2e/tabs-storybook/src/app/fit-layout/fit-layout.component.html
+++ b/apps/e2e/tabs-storybook/src/app/fit-layout/fit-layout.component.html
@@ -1,0 +1,29 @@
+<sky-page layout="fit">
+  <sky-page-header pageTitle="Fit Layout">
+    <sky-page-header-actions>
+      <button class="sky-btn sky-btn-primary" type="button">
+        <sky-icon iconName="add" />
+        New
+      </button>
+    </sky-page-header-actions>
+  </sky-page-header>
+  <sky-page-content>
+    <sky-tabset>
+      <sky-tab tabHeading="Tab 1" layout="fit">
+        <div class="placeholder">
+          <p>Tab 1 content</p>
+        </div>
+      </sky-tab>
+      <sky-tab tabHeading="Tab 2" layout="fit">
+        <div class="placeholder placeholder-danger">
+          <p>Tab 2 content</p>
+        </div>
+      </sky-tab>
+      <sky-tab tabHeading="Tab 3" layout="fit">
+        <div class="placeholder placeholder-warning">
+          <p>Tab 3 content</p>
+        </div>
+      </sky-tab>
+    </sky-tabset>
+  </sky-page-content>
+</sky-page>

--- a/apps/e2e/tabs-storybook/src/app/fit-layout/fit-layout.component.scss
+++ b/apps/e2e/tabs-storybook/src/app/fit-layout/fit-layout.component.scss
@@ -1,0 +1,25 @@
+:host {
+  display: block;
+}
+
+.placeholder {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  background-color: var(--sky-theme-color-background-container-info);
+  color: var(--sky-theme-color-text-action);
+  border: var(--sky-theme-border-container-default);
+  padding: var(--sky-theme-space-inset-balanced-m);
+  justify-content: center;
+  align-items: center;
+}
+
+.placeholder-warning {
+  background-color: var(--sky-theme-color-background-container-warning);
+  color: var(--sky-theme-color-text-default);
+}
+
+.placeholder-danger {
+  background-color: var(--sky-theme-color-background-container-danger);
+  color: var(--sky-theme-color-text-default);
+}

--- a/apps/e2e/tabs-storybook/src/app/fit-layout/fit-layout.component.stories.ts
+++ b/apps/e2e/tabs-storybook/src/app/fit-layout/fit-layout.component.stories.ts
@@ -1,0 +1,12 @@
+import type { Meta, StoryObj } from '@storybook/angular';
+
+import { FitLayoutComponent } from './fit-layout.component';
+
+export default {
+  id: 'fit-layoutcomponent',
+  title: 'Components/Fit Layout',
+  component: FitLayoutComponent,
+} as Meta<FitLayoutComponent>;
+type Story = StoryObj<FitLayoutComponent>;
+export const FitLayout: Story = {};
+FitLayout.args = {};

--- a/apps/e2e/tabs-storybook/src/app/fit-layout/fit-layout.component.ts
+++ b/apps/e2e/tabs-storybook/src/app/fit-layout/fit-layout.component.ts
@@ -1,0 +1,13 @@
+import { Component } from '@angular/core';
+import { SkyIconModule } from '@skyux/icon';
+import { SkyPageModule } from '@skyux/pages';
+import { SkyTabsModule } from '@skyux/tabs';
+
+@Component({
+  imports: [SkyIconModule, SkyPageModule, SkyTabsModule],
+  selector: 'app-fit-layout',
+  templateUrl: './fit-layout.component.html',
+  styleUrls: ['./fit-layout.component.scss'],
+})
+export class FitLayoutComponent {}
+export default FitLayoutComponent;

--- a/apps/e2e/tabs-storybook/src/main.ts
+++ b/apps/e2e/tabs-storybook/src/main.ts
@@ -5,6 +5,7 @@ import {
   withEnabledBlockingInitialNavigation,
 } from '@angular/router';
 
+import { provideInitialTheme } from '@skyux/theme';
 import { AppComponent } from './app/app.component';
 import { routes } from './app/app.routes';
 
@@ -12,5 +13,6 @@ bootstrapApplication(AppComponent, {
   providers: [
     provideZoneChangeDetection(),
     provideRouter(routes, withEnabledBlockingInitialNavigation()),
+    provideInitialTheme('modern'),
   ],
 }).catch((err) => console.error(err));

--- a/libs/components/tabs/src/lib/modules/tabs/tabset.component.scss
+++ b/libs/components/tabs/src/lib/modules/tabs/tabset.component.scss
@@ -32,6 +32,10 @@ sky-tabset {
     .sky-tabset {
       flex-grow: 0;
     }
+
+    sky-tab:has(> div.sky-tab[hidden]) {
+      display: contents;
+    }
   }
 }
 


### PR DESCRIPTION
:cherries: Cherry picked from #4471 [fix(components/tabs): fit layout tabs should not shift with hidden tabs](https://github.com/blackbaud/skyux/pull/4471)

[AB#4024923](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/4024923) 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new “Fit Layout” tabs story in the Storybook app with sample content and a primary action button.
  * The story now starts with the Modern theme for a consistent preview experience.

* **Bug Fixes**
  * Improved fit-layout tab rendering so hidden tab content no longer affects the overall layout.

* **Tests**
  * Added end-to-end coverage for the new tabs layout across themes, including visual snapshots.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->