### PR TITLE
feat(components/tabs): add `tabWidth` input to sectioned form with `auto` sizing and harness/example support (#4495)

### DIFF
--- a/libs/components/code-examples/src/lib/modules/tabs/sectioned-form/modal/example.component.spec.ts
+++ b/libs/components/code-examples/src/lib/modules/tabs/sectioned-form/modal/example.component.spec.ts
@@ -1,6 +1,10 @@
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideNoopSkyAnimations } from '@skyux/core';
+import {
+  SkyMediaQueryTestingController,
+  provideSkyMediaQueryTesting,
+} from '@skyux/core/testing';
 import { SkyInputBoxHarness } from '@skyux/forms/testing';
 import { SkySectionedFormHarness } from '@skyux/tabs/testing';
 
@@ -13,11 +17,17 @@ describe('Sectioned form in a modal example', () => {
   }> {
     await TestBed.configureTestingModule({
       imports: [TabsSectionedFormModalExampleComponent],
-      providers: [provideNoopSkyAnimations()],
+      providers: [provideNoopSkyAnimations(), provideSkyMediaQueryTesting()],
     }).compileComponents();
     const fixture = TestBed.createComponent(
       TabsSectionedFormModalExampleComponent,
     );
+
+    // Pin a wide breakpoint so the sectioned form renders its side-by-side
+    // layout (and applies `tabWidth`) regardless of the test runner's window
+    // size.
+    TestBed.inject(SkyMediaQueryTestingController).setBreakpoint('lg');
+
     fixture.componentInstance.openModal();
 
     const loader = TestbedHarnessEnvironment.documentRootLoader(fixture);
@@ -31,6 +41,11 @@ describe('Sectioned form in a modal example', () => {
 
   it('should set up the sectioned form', async () => {
     const { sectionedFormHarness } = await setupTest();
+
+    await expectAsync(sectionedFormHarness.getTabWidth()).toBeResolvedTo(
+      'auto',
+    );
+
     let activeSection = await sectionedFormHarness.getActiveSection();
     await expectAsync(activeSection?.getSectionHeading()).toBeResolvedTo(
       'Addresses',

--- a/libs/components/code-examples/src/lib/modules/tabs/sectioned-form/modal/modal.component.html
+++ b/libs/components/code-examples/src/lib/modules/tabs/sectioned-form/modal/modal.component.html
@@ -2,6 +2,7 @@
   <sky-modal-content>
     <sky-sectioned-form
       data-sky-id="modal-sectioned-form"
+      tabWidth="auto"
       [messageStream]="sectionedFormController"
       (indexChanged)="onIndexChanged($event)"
       (tabsVisibleChanged)="onTabsVisibleChanged($event)"

--- a/libs/components/tabs/src/lib/modules/sectioned-form/fixtures/sectioned-form.component.fixture.html
+++ b/libs/components/tabs/src/lib/modules/sectioned-form/fixtures/sectioned-form.component.fixture.html
@@ -2,6 +2,7 @@
 <sky-sectioned-form
   [maintainSectionContent]="maintainSectionContent"
   [messageStream]="messageStream"
+  [tabWidth]="tabWidth"
   (indexChanged)="updateIndex($event)"
   (tabsVisibleChanged)="tabsVisibleChanged($event)"
 >

--- a/libs/components/tabs/src/lib/modules/sectioned-form/fixtures/sectioned-form.component.fixture.ts
+++ b/libs/components/tabs/src/lib/modules/sectioned-form/fixtures/sectioned-form.component.fixture.ts
@@ -17,6 +17,7 @@ export class SkySectionedFormFixtureComponent implements AfterContentChecked {
   public activeTab = true;
   public activeIndexDisplay: number | undefined;
   public maintainSectionContent = false;
+  public tabWidth: string | undefined;
   public tabsVisible: boolean | undefined;
   public messageStream: Subject<SkySectionedFormMessage> | undefined =
     new Subject();

--- a/libs/components/tabs/src/lib/modules/sectioned-form/sectioned-form.component.html
+++ b/libs/components/tabs/src/lib/modules/sectioned-form/sectioned-form.component.html
@@ -18,6 +18,8 @@
   @if (maintainSectionContent || tabService.tabsVisible()) {
     <div
       class="sky-sectioned-form-tabs"
+      [style.flex-basis]="tabsFlexBasis()"
+      [style.max-width]="tabsMaxWidth()"
       [class.sky-animation-slide-enter-left]="animationEnabled()"
       [ngClass]="{
         'sky-sectioned-form-tabs-hidden': !tabService.tabsVisible(),

--- a/libs/components/tabs/src/lib/modules/sectioned-form/sectioned-form.component.scss
+++ b/libs/components/tabs/src/lib/modules/sectioned-form/sectioned-form.component.scss
@@ -67,12 +67,13 @@
   }
 
   .sky-sectioned-form-content {
-    flex-basis: 70%;
+    flex: 1 1 auto;
     overflow-y: auto;
   }
 
   .sky-sectioned-form-tabs {
-    flex-basis: 30%;
+    flex-grow: 0;
+    flex-shrink: 0;
     overflow-y: auto;
   }
 }

--- a/libs/components/tabs/src/lib/modules/sectioned-form/sectioned-form.component.spec.ts
+++ b/libs/components/tabs/src/lib/modules/sectioned-form/sectioned-form.component.spec.ts
@@ -36,6 +36,12 @@ function getActiveSection(el: any) {
   );
 }
 
+function getTabsContainer(fixture: ComponentFixture<unknown>): HTMLElement {
+  return (fixture.nativeElement as HTMLElement).querySelector(
+    '.sky-sectioned-form-tabs',
+  ) as HTMLElement;
+}
+
 describe('Sectioned form component', () => {
   let mediaQueryController: SkyMediaQueryTestingController;
 
@@ -448,6 +454,90 @@ describe('Sectioned form component', () => {
     fixture.detectChanges();
     await fixture.whenStable();
     await expectAsync(fixture.nativeElement).toBeAccessible();
+  });
+
+  it('should default tab width to 30%', () => {
+    mediaQueryController.setBreakpoint('lg');
+    const fixture = createTestComponent();
+    fixture.detectChanges();
+
+    const tabsContainer = getTabsContainer(fixture);
+
+    expect(tabsContainer.style.flexBasis).toBe('30%');
+    expect(tabsContainer.style.maxWidth).toBe('30%');
+  });
+
+  it('should size tabs automatically when tabWidth is set to auto', () => {
+    mediaQueryController.setBreakpoint('lg');
+    const fixture = createTestComponent();
+    fixture.componentInstance.tabWidth = 'auto';
+    fixture.detectChanges();
+
+    const tabsContainer = getTabsContainer(fixture);
+
+    expect(tabsContainer.style.flexBasis).toBe('auto');
+    expect(tabsContainer.style.maxWidth).toBe('30%');
+  });
+
+  it('should set custom tab width', () => {
+    mediaQueryController.setBreakpoint('lg');
+    const fixture = createTestComponent();
+    fixture.componentInstance.tabWidth = '18rem';
+    fixture.detectChanges();
+
+    const tabsContainer = getTabsContainer(fixture);
+
+    expect(tabsContainer.style.flexBasis).toBe('18rem');
+    expect(tabsContainer.style.maxWidth).toBe('30%');
+  });
+
+  it('should not constrain the tab width on mobile', () => {
+    mediaQueryController.setBreakpoint('xs');
+    const fixture = createTestComponent();
+    fixture.componentInstance.maintainSectionContent = true;
+    fixture.componentInstance.tabWidth = 'auto';
+    fixture.detectChanges();
+
+    const tabsContainer = getTabsContainer(fixture);
+
+    // Inline width styles must not be applied on mobile, where the sectioned
+    // form switches to a full-width block layout.
+    expect(tabsContainer.style.flexBasis).toBe('');
+    const mobileStyle = getComputedStyle(tabsContainer);
+    expect(mobileStyle.maxWidth).toBe('none');
+  });
+
+  it('should constrain the tab width only in the side-by-side layout', () => {
+    mediaQueryController.setBreakpoint('lg');
+    const fixture = createTestComponent();
+    fixture.componentInstance.tabWidth = 'auto';
+    fixture.detectChanges();
+
+    const tabsContainer = getTabsContainer(fixture);
+    // The `auto` 30% cap is applied only in the side-by-side (desktop)
+    // layout; the mobile layout leaves it unset (see the mobile test).
+    const desktopStyle = getComputedStyle(tabsContainer);
+    expect(desktopStyle.maxWidth).not.toBe('none');
+  });
+
+  it('should update tab width styles when switching between mobile and desktop', () => {
+    mediaQueryController.setBreakpoint('lg');
+    const fixture = createTestComponent();
+    fixture.componentInstance.maintainSectionContent = true;
+    fixture.detectChanges();
+
+    let tabsContainer = getTabsContainer(fixture);
+    expect(tabsContainer.style.flexBasis).toBe('30%');
+
+    mediaQueryController.setBreakpoint('xs');
+    fixture.detectChanges();
+    tabsContainer = getTabsContainer(fixture);
+    expect(tabsContainer.style.flexBasis).toBe('');
+
+    mediaQueryController.setBreakpoint('lg');
+    fixture.detectChanges();
+    tabsContainer = getTabsContainer(fixture);
+    expect(tabsContainer.style.flexBasis).toBe('30%');
   });
 
   it('maintainSectionContent - tab content remains in same order', () => {

--- a/libs/components/tabs/src/lib/modules/sectioned-form/sectioned-form.component.ts
+++ b/libs/components/tabs/src/lib/modules/sectioned-form/sectioned-form.component.ts
@@ -11,6 +11,8 @@ import {
   Output,
   ViewChild,
   afterNextRender,
+  computed,
+  input,
   signal,
 } from '@angular/core';
 import { SkyLogService } from '@skyux/core';
@@ -23,6 +25,12 @@ import { SkyTabIdService } from '../shared/tab-id.service';
 import { SkyVerticalTabsetService } from './../vertical-tabset/vertical-tabset.service';
 import { SkySectionedFormMessage } from './types/sectioned-form-message';
 import { SkySectionedFormMessageType } from './types/sectioned-form-message-type';
+
+/**
+ * The default width of the tabs pane. Also serves as the maximum width of the
+ * pane for any `tabWidth` value.
+ */
+const DEFAULT_TAB_WIDTH = '30%';
 
 /**
  * Creates a container for the sectioned forms.
@@ -45,6 +53,17 @@ export class SkySectionedFormComponent
    */
   @Input()
   public maintainSectionContent: boolean | undefined = false;
+
+  /**
+   * The width of the tabs pane as a CSS width value (such as `200px`, `15rem`,
+   * or `20%`). Set to `"auto"` to size based on tab label content. Maximum
+   * width is 30%.
+   * @default "30%"
+   */
+  public readonly tabWidth = input(DEFAULT_TAB_WIDTH, {
+    transform: (value: string | undefined): string =>
+      value?.trim() || DEFAULT_TAB_WIDTH,
+  });
 
   @Input()
   public set messageStream(
@@ -89,6 +108,8 @@ export class SkySectionedFormComponent
 
   protected animationEnabled = signal(false);
 
+  protected readonly isMobile = signal(false);
+
   constructor(
     public tabService: SkyVerticalTabsetService,
     changeRef: ChangeDetectorRef,
@@ -131,6 +152,7 @@ export class SkySectionedFormComponent
           this.ariaRole = undefined;
         }
 
+        this.isMobile.set(mobile);
         this.#changeRef.markForCheck();
       });
 
@@ -148,6 +170,7 @@ export class SkySectionedFormComponent
 
     if (this.tabService.isMobile()) {
       this.ariaRole = undefined;
+      this.isMobile.set(true);
       this.#changeRef.markForCheck();
     }
   }
@@ -214,4 +237,12 @@ export class SkySectionedFormComponent
         }
       });
   }
+
+  protected readonly tabsFlexBasis = computed<string | undefined>(() =>
+    this.isMobile() ? undefined : this.tabWidth(),
+  );
+
+  protected readonly tabsMaxWidth = computed<string | undefined>(() =>
+    this.isMobile() ? undefined : DEFAULT_TAB_WIDTH,
+  );
 }

--- a/libs/components/tabs/testing/src/modules/sectioned-form/fixtures/sectioned-form-harness-test.component.html
+++ b/libs/components/tabs/testing/src/modules/sectioned-form/fixtures/sectioned-form-harness-test.component.html
@@ -1,6 +1,7 @@
 <sky-sectioned-form
   data-sky-id="sectioned-form"
   [messageStream]="controller"
+  [tabWidth]="tabWidth()"
   (indexChanged)="onIndexChanged($event)"
 >
   <sky-sectioned-form-section heading="Basic information">

--- a/libs/components/tabs/testing/src/modules/sectioned-form/fixtures/sectioned-form-harness-test.component.ts
+++ b/libs/components/tabs/testing/src/modules/sectioned-form/fixtures/sectioned-form-harness-test.component.ts
@@ -15,6 +15,7 @@ import { Subject } from 'rxjs';
 export class SectionedFormHarnessTestComponent {
   public activeIndexDisplay: number | undefined;
   public activeTab = input<boolean>(true);
+  public tabWidth = input<string | undefined>(undefined);
 
   protected controller = new Subject<SkySectionedFormMessage>();
 

--- a/libs/components/tabs/testing/src/modules/sectioned-form/sectioned-form-harness.spec.ts
+++ b/libs/components/tabs/testing/src/modules/sectioned-form/sectioned-form-harness.spec.ts
@@ -120,6 +120,25 @@ describe('Sectioned form harness', () => {
     await expectAsync(activeSection?.getSectionItemCount()).toBeResolvedTo(2);
   });
 
+  it('should get the default tab width', async () => {
+    const { sectionedFormHarness, fixture } = await setupTest();
+    TestBed.inject(SkyMediaQueryTestingController).setBreakpoint('lg');
+    fixture.detectChanges();
+
+    await expectAsync(sectionedFormHarness.getTabWidth()).toBeResolvedTo('30%');
+  });
+
+  it('should get the auto tab width', async () => {
+    const { sectionedFormHarness, fixture } = await setupTest();
+    TestBed.inject(SkyMediaQueryTestingController).setBreakpoint('lg');
+    fixture.componentRef.setInput('tabWidth', 'auto');
+    fixture.detectChanges();
+
+    await expectAsync(sectionedFormHarness.getTabWidth()).toBeResolvedTo(
+      'auto',
+    );
+  });
+
   describe('in mobile view', () => {
     let mediaQueryController: SkyMediaQueryTestingController;
 
@@ -130,6 +149,27 @@ describe('Sectioned form harness', () => {
       mediaQueryController.setBreakpoint('xs');
       fixture.detectChanges();
     }
+
+    it('should return null for the tab width when tabs are not rendered', async () => {
+      const { sectionedFormHarness, fixture } = await setupTest();
+      shrinkScreen(fixture);
+
+      await expectAsync(sectionedFormHarness.getTabWidth()).toBeResolvedTo(
+        null,
+      );
+    });
+
+    it('should return null for the tab width when tabs are visible on mobile', async () => {
+      const { sectionedFormHarness, fixture } = await setupTest();
+      shrinkScreen(fixture);
+
+      fixture.componentInstance.showTabs();
+      fixture.detectChanges();
+
+      await expectAsync(sectionedFormHarness.getTabWidth()).toBeResolvedTo(
+        null,
+      );
+    });
 
     it('should get the active content', async () => {
       const { sectionedFormHarness, fixture } = await setupTest();

--- a/libs/components/tabs/testing/src/modules/sectioned-form/sectioned-form-harness.ts
+++ b/libs/components/tabs/testing/src/modules/sectioned-form/sectioned-form-harness.ts
@@ -66,6 +66,24 @@ export class SkySectionedFormHarness extends SkyComponentHarness {
   }
 
   /**
+   * Gets the tab width as a CSS `flex-basis` value (for example, `200px`),
+   * or `null` when no width is set. The width is only applied in the desktop
+   * layout, so this returns `null` in the mobile layout and when the tabs
+   * pane is not rendered at all.
+   */
+  public async getTabWidth(): Promise<string | null> {
+    const tabs = await this.#getTabs();
+    if (!tabs) {
+      return null;
+    }
+
+    const styleAttribute = await tabs.getAttribute('style');
+    const styleMatch = styleAttribute?.match(/flex-basis:\s*([^;]+)/i);
+
+    return styleMatch?.[1]?.trim() ?? null;
+  }
+
+  /**
    * Gets a specific section based on the filter criteria.
    * @param filters The filter criteria.
    */


### PR DESCRIPTION
:cherries: Cherry picked from #4495 [feat(components/tabs): add `tabWidth` input to sectioned form with `auto` sizing and harness/example support](https://github.com/blackbaud/skyux/pull/4495)

[AB#3934247](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3934247) 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sectioned forms now support configurable tab width, including a default width and an automatic option.
  * Responsive layout behavior has been improved so tab sizing adapts more cleanly between desktop and mobile views.

* **Bug Fixes**
  * Fixed tab width styling so it no longer applies inline sizing on mobile.
  * Improved consistency in how sectioned form layouts render in side-by-side mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->