### PR TITLE
chore: update component libraries `f` to `h` alphabetically to use and enforce `inject` (#4499)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@ Thumbs.db
 .nx/self-healing
 .nx/workspace-data
 nx-cloud.env
+.local.env
 
 .claude/worktrees
 .cursor/rules/nx-rules.mdc

--- a/eslint-overrides-angular.config.js
+++ b/eslint-overrides-angular.config.js
@@ -16,7 +16,7 @@ module.exports = [
     },
   },
   {
-    files: ['libs/components/[^a-eA-E]*/**/*.ts'],
+    files: ['libs/components/[^a-hA-H]*/**/*.ts'],
     rules: {
       '@angular-eslint/prefer-inject': 'warn',
     },

--- a/libs/components/flyout/src/lib/modules/flyout/fixtures/flyout-hosts.component.fixture.ts
+++ b/libs/components/flyout/src/lib/modules/flyout/fixtures/flyout-hosts.component.fixture.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { SkyModalService } from '@skyux/modals';
 import { SkyToastService, SkyToastType } from '@skyux/toast';
 
@@ -15,12 +15,8 @@ import { SkyFlyoutModalFixtureFormComponent } from './flyout-modal-form.componen
   standalone: false,
 })
 export class SkyFlyoutHostsTestComponent {
-  #modal: SkyModalService;
-  #toastService: SkyToastService;
-  constructor(modal: SkyModalService, toastService: SkyToastService) {
-    this.#modal = modal;
-    this.#toastService = toastService;
-  }
+  readonly #modal = inject(SkyModalService);
+  readonly #toastService = inject(SkyToastService);
 
   public openModal(): void {
     const context: SkyFlyoutModalFixtureContext = { valueA: 'Hello' };

--- a/libs/components/flyout/src/lib/modules/flyout/fixtures/flyout-modal-form.component.ts
+++ b/libs/components/flyout/src/lib/modules/flyout/fixtures/flyout-modal-form.component.ts
@@ -1,4 +1,4 @@
-import { Component, Inject } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { SkyModalInstance } from '@skyux/modals';
 
 import { SkyFlyoutModalFixtureContext } from './flyout-modal-context';
@@ -12,9 +12,8 @@ import { SKY_FLYOUT_MODAL_CONTEXT } from './flyout-modal-context-token';
 export class SkyFlyoutModalFixtureFormComponent {
   public title = 'Hello world';
 
-  constructor(
-    @Inject(SKY_FLYOUT_MODAL_CONTEXT)
-    public context: SkyFlyoutModalFixtureContext,
-    public instance: SkyModalInstance,
-  ) {}
+  public readonly context: SkyFlyoutModalFixtureContext = inject(
+    SKY_FLYOUT_MODAL_CONTEXT,
+  );
+  public readonly instance = inject(SkyModalInstance);
 }

--- a/libs/components/flyout/src/lib/modules/flyout/fixtures/flyout-sample.component.fixture.ts
+++ b/libs/components/flyout/src/lib/modules/flyout/fixtures/flyout-sample.component.fixture.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
 
 import { SkyFlyoutTestSampleContext } from './flyout-sample-context.fixture';
 
@@ -8,5 +8,5 @@ import { SkyFlyoutTestSampleContext } from './flyout-sample-context.fixture';
   standalone: false,
 })
 export class SkyFlyoutTestSampleComponent {
-  constructor(public data: SkyFlyoutTestSampleContext) {}
+  public readonly data = inject(SkyFlyoutTestSampleContext);
 }

--- a/libs/components/flyout/src/lib/modules/flyout/fixtures/flyout.component.fixture.ts
+++ b/libs/components/flyout/src/lib/modules/flyout/fixtures/flyout.component.fixture.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
 
 import { SkyFlyoutService } from '../../flyout/flyout.service';
 import { SkyFlyoutConfig } from '../../flyout/types/flyout-config';
@@ -20,11 +20,7 @@ export function flyoutTestSampleFactory(): SkyFlyoutTestSampleContext {
   standalone: false,
 })
 export class SkyFlyoutTestComponent {
-  #flyoutService: SkyFlyoutService;
-
-  constructor(flyoutService: SkyFlyoutService) {
-    this.#flyoutService = flyoutService;
-  }
+  readonly #flyoutService = inject(SkyFlyoutService);
 
   public openFlyout(options?: SkyFlyoutConfig): SkyFlyoutInstance<any> {
     if (!options) {

--- a/libs/components/flyout/src/lib/modules/flyout/flyout-adapter.service.ts
+++ b/libs/components/flyout/src/lib/modules/flyout/flyout-adapter.service.ts
@@ -3,6 +3,7 @@ import {
   Injectable,
   Renderer2,
   RendererFactory2,
+  inject,
 } from '@angular/core';
 import { SkyAppWindowRef } from '@skyux/core';
 
@@ -11,13 +12,12 @@ import { SkyAppWindowRef } from '@skyux/core';
  */
 @Injectable()
 export class SkyFlyoutAdapterService {
+  readonly #windowRef = inject(SkyAppWindowRef);
+
   #renderer: Renderer2;
 
-  #windowRef: SkyAppWindowRef;
-
-  constructor(rendererFactory: RendererFactory2, windowRef: SkyAppWindowRef) {
-    this.#windowRef = windowRef;
-    this.#renderer = rendererFactory.createRenderer(undefined, null);
+  constructor() {
+    this.#renderer = inject(RendererFactory2).createRenderer(undefined, null);
   }
 
   public adjustHeaderForHelp(header: ElementRef): void {

--- a/libs/components/flyout/src/lib/modules/flyout/flyout.service.ts
+++ b/libs/components/flyout/src/lib/modules/flyout/flyout.service.ts
@@ -47,6 +47,7 @@ export class SkyFlyoutService implements OnDestroy {
   #router: Router;
   #ngZone: NgZone;
 
+  /* eslint-disable @angular-eslint/prefer-inject -- constructor injection is required to maintain the public API for consumers who may instantiate this service directly (e.g. `new SkyFlyoutService(...)`) */
   constructor(
     coreAdapter: SkyCoreAdapterService,
     windowRef: SkyAppWindowRef,
@@ -54,6 +55,7 @@ export class SkyFlyoutService implements OnDestroy {
     router: Router,
     ngZone: NgZone,
   ) {
+    /* eslint-enable @angular-eslint/prefer-inject */
     this.#coreAdapter = coreAdapter;
     this.#windowRef = windowRef;
     this.#dynamicComponentService = dynamicComponentService;
@@ -234,6 +236,7 @@ export class SkyFlyoutService implements OnDestroy {
 })
 export class SkyFlyoutLegacyService extends SkyFlyoutService {
   /* istanbul ignore next */
+  /* eslint-disable @angular-eslint/prefer-inject -- constructor injection is required to override the type of `dynamicComponentService` passed to the parent class's constructor. */
   constructor(
     coreAdapter: SkyCoreAdapterService,
     windowRef: SkyAppWindowRef,
@@ -241,6 +244,7 @@ export class SkyFlyoutLegacyService extends SkyFlyoutService {
     router: Router,
     ngZone: NgZone,
   ) {
+    /* eslint-enable @angular-eslint/prefer-inject */
     super(coreAdapter, windowRef, dynamicComponentService, router, ngZone);
   }
 }

--- a/libs/components/forms/src/lib/modules/character-counter/character-counter-indicator.component.ts
+++ b/libs/components/forms/src/lib/modules/character-counter/character-counter-indicator.component.ts
@@ -3,6 +3,7 @@ import {
   ChangeDetectorRef,
   Component,
   Input,
+  inject,
 } from '@angular/core';
 
 @Component({
@@ -16,11 +17,7 @@ export class SkyCharacterCounterIndicatorComponent {
   #_characterCountLimit = 0;
   #_characterCount = 0;
 
-  #changeDetector: ChangeDetectorRef;
-
-  constructor(changeDetector: ChangeDetectorRef) {
-    this.#changeDetector = changeDetector;
-  }
+  readonly #changeDetector = inject(ChangeDetectorRef);
 
   public get characterCount(): number {
     return this.#_characterCount;

--- a/libs/components/forms/src/lib/modules/character-counter/fixtures/character-count-no-indicator.component.fixture.ts
+++ b/libs/components/forms/src/lib/modules/character-counter/fixtures/character-count-no-indicator.component.fixture.ts
@@ -3,6 +3,7 @@ import {
   ChangeDetectorRef,
   Component,
   ViewChild,
+  inject,
 } from '@angular/core';
 import {
   UntypedFormBuilder,
@@ -27,16 +28,10 @@ export class CharacterCountNoIndicatorTestComponent {
   @ViewChild(SkyCharacterCounterInputDirective)
   public inputDirective: SkyCharacterCounterInputDirective | undefined;
 
-  #changeDetector: ChangeDetectorRef;
-  #formBuilder: UntypedFormBuilder;
+  readonly #changeDetector = inject(ChangeDetectorRef);
+  readonly #formBuilder = inject(UntypedFormBuilder);
 
-  constructor(
-    formBuilder: UntypedFormBuilder,
-    changeDetector: ChangeDetectorRef,
-  ) {
-    this.#formBuilder = formBuilder;
-    this.#changeDetector = changeDetector;
-
+  constructor() {
     this.firstName = this.#formBuilder.control('test');
 
     this.testForm = this.#formBuilder.group({

--- a/libs/components/forms/src/lib/modules/character-counter/fixtures/character-count.component.fixture.ts
+++ b/libs/components/forms/src/lib/modules/character-counter/fixtures/character-count.component.fixture.ts
@@ -3,6 +3,7 @@ import {
   ChangeDetectorRef,
   Component,
   ViewChild,
+  inject,
 } from '@angular/core';
 import {
   UntypedFormBuilder,
@@ -29,16 +30,10 @@ export class CharacterCountTestComponent {
   @ViewChild(SkyCharacterCounterInputDirective)
   public inputDirective: SkyCharacterCounterInputDirective | undefined;
 
-  #changeDetector: ChangeDetectorRef;
-  #formBuilder: UntypedFormBuilder;
+  readonly #changeDetector = inject(ChangeDetectorRef);
+  readonly #formBuilder = inject(UntypedFormBuilder);
 
-  constructor(
-    formBuilder: UntypedFormBuilder,
-    changeDetector: ChangeDetectorRef,
-  ) {
-    this.#formBuilder = formBuilder;
-    this.#changeDetector = changeDetector;
-
+  constructor() {
     this.firstName = this.#formBuilder.control('test');
     this.lastName = this.#formBuilder.control('last');
 

--- a/libs/components/forms/src/lib/modules/checkbox/checkbox.component.spec.ts
+++ b/libs/components/forms/src/lib/modules/checkbox/checkbox.component.spec.ts
@@ -320,7 +320,7 @@ class CheckboxWithChangeEventComponent {
 })
 class CheckboxWithOnPushChangeDetectionComponent {
   public isChecked = false;
-  constructor(public ref: ChangeDetectorRef) {}
+  public readonly ref = inject(ChangeDetectorRef);
 }
 // #endregion
 

--- a/libs/components/forms/src/lib/modules/file-attachment/file-attachment/file-attachment.component.ts
+++ b/libs/components/forms/src/lib/modules/file-attachment/file-attachment/file-attachment.component.ts
@@ -13,10 +13,8 @@ import {
   Input,
   OnDestroy,
   OnInit,
-  Optional,
   Output,
   QueryList,
-  Self,
   TemplateRef,
   ViewChild,
   booleanAttribute,
@@ -298,16 +296,19 @@ export class SkyFileAttachmentComponent
 
   #_value: SkyFileItem | undefined;
 
-  #changeDetector: ChangeDetectorRef;
-  #fileAttachmentService: SkyFileAttachmentService;
-  #fileItemService: SkyFileItemService;
-  #themeSvc: SkyThemeService | undefined;
+  readonly #changeDetector = inject(ChangeDetectorRef);
+  readonly #fileAttachmentService = inject(SkyFileAttachmentService);
+  readonly #fileItemService = inject(SkyFileItemService);
+  readonly #themeSvc = inject(SkyThemeService, { optional: true });
 
   readonly #idSvc = inject(SkyIdService);
   readonly #liveAnnouncerSvc = inject(SkyLiveAnnouncerService);
   readonly #resourcesSvc = inject(SkyLibResourcesService);
 
-  protected ngControl: NgControl | undefined;
+  protected readonly ngControl = inject(NgControl, {
+    optional: true,
+    self: true,
+  });
   protected errorId = this.#idSvc.generateId();
   protected labelId = this.#idSvc.generateId();
 
@@ -315,19 +316,7 @@ export class SkyFileAttachmentComponent
   protected fileErrorParam: string | undefined;
   protected fileErrorValidation: ValidationErrors | null | undefined;
 
-  constructor(
-    changeDetector: ChangeDetectorRef,
-    fileAttachmentService: SkyFileAttachmentService,
-    fileItemService: SkyFileItemService,
-    @Self() @Optional() ngControl?: NgControl,
-    @Optional() themeSvc?: SkyThemeService,
-  ) {
-    this.#changeDetector = changeDetector;
-    this.#fileAttachmentService = fileAttachmentService;
-    this.#fileItemService = fileItemService;
-    this.ngControl = ngControl;
-    this.#themeSvc = themeSvc;
-
+  constructor() {
     if (this.ngControl) {
       this.ngControl.valueAccessor = this;
     }

--- a/libs/components/forms/src/lib/modules/file-attachment/file-attachment/fixtures/file-attachment.component.fixture.ts
+++ b/libs/components/forms/src/lib/modules/file-attachment/file-attachment/fixtures/file-attachment.component.fixture.ts
@@ -1,4 +1,4 @@
-import { Component, ViewChild, input } from '@angular/core';
+import { Component, ViewChild, inject, input } from '@angular/core';
 import {
   FormsModule,
   ReactiveFormsModule,
@@ -53,9 +53,9 @@ export class FileAttachmentTestComponent {
   @ViewChild(SkyFileAttachmentComponent)
   public fileAttachmentComponent!: SkyFileAttachmentComponent;
 
-  constructor(formBuilder: UntypedFormBuilder) {
+  constructor() {
     this.attachment = new UntypedFormControl(undefined);
-    this.fileForm = formBuilder.group({
+    this.fileForm = inject(UntypedFormBuilder).group({
       attachment: this.attachment,
     });
   }

--- a/libs/components/forms/src/lib/modules/file-attachment/file-drop/file-item.component.ts
+++ b/libs/components/forms/src/lib/modules/file-attachment/file-drop/file-item.component.ts
@@ -77,17 +77,14 @@ export class SkyFileItemComponent implements DoCheck {
 
   #_fileItem: SkyFileItem | SkyFileLink | undefined;
 
-  #differ: KeyValueDiffer<any, any>;
-  #fileItemService: SkyFileItemService;
+  readonly #differ: KeyValueDiffer<any, any> = inject(KeyValueDiffers)
+    .find({})
+    .create();
+  readonly #fileItemService = inject(SkyFileItemService);
 
   readonly #liveAnnouncerSvc = inject(SkyLiveAnnouncerService);
 
   readonly #resourcesSvc = inject(SkyLibResourcesService);
-
-  constructor(differs: KeyValueDiffers, fileItemService: SkyFileItemService) {
-    this.#differ = differs.find({}).create();
-    this.#fileItemService = fileItemService;
-  }
 
   public ngDoCheck(): void {
     if (this.fileItem) {

--- a/libs/components/forms/src/lib/modules/file-attachment/shared/file-size.pipe.spec.ts
+++ b/libs/components/forms/src/lib/modules/file-attachment/shared/file-size.pipe.spec.ts
@@ -1,5 +1,4 @@
 import { TestBed } from '@angular/core/testing';
-import { SkyLibResourcesService } from '@skyux/i18n';
 
 import { SkyFileSizePipe } from './file-size.pipe';
 
@@ -20,7 +19,7 @@ describe('File size pipe', () => {
       imports: [SkyFileSizePipe],
     });
 
-    fileSizePipe = new SkyFileSizePipe(TestBed.inject(SkyLibResourcesService));
+    fileSizePipe = TestBed.runInInjectionContext(() => new SkyFileSizePipe());
   });
 
   it('should format bytes', function () {

--- a/libs/components/forms/src/lib/modules/file-attachment/shared/file-size.pipe.ts
+++ b/libs/components/forms/src/lib/modules/file-attachment/shared/file-size.pipe.ts
@@ -1,5 +1,5 @@
 import { formatNumber } from '@angular/common';
-import { Pipe, PipeTransform } from '@angular/core';
+import { Pipe, PipeTransform, inject } from '@angular/core';
 import { SkyLibResourcesService } from '@skyux/i18n';
 
 /**
@@ -9,12 +9,8 @@ import { SkyLibResourcesService } from '@skyux/i18n';
   name: 'skyFileSize',
 })
 export class SkyFileSizePipe implements PipeTransform {
-  readonly #resourcesService: SkyLibResourcesService;
+  readonly #resourcesService = inject(SkyLibResourcesService);
   readonly #defaultLocale = 'en-US';
-
-  constructor(resourcesService: SkyLibResourcesService) {
-    this.#resourcesService = resourcesService;
-  }
 
   public transform(input?: number | string | null): string {
     let decimalPlaces = 0,

--- a/libs/components/forms/src/lib/modules/input-box/fixtures/input-box-host-service.component.fixture.ts
+++ b/libs/components/forms/src/lib/modules/input-box/fixtures/input-box-host-service.component.fixture.ts
@@ -1,4 +1,10 @@
-import { Component, OnInit, TemplateRef, ViewChild } from '@angular/core';
+import {
+  Component,
+  OnInit,
+  TemplateRef,
+  ViewChild,
+  inject,
+} from '@angular/core';
 
 import { SkyInputBoxHostService } from '../input-box-host.service';
 
@@ -24,11 +30,7 @@ export class InputBoxHostServiceFixtureComponent implements OnInit {
 
   public hintText: string | undefined = 'Host component hint text.';
 
-  #inputBoxHostSvc: SkyInputBoxHostService;
-
-  constructor(inputBoxHostSvc: SkyInputBoxHostService) {
-    this.#inputBoxHostSvc = inputBoxHostSvc;
-  }
+  readonly #inputBoxHostSvc = inject(SkyInputBoxHostService);
 
   public ngOnInit(): void {
     this.#inputBoxHostSvc.populate({

--- a/libs/components/forms/src/lib/modules/radio/fixtures/radio-group-boolean.component.fixture.ts
+++ b/libs/components/forms/src/lib/modules/radio/fixtures/radio-group-boolean.component.fixture.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { UntypedFormBuilder, UntypedFormGroup } from '@angular/forms';
 
 @Component({
@@ -9,8 +9,8 @@ import { UntypedFormBuilder, UntypedFormGroup } from '@angular/forms';
 export class SkyRadioGroupBooleanTestComponent {
   public radioForm: UntypedFormGroup;
 
-  constructor(formBuilder: UntypedFormBuilder) {
-    this.radioForm = formBuilder.group({
+  constructor() {
+    this.radioForm = inject(UntypedFormBuilder).group({
       booleanValue: false,
     });
   }

--- a/libs/components/forms/src/lib/modules/radio/fixtures/radio-group-reactive.component.fixture.ts
+++ b/libs/components/forms/src/lib/modules/radio/fixtures/radio-group-reactive.component.fixture.ts
@@ -1,4 +1,11 @@
-import { Component, OnInit, ViewChild, input, signal } from '@angular/core';
+import {
+  Component,
+  OnInit,
+  ViewChild,
+  inject,
+  input,
+  signal,
+} from '@angular/core';
 import {
   AbstractControl,
   UntypedFormBuilder,
@@ -61,11 +68,7 @@ export class SkyRadioGroupReactiveFixtureComponent implements OnInit {
   @ViewChild(SkyRadioGroupComponent)
   public radioGroupComponent: SkyRadioGroupComponent | undefined;
 
-  #formBuilder: UntypedFormBuilder;
-
-  constructor(formBuilder: UntypedFormBuilder) {
-    this.#formBuilder = formBuilder;
-  }
+  readonly #formBuilder = inject(UntypedFormBuilder);
 
   public ngOnInit(): void {
     this.radioControl = new UntypedFormControl(

--- a/libs/components/forms/src/lib/modules/radio/fixtures/radio-on-push.component.fixture.ts
+++ b/libs/components/forms/src/lib/modules/radio/fixtures/radio-on-push.component.fixture.ts
@@ -2,6 +2,7 @@ import {
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
+  inject,
 } from '@angular/core';
 
 @Component({
@@ -22,5 +23,5 @@ export class SkyRadioOnPushTestComponent {
 
   public tabindex2: number | undefined;
 
-  constructor(public ref: ChangeDetectorRef) {}
+  public readonly ref = inject(ChangeDetectorRef);
 }

--- a/libs/components/forms/src/lib/modules/radio/radio-group.component.ts
+++ b/libs/components/forms/src/lib/modules/radio/radio-group.component.ts
@@ -7,9 +7,7 @@ import {
   HostBinding,
   Input,
   OnDestroy,
-  Optional,
   QueryList,
-  Self,
   TemplateRef,
   booleanAttribute,
   inject,
@@ -309,26 +307,19 @@ export class SkyRadioGroupComponent implements AfterContentInit, OnDestroy {
 
   #_stacked = false;
 
-  #changeDetector: ChangeDetectorRef;
-  #radioGroupIdSvc: SkyRadioGroupIdService;
+  readonly #changeDetector = inject(ChangeDetectorRef);
+  readonly #radioGroupIdSvc = inject(SkyRadioGroupIdService);
 
   readonly #logger = inject(SkyLogService);
   readonly #idService = inject(SkyIdService);
 
   protected errorId = this.#idService.generateId();
-  protected ngControl: NgControl | undefined;
+  protected ngControl = inject(NgControl, { optional: true, self: true });
 
-  constructor(
-    changeDetector: ChangeDetectorRef,
-    radioGroupIdSvc: SkyRadioGroupIdService,
-    @Self() @Optional() ngControl: NgControl,
-  ) {
-    if (ngControl) {
-      ngControl.valueAccessor = this;
+  constructor() {
+    if (this.ngControl) {
+      this.ngControl.valueAccessor = this;
     }
-    this.#changeDetector = changeDetector;
-    this.#radioGroupIdSvc = radioGroupIdSvc;
-    this.ngControl = ngControl;
     this.name = this.#defaultName;
 
     this.#radioGroupIdSvc.radioIds

--- a/libs/components/forms/src/lib/modules/selection-box/fixtures/selection-box.component.fixture.ts
+++ b/libs/components/forms/src/lib/modules/selection-box/fixtures/selection-box.component.fixture.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import {
   UntypedFormArray,
   UntypedFormBuilder,
@@ -52,10 +52,9 @@ export class SelectionBoxTestComponent {
     },
   ];
 
-  #formBuilder: UntypedFormBuilder;
+  readonly #formBuilder = inject(UntypedFormBuilder);
 
-  constructor(formBuilder: UntypedFormBuilder) {
-    this.#formBuilder = formBuilder;
+  constructor() {
     this.selectionBoxFormArray = this.#buildCheckboxes();
     this.myForm = this.#formBuilder.group({
       checkboxes: this.selectionBoxFormArray,

--- a/libs/components/forms/src/lib/modules/selection-box/selection-box-adapter.service.ts
+++ b/libs/components/forms/src/lib/modules/selection-box/selection-box-adapter.service.ts
@@ -3,6 +3,7 @@ import {
   Injectable,
   Renderer2,
   RendererFactory2,
+  inject,
 } from '@angular/core';
 import { SkyCoreAdapterService, SkyMediaBreakpoints } from '@skyux/core';
 
@@ -22,15 +23,11 @@ const BREAKPOINT_MD_MAX_PIXELS = 1439;
  */
 @Injectable()
 export class SkySelectionBoxAdapterService {
-  #coreAdapterService: SkyCoreAdapterService;
+  readonly #coreAdapterService = inject(SkyCoreAdapterService);
   #renderer: Renderer2;
 
-  constructor(
-    coreAdapterService: SkyCoreAdapterService,
-    rendererFactory: RendererFactory2,
-  ) {
-    this.#coreAdapterService = coreAdapterService;
-    this.#renderer = rendererFactory.createRenderer(undefined, null);
+  constructor() {
+    this.#renderer = inject(RendererFactory2).createRenderer(undefined, null);
   }
 
   /**

--- a/libs/components/forms/src/lib/modules/selection-box/selection-box-grid.component.ts
+++ b/libs/components/forms/src/lib/modules/selection-box/selection-box-grid.component.ts
@@ -8,10 +8,10 @@ import {
   NgZone,
   OnDestroy,
   OnInit,
-  Optional,
   QueryList,
   ViewChild,
   ViewEncapsulation,
+  inject,
 } from '@angular/core';
 import { SkyCoreAdapterService, SkyMutationObserverService } from '@skyux/core';
 import { SkyThemeService } from '@skyux/theme';
@@ -85,28 +85,12 @@ export class SkySelectionBoxGridComponent implements OnDestroy, OnInit {
 
   #_containerElementRef: ElementRef | undefined;
 
-  #coreAdapterService: SkyCoreAdapterService;
-  #selectionBoxAdapter: SkySelectionBoxAdapterService;
-  #hostElRef: ElementRef;
-  #mutationObserverSvc: SkyMutationObserverService;
-  #ngZone: NgZone;
-  #themeSvc: SkyThemeService | undefined;
-
-  constructor(
-    coreAdapterService: SkyCoreAdapterService,
-    selectionBoxAdapter: SkySelectionBoxAdapterService,
-    hostElRef: ElementRef,
-    mutationObserverSvc: SkyMutationObserverService,
-    ngZone: NgZone,
-    @Optional() themeSvc?: SkyThemeService,
-  ) {
-    this.#coreAdapterService = coreAdapterService;
-    this.#selectionBoxAdapter = selectionBoxAdapter;
-    this.#hostElRef = hostElRef;
-    this.#mutationObserverSvc = mutationObserverSvc;
-    this.#ngZone = ngZone;
-    this.#themeSvc = themeSvc;
-  }
+  readonly #coreAdapterService = inject(SkyCoreAdapterService);
+  readonly #selectionBoxAdapter = inject(SkySelectionBoxAdapterService);
+  readonly #hostElRef = inject(ElementRef);
+  readonly #mutationObserverSvc = inject(SkyMutationObserverService);
+  readonly #ngZone = inject(NgZone);
+  readonly #themeSvc = inject(SkyThemeService, { optional: true });
 
   public ngOnInit(): void {
     /* istanbul ignore else */

--- a/libs/components/forms/src/lib/modules/selection-box/selection-box.component.ts
+++ b/libs/components/forms/src/lib/modules/selection-box/selection-box.component.ts
@@ -7,6 +7,7 @@ import {
   OnDestroy,
   ViewChild,
   ViewEncapsulation,
+  inject,
 } from '@angular/core';
 
 import { Subject } from 'rxjs';
@@ -116,16 +117,8 @@ export class SkySelectionBoxComponent implements OnDestroy {
 
   #_selectionBoxEl: ElementRef | undefined;
 
-  #changeDetector: ChangeDetectorRef;
-  #selectionBoxAdapterService: SkySelectionBoxAdapterService;
-
-  constructor(
-    changeDetector: ChangeDetectorRef,
-    selectionBoxAdapterService: SkySelectionBoxAdapterService,
-  ) {
-    this.#changeDetector = changeDetector;
-    this.#selectionBoxAdapterService = selectionBoxAdapterService;
-  }
+  readonly #changeDetector = inject(ChangeDetectorRef);
+  readonly #selectionBoxAdapterService = inject(SkySelectionBoxAdapterService);
 
   public ngOnDestroy(): void {
     this.#ngUnsubscribe.next();

--- a/libs/components/forms/src/lib/modules/toggle-switch/fixtures/toggle-switch-on-push.component.fixture.ts
+++ b/libs/components/forms/src/lib/modules/toggle-switch/fixtures/toggle-switch-on-push.component.fixture.ts
@@ -2,6 +2,7 @@ import {
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
+  inject,
 } from '@angular/core';
 
 @Component({
@@ -10,9 +11,9 @@ import {
   standalone: false,
 })
 export class SkyToggleSwitchOnPushFixtureComponent {
+  public readonly ref = inject(ChangeDetectorRef);
+
   public isChecked = false;
 
   public showLabel = true;
-
-  constructor(public ref: ChangeDetectorRef) {}
 }

--- a/libs/components/forms/src/lib/modules/toggle-switch/toggle-switch.component.ts
+++ b/libs/components/forms/src/lib/modules/toggle-switch/toggle-switch.component.ts
@@ -175,11 +175,10 @@ export class SkyToggleSwitchComponent
   #_ariaLabel: string | undefined;
   #_checked = false;
 
-  #changeDetector: ChangeDetectorRef;
+  readonly #changeDetector = inject(ChangeDetectorRef);
 
-  constructor(changeDetector: ChangeDetectorRef, idService: SkyIdService) {
-    this.#changeDetector = changeDetector;
-    this.labelId = idService.generateId();
+  constructor() {
+    this.labelId = inject(SkyIdService).generateId();
   }
 
   public ngAfterContentInit(): void {

--- a/libs/components/forms/testing/src/modules/file-attachment/file-attachment/file-attachment-harness.spec.ts
+++ b/libs/components/forms/testing/src/modules/file-attachment/file-attachment/file-attachment-harness.spec.ts
@@ -1,5 +1,5 @@
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
-import { Component, signal } from '@angular/core';
+import { Component, inject, signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import {
   FormBuilder,
@@ -75,10 +75,10 @@ class TestComponent {
   public showCustomError = signal(false);
   public stacked = signal(false);
 
-  constructor(formBuilder: FormBuilder) {
+  constructor() {
     this.attachment = new FormControl(null, Validators.required);
 
-    this.formGroup = formBuilder.group({
+    this.formGroup = inject(FormBuilder).group({
       attachment: this.attachment,
     });
   }

--- a/libs/components/forms/testing/src/modules/input-box/fixtures/input-box-harness-test.component.ts
+++ b/libs/components/forms/testing/src/modules/input-box/fixtures/input-box-harness-test.component.ts
@@ -1,4 +1,10 @@
-import { Component, model, TemplateRef, ViewChild } from '@angular/core';
+import {
+  Component,
+  inject,
+  model,
+  TemplateRef,
+  ViewChild,
+} from '@angular/core';
 import {
   UntypedFormBuilder,
   UntypedFormControl,
@@ -33,12 +39,14 @@ export class InputBoxHarnessTestComponent {
   public maxDate = new Date('01/01/2100');
   public minDate = new Date('01/01/2000');
 
-  constructor(formBuilder: UntypedFormBuilder) {
-    this.myForm = formBuilder.group({
+  readonly #formBuilder = inject(UntypedFormBuilder);
+
+  constructor() {
+    this.myForm = this.#formBuilder.group({
       firstName: new UntypedFormControl('John'),
       lastName: new UntypedFormControl('Doe'),
     });
-    this.directiveErrorForm = formBuilder.group({
+    this.directiveErrorForm = this.#formBuilder.group({
       easyModeDatepicker: new UntypedFormControl('123'),
       easyModeTimepicker: new UntypedFormControl('abc'),
       easyModePhoneField: new UntypedFormControl('abc'),

--- a/libs/components/grids/src/lib/modules/grid/grid-adapter.service.ts
+++ b/libs/components/grids/src/lib/modules/grid/grid-adapter.service.ts
@@ -4,6 +4,7 @@ import {
   Injectable,
   Renderer2,
   RendererFactory2,
+  inject,
 } from '@angular/core';
 
 import { SkyGridColumnModel } from './grid-column.model';
@@ -13,10 +14,13 @@ import { SkyGridColumnModel } from './grid-column.model';
  */
 @Injectable()
 export class SkyGridAdapterService {
-  private renderer: Renderer2;
+  private readonly renderer: Renderer2;
 
-  constructor(private rendererFactory: RendererFactory2) {
-    this.renderer = this.rendererFactory.createRenderer(undefined, undefined);
+  constructor() {
+    this.renderer = inject(RendererFactory2).createRenderer(
+      undefined,
+      undefined,
+    );
   }
 
   /**

--- a/libs/components/grids/src/lib/modules/grid/grid.component.ts
+++ b/libs/components/grids/src/lib/modules/grid/grid.component.ts
@@ -343,18 +343,17 @@ export class SkyGridComponent
   private _selectedColumnIds: string[];
   private _selectedRowIds: string[];
 
+  private readonly affixService = inject(SkyAffixService);
+  private readonly changeDetector = inject(ChangeDetectorRef);
+  private readonly gridAdapter = inject(SkyGridAdapterService);
+  private readonly overlayService = inject(SkyOverlayService);
+  private readonly skyWindow = inject(SkyAppWindowRef);
+  private readonly uiConfigService = inject(SkyUIConfigService);
+
   readonly #environmentInjector = inject(EnvironmentInjector);
 
-  constructor(
-    private affixService: SkyAffixService,
-    private changeDetector: ChangeDetectorRef,
-    private gridAdapter: SkyGridAdapterService,
-    private overlayService: SkyOverlayService,
-    private skyWindow: SkyAppWindowRef,
-    private uiConfigService: SkyUIConfigService,
-    logger: SkyLogService,
-  ) {
-    logger.deprecated('SkyGridComponent', {
+  constructor() {
+    inject(SkyLogService).deprecated('SkyGridComponent', {
       deprecationMajorVersion: 6,
       moreInfoUrl: 'https://developer.blackbaud.com/skyux/components/data-grid',
       replacementRecommendation: 'Use data grid instead.',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated several UI components and services to use a newer dependency injection approach, with no expected behavior changes.
  * Kept existing form, flyout, grid, radio, selection box, toggle switch, and file attachment interactions intact.

* **Chores**
  * Adjusted linting coverage for component files.
  * Added a new ignored local environment file pattern to version control rules.

* **Tests**
  * Updated test fixtures and harness setup to match the latest component injection patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->