### PR TITLE
ci: use latest e2e job executions

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -513,17 +513,15 @@ jobs:
 
               const listJobsForWorkflowRun = async () => {
                 try {
-                  return await Promise.all(
-                    Array.from(Array(context.runAttempt).keys(),i=>++i).reverse().map((attempt) =>
-                      github.paginate('GET /repos/{owner}/{repo}/actions/runs/{run_id}/attempts/{attempt}/jobs', {
-                        owner: context.repo.owner,
-                        repo: context.repo.repo,
-                        run_id: context.runId,
-                        attempt,
-                        headers: { 'X-GitHub-Api-Version': '2022-11-28' }
-                      })
-                    )
-                  );
+                  const jobs = await github.paginate('GET /repos/{owner}/{repo}/actions/runs/{run_id}/jobs', {
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    run_id: context.runId,
+                    filter: 'latest',
+                    per_page: 100,
+                    headers: { 'X-GitHub-Api-Version': '2022-11-28' }
+                  });
+                  return [jobs];
                 } catch (e) {
                   core.warning(`Error getting workflow jobs for this run: ${e}`);
                   return [];

--- a/libs/sdk/e2e-schematics/src/workflow/verify-e2e/verify-e2e.spec.ts
+++ b/libs/sdk/e2e-schematics/src/workflow/verify-e2e/verify-e2e.spec.ts
@@ -355,6 +355,69 @@ More unrelated log output
     expect(exit).toHaveBeenCalledWith(1);
   });
 
+  it('should fail when the latest e2e job execution was cancelled', async () => {
+    const { verifyE2e, checkPercyBuild, core, githubApi, exit, fetch } =
+      await setupTest();
+    githubApi.listJobsForWorkflowRun.mockResolvedValue([
+      [
+        {
+          id: 'review-3',
+          name: 'E2E Visual Review',
+          steps: [
+            {
+              name: 'Verify E2E Visual Review',
+              conclusion: 'success',
+            },
+          ],
+        },
+      ],
+      [
+        {
+          id: 'cancelled-2',
+          name: 'End to end tests (project1,',
+          steps: [
+            {
+              name: 'Percy project1',
+              conclusion: 'cancelled',
+            },
+          ],
+        },
+      ],
+      [
+        {
+          id: 'success-1',
+          name: 'End to end tests (project1,',
+          steps: [
+            {
+              name: 'Percy project1',
+              conclusion: 'success',
+            },
+          ],
+        },
+      ],
+    ]);
+    githubApi.downloadJobLogs.mockResolvedValue(`
+Some unrelated log output
+Checking for finalized build: [percy] Finalized build #6134: https://percy.io/82a32315/web/skyux-integration-e2e/builds/41420284
+More unrelated log output
+`);
+
+    await verifyE2e(
+      ['project1'],
+      [],
+      core,
+      githubApi,
+      true, // allowMissingScreenshots
+      fetch,
+      exit,
+    );
+
+    expect(core.setFailed).toHaveBeenCalledWith(`E2E workflow failed.`);
+    expect(exit).toHaveBeenCalledWith(1);
+    expect(checkPercyBuild).not.toHaveBeenCalled();
+    expect(githubApi.downloadJobLogs).not.toHaveBeenCalled();
+  });
+
   it('should check for missing screenshots', async () => {
     const { verifyE2e, core, githubApi, exit } = await setupTest();
     await verifyE2e(

--- a/libs/sdk/e2e-schematics/src/workflow/verify-e2e/verify-e2e.ts
+++ b/libs/sdk/e2e-schematics/src/workflow/verify-e2e/verify-e2e.ts
@@ -67,13 +67,14 @@ export async function verifyE2e(
     // Verify that Percy has finished processing the E2E Visual Review and that all snapshots have passed.
 
     core.info('Fetching workflow jobs...');
-    const jobs = await listJobsForWorkflowRun(githubApi);
+    const workflowJobAttempts = await listJobsForWorkflowRun(githubApi);
+    const jobs = listLatestWorkflowJobs(workflowJobAttempts);
     // This job always runs, so check if any previous jobs failed and fail this job before doing any more work.
-    if (!jobs || jobs.length === 0 || !allWorkflowJobsPassed(jobs[0])) {
+    if (jobs.length === 0 || !allWorkflowJobsPassed(jobs)) {
       core.setFailed('E2E workflow failed.');
       return exit(1);
     }
-    const e2eSteps = listPercyWorkflowSteps(jobs[0]);
+    const e2eSteps = listPercyWorkflowSteps(jobs);
     const skippedPercyProjects = e2eSteps
       .filter((step) => step.skipped)
       .map((step) => step.project);
@@ -229,6 +230,20 @@ export async function verifyE2e(
     return allJobsPassed;
   }
 
+  function listLatestWorkflowJobs(jobs: WorkflowJob[][]): WorkflowJob[] {
+    const latestJobs = new Map<string, WorkflowJob>();
+
+    for (const jobAttempt of jobs) {
+      for (const job of jobAttempt) {
+        if (!latestJobs.has(job.name)) {
+          latestJobs.set(job.name, job);
+        }
+      }
+    }
+
+    return Array.from(latestJobs.values());
+  }
+
   function listE2eJobsForWorkflowRun(jobs: WorkflowJob[]): WorkflowJob[] {
     return jobs.filter((job: WorkflowJob) =>
       job.name.startsWith('End to end tests'),
@@ -259,29 +274,24 @@ export async function verifyE2e(
 
   async function readBuildIdFromLogs(
     e2eProject: string,
-    jobs: WorkflowJob[][],
+    jobs: WorkflowJob[],
     downloadJobLogs: (job_id: string) => Promise<string>,
   ): Promise<string | undefined> {
-    const jobsForThisProject = jobs
-      .flatMap((run) =>
-        run.find((job) =>
-          job.name.startsWith(`End to end tests (${e2eProject},`),
-        ),
-      )
-      .filter(Boolean) as WorkflowJob[];
-    for (const jobForThisProject of jobsForThisProject) {
-      const step = jobForThisProject.steps.find((step) =>
-        step.name.startsWith('Percy'),
-      );
+    const jobForThisProject = jobs.find((job) =>
+      job.name.startsWith(`End to end tests (${e2eProject},`),
+    );
+    const step = jobForThisProject?.steps.find((step) =>
+      step.name.startsWith('Percy'),
+    );
 
-      if (step && step.conclusion === 'success') {
-        const log = await downloadJobLogs(jobForThisProject.id);
-        const buildId = readPercyBuildNumberFromLogString(log);
-        if (buildId) {
-          return buildId;
-        }
+    if (jobForThisProject && step?.conclusion === 'success') {
+      const log = await downloadJobLogs(jobForThisProject.id);
+      const buildId = readPercyBuildNumberFromLogString(log);
+      if (buildId) {
+        return buildId;
       }
     }
+
     return undefined;
   }
 


### PR DESCRIPTION
[Example run](https://github.com/blackbaud/skyux/actions/runs/28806474097)

## Summary
- use the GitHub Actions latest jobs view in the E2E visual review workflow
- normalize workflow job attempts before checking E2E job success and Percy logs
- add regression coverage for stale attempt history masking a cancelled E2E job

## Test Plan
- [x] NX_SOCKET_DIR=/tmp/nx-skyux-e2e npx nx test e2e-schematics
- [x] NX_SOCKET_DIR=/tmp/nx-skyux-e2e npx nx lint e2e-schematics
- [x] NX_SOCKET_DIR=/tmp/nx-skyux-e2e npx nx build e2e-schematics


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved E2E validation to use the latest workflow jobs, helping avoid false failures from older run attempts.
  * Cancelled visual review runs are now treated as failed checks, so broken or incomplete runs stop the release flow sooner.
  * Percy build details are now read from the current consolidated job set, making status checks more reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->