### PR TITLE
feat(components/packages): create `convert-grid-to-data-grid` schematics

### DIFF
--- a/libs/components/packages/collection.json
+++ b/libs/components/packages/collection.json
@@ -26,6 +26,11 @@
       "factory": "./src/schematics/ng-generate/convert-page-summary-to-page-header/convert-page-summary-to-page-header.schematic",
       "schema": "./src/schematics/ng-generate/convert-page-summary-to-page-header/schema.json"
     },
+    "convert-grid-to-data-grid": {
+      "description": "Convert <sky-grid> components to <sky-data-grid> components.",
+      "factory": "./src/schematics/ng-generate/convert-grid-to-data-grid/convert-grid-to-data-grid.schematic",
+      "schema": "./src/schematics/ng-generate/convert-grid-to-data-grid/schema.json"
+    },
     "convert-progress-indicator-wizard-to-tab-wizard": {
       "description": "Convert <sky-progress-indicator> components using wizard to use <sky-tabset> components.",
       "factory": "./src/schematics/ng-generate/convert-progress-indicator-wizard-to-tab-wizard/convert-progress-indicator-wizard-to-tab-wizard.schematic",

--- a/libs/components/packages/src/schematics/ng-generate/convert-grid-to-data-grid/convert-grid-to-data-grid.schematic.ts
+++ b/libs/components/packages/src/schematics/ng-generate/convert-grid-to-data-grid/convert-grid-to-data-grid.schematic.ts
@@ -1,0 +1,17 @@
+import { Rule } from '@angular-devkit/schematics';
+
+import { convertGridToDataGrid } from '../../rules/convert-grid-to-data-grid/convert-grid-to-data-grid';
+import { getRequiredProject } from '../../utility/workspace';
+
+import { Schema } from './schema';
+
+/**
+ * Converts `<sky-grid>` components to `<sky-data-grid>` components.
+ */
+export default function convertGridToDataGridSchematic(options: Schema): Rule {
+  return async (tree) => {
+    const { project } = await getRequiredProject(tree, options.project);
+
+    return convertGridToDataGrid(project.root);
+  };
+}

--- a/libs/components/packages/src/schematics/ng-generate/convert-grid-to-data-grid/schema.json
+++ b/libs/components/packages/src/schematics/ng-generate/convert-grid-to-data-grid/schema.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "type": "object",
+  "properties": {
+    "project": {
+      "type": "string",
+      "description": "The name of the project.",
+      "$default": {
+        "$source": "projectName"
+      }
+    }
+  }
+}

--- a/libs/components/packages/src/schematics/ng-generate/convert-grid-to-data-grid/schema.ts
+++ b/libs/components/packages/src/schematics/ng-generate/convert-grid-to-data-grid/schema.ts
@@ -1,0 +1,9 @@
+/**
+ * Represents options passed via Angular CLI.
+ */
+export interface Schema {
+  /**
+   * The name of the project to convert.
+   */
+  project?: string;
+}

--- a/libs/components/packages/src/schematics/rules/convert-grid-to-data-grid/convert-grid-to-data-grid.spec.ts
+++ b/libs/components/packages/src/schematics/rules/convert-grid-to-data-grid/convert-grid-to-data-grid.spec.ts
@@ -1,0 +1,292 @@
+import { stripIndents } from '@angular-devkit/core/src/utils/literals';
+import {
+  SchematicTestRunner,
+  UnitTestTree,
+} from '@angular-devkit/schematics/testing';
+
+import { createTestApp } from '../../testing/scaffold';
+
+describe('Convert Grid to Data Grid', () => {
+  const runner = new SchematicTestRunner(
+    'schematics',
+    require.resolve('../../../../collection.json'),
+  );
+
+  const logs: { level: string; message: string }[] = [];
+
+  beforeAll(() => {
+    runner.logger.subscribe((entry) => {
+      logs.push({ level: entry.level, message: entry.message });
+    });
+  });
+
+  beforeEach(() => {
+    logs.length = 0;
+  });
+
+  function hasLog(substring: string): boolean {
+    return logs.some((log) => log.message.includes(substring));
+  }
+
+  async function convert(tree: UnitTestTree): Promise<UnitTestTree> {
+    return await runner.runSchematic(
+      'convert-grid-to-data-grid',
+      { project: 'test-app' },
+      tree,
+    );
+  }
+
+  it('should convert grid and column tags and rename inputs', async () => {
+    const tree = await createTestApp(runner, { projectName: 'test-app' });
+    const input = stripIndents`
+      <sky-grid [data]="data" [enableMultiselect]="true" [selectedRowIds]="ids" [sortField]="sort" (sortFieldChange)="onSort($event)">
+        <sky-grid-column id="name" heading="Name" field="name" [isSortable]="true" [width]="200" [hidden]="false" />
+      </sky-grid>
+    `;
+    tree.create('src/app/test.component.html', input);
+    const result = await convert(tree);
+    expect(stripIndents`${result.readText('src/app/test.component.html')}`)
+      .toBe(stripIndents`
+      <sky-data-grid [data]="data" [multiselect]="true" [selectedRowIds]="ids" [sort]="sort" (sortChange)="onSort($event)">
+        <sky-data-grid-column columnId="name" headingText="Name" field="name" [sortable]="true" [width]="200" [columnHidden]="false" />
+      </sky-data-grid>
+    `);
+    expect(hasLog('"sortField"/"(sortFieldChange)" bindings')).toBe(true);
+  });
+
+  it('should translate fit literal values and warn on a bound fit', async () => {
+    const tree = await createTestApp(runner, { projectName: 'test-app' });
+    tree.create(
+      'src/app/test.component.html',
+      stripIndents`
+        <sky-grid [data]="data1" fit="scroll"></sky-grid>
+        <sky-grid [data]="data2" fit="width"></sky-grid>
+        <sky-grid [data]="data3" [fit]="fitValue"></sky-grid>
+      `,
+    );
+    const result = await convert(tree);
+    expect(stripIndents`${result.readText('src/app/test.component.html')}`)
+      .toBe(stripIndents`
+      <sky-data-grid [data]="data1" columnFit="content"></sky-data-grid>
+      <sky-data-grid [data]="data2" columnFit="container"></sky-data-grid>
+      <sky-data-grid [data]="data3" [columnFit]="fitValue"></sky-data-grid>
+    `);
+    expect(hasLog('"fit" input on <sky-grid> was renamed')).toBe(true);
+  });
+
+  it('should rename the multiselectSelectionChange output and warn', async () => {
+    const tree = await createTestApp(runner, { projectName: 'test-app' });
+    tree.create(
+      'src/app/test.component.html',
+      stripIndents`
+        <sky-grid [data]="data" (multiselectSelectionChange)="onSelect($event)"></sky-grid>
+      `,
+    );
+    const result = await convert(tree);
+    expect(stripIndents`${result.readText('src/app/test.component.html')}`)
+      .toBe(stripIndents`
+      <sky-data-grid [data]="data" (selectedRowIdsChange)="onSelect($event)"></sky-data-grid>
+    `);
+    expect(hasLog('"(multiselectSelectionChange)" output')).toBe(true);
+  });
+
+  it('should drop unsupported grid inputs and warn', async () => {
+    const tree = await createTestApp(runner, { projectName: 'test-app' });
+    tree.create(
+      'src/app/test.component.html',
+      stripIndents`
+        <sky-grid [data]="data" hasToolbar="true" [height]="300" highlightText="x" [messageStream]="ms" multiselectRowId="key" [rowHighlightedId]="rid" [selectedColumnIds]="cols" (selectedColumnIdsChange)="onCols($event)" settingsKey="grid1" [width]="500" (columnWidthChange)="onW($event)" (rowDeleteCancel)="onCancel($event)" (rowDeleteConfirm)="onConfirm($event)"></sky-grid>
+      `,
+    );
+    const result = await convert(tree);
+    expect(stripIndents`${result.readText('src/app/test.component.html')}`)
+      .toBe(stripIndents`
+      <sky-data-grid [data]="data"></sky-data-grid>
+    `);
+    expect(hasLog('"hasToolbar" binding')).toBe(true);
+    expect(hasLog('"settingsKey" binding')).toBe(true);
+    expect(hasLog('"columnWidthChange" binding')).toBe(true);
+    expect(hasLog('"selectedColumnIdsChange" binding')).toBe(true);
+    expect(hasLog('"rowDeleteCancel" binding')).toBe(true);
+    expect(hasLog('"rowDeleteConfirm" binding')).toBe(true);
+  });
+
+  it('should map description to helpPopoverContent and drop other column inputs', async () => {
+    const tree = await createTestApp(runner, { projectName: 'test-app' });
+    tree.create(
+      'src/app/test.component.html',
+      stripIndents`
+        <sky-grid [data]="data">
+          <sky-grid-column field="amount" heading="Amount" description="The gift amount" alignment="right" [excludeFromHighlighting]="true" [search]="searchFn" type="number"></sky-grid-column>
+        </sky-grid>
+      `,
+    );
+    const result = await convert(tree);
+    expect(stripIndents`${result.readText('src/app/test.component.html')}`)
+      .toBe(stripIndents`
+      <sky-data-grid [data]="data">
+        <sky-data-grid-column field="amount" headingText="Amount" helpPopoverContent="The gift amount"></sky-data-grid-column>
+      </sky-data-grid>
+    `);
+    expect(hasLog('"description" input on <sky-grid-column> was mapped')).toBe(
+      true,
+    );
+    expect(hasLog('For right alignment, set dataType="number"')).toBe(true);
+    expect(hasLog('"excludeFromHighlighting" binding')).toBe(true);
+    expect(hasLog('"search" binding')).toBe(true);
+    expect(hasLog('"type" binding')).toBe(true);
+  });
+
+  it('should map inlineHelpPopover, drop description when both present, and drop non-right alignment', async () => {
+    const tree = await createTestApp(runner, { projectName: 'test-app' });
+    tree.create(
+      'src/app/test.component.html',
+      stripIndents`
+        <sky-grid [data]="data">
+          <sky-grid-column field="a" heading="A" [inlineHelpPopover]="helpTmpl" description="desc" alignment="center" />
+        </sky-grid>
+      `,
+    );
+    const result = await convert(tree);
+    expect(stripIndents`${result.readText('src/app/test.component.html')}`)
+      .toBe(stripIndents`
+      <sky-data-grid [data]="data">
+        <sky-data-grid-column field="a" headingText="A" [helpPopoverContent]="helpTmpl" />
+      </sky-data-grid>
+    `);
+    expect(
+      hasLog('"inlineHelpPopover" input on <sky-grid-column> was mapped'),
+    ).toBe(true);
+    expect(
+      hasLog('"description" input on <sky-grid-column> could not be migrated'),
+    ).toBe(true);
+    expect(hasLog('Apply alignment via a cell template or CSS')).toBe(true);
+  });
+
+  it('should map inlineHelpPopover without a description and drop bound alignment', async () => {
+    const tree = await createTestApp(runner, { projectName: 'test-app' });
+    tree.create(
+      'src/app/test.component.html',
+      stripIndents`
+        <sky-grid [data]="data">
+          <sky-grid-column field="a" heading="A" [inlineHelpPopover]="tmpl" [alignment]="al"></sky-grid-column>
+        </sky-grid>
+      `,
+    );
+    const result = await convert(tree);
+    expect(stripIndents`${result.readText('src/app/test.component.html')}`)
+      .toBe(stripIndents`
+      <sky-data-grid [data]="data">
+        <sky-data-grid-column field="a" headingText="A" [helpPopoverContent]="tmpl"></sky-data-grid-column>
+      </sky-data-grid>
+    `);
+  });
+
+  it('should leave a grid using the columns input unchanged and warn', async () => {
+    const tree = await createTestApp(runner, { projectName: 'test-app' });
+    const input = stripIndents`
+      <sky-grid [data]="data" [columns]="myColumns">
+        <sky-grid-column field="a" heading="A"></sky-grid-column>
+      </sky-grid>
+    `;
+    tree.create('src/app/test.component.html', input);
+    const result = await convert(tree);
+    expect(
+      stripIndents`${result.readText('src/app/test.component.html')}`,
+    ).toBe(input);
+    expect(hasLog('using the "columns" input was left unchanged')).toBe(true);
+  });
+
+  it('should convert multiple self-closing columns', async () => {
+    const tree = await createTestApp(runner, { projectName: 'test-app' });
+    tree.create(
+      'src/app/test.component.html',
+      stripIndents`
+        <sky-grid [data]="data">
+          <sky-grid-column id="a" heading="A" />
+          <sky-grid-column id="b" heading="B" />
+          <sky-grid-column id="c" heading="C" />
+        </sky-grid>
+      `,
+    );
+    const result = await convert(tree);
+    expect(stripIndents`${result.readText('src/app/test.component.html')}`)
+      .toBe(stripIndents`
+      <sky-data-grid [data]="data">
+        <sky-data-grid-column columnId="a" headingText="A" />
+        <sky-data-grid-column columnId="b" headingText="B" />
+        <sky-data-grid-column columnId="c" headingText="C" />
+      </sky-data-grid>
+    `);
+  });
+
+  it('should convert tags that have no attributes', async () => {
+    const tree = await createTestApp(runner, { projectName: 'test-app' });
+    tree.create(
+      'src/app/test.component.html',
+      stripIndents`
+        <sky-grid>
+          <sky-grid-column></sky-grid-column>
+        </sky-grid>
+      `,
+    );
+    const result = await convert(tree);
+    expect(stripIndents`${result.readText('src/app/test.component.html')}`)
+      .toBe(stripIndents`
+      <sky-data-grid>
+        <sky-data-grid-column></sky-data-grid-column>
+      </sky-data-grid>
+    `);
+  });
+
+  it('should do nothing when there is no grid', async () => {
+    const tree = await createTestApp(runner, { projectName: 'test-app' });
+    tree.create('src/app/test.component.html', '<div>No grid here</div>');
+    const result = await convert(tree);
+    expect(result.readText('src/app/test.component.html')).toBe(
+      '<div>No grid here</div>',
+    );
+  });
+
+  it('should convert an inline template and swap the module import', async () => {
+    const tree = await createTestApp(runner, { projectName: 'test-app' });
+    const backtick = '`';
+    tree.create(
+      'src/app/test.component.ts',
+      stripIndents`
+        import { Component } from '@angular/core';
+        import { SkyGridModule } from '@skyux/grids';
+
+        @Component({
+          selector: 'app-test',
+          template: ${backtick}
+            <sky-grid [data]="data">
+              <sky-grid-column id="name" heading="Name" field="name" />
+            </sky-grid>
+          ${backtick},
+          imports: [SkyGridModule],
+        })
+        export class TestComponent {}
+      `,
+    );
+    const result = await convert(tree);
+    expect(stripIndents`${result.readText('src/app/test.component.ts')}`).toBe(
+      stripIndents`
+        import { Component } from '@angular/core';
+
+        import { SkyDataGrid, SkyDataGridColumn } from '@skyux/data-grid';
+
+        @Component({
+          selector: 'app-test',
+          template: ${backtick}
+            <sky-data-grid [data]="data">
+              <sky-data-grid-column columnId="name" headingText="Name" field="name" />
+            </sky-data-grid>
+          ${backtick},
+          imports: [SkyDataGrid, SkyDataGridColumn],
+        })
+        export class TestComponent {}
+      `,
+    );
+  });
+});

--- a/libs/components/packages/src/schematics/rules/convert-grid-to-data-grid/convert-grid-to-data-grid.ts
+++ b/libs/components/packages/src/schematics/rules/convert-grid-to-data-grid/convert-grid-to-data-grid.ts
@@ -1,0 +1,470 @@
+import {
+  Rule,
+  SchematicContext,
+  Tree,
+  UpdateRecorder,
+  chain,
+} from '@angular-devkit/schematics';
+import { ExistingBehavior, addDependency } from '@schematics/angular/utility';
+
+import { logOnce } from '../../utility/log-once';
+import {
+  ElementWithLocation,
+  SwapAttributeCallback,
+  SwapTagCallback,
+  getAttributeValueText,
+  getElementsByTagName,
+  parseTemplate,
+  swapAttributes,
+  swapTags,
+} from '../../utility/template';
+import {
+  getInlineTemplates,
+  isImportedFromPackage,
+  parseSourceFile,
+} from '../../utility/typescript/ng-ast';
+import { swapImportedClass } from '../../utility/typescript/swap-imported-class';
+import { visitProjectFiles } from '../../utility/visit-project-files';
+
+const MIGRATION_DOC_URL =
+  'https://developer.blackbaud.com/skyux/components/data-grid';
+
+const GRID_TAG: 'sky-grid'[] = ['sky-grid'];
+const COLUMN_TAG: 'sky-grid-column'[] = ['sky-grid-column'];
+
+/**
+ * Attribute name swaps applied to `<sky-grid>`. A value of `''` drops the
+ * attribute. Bound (`[x]`) and event (`(x)`) spellings are listed separately
+ * because parse5 treats them as distinct attribute names. `fit`'s unbound
+ * `width`/`scroll` literal values are additionally translated to `columnFit`'s
+ * `container`/`content` values by `gridAttributeSwapCallback`. Anything not
+ * listed (`data`, `selectedRowIds`) is copied through unchanged.
+ */
+const GRID_ATTRIBUTE_SWAPS: Record<string, string> = {
+  enableMultiselect: 'multiselect',
+  '[enableMultiselect]': '[multiselect]',
+  '(multiselectSelectionChange)': '(selectedRowIdsChange)',
+  fit: 'columnFit',
+  '[fit]': '[columnFit]',
+  hasToolbar: '',
+  '[hasToolbar]': '',
+  height: '',
+  '[height]': '',
+  highlightText: '',
+  '[highlightText]': '',
+  messageStream: '',
+  '[messageStream]': '',
+  multiselectRowId: '',
+  '[multiselectRowId]': '',
+  '(rowDeleteCancel)': '',
+  '(rowDeleteConfirm)': '',
+  rowHighlightedId: '',
+  '[rowHighlightedId]': '',
+  selectedColumnIds: '',
+  '[selectedColumnIds]': '',
+  '(selectedColumnIdsChange)': '',
+  settingsKey: '',
+  '[settingsKey]': '',
+  sortField: 'sort',
+  '[sortField]': '[sort]',
+  '(sortFieldChange)': '(sortChange)',
+  width: '',
+  '[width]': '',
+  '(columnWidthChange)': '',
+};
+
+/**
+ * Inputs removed from `<sky-grid>` with no `<sky-data-grid>` equivalent.
+ */
+const GRID_REMOVED_INPUTS = [
+  'hasToolbar',
+  'height',
+  'highlightText',
+  'messageStream',
+  'multiselectRowId',
+  'rowHighlightedId',
+  'selectedColumnIds',
+  'settingsKey',
+  'width',
+];
+
+/** Outputs removed from `<sky-grid>` with no `<sky-data-grid>` equivalent. */
+const GRID_REMOVED_OUTPUTS = [
+  'selectedColumnIdsChange',
+  'columnWidthChange',
+  'rowDeleteCancel',
+  'rowDeleteConfirm',
+];
+
+/**
+ * Inputs removed from `<sky-grid-column>` with no `<sky-data-grid-column>`
+ * equivalent. `alignment` and the help-popover inputs are handled separately
+ * because their messages depend on the value or on sibling attributes.
+ */
+const COLUMN_REMOVED_INPUTS = ['excludeFromHighlighting', 'search', 'type'];
+
+/**
+ * Returns the parse5 attribute names for an input, covering the plain and
+ * property-bound (`[x]`) spellings. parse5 lowercases attribute names.
+ */
+function inputForms(name: string): string[] {
+  const lower = name.toLowerCase();
+  return [lower, `[${lower}]`];
+}
+
+/** Returns the parse5 attribute name for an event binding (`(x)`). */
+function outputForm(name: string): string {
+  return `(${name.toLowerCase()})`;
+}
+
+function gridRemovedMessage(label: string): string {
+  return `The "${label}" binding on <sky-grid> is not supported on <sky-data-grid> and was removed. Review the component for an alternative.`;
+}
+
+function columnRemovedMessage(label: string): string {
+  return `The "${label}" binding on <sky-grid-column> is not supported on <sky-data-grid-column> and was removed. Review the component for an alternative.`;
+}
+
+function hasAttribute(node: ElementWithLocation, names: string[]): boolean {
+  return node.attrs.some((attr) => names.includes(attr.name));
+}
+
+function findAttribute(
+  node: ElementWithLocation,
+  names: string[],
+): { name: string; value: string } | undefined {
+  return node.attrs.find((attr) => names.includes(attr.name));
+}
+
+/**
+ * Builds the replacement open tag, rewriting the attribute list with
+ * `swapAttributes` (which preserves the spacing between attributes) and
+ * preserving whether the original tag was self-closing.
+ */
+function buildOpenTag(
+  newTag: string,
+  swaps: Record<string, string>,
+  node: ElementWithLocation,
+  content: string,
+  callback?: SwapAttributeCallback<string, string>,
+): string {
+  const attributes =
+    node.attrs.length > 0
+      ? swapAttributes(node, swaps, content, callback).replace(/\s+$/, '')
+      : '';
+  const startTagText = content.substring(
+    node.sourceCodeLocation.startTag.startOffset,
+    node.sourceCodeLocation.startTag.endOffset,
+  );
+  const selfClosing = /\/>\s*$/.test(startTagText);
+  return `<${newTag}${attributes}${selfClosing ? ' />' : '>'}`;
+}
+
+/**
+ * Translates `fit`'s unbound `"width"`/`"scroll"` literal values to
+ * `columnFit`'s `"container"`/`"content"` values. Falls back to a plain
+ * name swap (keeping the original value text) for `[fit]` (bound, so the
+ * runtime value can't be statically translated) and for every other
+ * attribute in `GRID_ATTRIBUTE_SWAPS`.
+ */
+const gridAttributeSwapCallback: SwapAttributeCallback<string, string> = (
+  oldAttribute,
+  newAttribute,
+  node,
+  content,
+) => {
+  if (oldAttribute === 'fit') {
+    const valueText = getAttributeValueText(content, node, oldAttribute);
+    const match = /^=(["'])(width|scroll)\1$/.exec(valueText);
+    if (match) {
+      const translated = match[2] === 'width' ? 'container' : 'content';
+      return `${newAttribute}=${match[1]}${translated}${match[1]}`;
+    }
+  }
+  return newAttribute + getAttributeValueText(content, node, oldAttribute);
+};
+
+function gridTagSwap(context: SchematicContext): SwapTagCallback<'sky-grid'> {
+  return (position, _tag, node, content) => {
+    if (position === 'close') {
+      return '</sky-data-grid>';
+    }
+    if (hasAttribute(node, [outputForm('multiselectSelectionChange')])) {
+      logOnce(
+        context,
+        'warn',
+        'The "(multiselectSelectionChange)" output on <sky-grid> was renamed to "(selectedRowIdsChange)" on <sky-data-grid>. The emitted value is now a string[] of selected row IDs instead of a SkyGridSelectedRowsModelChange object (the "source" property is no longer available). Review the handler.',
+      );
+    }
+    if (
+      hasAttribute(node, [
+        ...inputForms('sortField'),
+        outputForm('sortFieldChange'),
+      ])
+    ) {
+      logOnce(
+        context,
+        'warn',
+        'The "sortField"/"(sortFieldChange)" bindings on <sky-grid> were renamed to "sort"/"(sortChange)" on <sky-data-grid>. The value shape changed from { fieldSelector: string, descending: boolean } to { field: string, direction: "asc" | "desc" }. Review the bound value and handler.',
+      );
+    }
+    if (hasAttribute(node, inputForms('fit'))) {
+      logOnce(
+        context,
+        'warn',
+        'The "fit" input on <sky-grid> was renamed to "columnFit" on <sky-data-grid>, with values "width"/"scroll" renamed to "container"/"content". A bound "[fit]" value could not be translated automatically; review it.',
+      );
+    }
+    for (const label of GRID_REMOVED_INPUTS) {
+      if (hasAttribute(node, inputForms(label))) {
+        logOnce(context, 'warn', gridRemovedMessage(label));
+      }
+    }
+    for (const label of GRID_REMOVED_OUTPUTS) {
+      if (hasAttribute(node, [outputForm(label)])) {
+        logOnce(context, 'warn', gridRemovedMessage(label));
+      }
+    }
+    return buildOpenTag(
+      'sky-data-grid',
+      GRID_ATTRIBUTE_SWAPS,
+      node,
+      content,
+      gridAttributeSwapCallback,
+    );
+  };
+}
+
+/**
+ * Logs the help-popover, alignment, and removed-input warnings for a single
+ * `<sky-grid-column>`.
+ */
+function warnColumnAttributes(
+  context: SchematicContext,
+  node: ElementWithLocation,
+  hasInlineHelp: boolean,
+  hasDescription: boolean,
+): void {
+  if (hasInlineHelp) {
+    logOnce(
+      context,
+      'warn',
+      'The "inlineHelpPopover" input on <sky-grid-column> was mapped to "helpPopoverContent" on <sky-data-grid-column>. Review the binding: "helpPopoverContent" accepts a string or a TemplateRef.',
+    );
+    if (hasDescription) {
+      logOnce(
+        context,
+        'warn',
+        'The "description" input on <sky-grid-column> could not be migrated because "helpPopoverContent" was already mapped from "inlineHelpPopover". Review the column.',
+      );
+    }
+  } else if (hasDescription) {
+    logOnce(
+      context,
+      'warn',
+      'The "description" input on <sky-grid-column> was mapped to "helpPopoverContent" on <sky-data-grid-column>. Review the result.',
+    );
+  }
+
+  const alignment = findAttribute(node, inputForms('alignment'));
+  if (alignment) {
+    if (alignment.name === 'alignment' && alignment.value === 'right') {
+      logOnce(
+        context,
+        'warn',
+        'The "alignment" input is not supported on <sky-data-grid-column>. For right alignment, set dataType="number" on the column.',
+      );
+    } else {
+      logOnce(
+        context,
+        'warn',
+        'The "alignment" input is not supported on <sky-data-grid-column> and was removed. Apply alignment via a cell template or CSS.',
+      );
+    }
+  }
+
+  for (const label of COLUMN_REMOVED_INPUTS) {
+    if (hasAttribute(node, inputForms(label))) {
+      logOnce(context, 'warn', columnRemovedMessage(label));
+    }
+  }
+}
+
+function buildColumnSwaps(hasInlineHelp: boolean): Record<string, string> {
+  return {
+    heading: 'headingText',
+    '[heading]': '[headingText]',
+    hidden: 'columnHidden',
+    '[hidden]': '[columnHidden]',
+    id: 'columnId',
+    '[id]': '[columnId]',
+    isSortable: 'sortable',
+    '[isSortable]': '[sortable]',
+    inlineHelpPopover: 'helpPopoverContent',
+    '[inlineHelpPopover]': '[helpPopoverContent]',
+    description: hasInlineHelp ? '' : 'helpPopoverContent',
+    '[description]': hasInlineHelp ? '' : '[helpPopoverContent]',
+    alignment: '',
+    '[alignment]': '',
+    excludeFromHighlighting: '',
+    '[excludeFromHighlighting]': '',
+    search: '',
+    '[search]': '',
+    type: '',
+    '[type]': '',
+  };
+}
+
+function columnTagSwap(
+  context: SchematicContext,
+): SwapTagCallback<'sky-grid-column'> {
+  return (position, _tag, node, content) => {
+    if (position === 'close') {
+      return '</sky-data-grid-column>';
+    }
+
+    const hasInlineHelp = hasAttribute(node, inputForms('inlineHelpPopover'));
+    const hasDescription = hasAttribute(node, inputForms('description'));
+
+    warnColumnAttributes(context, node, hasInlineHelp, hasDescription);
+
+    return buildOpenTag(
+      'sky-data-grid-column',
+      buildColumnSwaps(hasInlineHelp),
+      node,
+      content,
+    );
+  };
+}
+
+function convertTemplate(
+  recorder: UpdateRecorder,
+  content: string,
+  context: SchematicContext,
+  offset = 0,
+): void {
+  const fragment = parseTemplate(content);
+  const grids = getElementsByTagName('sky-grid', fragment);
+
+  // Columns belonging to a skipped `[columns]` grid are excluded from the
+  // column swap so we never leave `<sky-data-grid-column>` inside `<sky-grid>`.
+  const skippedColumns = new Set<ElementWithLocation>();
+  let converted = 0;
+
+  for (const grid of grids) {
+    if (hasAttribute(grid, ['columns', '[columns]'])) {
+      logOnce(
+        context,
+        'warn',
+        'A <sky-grid> using the "columns" input was left unchanged. The data grid has no "columns" input; define columns with <sky-data-grid-column> elements and migrate this usage manually.',
+      );
+      getElementsByTagName('sky-grid-column', grid).forEach((column) =>
+        skippedColumns.add(column),
+      );
+      continue;
+    }
+    // Each grid is swapped on its own so traversal never has to descend into
+    // self-closing columns (which parse5 nests instead of treating as siblings).
+    swapTags(content, recorder, offset, GRID_TAG, gridTagSwap(context), grid);
+    converted++;
+  }
+
+  // Collect columns from the whole fragment (getElementsByTagName traverses
+  // unconditionally) and swap each individually for the same reason.
+  const columns = getElementsByTagName('sky-grid-column', fragment).filter(
+    (column) => !skippedColumns.has(column),
+  );
+  for (const column of columns) {
+    swapTags(
+      content,
+      recorder,
+      offset,
+      COLUMN_TAG,
+      columnTagSwap(context),
+      column,
+    );
+  }
+
+  if (converted > 0) {
+    logOnce(
+      context,
+      'info',
+      `Converted <sky-grid> component(s) to <sky-data-grid> component(s). Next steps: ${MIGRATION_DOC_URL}`,
+    );
+    logOnce(
+      context,
+      'info',
+      'Data grid columns default to dataType="text". Review numeric and date columns and set "dataType" so sorting and formatting behave correctly.',
+    );
+    logOnce(
+      context,
+      'warn',
+      'Some <sky-grid> features have no <sky-data-grid> equivalent (toolbar, text and row highlighting, custom per-column search, message-stream commands such as row delete, settingsKey persistence, and explicit width/height). Reimplement these manually as needed.',
+    );
+  }
+}
+
+function convertHtmlFile(
+  tree: Tree,
+  filePath: string,
+  context: SchematicContext,
+): void {
+  const content = tree.readText(filePath);
+  if (content.includes('<sky-grid')) {
+    const recorder = tree.beginUpdate(filePath);
+    convertTemplate(recorder, content, context);
+    tree.commitUpdate(recorder);
+  }
+}
+
+function convertTypescriptFile(
+  tree: Tree,
+  filePath: string,
+  context: SchematicContext,
+): void {
+  const source = parseSourceFile(tree, filePath);
+  const templates = getInlineTemplates(source);
+  const recorder = tree.beginUpdate(filePath);
+  if (templates.length > 0) {
+    const content = tree.readText(filePath);
+    for (const template of templates) {
+      convertTemplate(
+        recorder,
+        content.slice(template.start, template.end),
+        context,
+        template.start,
+      );
+    }
+  }
+  if (isImportedFromPackage(source, 'SkyGridModule', '@skyux/grids')) {
+    swapImportedClass(recorder, filePath, source, [
+      {
+        classNames: {
+          SkyGridModule: ['SkyDataGrid', 'SkyDataGridColumn'],
+        },
+        moduleName: {
+          old: '@skyux/grids',
+          new: '@skyux/data-grid',
+        },
+      },
+    ]);
+  }
+  tree.commitUpdate(recorder);
+}
+
+export function convertGridToDataGrid(projectPath: string): Rule {
+  return chain([
+    (tree, context): void => {
+      visitProjectFiles(tree, projectPath, (filePath) => {
+        if (filePath.endsWith('.html')) {
+          convertHtmlFile(tree, filePath, context);
+        } else if (filePath.endsWith('.ts')) {
+          convertTypescriptFile(tree, filePath, context);
+        }
+      });
+    },
+    addDependency('@skyux/data-grid', `0.0.0-PLACEHOLDER`, {
+      existing: ExistingBehavior.Skip,
+    }),
+  ]);
+}

--- a/libs/components/packages/src/schematics/utility/typescript/swap-imported-class.spec.ts
+++ b/libs/components/packages/src/schematics/utility/typescript/swap-imported-class.spec.ts
@@ -139,6 +139,42 @@ describe('swap-imported-class', () => {
     );
   });
 
+  it('should not duplicate a class name that is already imported when swapping to an array of class names', () => {
+    const path = 'file.ts';
+    const content = stripIndents`
+    import { SkyDataGrid } from 'new-module';
+    import { B } from 'old-module';
+
+    A(B) && SkyDataGrid;`;
+    tree.create(path, content);
+    const sourceFile = ts.createSourceFile(
+      path,
+      content,
+      ts.ScriptTarget.Latest,
+      true,
+    );
+
+    const recorder = tree.beginUpdate(path);
+    swapImportedClass(recorder, path, sourceFile, [
+      {
+        classNames: { B: ['SkyDataGrid', 'SkyDataGridColumn'] },
+        moduleName: {
+          old: 'old-module',
+          new: 'new-module',
+        },
+      },
+    ]);
+    tree.commitUpdate(recorder);
+
+    expect(tree.readText(path)).toBe(
+      stripIndents`
+      import { SkyDataGrid, SkyDataGridColumn } from 'new-module';` +
+        `\n\n\n` +
+        stripIndents`
+      A(SkyDataGrid, SkyDataGridColumn) && SkyDataGrid;`,
+    );
+  });
+
   it('should avoid double importing classes', () => {
     const path = 'file.ts';
     const content = stripIndents`

--- a/libs/components/packages/src/schematics/utility/typescript/swap-imported-class.ts
+++ b/libs/components/packages/src/schematics/utility/typescript/swap-imported-class.ts
@@ -11,7 +11,7 @@ import { isImportedFromPackage } from './ng-ast';
 import { removeImport } from './remove-import';
 
 export interface SwapImportedClassOptions {
-  classNames: Record<string, string>;
+  classNames: Record<string, string | string[]>;
   moduleName: string | { old: string; new: string };
   filter?: (node: ts.Identifier) => boolean;
 }
@@ -88,13 +88,25 @@ export function swapImportedClass(
       const referencesFiltered = referencesInCode.filter(
         filter ?? ((): boolean => true),
       );
+      const newClassNameString = Array.isArray(newClassName)
+        ? newClassName.join(', ')
+        : newClassName;
       referencesFiltered.forEach((reference) => {
-        swapReference(recorder, reference, newClassName);
+        swapReference(recorder, reference, newClassNameString);
       });
       if (referencesFiltered.length > 0) {
         const allReferencesToBeReplaced =
           referencesFiltered.length === referencesInCode.length;
-        if (!isImportedFromPackage(sourceFile, newClassName, newModuleName)) {
+        const newClassNameArray = Array.isArray(newClassName)
+          ? newClassName
+          : [newClassName];
+
+        // Assumes that the new thing wouldn't have been partially imported previously.
+        if (
+          !newClassNameArray.every((newClassName) =>
+            isImportedFromPackage(sourceFile, newClassName, newModuleName),
+          )
+        ) {
           if (allReferencesToBeReplaced) {
             if (oldModuleName === newModuleName) {
               const referencesInImport = findReferences(
@@ -106,12 +118,16 @@ export function swapImportedClass(
                   `Expected exactly one import for ${oldClassName} from ${oldModuleName}, found ${referencesInImport.length}.`,
                 );
               }
-              swapReference(recorder, referencesInImport[0], newClassName);
+              swapReference(
+                recorder,
+                referencesInImport[0],
+                newClassNameString,
+              );
             } else {
               const change = insertImport(
                 sourceFile,
                 filePath,
-                newClassName,
+                newClassNameString,
                 newModuleName,
               ) as InsertChange;
               shiftLineBreakForInsertedImport(change, eol);
@@ -121,7 +137,12 @@ export function swapImportedClass(
             }
           } else {
             applyToUpdateRecorder(recorder, [
-              insertImport(sourceFile, filePath, newClassName, newModuleName),
+              insertImport(
+                sourceFile,
+                filePath,
+                newClassNameString,
+                newModuleName,
+              ),
             ]);
           }
         } else {

--- a/libs/components/packages/src/schematics/utility/typescript/swap-imported-class.ts
+++ b/libs/components/packages/src/schematics/utility/typescript/swap-imported-class.ts
@@ -101,12 +101,12 @@ export function swapImportedClass(
           ? newClassName
           : [newClassName];
 
-        // Assumes that the new thing wouldn't have been partially imported previously.
-        if (
-          !newClassNameArray.every((newClassName) =>
-            isImportedFromPackage(sourceFile, newClassName, newModuleName),
-          )
-        ) {
+        const missingClassNames = newClassNameArray.filter(
+          (name) => !isImportedFromPackage(sourceFile, name, newModuleName),
+        );
+
+        if (missingClassNames.length > 0) {
+          const missingClassNameString = missingClassNames.join(', ');
           if (allReferencesToBeReplaced) {
             if (oldModuleName === newModuleName) {
               const referencesInImport = findReferences(
@@ -121,13 +121,13 @@ export function swapImportedClass(
               swapReference(
                 recorder,
                 referencesInImport[0],
-                newClassNameString,
+                missingClassNameString,
               );
             } else {
               const change = insertImport(
                 sourceFile,
                 filePath,
-                newClassNameString,
+                missingClassNameString,
                 newModuleName,
               ) as InsertChange;
               shiftLineBreakForInsertedImport(change, eol);
@@ -140,7 +140,7 @@ export function swapImportedClass(
               insertImport(
                 sourceFile,
                 filePath,
-                newClassNameString,
+                missingClassNameString,
                 newModuleName,
               ),
             ]);


### PR DESCRIPTION
[AB#3677447](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3677447)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a migration schematic to convert existing grid templates to the new data grid components.
  * Updates both external HTML templates and inline component templates, including related import/class updates.
* **Bug Fixes**
  * Improves binding/input translation and emits warnings when values can’t be mapped directly.
  * Handles scenarios where multiple target component classes are already imported without duplicating imports.
* **Tests**
  * Added comprehensive coverage for grid/column conversions and import swapping behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->