### PR TITLE
fix(components/ag-grid): header focus ring should meet minimum contrast ratio

### DIFF
--- a/libs/components/ag-grid/src/lib/modules/ag-grid/ag-grid-wrapper.component.spec.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/ag-grid-wrapper.component.spec.ts
@@ -768,6 +768,42 @@ describe('SkyAgGridWrapperComponent via fixture', () => {
       });
     });
 
+    it(`should be accessible when a header cell has focus`, async () => {
+      TestBed.overrideProvider(Editable, { useValue: false });
+      gridWrapperFixture = TestBed.createComponent(SkyAgGridFixtureComponent);
+      gridWrapperNativeElement = gridWrapperFixture.nativeElement;
+
+      gridWrapperFixture.detectChanges();
+      await gridWrapperFixture.whenStable();
+
+      const headerCell = gridWrapperNativeElement.querySelector(
+        '.ag-header-cell[col-id="name"]',
+      ) as HTMLElement;
+      headerCell.focus();
+      gridWrapperFixture.detectChanges();
+
+      expect(gridWrapperNativeElement.ownerDocument.activeElement).toBe(
+        headerCell,
+      );
+      await expectAsync(gridWrapperNativeElement).toBeAccessible();
+
+      // The axe-core test does not assert the contrast for the focus ring; it only checks contrast between text and backgrounds.
+      const skyAgGridEl = gridWrapperNativeElement.querySelector(
+        '.sky-ag-grid',
+      ) as HTMLElement;
+      expect(
+        getComputedStyle(headerCell)
+          .getPropertyValue('--ag-focus-shadow')
+          .trim()
+          .split(' ')
+          .pop(),
+      ).toBe(
+        getComputedStyle(skyAgGridEl)
+          .getPropertyValue('--sky-override-ag-grid-focus-border-color')
+          .trim(),
+      );
+    });
+
     it(`should be accessible in edit mode`, async () => {
       gridWrapperFixture = TestBed.createComponent(SkyAgGridFixtureComponent);
       gridWrapperNativeElement = gridWrapperFixture.nativeElement;

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/ag-grid-wrapper.component.spec.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/ag-grid-wrapper.component.spec.ts
@@ -787,21 +787,24 @@ describe('SkyAgGridWrapperComponent via fixture', () => {
       );
       await expectAsync(gridWrapperNativeElement).toBeAccessible();
 
-      // The axe-core test does not assert the contrast for the focus ring; it only checks contrast between text and backgrounds.
+      // The axe-core test does not assert the contrast for the focus ring, it
+      // only checks contrast between text and backgrounds, so this test is also
+      // asserting that the focus shadow is our color.
       const skyAgGridEl = gridWrapperNativeElement.querySelector(
         '.sky-ag-grid',
       ) as HTMLElement;
-      expect(
-        getComputedStyle(headerCell)
-          .getPropertyValue('--ag-focus-shadow')
-          .trim()
-          .split(' ')
-          .pop(),
-      ).toBe(
-        getComputedStyle(skyAgGridEl)
-          .getPropertyValue('--sky-override-ag-grid-focus-border-color')
-          .trim(),
-      );
+      const styleResolver = document.createElement('span');
+      styleResolver.style.color =
+        'var(--sky-override-ag-grid-focus-border-color, var(--sky-color-border-input-focus))';
+      skyAgGridEl.append(styleResolver);
+      const focusBorderColor = getComputedStyle(styleResolver).color;
+      expect(focusBorderColor).toBeTruthy();
+      styleResolver.remove();
+
+      const headerCellFocusShadow = getComputedStyle(headerCell).boxShadow;
+      expect(headerCellFocusShadow).toContain(focusBorderColor);
+      expect(headerCellFocusShadow).toContain('0px 0px 0px 2px');
+      expect(headerCellFocusShadow).toContain('inset');
     });
 
     it(`should be accessible in edit mode`, async () => {

--- a/libs/components/ag-grid/src/lib/styles/_overrides.scss
+++ b/libs/components/ag-grid/src/lib/styles/_overrides.scss
@@ -1,6 +1,7 @@
 @use 'libs/components/theme/src/lib/styles/compat-tokens-mixins' as compatMixins;
 
 @include compatMixins.sky-default-overrides('.sky-ag-grid') {
+  --sky-override-ag-grid-accent-color: var(--sky-highlight-color-info);
   --sky-override-ag-grid-background-color: #fbfbfb;
   --sky-override-ag-grid-border-color: var(--sky-border-color-neutral-medium);
   --sky-override-ag-grid-border-radius: 3px;
@@ -35,6 +36,8 @@
   );
   --sky-override-ag-grid-column-border: 1px solid
     var(--sky-border-color-neutral-medium);
+  --sky-override-ag-grid-focus-border-color: var(--sky-highlight-color-info);
+  --sky-override-ag-grid-focus-border-width: 2px;
   --sky-override-ag-grid-font-family:
     'BLKB Sans', 'Helvetica Neue', 'Arial', 'sans-serif';
   --sky-override-ag-grid-font-size: 15px;

--- a/libs/components/ag-grid/src/lib/styles/ag-grid-theme.ts
+++ b/libs/components/ag-grid/src/lib/styles/ag-grid-theme.ts
@@ -8,6 +8,10 @@ import {
 } from 'ag-grid-community';
 
 const defaultsForAllThemes: Partial<ThemeDefaultParams> = {
+  accentColor:
+    'var(--sky-override-ag-grid-accent-color, var(--sky-color-border-input-focus))',
+  focusShadow:
+    '0px 0px 0px var(--sky-override-ag-grid-focus-border-width, var(--sky-border-width-input-focus)) var(--sky-override-ag-grid-focus-border-color, var(--sky-color-border-input-focus))',
   backgroundColor:
     'var(--sky-override-ag-grid-background-color, var(--sky-color-background-row-base))',
   borderColor:


### PR DESCRIPTION
[AB#3693206](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3693206)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard focus visibility in the grid, including refined focus ring styling for header cells.
  * Enhanced accessibility validation to ensure focused header cells maintain accessible, visible focus states.  
* **New Features**
  * Added theme support for configurable AG Grid focus styling via new focus-related CSS variables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->