### PR TITLE
fix(components/ag-grid): checkbox styles not working in dark mode

### DIFF
--- a/libs/components/ag-grid/src/lib/styles/ag-grid-theme.ts
+++ b/libs/components/ag-grid/src/lib/styles/ag-grid-theme.ts
@@ -144,7 +144,7 @@ export function getSkyAgGridThemeClassName(
 ): SkyAgGridThemeType {
   let theme = `ag-theme-sky-${editable ? 'data-entry-grid' : 'data-grid'}-`;
   if (themeSettings?.theme.name === 'modern') {
-    theme += `modern-${themeSettings.mode.name}`;
+    theme += `modern-light`;
     if (agGridThemeIsCompact(themeSettings, compactLayout)) {
       theme += `-compact`;
     }


### PR DESCRIPTION
[AB#4044305](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/4044305)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the modern grid theme to consistently use the light styling.
  * Preserved compact-mode styling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->