### PR TITLE
chore: update component libraries `d` to `e` alphabetically to use and enforce `inject`

### DIFF
--- a/eslint-overrides-angular.config.js
+++ b/eslint-overrides-angular.config.js
@@ -10,7 +10,7 @@ module.exports = [
     },
   },
   {
-    files: ['libs/components/[^a-cA-C]*/**/*.ts'],
+    files: ['libs/components/[^a-eA-E]*/**/*.ts'],
     rules: {
       '@angular-eslint/prefer-inject': 'warn',
     },

--- a/libs/components/data-manager/src/lib/modules/data-manager/data-manager.service.ts
+++ b/libs/components/data-manager/src/lib/modules/data-manager/data-manager.service.ts
@@ -54,6 +54,7 @@ export class SkyDataManagerService implements OnDestroy {
   #initSource = 'dataManagerServiceInit';
   #uiConfigService: SkyUIConfigService;
 
+  // eslint-disable-next-line @angular-eslint/prefer-inject -- constructor injection is required to maintain the public API for consumers who may instantiate this service directly (e.g. `new SkyDataManagerService(...)`).
   constructor(uiConfigService: SkyUIConfigService) {
     this.#uiConfigService = uiConfigService;
   }

--- a/libs/components/data-manager/src/lib/modules/data-manager/fixtures/data-manager-card-view.component.fixture.ts
+++ b/libs/components/data-manager/src/lib/modules/data-manager/fixtures/data-manager-card-view.component.fixture.ts
@@ -4,6 +4,7 @@ import {
   Component,
   Input,
   OnInit,
+  inject,
 } from '@angular/core';
 
 import { SkyDataManagerService } from '../data-manager.service';
@@ -35,16 +36,8 @@ export class DataViewCardFixtureComponent implements OnInit {
     showSortButtonText: true,
   };
 
-  #changeDetector: ChangeDetectorRef;
-  #dataManagerService: SkyDataManagerService;
-
-  constructor(
-    changeDetector: ChangeDetectorRef,
-    dataManagerService: SkyDataManagerService,
-  ) {
-    this.#changeDetector = changeDetector;
-    this.#dataManagerService = dataManagerService;
-  }
+  readonly #changeDetector = inject(ChangeDetectorRef);
+  readonly #dataManagerService = inject(SkyDataManagerService);
 
   public ngOnInit(): void {
     this.displayedItems = this.items;

--- a/libs/components/data-manager/src/lib/modules/data-manager/fixtures/data-manager-repeater-view.component.fixture.ts
+++ b/libs/components/data-manager/src/lib/modules/data-manager/fixtures/data-manager-repeater-view.component.fixture.ts
@@ -4,6 +4,7 @@ import {
   Component,
   Input,
   OnInit,
+  inject,
 } from '@angular/core';
 
 import { SkyDataManagerService } from '../data-manager.service';
@@ -37,16 +38,8 @@ export class DataViewRepeaterFixtureComponent implements OnInit {
     onSelectAllClick: this.selectAll.bind(this),
   };
 
-  #changeDetector: ChangeDetectorRef;
-  #dataManagerService: SkyDataManagerService;
-
-  constructor(
-    changeDetector: ChangeDetectorRef,
-    dataManagerService: SkyDataManagerService,
-  ) {
-    this.#changeDetector = changeDetector;
-    this.#dataManagerService = dataManagerService;
-  }
+  readonly #changeDetector = inject(ChangeDetectorRef);
+  readonly #dataManagerService = inject(SkyDataManagerService);
 
   public ngOnInit(): void {
     this.displayedItems = this.items;

--- a/libs/components/data-manager/src/lib/modules/data-manager/fixtures/data-manager.component.fixture.ts
+++ b/libs/components/data-manager/src/lib/modules/data-manager/fixtures/data-manager.component.fixture.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, ViewChild } from '@angular/core';
+import { Component, OnInit, ViewChild, inject } from '@angular/core';
 
 import { SkyDataManagerComponent } from '../data-manager.component';
 import { SkyDataManagerService } from '../data-manager.service';
@@ -114,16 +114,15 @@ export class DataManagerFixtureComponent implements OnInit {
     },
   });
 
-  #dataManagerService: SkyDataManagerService;
+  readonly #dataManagerService = inject(SkyDataManagerService);
 
-  constructor(dataManagerService: SkyDataManagerService) {
-    this.#dataManagerService = dataManagerService;
-    dataManagerService
+  constructor() {
+    this.#dataManagerService
       .getDataStateUpdates(this.dataManagerSourceId)
       .subscribe((state) => {
         this.#dataState = state;
       });
-    dataManagerService
+    this.#dataManagerService
       .getActiveViewIdUpdates()
       .subscribe((activeViewId) => (this.activeViewId = activeViewId));
   }

--- a/libs/components/datetime/src/lib/modules/date-pipe/fixtures/date-pipe.component.fixture.ts
+++ b/libs/components/datetime/src/lib/modules/date-pipe/fixtures/date-pipe.component.fixture.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
 
 import { SkyDatePipeModule } from '../date-pipe.module';
 import { SkyDatePipe } from '../date.pipe';
@@ -14,11 +14,7 @@ export class DatePipeTestComponent {
   public format: string | undefined;
   public locale: string | undefined;
 
-  #datePipe: SkyDatePipe;
-
-  constructor(datePipe: SkyDatePipe) {
-    this.#datePipe = datePipe;
-  }
+  readonly #datePipe = inject(SkyDatePipe);
 
   public getDatePipeResult(
     value: Date,

--- a/libs/components/datetime/src/lib/modules/date-pipe/fixtures/fuzzy-date-pipe.component.fixture.ts
+++ b/libs/components/datetime/src/lib/modules/date-pipe/fixtures/fuzzy-date-pipe.component.fixture.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
 
 import { SkyFuzzyDate } from '../../datepicker/fuzzy/fuzzy-date';
 import { SkyDatePipeModule } from '../date-pipe.module';
@@ -20,11 +20,7 @@ export class FuzzyDatePipeTestComponent {
 
   public locale: string | undefined;
 
-  #fuzzyDatePipe: SkyFuzzyDatePipe;
-
-  constructor(fuzzyDatePipe: SkyFuzzyDatePipe) {
-    this.#fuzzyDatePipe = fuzzyDatePipe;
-  }
+  readonly #fuzzyDatePipe = inject(SkyFuzzyDatePipe);
 
   public getFuzzyDatePipeResult(
     value: SkyFuzzyDate,

--- a/libs/components/datetime/src/lib/modules/date-pipe/fuzzy-date.pipe.ts
+++ b/libs/components/datetime/src/lib/modules/date-pipe/fuzzy-date.pipe.ts
@@ -19,6 +19,7 @@ import { SkyFuzzyDateService } from '../datepicker/fuzzy/fuzzy-date.service';
 export class SkyFuzzyDatePipe implements PipeTransform {
   #fuzzyDateService: SkyFuzzyDateService;
 
+  // eslint-disable-next-line @angular-eslint/prefer-inject -- constructor injection is required to maintain the public API for consumers who may instantiate this pipe directly (e.g. `new SkyFuzzyDatePipe(...)`).
   constructor(fuzzyDateService: SkyFuzzyDateService) {
     this.#fuzzyDateService = fuzzyDateService;
   }

--- a/libs/components/datetime/src/lib/modules/date-range-picker/fixtures/date-range-picker.component.fixture.ts
+++ b/libs/components/datetime/src/lib/modules/date-range-picker/fixtures/date-range-picker.component.fixture.ts
@@ -1,4 +1,4 @@
-import { Component, OnDestroy, OnInit, ViewChild } from '@angular/core';
+import { Component, OnDestroy, OnInit, ViewChild, inject } from '@angular/core';
 import {
   AbstractControl,
   FormsModule,
@@ -45,10 +45,11 @@ export class DateRangePickerTestComponent implements OnInit, OnDestroy {
   public helpPopoverContent: string | undefined;
   public stacked: boolean | undefined;
 
+  readonly #formBuilder = inject(UntypedFormBuilder);
   #ngUnsubscribe = new Subject<void>();
 
-  constructor(formBuilder: UntypedFormBuilder) {
-    this.reactiveForm = formBuilder.group({
+  constructor() {
+    this.reactiveForm = this.#formBuilder.group({
       dateRange: new UntypedFormControl(),
     });
   }

--- a/libs/components/datetime/src/lib/modules/datepicker/calendar/datepicker-calendar.component.ts
+++ b/libs/components/datetime/src/lib/modules/datepicker/calendar/datepicker-calendar.component.ts
@@ -83,10 +83,9 @@ export class SkyDatepickerCalendarComponent {
 
   #_startingDay = 0;
 
-  #config: SkyDatepickerConfigService;
+  readonly #config = inject(SkyDatepickerConfigService);
 
-  constructor(config: SkyDatepickerConfigService) {
-    this.#config = config;
+  constructor() {
     this.configureOptions();
   }
 

--- a/libs/components/datetime/src/lib/modules/datepicker/calendar/datepicker-calendar.component.ts
+++ b/libs/components/datetime/src/lib/modules/datepicker/calendar/datepicker-calendar.component.ts
@@ -4,6 +4,7 @@ import {
   Input,
   Output,
   ViewChild,
+  inject,
 } from '@angular/core';
 
 import { SkyDateFormatter } from '../date-formatter';

--- a/libs/components/datetime/src/lib/modules/datepicker/calendar/daypicker-button.component.ts
+++ b/libs/components/datetime/src/lib/modules/datepicker/calendar/daypicker-button.component.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { Component, Input } from '@angular/core';
+import { Component, Input, inject } from '@angular/core';
 
 import { SkyDatepickerCalendarInnerComponent } from './datepicker-calendar-inner.component';
 import { SkyDatepickerCalendarLabelPipe } from './datepicker-calendar-label.pipe';
@@ -21,5 +21,5 @@ export class SkyDayPickerButtonComponent {
   @Input()
   public date: SkyDayPickerContext | undefined;
 
-  constructor(public datepicker: SkyDatepickerCalendarInnerComponent) {}
+  public readonly datepicker = inject(SkyDatepickerCalendarInnerComponent);
 }

--- a/libs/components/datetime/src/lib/modules/datepicker/calendar/daypicker.component.ts
+++ b/libs/components/datetime/src/lib/modules/datepicker/calendar/daypicker.component.ts
@@ -5,6 +5,7 @@ import {
   OnDestroy,
   OnInit,
   Output,
+  inject,
 } from '@angular/core';
 import { SkyWaitModule } from '@skyux/indicators';
 
@@ -56,16 +57,12 @@ export class SkyDayPickerComponent implements OnDestroy, OnInit {
   public title = '';
   public rows: SkyDayPickerContext[][] = [];
   public weekNumbers: number[] = [];
-  public datepicker: SkyDatepickerCalendarInnerComponent;
+  public readonly datepicker = inject(SkyDatepickerCalendarInnerComponent);
   public CURRENT_THEME_TEMPLATE: any;
 
   #daysInMonth: number[] = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
   #initialDate: number | undefined;
   #ngUnsubscribe = new Subject<void>();
-
-  constructor(datepicker: SkyDatepickerCalendarInnerComponent) {
-    this.datepicker = datepicker;
-  }
 
   public ngOnInit(): void {
     this.datepicker.stepDay = { months: 1 };

--- a/libs/components/datetime/src/lib/modules/datepicker/calendar/monthpicker.component.ts
+++ b/libs/components/datetime/src/lib/modules/datepicker/calendar/monthpicker.component.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, inject } from '@angular/core';
 
 import { SkyDatepickerCalendarInnerComponent } from './datepicker-calendar-inner.component';
 import { SkyDatepickerCalendarLabelPipe } from './datepicker-calendar-label.pipe';
@@ -14,15 +14,11 @@ import { SkyDayPickerContext } from './daypicker-context';
   templateUrl: 'monthpicker.component.html',
 })
 export class SkyMonthPickerComponent implements OnInit {
-  public datepicker: SkyDatepickerCalendarInnerComponent;
+  public readonly datepicker = inject(SkyDatepickerCalendarInnerComponent);
 
   public rows: SkyDayPickerContext[][] = [];
 
   public title = '';
-
-  constructor(datepicker: SkyDatepickerCalendarInnerComponent) {
-    this.datepicker = datepicker;
-  }
 
   public ngOnInit(): void {
     this.datepicker.stepMonth = {

--- a/libs/components/datetime/src/lib/modules/datepicker/calendar/yearpicker.component.ts
+++ b/libs/components/datetime/src/lib/modules/datepicker/calendar/yearpicker.component.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, inject } from '@angular/core';
 
 import { SkyDatepickerCalendarInnerComponent } from './datepicker-calendar-inner.component';
 import { SkyDatepickerCalendarLabelPipe } from './datepicker-calendar-label.pipe';
@@ -14,15 +14,11 @@ import { SkyDayPickerContext } from './daypicker-context';
   templateUrl: 'yearpicker.component.html',
 })
 export class SkyYearPickerComponent implements OnInit {
-  public datepicker: SkyDatepickerCalendarInnerComponent;
+  public readonly datepicker = inject(SkyDatepickerCalendarInnerComponent);
 
   public rows: SkyDayPickerContext[][] = [];
 
   public title = '';
-
-  constructor(datepicker: SkyDatepickerCalendarInnerComponent) {
-    this.datepicker = datepicker;
-  }
 
   public ngOnInit(): void {
     this.datepicker.stepYear = { years: this.datepicker.yearRange };

--- a/libs/components/datetime/src/lib/modules/datepicker/datepicker-input.directive.ts
+++ b/libs/components/datetime/src/lib/modules/datepicker/datepicker-input.directive.ts
@@ -248,9 +248,11 @@ export class SkyDatepickerInputDirective
   readonly #elementRef = inject(ElementRef);
   readonly #localeProvider = inject(SkyAppLocaleProvider);
   readonly #renderer = inject(Renderer2);
-  readonly #datepickerComponent = inject(SkyDatepickerComponent, {
-    optional: true,
-  });
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  readonly #datepickerComponent: SkyDatepickerComponent = inject(
+    SkyDatepickerComponent,
+    { optional: true },
+  )!;
 
   readonly #datepickerHostSvc = inject(SkyDatepickerHostService, {
     optional: true,

--- a/libs/components/datetime/src/lib/modules/datepicker/datepicker-input.directive.ts
+++ b/libs/components/datetime/src/lib/modules/datepicker/datepicker-input.directive.ts
@@ -8,7 +8,6 @@ import {
   Input,
   OnDestroy,
   OnInit,
-  Optional,
   Renderer2,
   forwardRef,
   inject,
@@ -244,38 +243,26 @@ export class SkyDatepickerInputDirective
   #_strict = false;
   #_value: any;
 
-  #changeDetector: ChangeDetectorRef;
-  #configService: SkyDatepickerConfigService;
-  #elementRef: ElementRef;
-  #localeProvider: SkyAppLocaleProvider;
-  #renderer: Renderer2;
-  #datepickerComponent: SkyDatepickerComponent;
+  readonly #changeDetector = inject(ChangeDetectorRef);
+  readonly #configService = inject(SkyDatepickerConfigService);
+  readonly #elementRef = inject(ElementRef);
+  readonly #localeProvider = inject(SkyAppLocaleProvider);
+  readonly #renderer = inject(Renderer2);
+  readonly #datepickerComponent = inject(SkyDatepickerComponent, {
+    optional: true,
+  });
 
   readonly #datepickerHostSvc = inject(SkyDatepickerHostService, {
     optional: true,
   });
 
-  constructor(
-    changeDetector: ChangeDetectorRef,
-    configService: SkyDatepickerConfigService,
-    elementRef: ElementRef,
-    localeProvider: SkyAppLocaleProvider,
-    renderer: Renderer2,
-    @Optional() datepickerComponent?: SkyDatepickerComponent,
-  ) {
-    if (!datepickerComponent) {
+  constructor() {
+    if (!this.#datepickerComponent) {
       throw new Error(
         'You must wrap the `skyDatepickerInput` directive within a ' +
           '`<sky-datepicker>` component!',
       );
     }
-    this.#changeDetector = changeDetector;
-    this.#configService = configService;
-    this.#elementRef = elementRef;
-    this.#localeProvider = localeProvider;
-    this.#renderer = renderer;
-    this.#datepickerComponent = datepickerComponent;
-
     this.#localeProvider
       .getLocaleInfo()
       .pipe(takeUntil(this.#ngUnsubscribe))

--- a/libs/components/datetime/src/lib/modules/datepicker/datepicker.component.ts
+++ b/libs/components/datetime/src/lib/modules/datepicker/datepicker.component.ts
@@ -7,11 +7,9 @@ import {
   ElementRef,
   EnvironmentInjector,
   EventEmitter,
-  Inject,
   Input,
   OnDestroy,
   OnInit,
-  Optional,
   Output,
   TemplateRef,
   ViewChild,
@@ -34,7 +32,7 @@ import { SkyLibResourcesService } from '@skyux/i18n';
 import { SkyIconModule } from '@skyux/icon';
 import { SkyThemeService } from '@skyux/theme';
 
-import { Observable, Subject, Subscription, fromEvent } from 'rxjs';
+import { Subject, Subscription, fromEvent } from 'rxjs';
 import { debounceTime, takeUntil } from 'rxjs/operators';
 
 import { SkyDatetimeResourcesModule } from '../shared/sky-datetime-resources.module';
@@ -232,42 +230,32 @@ export class SkyDatepickerComponent
 
   #_selectedDate: Date | undefined;
 
-  #affixService: SkyAffixService;
+  readonly #affixService = inject(SkyAffixService);
   readonly #appFormatter = inject(SkyAppFormat);
-  #changeDetector: ChangeDetectorRef;
-  #coreAdapter: SkyCoreAdapterService;
+  readonly #changeDetector = inject(ChangeDetectorRef);
+  readonly #coreAdapter = inject(SkyCoreAdapterService);
   #dateFormatHintTextTemplateString = '';
   readonly #environmentInjector = inject(EnvironmentInjector);
   readonly #resourceSvc = inject(SkyLibResourcesService);
-  #overlayService: SkyOverlayService;
-  readonly #zIndex: Observable<number> | undefined;
+  readonly #overlayService = inject(SkyOverlayService);
+  public readonly inputBoxHostService = inject(SkyInputBoxHostService, {
+    optional: true,
+  });
+  readonly #zIndex = inject<SkyStackingContext>(SKY_STACKING_CONTEXT, {
+    optional: true,
+  })?.zIndex;
 
   readonly #datepickerHostSvc = inject(SkyDatepickerHostService);
   readonly #elementRef = inject(ElementRef);
 
-  constructor(
-    affixService: SkyAffixService,
-    changeDetector: ChangeDetectorRef,
-    coreAdapter: SkyCoreAdapterService,
-    overlayService: SkyOverlayService,
-    @Optional() public inputBoxHostService?: SkyInputBoxHostService,
-    @Optional() themeSvc?: SkyThemeService,
-    @Optional()
-    @Inject(SKY_STACKING_CONTEXT)
-    stackingContext?: SkyStackingContext,
-  ) {
-    this.#affixService = affixService;
-    this.#changeDetector = changeDetector;
-    this.#coreAdapter = coreAdapter;
-    this.#overlayService = overlayService;
+  constructor() {
     const uniqueId = nextId++;
     this.calendarId = `sky-datepicker-calendar-${uniqueId}`;
     this.triggerButtonId = `sky-datepicker-button-${uniqueId}`;
-    this.#zIndex = stackingContext?.zIndex;
 
     // Update icons when theme changes.
-    themeSvc?.settingsChange
-      .pipe(takeUntil(this.#ngUnsubscribe))
+    inject(SkyThemeService, { optional: true })
+      ?.settingsChange.pipe(takeUntil(this.#ngUnsubscribe))
       .subscribe(() => {
         this.#changeDetector.markForCheck();
       });

--- a/libs/components/datetime/src/lib/modules/datepicker/fixtures/datepicker-reactive.component.fixture.ts
+++ b/libs/components/datetime/src/lib/modules/datepicker/fixtures/datepicker-reactive.component.fixture.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, ViewChild } from '@angular/core';
+import { Component, OnInit, ViewChild, inject } from '@angular/core';
 import {
   UntypedFormBuilder,
   UntypedFormControl,
@@ -44,11 +44,7 @@ export class DatepickerReactiveTestComponent implements OnInit {
   @ViewChild(SkyDatepickerComponent)
   public datepicker!: SkyDatepickerComponent;
 
-  #formBuilder: UntypedFormBuilder;
-
-  constructor(formBuilder: UntypedFormBuilder) {
-    this.#formBuilder = formBuilder;
-  }
+  readonly #formBuilder = inject(UntypedFormBuilder);
 
   public ngOnInit() {
     this.dateControl = new UntypedFormControl(this.initialValue);

--- a/libs/components/datetime/src/lib/modules/datepicker/fuzzy/datepicker-input-fuzzy.directive.ts
+++ b/libs/components/datetime/src/lib/modules/datepicker/fuzzy/datepicker-input-fuzzy.directive.ts
@@ -8,7 +8,6 @@ import {
   Input,
   OnDestroy,
   OnInit,
-  Optional,
   Renderer2,
   forwardRef,
   inject,
@@ -261,40 +260,27 @@ export class SkyFuzzyDatepickerInputDirective
 
   #_yearRequired: boolean | undefined = false;
 
-  #changeDetector: ChangeDetectorRef;
-  #configService: SkyDatepickerConfigService;
-  #elementRef: ElementRef;
-  #fuzzyDateService: SkyFuzzyDateService;
-  #renderer: Renderer2;
-  #datepickerComponent: SkyDatepickerComponent;
+  readonly #changeDetector = inject(ChangeDetectorRef);
+  readonly #configService = inject(SkyDatepickerConfigService);
+  readonly #elementRef = inject(ElementRef);
+  readonly #fuzzyDateService = inject(SkyFuzzyDateService);
+  readonly #renderer = inject(Renderer2);
+  readonly #datepickerComponent = inject(SkyDatepickerComponent, {
+    optional: true,
+  });
 
   readonly #datepickerHostSvc = inject(SkyDatepickerHostService, {
     optional: true,
   });
 
-  constructor(
-    changeDetector: ChangeDetectorRef,
-    configService: SkyDatepickerConfigService,
-    elementRef: ElementRef,
-    fuzzyDateService: SkyFuzzyDateService,
-    localeProvider: SkyAppLocaleProvider,
-    renderer: Renderer2,
-    @Optional() datepickerComponent?: SkyDatepickerComponent,
-  ) {
-    if (!datepickerComponent) {
+  constructor() {
+    if (!this.#datepickerComponent) {
       throw new Error(
         'You must wrap the `skyFuzzyDatepickerInput` directive within a ' +
           '`<sky-datepicker>` component!',
       );
     }
-
-    this.#changeDetector = changeDetector;
-    this.#configService = configService;
-    this.#elementRef = elementRef;
-    this.#fuzzyDateService = fuzzyDateService;
-    this.#renderer = renderer;
-    this.#datepickerComponent = datepickerComponent;
-
+    const localeProvider = inject(SkyAppLocaleProvider);
     this.#locale = localeProvider.defaultLocale;
     localeProvider
       .getLocaleInfo()

--- a/libs/components/datetime/src/lib/modules/datepicker/fuzzy/datepicker-input-fuzzy.directive.ts
+++ b/libs/components/datetime/src/lib/modules/datepicker/fuzzy/datepicker-input-fuzzy.directive.ts
@@ -265,9 +265,11 @@ export class SkyFuzzyDatepickerInputDirective
   readonly #elementRef = inject(ElementRef);
   readonly #fuzzyDateService = inject(SkyFuzzyDateService);
   readonly #renderer = inject(Renderer2);
-  readonly #datepickerComponent = inject(SkyDatepickerComponent, {
-    optional: true,
-  });
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  readonly #datepickerComponent: SkyDatepickerComponent = inject(
+    SkyDatepickerComponent,
+    { optional: true },
+  )!;
 
   readonly #datepickerHostSvc = inject(SkyDatepickerHostService, {
     optional: true,

--- a/libs/components/datetime/src/lib/modules/datepicker/fuzzy/fixtures/fuzzy-datepicker-reactive.component.fixture.ts
+++ b/libs/components/datetime/src/lib/modules/datepicker/fuzzy/fixtures/fuzzy-datepicker-reactive.component.fixture.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, ViewChild } from '@angular/core';
+import { Component, OnInit, ViewChild, inject } from '@angular/core';
 import {
   UntypedFormBuilder,
   UntypedFormControl,
@@ -40,11 +40,7 @@ export class FuzzyDatepickerReactiveTestComponent implements OnInit {
   @ViewChild(SkyFuzzyDatepickerInputDirective)
   public inputDirective!: SkyFuzzyDatepickerInputDirective;
 
-  #formBuilder: UntypedFormBuilder;
-
-  constructor(formBuilder: UntypedFormBuilder) {
-    this.#formBuilder = formBuilder;
-  }
+  readonly #formBuilder = inject(UntypedFormBuilder);
 
   public ngOnInit(): void {
     this.dateControl = new UntypedFormControl(this.initialValue);

--- a/libs/components/datetime/src/lib/modules/datepicker/fuzzy/fuzzy-date.service.ts
+++ b/libs/components/datetime/src/lib/modules/datepicker/fuzzy/fuzzy-date.service.ts
@@ -39,6 +39,7 @@ export class SkyFuzzyDateService implements OnDestroy {
 
   #ngUnsubscribe = new Subject<void>();
 
+  // eslint-disable-next-line @angular-eslint/prefer-inject -- constructor injection is required to maintain the public API for consumers who may instantiate this service directly (e.g. `new SkyFuzzyDateService(...)`).
   constructor(localeProvider: SkyAppLocaleProvider) {
     this.#currentLocale = localeProvider.defaultLocale;
     localeProvider

--- a/libs/components/datetime/src/lib/modules/timepicker/timepicker.component.ts
+++ b/libs/components/datetime/src/lib/modules/timepicker/timepicker.component.ts
@@ -6,10 +6,8 @@ import {
   ElementRef,
   EnvironmentInjector,
   EventEmitter,
-  Inject,
   OnDestroy,
   OnInit,
-  Optional,
   Output,
   TemplateRef,
   ViewChild,
@@ -32,7 +30,7 @@ import { SkyIconModule } from '@skyux/icon';
 import { SkyThemeModule, SkyThemeService } from '@skyux/theme';
 
 import moment from 'moment';
-import { Observable, Subject, Subscription, fromEvent } from 'rxjs';
+import { Subject, Subscription, fromEvent } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 
 import { SkyDatetimeResourcesModule } from '../shared/sky-datetime-resources.module';
@@ -256,37 +254,26 @@ export class SkyTimepickerComponent implements OnInit, OnDestroy {
 
   #_timepickerRef: ElementRef | undefined;
 
-  #affixService: SkyAffixService;
-  #changeDetector: ChangeDetectorRef;
-  #coreAdapter: SkyCoreAdapterService;
+  readonly #affixService = inject(SkyAffixService);
+  readonly #changeDetector = inject(ChangeDetectorRef);
+  readonly #coreAdapter = inject(SkyCoreAdapterService);
   readonly #environmentInjector = inject(EnvironmentInjector);
-  #overlayService: SkyOverlayService;
-  #zIndex: Observable<number> | undefined;
+  readonly #overlayService = inject(SkyOverlayService);
+  public readonly inputBoxHostService = inject(SkyInputBoxHostService, {
+    optional: true,
+  });
+  readonly #zIndex = inject<SkyStackingContext>(SKY_STACKING_CONTEXT, {
+    optional: true,
+  })?.zIndex;
 
-  constructor(
-    affixService: SkyAffixService,
-    changeDetector: ChangeDetectorRef,
-    coreAdapter: SkyCoreAdapterService,
-    overlayService: SkyOverlayService,
-    @Optional() public inputBoxHostService?: SkyInputBoxHostService,
-    @Optional() themeSvc?: SkyThemeService,
-    @Optional()
-    @Inject(SKY_STACKING_CONTEXT)
-    stackingContext?: SkyStackingContext,
-  ) {
-    this.#affixService = affixService;
-    this.#changeDetector = changeDetector;
-    this.#coreAdapter = coreAdapter;
-    this.#overlayService = overlayService;
-    this.#zIndex = stackingContext?.zIndex;
-
+  constructor() {
     const uniqueId = nextId++;
     this.timepickerId = `sky-timepicker-${uniqueId}`;
     this.triggerButtonId = `sky-timepicker-button-${uniqueId}`;
 
     // Update icons when theme changes.
-    themeSvc?.settingsChange
-      .pipe(takeUntil(this.#ngUnsubscribe))
+    inject(SkyThemeService, { optional: true })
+      ?.settingsChange.pipe(takeUntil(this.#ngUnsubscribe))
       .subscribe(() => {
         this.#changeDetector.markForCheck();
       });

--- a/libs/components/datetime/src/lib/modules/timepicker/timepicker.directive.ts
+++ b/libs/components/datetime/src/lib/modules/timepicker/timepicker.directive.ts
@@ -11,6 +11,7 @@ import {
   OnInit,
   Renderer2,
   forwardRef,
+  inject,
 } from '@angular/core';
 import {
   AbstractControl,
@@ -138,19 +139,9 @@ export class SkyTimepickerInputDirective
   #_modelValue: SkyTimepickerTimeOutput | undefined;
   #_skyTimepickerInput: SkyTimepickerComponent | undefined;
 
-  #renderer: Renderer2;
-  #elRef: ElementRef;
-  #changeDetector: ChangeDetectorRef;
-
-  constructor(
-    renderer: Renderer2,
-    elRef: ElementRef,
-    changeDetector: ChangeDetectorRef,
-  ) {
-    this.#renderer = renderer;
-    this.#elRef = elRef;
-    this.#changeDetector = changeDetector;
-  }
+  readonly #renderer = inject(Renderer2);
+  readonly #elRef = inject(ElementRef);
+  readonly #changeDetector = inject(ChangeDetectorRef);
 
   public ngOnInit(): void {
     this.#renderer.addClass(this.#elRef.nativeElement, 'sky-form-control');

--- a/libs/components/errors/src/lib/modules/error/error-description.component.ts
+++ b/libs/components/errors/src/lib/modules/error/error-description.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from '@angular/core';
+import { Component, Input, inject } from '@angular/core';
 
 import { SkyErrorService } from './error.service';
 
@@ -21,10 +21,9 @@ export class SkyErrorDescriptionComponent {
     this.#errorSvc.replaceDefaultDescription.next(!!value);
   }
 
-  #errorSvc: SkyErrorService;
+  readonly #errorSvc = inject(SkyErrorService);
 
-  constructor(errorSvc: SkyErrorService) {
-    this.#errorSvc = errorSvc;
-    errorSvc.replaceDefaultDescription.next(false);
+  constructor() {
+    this.#errorSvc.replaceDefaultDescription.next(false);
   }
 }

--- a/libs/components/errors/src/lib/modules/error/error-modal-form.component.ts
+++ b/libs/components/errors/src/lib/modules/error/error-modal-form.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { SkyIdModule } from '@skyux/core';
 import { SkyModalInstance, SkyModalModule } from '@skyux/modals';
 
@@ -14,8 +14,6 @@ import { ErrorModalConfig } from './error-modal-config';
   imports: [SkyIdModule, SkyModalModule],
 })
 export class SkyErrorModalFormComponent {
-  constructor(
-    public context: ErrorModalConfig,
-    public instance: SkyModalInstance,
-  ) {}
+  public readonly context = inject(ErrorModalConfig);
+  public readonly instance = inject(SkyModalInstance);
 }

--- a/libs/components/errors/src/lib/modules/error/error-modal.service.ts
+++ b/libs/components/errors/src/lib/modules/error/error-modal.service.ts
@@ -16,10 +16,12 @@ export class SkyErrorModalService {
   #modalSvc: SkyModalService;
   #logSvc: SkyLogService | undefined;
 
+  /* eslint-disable @angular-eslint/prefer-inject -- constructor injection is required to maintain the public API for consumers who may instantiate this service directly (e.g. `new SkyErrorModalService(...)`) */
   constructor(
     modalSvc: SkyModalService,
     @Optional() logService?: SkyLogService,
   ) {
+    /* eslint-enable @angular-eslint/prefer-inject */
     this.#modalSvc = modalSvc;
     this.#logSvc = logService;
   }

--- a/libs/components/errors/src/lib/modules/error/error-title.component.ts
+++ b/libs/components/errors/src/lib/modules/error/error-title.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from '@angular/core';
+import { Component, Input, inject } from '@angular/core';
 
 import { SkyErrorService } from './error.service';
 
@@ -21,10 +21,9 @@ export class SkyErrorTitleComponent {
     this.#errorSvc.replaceDefaultTitle.next(!!value);
   }
 
-  #errorSvc: SkyErrorService;
+  readonly #errorSvc = inject(SkyErrorService);
 
-  constructor(errorSvc: SkyErrorService) {
-    this.#errorSvc = errorSvc;
-    errorSvc.replaceDefaultTitle.next(false);
+  constructor() {
+    this.#errorSvc.replaceDefaultTitle.next(false);
   }
 }

--- a/libs/components/errors/src/lib/modules/error/error.component.ts
+++ b/libs/components/errors/src/lib/modules/error/error.component.ts
@@ -1,4 +1,4 @@
-import { Component, HostBinding, Input, OnInit } from '@angular/core';
+import { Component, HostBinding, Input, OnInit, inject } from '@angular/core';
 import { SkyLibResourcesService } from '@skyux/i18n';
 
 import { SkyErrorType } from './error-type';
@@ -45,16 +45,10 @@ export class SkyErrorComponent implements OnInit {
   public defaultTitle: string | undefined;
   public defaultDescription: string | undefined;
 
-  #resourcesSvc: SkyLibResourcesService;
+  readonly #resourcesSvc = inject(SkyLibResourcesService);
+  public readonly errorSvc = inject(SkyErrorService);
 
   #_errorType: SkyErrorType | undefined;
-
-  constructor(
-    resourcesSvc: SkyLibResourcesService,
-    public errorSvc: SkyErrorService,
-  ) {
-    this.#resourcesSvc = resourcesSvc;
-  }
 
   public ngOnInit(): void {
     if (this.errorType) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated multiple Angular components and test fixtures to use field-level dependency injection for more consistent initialization.
  * Kept existing UI behavior and date/time/forms interactions unchanged, including runtime guards and subscription behavior.

* **Chores**
  * Adjusted lint configuration and added targeted lint exceptions for specific injection patterns.
  * Improved consistency across shared error, datetime, timepicker, and data manager areas without changing user-facing functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

**Services and pipes that were and were not converted (all other things were converted)**

Service | Conversion | Reason
-- | -- | --
SkyDataManagerService | eslint-disable | Publicly exported
SkyFuzzyDatePipe | eslint-disable | Publicly exported
SkyFuzzyDateService | eslint-disable | Publicly exported
SkyErrorModalService | eslint-disable | Publicly exported
