### PR TITLE
fix(components/ag-grid): checkbox styles not working in dark mode (#4507)

### DIFF
--- a/libs/components/ag-grid/src/lib/styles/ag-grid-theme.ts
+++ b/libs/components/ag-grid/src/lib/styles/ag-grid-theme.ts
@@ -144,7 +144,7 @@ export function getSkyAgGridThemeClassName(
 ): SkyAgGridThemeType {
   let theme = `ag-theme-sky-${editable ? 'data-entry-grid' : 'data-grid'}-`;
   if (themeSettings?.theme.name === 'modern') {
-    theme += `modern-${themeSettings.mode.name}`;
+    theme += `modern-light`;
     if (agGridThemeIsCompact(themeSettings, compactLayout)) {
       theme += `-compact`;
     }


### PR DESCRIPTION
:cherries: Cherry picked from #4507 [fix(components/ag-grid): checkbox styles not working in dark mode](https://github.com/blackbaud/skyux/pull/4507)

[AB#4044305](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/4044305) 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the modern grid theme styling to consistently use the light variant.
  * Preserved compact mode styling for modern themes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->