### PR TITLE
chore: unset release-as for 15 prereleases

### DIFF
--- a/.versionrc
+++ b/.versionrc
@@ -1,6 +1,6 @@
 {
   "//": "Configuration for https://github.com/absolute-version/commit-and-tag-version",
-  "releaseAs": "15.0.0-alpha.0",
+  "releaseAs": null,
   "prerelease": true,
   "preset": "conventionalcommits",
   "header": "# Changelog\n\n",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release version configuration so automated versioning no longer defaults to a prefilled alpha release tag.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->