### PR TITLE
chore: update component libraries `m` to `z` alphabetically to use and enforce `inject` (#4511)

### DIFF
--- a/eslint-overrides-angular.config.js
+++ b/eslint-overrides-angular.config.js
@@ -16,12 +16,6 @@ module.exports = [
     },
   },
   {
-    files: ['libs/components/[^a-nA-N]*/**/*.ts'],
-    rules: {
-      '@angular-eslint/prefer-inject': 'warn',
-    },
-  },
-  {
     files: ['**/*.spec.ts', '**/fixtures/**/*.ts'],
     rules: {
       '@nx/enforce-module-boundaries': 'warn',

--- a/libs/components/pages/src/lib/modules/action-hub/action-hub-recent-links-resolve.pipe.ts
+++ b/libs/components/pages/src/lib/modules/action-hub/action-hub-recent-links-resolve.pipe.ts
@@ -1,9 +1,9 @@
 import {
   ChangeDetectorRef,
   OnDestroy,
-  Optional,
   Pipe,
   PipeTransform,
+  inject,
 } from '@angular/core';
 import {
   SkyRecentlyAccessedGetLinksArgs,
@@ -62,16 +62,10 @@ export class SkyActionHubRecentLinksResolvePipe
 
   #ngUnsubscribe = new Subject<void>();
 
-  #changeDetector: ChangeDetectorRef;
-  #recentlyAccessedSvc: SkyRecentlyAccessedService | undefined;
-
-  constructor(
-    changeDetector: ChangeDetectorRef,
-    @Optional() recentlyAccessedSvc?: SkyRecentlyAccessedService,
-  ) {
-    this.#changeDetector = changeDetector;
-    this.#recentlyAccessedSvc = recentlyAccessedSvc;
-  }
+  readonly #changeDetector = inject(ChangeDetectorRef);
+  readonly #recentlyAccessedSvc = inject(SkyRecentlyAccessedService, {
+    optional: true,
+  });
 
   public transform(recentLinks: SkyRecentLinksInput): SkyRecentLinksResolved {
     if (recentLinks !== this.#currentRecentLinks) {

--- a/libs/components/popovers/src/lib/modules/dropdown/dropdown-item.component.ts
+++ b/libs/components/popovers/src/lib/modules/dropdown/dropdown-item.component.ts
@@ -7,6 +7,7 @@ import {
   Input,
   Renderer2,
   ViewEncapsulation,
+  inject,
 } from '@angular/core';
 
 /**
@@ -42,17 +43,10 @@ export class SkyDropdownItemComponent implements AfterViewInit {
 
   #_ariaRole = 'menuitem';
 
-  #changeDetector: ChangeDetectorRef;
-  #renderer: Renderer2;
+  public readonly elementRef = inject(ElementRef);
 
-  constructor(
-    public elementRef: ElementRef,
-    changeDetector: ChangeDetectorRef,
-    renderer: Renderer2,
-  ) {
-    this.#changeDetector = changeDetector;
-    this.#renderer = renderer;
-  }
+  readonly #changeDetector = inject(ChangeDetectorRef);
+  readonly #renderer = inject(Renderer2);
 
   public ngAfterViewInit(): void {
     // Make sure anchor elements are tab-able.

--- a/libs/components/popovers/src/lib/modules/dropdown/dropdown-menu.component.ts
+++ b/libs/components/popovers/src/lib/modules/dropdown/dropdown-menu.component.ts
@@ -8,10 +8,10 @@ import {
   EventEmitter,
   Input,
   OnDestroy,
-  Optional,
   Output,
   QueryList,
   ViewEncapsulation,
+  inject,
 } from '@angular/core';
 
 import { Subject, fromEvent as observableFromEvent } from 'rxjs';
@@ -119,19 +119,11 @@ export class SkyDropdownMenuComponent implements AfterContentInit, OnDestroy {
 
   #_useNativeFocus = true;
 
-  #changeDetector: ChangeDetectorRef;
-  #elementRef: ElementRef;
-  #dropdownComponent: SkyDropdownComponent | undefined;
-
-  constructor(
-    changeDetector: ChangeDetectorRef,
-    elementRef: ElementRef,
-    @Optional() dropdownComponent?: SkyDropdownComponent,
-  ) {
-    this.#changeDetector = changeDetector;
-    this.#elementRef = elementRef;
-    this.#dropdownComponent = dropdownComponent;
-  }
+  readonly #changeDetector = inject(ChangeDetectorRef);
+  readonly #elementRef = inject(ElementRef);
+  readonly #dropdownComponent = inject(SkyDropdownComponent, {
+    optional: true,
+  });
 
   public ngAfterContentInit(): void {
     /* istanbul ignore else */

--- a/libs/components/popovers/src/lib/modules/dropdown/fixtures/dropdown.component.fixture.ts
+++ b/libs/components/popovers/src/lib/modules/dropdown/fixtures/dropdown.component.fixture.ts
@@ -4,6 +4,7 @@ import {
   QueryList,
   ViewChild,
   ViewChildren,
+  inject,
   input,
 } from '@angular/core';
 
@@ -76,11 +77,7 @@ export class DropdownFixtureComponent {
 
   public show = input<boolean>(true);
 
-  #changeDetector: ChangeDetectorRef;
-
-  constructor(changeDetector: ChangeDetectorRef) {
-    this.#changeDetector = changeDetector;
-  }
+  readonly #changeDetector = inject(ChangeDetectorRef);
 
   public onMenuChanges(): void {}
 

--- a/libs/components/popovers/src/lib/modules/popover/popover-content.component.ts
+++ b/libs/components/popovers/src/lib/modules/popover/popover-content.component.ts
@@ -6,9 +6,9 @@ import {
   HostBinding,
   OnDestroy,
   OnInit,
-  Optional,
   ViewChild,
   ViewContainerRef,
+  inject,
   signal,
 } from '@angular/core';
 import {
@@ -112,35 +112,19 @@ export class SkyPopoverContentComponent implements OnInit, OnDestroy {
 
   #_opened = new Subject<void>();
 
-  #changeDetector: ChangeDetectorRef;
-  #elementRef: ElementRef;
-  #affixService: SkyAffixService;
+  readonly #changeDetector = inject(ChangeDetectorRef);
+  readonly #elementRef = inject(ElementRef);
+  readonly #affixService = inject(SkyAffixService);
   #arrowAffixer: SkyAffixer | undefined;
-  #coreAdapterService: SkyCoreAdapterService;
-  #context: SkyPopoverContext;
-  #themeSvc: SkyThemeService | undefined;
+  readonly #coreAdapterService = inject(SkyCoreAdapterService);
+  readonly #context = inject(SkyPopoverContext);
+  readonly #themeSvc = inject(SkyThemeService, { optional: true });
 
   /**
    * Tracks the pending `setTimeout` in `open()` so `close()` and
    * `ngOnDestroy()` can cancel it before it fires.
    */
   #openTimeoutId: ReturnType<typeof setTimeout> | undefined;
-
-  constructor(
-    changeDetector: ChangeDetectorRef,
-    elementRef: ElementRef,
-    affixService: SkyAffixService,
-    coreAdapterService: SkyCoreAdapterService,
-    context: SkyPopoverContext,
-    @Optional() themeSvc?: SkyThemeService,
-  ) {
-    this.#changeDetector = changeDetector;
-    this.#elementRef = elementRef;
-    this.#affixService = affixService;
-    this.#coreAdapterService = coreAdapterService;
-    this.#context = context;
-    this.#themeSvc = themeSvc;
-  }
 
   public hasFocusableContent(): boolean {
     return (

--- a/libs/components/popovers/src/lib/modules/popover/popover.component.ts
+++ b/libs/components/popovers/src/lib/modules/popover/popover.component.ts
@@ -4,10 +4,8 @@ import {
   ElementRef,
   EnvironmentInjector,
   EventEmitter,
-  Inject,
   Input,
   OnDestroy,
-  Optional,
   Output,
   TemplateRef,
   ViewChild,
@@ -19,7 +17,6 @@ import {
   SkyIdService,
   SkyOverlayInstance,
   SkyOverlayService,
-  SkyStackingContext,
 } from '@skyux/core';
 
 import { Observable, Subject } from 'rxjs';
@@ -107,7 +104,7 @@ export class SkyPopoverComponent implements OnDestroy {
 
   public isMouseEnter = false;
 
-  public popoverId: string;
+  public popoverId = inject(SkyIdService).generateId();
 
   @ViewChild('templateRef', {
     read: TemplateRef,
@@ -137,21 +134,12 @@ export class SkyPopoverComponent implements OnDestroy {
 
   readonly #environmentInjector = inject(EnvironmentInjector);
 
-  #overlayService: SkyOverlayService;
+  readonly #overlayService = inject(SkyOverlayService);
 
-  #zIndex: Observable<number> | undefined;
-
-  constructor(
-    overlayService: SkyOverlayService,
-    @Optional()
-    @Inject(SKY_STACKING_CONTEXT)
-    stackingContext?: SkyStackingContext,
-  ) {
-    this.#overlayService = overlayService;
-    this.#zIndex = stackingContext?.zIndex;
-
-    this.popoverId = inject(SkyIdService).generateId();
-  }
+  readonly #zIndex: Observable<number> | undefined = inject(
+    SKY_STACKING_CONTEXT,
+    { optional: true },
+  )?.zIndex;
 
   public ngOnDestroy(): void {
     this.#ngUnsubscribe.next();

--- a/libs/components/popovers/src/lib/modules/popover/popover.directive.ts
+++ b/libs/components/popovers/src/lib/modules/popover/popover.directive.ts
@@ -101,14 +101,13 @@ export class SkyPopoverDirective implements OnInit, OnDestroy {
 
   #_trigger: SkyPopoverTrigger = 'click';
 
-  #elementRef: ElementRef;
+  readonly #elementRef = inject(ElementRef);
   #expanded = false;
   #popoverClosedSubscription: Subscription | undefined;
 
   readonly #srPointerSvc = inject(SkyPopoverSRPointerService);
 
-  constructor(elementRef: ElementRef) {
-    this.#elementRef = elementRef;
+  constructor() {
     this.#subscribeMessageStream();
   }
 

--- a/libs/components/progress-indicator/src/lib/modules/progress-indicator/fixtures/progress-indicator.component.fixture.ts
+++ b/libs/components/progress-indicator/src/lib/modules/progress-indicator/fixtures/progress-indicator.component.fixture.ts
@@ -7,6 +7,7 @@ import {
   TemplateRef,
   ViewChild,
   ViewChildren,
+  inject,
 } from '@angular/core';
 
 import { Subject } from 'rxjs';
@@ -121,11 +122,9 @@ export class SkyProgressIndicatorFixtureComponent {
   public helpPopoverContent: string | undefined;
   public helpPopoverTitle: string | undefined;
 
-  #changeDetector: ChangeDetectorRef;
+  readonly #changeDetector = inject(ChangeDetectorRef);
 
-  constructor(changeDetector: ChangeDetectorRef) {
-    this.#changeDetector = changeDetector;
-
+  constructor() {
     this.buttonConfigs = [
       {
         type: 'finish',

--- a/libs/components/progress-indicator/src/lib/modules/progress-indicator/progress-indicator-item/progress-indicator-item.component.ts
+++ b/libs/components/progress-indicator/src/lib/modules/progress-indicator/progress-indicator-item/progress-indicator-item.component.ts
@@ -5,6 +5,7 @@ import {
   Input,
   OnInit,
   TemplateRef,
+  inject,
 } from '@angular/core';
 
 import { SkyProgressIndicatorItemStatus } from '../types/progress-indicator-item-status';
@@ -123,17 +124,13 @@ export class SkyProgressIndicatorItemComponent implements OnInit {
   public statusName = STATUS_NAME_DEFAULT;
 
   #titlePrefix: string | undefined;
-  #changeDetector: ChangeDetectorRef;
+  readonly #changeDetector = inject(ChangeDetectorRef);
 
   #_isVisible = false;
   #_title: string | undefined;
   #_showStatusMarker = true;
   #_showTitle = true;
   #_status = STATUS_DEFAULT;
-
-  constructor(changeDetector: ChangeDetectorRef) {
-    this.#changeDetector = changeDetector;
-  }
 
   public ngOnInit(): void {
     this.#updateFormattedTitle();

--- a/libs/components/progress-indicator/src/lib/modules/progress-indicator/progress-indicator-nav-button/progress-indicator-nav-button.component.ts
+++ b/libs/components/progress-indicator/src/lib/modules/progress-indicator/progress-indicator-nav-button/progress-indicator-nav-button.component.ts
@@ -6,8 +6,8 @@ import {
   EventEmitter,
   Input,
   OnDestroy,
-  Optional,
   Output,
+  inject,
 } from '@angular/core';
 
 import { Subject } from 'rxjs';
@@ -147,16 +147,10 @@ export class SkyProgressIndicatorNavButtonComponent
   #_isVisible: boolean | undefined;
   #_progressIndicator: SkyProgressIndicatorComponent | undefined;
 
-  #changeDetector: ChangeDetectorRef;
-  #parentComponent: SkyProgressIndicatorComponent | undefined;
-
-  constructor(
-    changeDetector: ChangeDetectorRef,
-    @Optional() parentComponent?: SkyProgressIndicatorComponent,
-  ) {
-    this.#changeDetector = changeDetector;
-    this.#parentComponent = parentComponent;
-  }
+  readonly #changeDetector = inject(ChangeDetectorRef);
+  readonly #parentComponent = inject(SkyProgressIndicatorComponent, {
+    optional: true,
+  });
 
   public ngAfterViewInit(): void {
     if (!this.progressIndicator && this.#parentComponent) {

--- a/libs/components/progress-indicator/src/lib/modules/progress-indicator/progress-indicator-reset-button/progress-indicator-reset-button.component.ts
+++ b/libs/components/progress-indicator/src/lib/modules/progress-indicator/progress-indicator-reset-button/progress-indicator-reset-button.component.ts
@@ -6,6 +6,7 @@ import {
   Input,
   OnDestroy,
   Output,
+  inject,
 } from '@angular/core';
 
 import { SkyProgressIndicatorComponent } from '../progress-indicator.component';
@@ -52,11 +53,7 @@ export class SkyProgressIndicatorResetButtonComponent implements OnDestroy {
   public resetClick = new EventEmitter<void>();
 
   #_disabled: boolean | undefined;
-  #changeDetector: ChangeDetectorRef;
-
-  constructor(changeDetector: ChangeDetectorRef) {
-    this.#changeDetector = changeDetector;
-  }
+  readonly #changeDetector = inject(ChangeDetectorRef);
 
   public ngOnDestroy(): void {
     this.resetClick.complete();

--- a/libs/components/progress-indicator/src/lib/modules/progress-indicator/progress-indicator-status-marker/progress-indicator-status-marker.component.ts
+++ b/libs/components/progress-indicator/src/lib/modules/progress-indicator/progress-indicator-status-marker/progress-indicator-status-marker.component.ts
@@ -4,7 +4,7 @@ import {
   Component,
   Input,
   OnDestroy,
-  Optional,
+  inject,
 } from '@angular/core';
 import { SkyThemeService } from '@skyux/theme';
 
@@ -47,21 +47,16 @@ export class SkyProgressIndicatorStatusMarkerComponent implements OnDestroy {
   public isComplete = false;
 
   #ngUnsubscribe = new Subject<void>();
-  #changeDetector: ChangeDetectorRef;
+  readonly #changeDetector = inject(ChangeDetectorRef);
 
   #_status: SkyProgressIndicatorItemStatus =
     SkyProgressIndicatorItemStatus.Active;
   #_displayMode: 'vertical' | 'horizontal' = 'vertical';
 
-  constructor(
-    changeDetector: ChangeDetectorRef,
-    @Optional() themeSvc?: SkyThemeService,
-  ) {
-    this.#changeDetector = changeDetector;
-
+  constructor() {
     // Update icons when theme changes.
-    themeSvc?.settingsChange
-      .pipe(takeUntil(this.#ngUnsubscribe))
+    inject(SkyThemeService, { optional: true })
+      ?.settingsChange.pipe(takeUntil(this.#ngUnsubscribe))
       .subscribe(() => {
         this.#changeDetector.markForCheck();
       });

--- a/libs/components/progress-indicator/src/lib/modules/progress-indicator/progress-indicator.component.ts
+++ b/libs/components/progress-indicator/src/lib/modules/progress-indicator/progress-indicator.component.ts
@@ -10,6 +10,7 @@ import {
   OnInit,
   Output,
   QueryList,
+  inject,
 } from '@angular/core';
 import { SkyAppWindowRef, SkyLogService } from '@skyux/core';
 
@@ -159,19 +160,9 @@ export class SkyProgressIndicatorComponent
   #messageStream = new Subject<
     SkyProgressIndicatorMessage | SkyProgressIndicatorMessageType
   >();
-  #changeDetector: ChangeDetectorRef;
-  #windowRef: SkyAppWindowRef;
-  #logger: SkyLogService;
-
-  constructor(
-    changeDetector: ChangeDetectorRef,
-    windowRef: SkyAppWindowRef,
-    logger: SkyLogService,
-  ) {
-    this.#changeDetector = changeDetector;
-    this.#windowRef = windowRef;
-    this.#logger = logger;
-  }
+  readonly #changeDetector = inject(ChangeDetectorRef);
+  readonly #windowRef = inject(SkyAppWindowRef);
+  readonly #logger = inject(SkyLogService);
 
   public ngOnInit(): void {
     this.#initialized = true;

--- a/libs/components/router/src/lib/modules/href/fixtures/href-fixture.component.ts
+++ b/libs/components/router/src/lib/modules/href/fixtures/href-fixture.component.ts
@@ -3,6 +3,7 @@ import {
   ChangeDetectorRef,
   Component,
   Input,
+  inject,
 } from '@angular/core';
 
 import { SkyHrefModule } from '../href.module';
@@ -39,11 +40,7 @@ export class HrefDirectiveFixtureComponent {
   #_dynamicElse: 'hide' | 'unlink' = 'hide';
   #_dynamicLink: string | any[] | undefined = '1bb-nav://simple-app/';
 
-  #changeDetectorRef: ChangeDetectorRef;
-
-  constructor(changeDetectorRef: ChangeDetectorRef) {
-    this.#changeDetectorRef = changeDetectorRef;
-  }
+  readonly #changeDetectorRef = inject(ChangeDetectorRef);
 
   public setSlowLink(value: boolean) {
     this.testSlowLink = value;

--- a/libs/components/router/src/lib/modules/link/link-external.directive.ts
+++ b/libs/components/router/src/lib/modules/link/link-external.directive.ts
@@ -4,9 +4,9 @@ import {
   ElementRef,
   Input,
   OnChanges,
-  Optional,
   Renderer2,
   SimpleChanges,
+  inject,
 } from '@angular/core';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import {
@@ -34,35 +34,28 @@ export class SkyAppLinkExternalDirective
     this.routerLink = commands;
   }
 
-  #window: SkyAppWindowRef;
-  #skyAppConfig: SkyAppConfig | undefined;
-  #paramsProvider: SkyAppRuntimeConfigParamsProvider | undefined;
+  readonly #window = inject(SkyAppWindowRef);
+  readonly #skyAppConfig: SkyAppConfig | null;
+  readonly #paramsProvider = inject(SkyAppRuntimeConfigParamsProvider, {
+    optional: true,
+  });
 
-  constructor(
-    router: Router,
-    route: ActivatedRoute,
-    renderer: Renderer2,
-    elementRef: ElementRef,
-    platformLocation: PlatformLocation,
-    window: SkyAppWindowRef,
-    @Optional() skyAppConfig?: SkyAppConfig,
-    @Optional() paramsProvider?: SkyAppRuntimeConfigParamsProvider,
-    @Optional() hostConfig?: SkyAppConfigHost,
-  ) {
+  constructor() {
+    const skyAppConfig = inject(SkyAppConfig, { optional: true });
+    const hostConfig = inject(SkyAppConfigHost, { optional: true });
+
     super(
-      router,
-      route,
+      inject(Router),
+      inject(ActivatedRoute),
       undefined,
-      renderer,
-      elementRef,
+      inject(Renderer2),
+      inject(ElementRef),
       new PathLocationStrategy(
-        platformLocation,
+        inject(PlatformLocation),
         hostConfig ? hostConfig.host.url : skyAppConfig?.skyux.host?.url,
       ),
     );
-    this.#window = window;
     this.#skyAppConfig = skyAppConfig;
-    this.#paramsProvider = paramsProvider;
 
     if (
       this.#window.nativeWindow.window.name &&

--- a/libs/components/router/src/lib/modules/link/link.directive.ts
+++ b/libs/components/router/src/lib/modules/link/link.directive.ts
@@ -4,9 +4,9 @@ import {
   ElementRef,
   Input,
   OnChanges,
-  Optional,
   Renderer2,
   SimpleChanges,
+  inject,
 } from '@angular/core';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { SkyAppConfig, SkyAppRuntimeConfigParamsProvider } from '@skyux/config';
@@ -23,21 +23,20 @@ export class SkyAppLinkDirective extends RouterLink implements OnChanges {
     this.routerLink = commands;
   }
 
-  #skyAppConfig: SkyAppConfig | undefined;
-  #paramsProvider: SkyAppRuntimeConfigParamsProvider | undefined;
+  readonly #skyAppConfig = inject(SkyAppConfig, { optional: true });
+  readonly #paramsProvider = inject(SkyAppRuntimeConfigParamsProvider, {
+    optional: true,
+  });
 
-  constructor(
-    router: Router,
-    route: ActivatedRoute,
-    locationStrategy: LocationStrategy,
-    renderer: Renderer2,
-    elementRef: ElementRef,
-    @Optional() skyAppConfig?: SkyAppConfig,
-    @Optional() paramsProvider?: SkyAppRuntimeConfigParamsProvider,
-  ) {
-    super(router, route, undefined, renderer, elementRef, locationStrategy);
-    this.#skyAppConfig = skyAppConfig;
-    this.#paramsProvider = paramsProvider;
+  constructor() {
+    super(
+      inject(Router),
+      inject(ActivatedRoute),
+      undefined,
+      inject(Renderer2),
+      inject(ElementRef),
+      inject(LocationStrategy),
+    );
   }
 
   public override ngOnChanges(changes: SimpleChanges): void {

--- a/libs/components/router/testing/src/modules/href/href-resolver-mock.service.ts
+++ b/libs/components/router/testing/src/modules/href/href-resolver-mock.service.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable, InjectionToken } from '@angular/core';
+import { Injectable, InjectionToken, inject } from '@angular/core';
 import { SkyHref, SkyHrefResolver } from '@skyux/router';
 
 export const MockUserHasAccess = new InjectionToken<boolean>(
@@ -10,7 +10,7 @@ export const MockUserHasAccess = new InjectionToken<boolean>(
  */
 @Injectable()
 export class SkyHrefResolverMockService implements SkyHrefResolver {
-  constructor(@Inject(MockUserHasAccess) private userHasAccess: boolean) {}
+  private readonly userHasAccess = inject(MockUserHasAccess);
 
   public resolveHref(param: { url: string }): Promise<SkyHref> {
     return Promise.resolve({

--- a/libs/components/select-field/src/lib/modules/select-field/select-field.component.ts
+++ b/libs/components/select-field/src/lib/modules/select-field/select-field.component.ts
@@ -9,6 +9,7 @@ import {
   OnDestroy,
   Output,
   forwardRef,
+  inject,
 } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { SkyLogService } from '@skyux/core';
@@ -236,14 +237,13 @@ export class SkySelectFieldComponent
   private _value: any;
   private isPickerOpen = false;
 
-  constructor(
-    private changeDetector: ChangeDetectorRef,
-    private modalService: SkyModalService,
-    private resourcesService: SkyLibResourcesService,
-    private elementRef: ElementRef,
-    logger: SkyLogService,
-  ) {
-    logger.deprecated('SkySelectFieldComponent', {
+  private readonly changeDetector = inject(ChangeDetectorRef);
+  private readonly modalService = inject(SkyModalService);
+  private readonly resourcesService = inject(SkyLibResourcesService);
+  private readonly elementRef = inject(ElementRef);
+
+  constructor() {
+    inject(SkyLogService).deprecated('SkySelectFieldComponent', {
       deprecationMajorVersion: 6,
       moreInfoUrl: 'https://developer.blackbaud.com/skyux/components/lookup',
       replacementRecommendation: 'Use `SkyLookupComponent` instead.',

--- a/libs/components/split-view/src/lib/modules/split-view/fixtures/split-view.fixture.ts
+++ b/libs/components/split-view/src/lib/modules/split-view/fixtures/split-view.fixture.ts
@@ -1,4 +1,4 @@
-import { Component, ViewChild, input } from '@angular/core';
+import { Component, ViewChild, inject, input } from '@angular/core';
 import { SkyConfirmService } from '@skyux/modals';
 
 import { Subject } from 'rxjs';
@@ -48,5 +48,5 @@ export class SplitViewFixtureComponent {
   @ViewChild(SkySplitViewComponent)
   public splitViewComponent!: SkySplitViewComponent;
 
-  constructor(public confirmService: SkyConfirmService) {}
+  public confirmService = inject(SkyConfirmService);
 }

--- a/libs/components/split-view/src/lib/modules/split-view/split-view-adapter.service.ts
+++ b/libs/components/split-view/src/lib/modules/split-view/split-view-adapter.service.ts
@@ -3,6 +3,7 @@ import {
   Injectable,
   Renderer2,
   RendererFactory2,
+  inject,
 } from '@angular/core';
 import { SkyAppWindowRef, SkyMutationObserverService } from '@skyux/core';
 
@@ -17,20 +18,11 @@ import { take, takeUntil } from 'rxjs/operators';
 export class SkySplitViewAdapterService {
   #observer: MutationObserver | undefined;
   #renderer: Renderer2;
-  #observerSvc: SkyMutationObserverService;
-  #rendererFactory: RendererFactory2;
-  #windowRef: SkyAppWindowRef;
+  readonly #observerSvc = inject(SkyMutationObserverService);
+  readonly #windowRef = inject(SkyAppWindowRef);
 
-  constructor(
-    observerSvc: SkyMutationObserverService,
-    rendererFactory: RendererFactory2,
-    windowRef: SkyAppWindowRef,
-  ) {
-    this.#observerSvc = observerSvc;
-    this.#rendererFactory = rendererFactory;
-    this.#windowRef = windowRef;
-
-    this.#renderer = this.#rendererFactory.createRenderer(undefined, null);
+  constructor() {
+    this.#renderer = inject(RendererFactory2).createRenderer(undefined, null);
   }
 
   public bindHeightToWindow(

--- a/libs/components/split-view/src/lib/modules/split-view/split-view-workspace-header.component.ts
+++ b/libs/components/split-view/src/lib/modules/split-view/split-view-workspace-header.component.ts
@@ -3,6 +3,7 @@ import {
   Component,
   OnDestroy,
   OnInit,
+  inject,
 } from '@angular/core';
 import { SkyIconModule } from '@skyux/icon';
 
@@ -26,11 +27,7 @@ export class SkySplitViewWorkspaceHeaderComponent implements OnDestroy, OnInit {
   public backButtonText: string | undefined;
 
   #ngUnsubscribe = new Subject<void>();
-  #splitViewSvc: SkySplitViewService;
-
-  constructor(splitViewSvc: SkySplitViewService) {
-    this.#splitViewSvc = splitViewSvc;
-  }
+  readonly #splitViewSvc = inject(SkySplitViewService);
 
   public ngOnInit(): void {
     this.#splitViewSvc.backButtonTextStream

--- a/libs/components/split-view/src/lib/modules/split-view/split-view.component.ts
+++ b/libs/components/split-view/src/lib/modules/split-view/split-view.component.ts
@@ -8,6 +8,7 @@ import {
   OnDestroy,
   OnInit,
   afterNextRender,
+  inject,
   signal,
 } from '@angular/core';
 import {
@@ -126,30 +127,18 @@ export class SkySplitViewComponent implements OnInit, OnDestroy {
   #animationComplete = new Subject<void>();
   #bindHeightToWindowUnsubscribe: Subject<void> | undefined;
   #ngUnsubscribe = new Subject<void>();
-  #adapter: SkySplitViewAdapterService;
-  #changeDetectorRef: ChangeDetectorRef;
-  #coreAdapterService: SkyCoreAdapterService;
-  #elementRef: ElementRef;
-  #splitViewService: SkySplitViewService;
+  readonly #adapter = inject(SkySplitViewAdapterService);
+  readonly #changeDetectorRef = inject(ChangeDetectorRef);
+  readonly #coreAdapterService = inject(SkyCoreAdapterService);
+  readonly #elementRef = inject(ElementRef);
+  readonly #splitViewService = inject(SkySplitViewService);
 
   #_bindHeightToWindow = false;
   #_drawerVisible = true;
   #_dock: SkySplitViewDockType = 'none';
 
-  constructor(
-    adapter: SkySplitViewAdapterService,
-    changeDetectorRef: ChangeDetectorRef,
-    coreAdapterService: SkyCoreAdapterService,
-    elementRef: ElementRef,
-    splitViewService: SkySplitViewService,
-  ) {
-    this.#adapter = adapter;
-    this.#changeDetectorRef = changeDetectorRef;
-    this.#coreAdapterService = coreAdapterService;
-    this.#elementRef = elementRef;
-    this.#splitViewService = splitViewService;
-
-    splitViewService.splitViewElementRef = elementRef;
+  constructor() {
+    this.#splitViewService.splitViewElementRef = this.#elementRef;
 
     // Enable animations after the first render.
     afterNextRender(() => {

--- a/libs/components/split-view/src/lib/modules/split-view/split-view.service.ts
+++ b/libs/components/split-view/src/lib/modules/split-view/split-view.service.ts
@@ -36,9 +36,9 @@ export class SkySplitViewService {
   #_isMobile = false;
   #_isMobileStream = new BehaviorSubject<boolean>(false);
 
-  constructor(resources: SkyLibResourcesService) {
+  constructor() {
     // Set default back button text.
-    resources
+    inject(SkyLibResourcesService)
       .getString('skyux_split_view_back_to_list')
       .pipe(take(1))
       .subscribe((resource) => {

--- a/libs/components/storybook/src/lib/preview-wrapper/preview-wrapper.component.ts
+++ b/libs/components/storybook/src/lib/preview-wrapper/preview-wrapper.component.ts
@@ -1,7 +1,6 @@
 import {
   ChangeDetectionStrategy,
   Component,
-  Inject,
   Input,
   OnDestroy,
   OnInit,
@@ -74,19 +73,9 @@ export class PreviewWrapperComponent implements OnInit, OnDestroy {
   );
   #initialized = false;
 
-  #body: HTMLElement;
-  #themeService: SkyThemeService;
-  #renderer: Renderer2;
-
-  constructor(
-    themeService: SkyThemeService,
-    @Inject('BODY') body: HTMLElement,
-    renderer: Renderer2,
-  ) {
-    this.#themeService = themeService;
-    this.#body = body;
-    this.#renderer = renderer;
-  }
+  readonly #body: HTMLElement = inject('BODY' as any);
+  readonly #themeService = inject(SkyThemeService);
+  readonly #renderer = inject(Renderer2);
 
   public ngOnInit(): void {
     this.#themeService.init(this.#body, this.#renderer, this.themeSettings);

--- a/libs/components/tabs/src/lib/modules/sectioned-form/fixtures/sectioned-form-fixture-information-1.component.ts
+++ b/libs/components/tabs/src/lib/modules/sectioned-form/fixtures/sectioned-form-fixture-information-1.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
 
 import { SkySectionedFormService } from './../sectioned-form.service';
 
@@ -29,9 +29,5 @@ export class SkySectionedFormFixtureInformation1Component {
   #_invalid: boolean | undefined;
   #_required: boolean | undefined;
 
-  #sectionedFormService: SkySectionedFormService;
-
-  constructor(sectionedFormService: SkySectionedFormService) {
-    this.#sectionedFormService = sectionedFormService;
-  }
+  readonly #sectionedFormService = inject(SkySectionedFormService);
 }

--- a/libs/components/tabs/src/lib/modules/sectioned-form/sectioned-form-section.component.ts
+++ b/libs/components/tabs/src/lib/modules/sectioned-form/sectioned-form-section.component.ts
@@ -6,6 +6,7 @@ import {
   OnDestroy,
   OnInit,
   ViewChild,
+  inject,
 } from '@angular/core';
 
 import { Subject } from 'rxjs';
@@ -60,19 +61,9 @@ export class SkySectionedFormSectionComponent implements OnInit, OnDestroy {
 
   #ngUnsubscribe = new Subject<void>();
 
-  #sectionedFormService: SkySectionedFormService;
-  #tabsetService: SkyVerticalTabsetService;
-  #changeRef: ChangeDetectorRef;
-
-  constructor(
-    sectionedFormService: SkySectionedFormService,
-    tabsetService: SkyVerticalTabsetService,
-    changeRef: ChangeDetectorRef,
-  ) {
-    this.#sectionedFormService = sectionedFormService;
-    this.#tabsetService = tabsetService;
-    this.#changeRef = changeRef;
-  }
+  readonly #sectionedFormService = inject(SkySectionedFormService);
+  readonly #tabsetService = inject(SkyVerticalTabsetService);
+  readonly #changeRef = inject(ChangeDetectorRef);
 
   public ngOnInit(): void {
     this.#changeRef.detectChanges();

--- a/libs/components/tabs/src/lib/modules/sectioned-form/sectioned-form.component.ts
+++ b/libs/components/tabs/src/lib/modules/sectioned-form/sectioned-form.component.ts
@@ -12,6 +12,7 @@ import {
   ViewChild,
   afterNextRender,
   computed,
+  inject,
   input,
   signal,
 } from '@angular/core';
@@ -100,9 +101,9 @@ export class SkySectionedFormComponent
   #ngUnsubscribe = new Subject<void>();
 
   #messageStreamSub: Subscription | undefined;
-  #changeRef: ChangeDetectorRef;
-  #tabIdSvc: SkyTabIdService;
-  #logger: SkyLogService;
+  readonly #changeRef = inject(ChangeDetectorRef);
+  readonly #tabIdSvc = inject(SkyTabIdService);
+  readonly #logger = inject(SkyLogService);
 
   #_messageStream = new Subject<SkySectionedFormMessage>();
 
@@ -110,16 +111,9 @@ export class SkySectionedFormComponent
 
   protected readonly isMobile = signal(false);
 
-  constructor(
-    public tabService: SkyVerticalTabsetService,
-    changeRef: ChangeDetectorRef,
-    tabIdSvc: SkyTabIdService,
-    logger: SkyLogService,
-  ) {
-    this.#changeRef = changeRef;
-    this.#tabIdSvc = tabIdSvc;
-    this.#logger = logger;
+  public readonly tabService = inject(SkyVerticalTabsetService);
 
+  constructor() {
     // Enable animations after the first render.
     afterNextRender(() => {
       this.animationEnabled.set(true);

--- a/libs/components/tabs/src/lib/modules/tabs/fixtures/tabset-permalinks.component.fixture.ts
+++ b/libs/components/tabs/src/lib/modules/tabs/fixtures/tabset-permalinks.component.fixture.ts
@@ -1,4 +1,4 @@
-import { Component, model } from '@angular/core';
+import { Component, inject, model } from '@angular/core';
 import { Router } from '@angular/router';
 
 import { SkyTabIndex } from '../tab-index';
@@ -19,7 +19,7 @@ export class SkyTabsetPermalinksFixtureComponent {
 
   public showIt = model<boolean>(true);
 
-  constructor(public router: Router) {}
+  public readonly router = inject(Router);
 
   public onActiveChange(index: SkyTabIndex): void {
     this.activeIndex.set(index);

--- a/libs/components/tabs/src/lib/modules/tabs/tab-button.component.ts
+++ b/libs/components/tabs/src/lib/modules/tabs/tab-button.component.ts
@@ -9,6 +9,7 @@ import {
   OnDestroy,
   Output,
   ViewEncapsulation,
+  inject,
 } from '@angular/core';
 
 import { Subject } from 'rxjs';
@@ -98,27 +99,15 @@ export class SkyTabButtonComponent implements AfterViewInit, OnDestroy {
   @Output()
   public closeClick = new EventEmitter<void>();
 
-  constructor(
-    elementRef: ElementRef,
-    adapterService: SkyTabButtonAdapterService,
-    changeDetectorRef: ChangeDetectorRef,
-    tabsetService: SkyTabsetService,
-  ) {
-    this.#adapterService = adapterService;
-    this.#changeDetectorRef = changeDetectorRef;
-    this.#elementRef = elementRef;
-    this.#tabsetService = tabsetService;
-  }
-
   public closeBtnTabIndex = '-1';
   public wizardStepState: SkyWizardStepState | undefined;
   #_isActive: boolean | undefined = false;
   #_isDisabled = DEFAULT_DISABLED;
   #_tabStyle: SkyTabsetStyle | undefined;
-  #adapterService: SkyTabButtonAdapterService;
-  #changeDetectorRef: ChangeDetectorRef;
-  #elementRef: ElementRef;
-  #tabsetService: SkyTabsetService;
+  readonly #adapterService = inject(SkyTabButtonAdapterService);
+  readonly #changeDetectorRef = inject(ChangeDetectorRef);
+  readonly #elementRef = inject(ElementRef);
+  readonly #tabsetService = inject(SkyTabsetService);
   #ngUnsubscribe = new Subject<void>();
 
   public ngAfterViewInit(): void {

--- a/libs/components/tabs/src/lib/modules/tabs/tab.component.ts
+++ b/libs/components/tabs/src/lib/modules/tabs/tab.component.ts
@@ -9,6 +9,7 @@ import {
   OnDestroy,
   Output,
   SimpleChanges,
+  inject,
 } from '@angular/core';
 import { SkyResponsiveHostDirective } from '@skyux/core';
 
@@ -197,18 +198,11 @@ export class SkyTabComponent implements OnChanges, OnDestroy {
 
   #tabIndexChange: BehaviorSubject<SkyTabIndex | undefined>;
 
-  #changeDetector: ChangeDetectorRef;
-  #permalinkService: SkyTabsetPermalinkService;
-  #tabsetService: SkyTabsetService;
+  readonly #changeDetector = inject(ChangeDetectorRef);
+  readonly #permalinkService = inject(SkyTabsetPermalinkService);
+  readonly #tabsetService = inject(SkyTabsetService);
 
-  constructor(
-    changeDetector: ChangeDetectorRef,
-    permalinkService: SkyTabsetPermalinkService,
-    tabsetService: SkyTabsetService,
-  ) {
-    this.#changeDetector = changeDetector;
-    this.#permalinkService = permalinkService;
-    this.#tabsetService = tabsetService;
+  constructor() {
     const id = nextId++;
     this.tabPanelId = `sky-tab-${id}`;
     this.tabButtonId = `${this.tabPanelId}-nav-btn`;

--- a/libs/components/tabs/src/lib/modules/tabs/tabset-nav-button.component.ts
+++ b/libs/components/tabs/src/lib/modules/tabs/tabset-nav-button.component.ts
@@ -4,6 +4,7 @@ import {
   HostBinding,
   Input,
   OnDestroy,
+  inject,
 } from '@angular/core';
 import { SkyLogService } from '@skyux/core';
 
@@ -123,13 +124,9 @@ export class SkyTabsetNavButtonComponent implements OnDestroy {
   #activeIndexNumber: number | undefined;
   #activeSkyTabIndex: SkyTabIndex | undefined;
   #currentTabsetSub: Subscription | undefined;
-  #logger: SkyLogService;
+  readonly #logger = inject(SkyLogService);
   #tabCount: number | undefined;
   #ngUnsubscribe = new Subject<void>();
-
-  constructor(logger: SkyLogService) {
-    this.#logger = logger;
-  }
 
   public ngOnDestroy(): void {
     this.#ngUnsubscribe.next();

--- a/libs/components/tabs/src/lib/modules/tabs/tabset.component.ts
+++ b/libs/components/tabs/src/lib/modules/tabs/tabset.component.ts
@@ -219,27 +219,13 @@ export class SkyTabsetComponent implements AfterViewInit, OnDestroy {
 
   #_tabStyle: SkyTabsetStyle = 'tabs';
 
-  #changeDetector: ChangeDetectorRef;
-  #elementRef: ElementRef;
-  #adapterService: SkyTabsetAdapterService;
-  #permalinkService: SkyTabsetPermalinkService;
-  #tabsetService: SkyTabsetService;
+  readonly #changeDetector = inject(ChangeDetectorRef);
+  readonly #elementRef = inject(ElementRef);
+  readonly #adapterService = inject(SkyTabsetAdapterService);
+  readonly #permalinkService = inject(SkyTabsetPermalinkService);
+  readonly #tabsetService = inject(SkyTabsetService);
 
   #layoutHostSvc = inject(SkyLayoutHostService, { optional: true });
-
-  constructor(
-    changeDetector: ChangeDetectorRef,
-    elementRef: ElementRef,
-    adapterService: SkyTabsetAdapterService,
-    permalinkService: SkyTabsetPermalinkService,
-    tabsetService: SkyTabsetService,
-  ) {
-    this.#changeDetector = changeDetector;
-    this.#elementRef = elementRef;
-    this.#adapterService = adapterService;
-    this.#permalinkService = permalinkService;
-    this.#tabsetService = tabsetService;
-  }
 
   public ngAfterViewInit(): void {
     this.#initTabComponents();

--- a/libs/components/tabs/src/lib/modules/vertical-tabset/vertical-tab.component.ts
+++ b/libs/components/tabs/src/lib/modules/vertical-tabset/vertical-tab.component.ts
@@ -6,7 +6,6 @@ import {
   Input,
   OnDestroy,
   OnInit,
-  Optional,
   ViewChild,
   inject,
 } from '@angular/core';
@@ -177,22 +176,12 @@ export class SkyVerticalTabComponent implements OnInit, OnDestroy {
 
   #ngUnsubscribe = new Subject<void>();
 
-  #adapterService: SkyVerticalTabsetAdapterService;
-  #changeRef: ChangeDetectorRef;
-  #tabsetService: SkyVerticalTabsetService;
-  #tabIdSvc: SkyTabIdService | undefined;
+  readonly #adapterService = inject(SkyVerticalTabsetAdapterService);
+  readonly #changeRef = inject(ChangeDetectorRef);
+  readonly #tabsetService = inject(SkyVerticalTabsetService);
+  readonly #tabIdSvc = inject(SkyTabIdService, { optional: true });
 
-  constructor(
-    adapterService: SkyVerticalTabsetAdapterService,
-    changeRef: ChangeDetectorRef,
-    tabsetService: SkyVerticalTabsetService,
-    @Optional() tabIdSvc?: SkyTabIdService,
-  ) {
-    this.#adapterService = adapterService;
-    this.#changeRef = changeRef;
-    this.#tabsetService = tabsetService;
-    this.#tabIdSvc = tabIdSvc;
-
+  constructor() {
     this.#tabIdOrDefault = this.#defaultTabId = `sky-vertical-tab-${++nextId}`;
     this.tabId = this.#defaultTabId;
   }

--- a/libs/components/tabs/src/lib/modules/vertical-tabset/vertical-tabset-group.component.ts
+++ b/libs/components/tabs/src/lib/modules/vertical-tabset/vertical-tabset-group.component.ts
@@ -77,8 +77,8 @@ export class SkyVerticalTabsetGroupComponent implements OnInit, OnDestroy {
 
   #ngUnsubscribe = new Subject<void>();
 
-  #tabService: SkyVerticalTabsetService;
-  #changeRef: ChangeDetectorRef;
+  readonly #tabService = inject(SkyVerticalTabsetService);
+  readonly #changeRef = inject(ChangeDetectorRef);
   #adapterService = inject(SkyVerticalTabsetAdapterService);
   #idService = inject(SkyIdService);
   #tabIdService = inject(SkyTabIdService);
@@ -87,13 +87,7 @@ export class SkyVerticalTabsetGroupComponent implements OnInit, OnDestroy {
   #_disabled: boolean | undefined;
   #_open: boolean | undefined = false;
 
-  constructor(
-    tabService: SkyVerticalTabsetService,
-    changeRef: ChangeDetectorRef,
-  ) {
-    this.#tabService = tabService;
-    this.#changeRef = changeRef;
-
+  constructor() {
     this.groupId = this.#idService.generateId();
 
     this.#groupService.messageStream.subscribe((message) => {

--- a/libs/components/tabs/src/lib/modules/vertical-tabset/vertical-tabset.component.ts
+++ b/libs/components/tabs/src/lib/modules/vertical-tabset/vertical-tabset.component.ts
@@ -10,6 +10,7 @@ import {
   OnInit,
   Output,
   ViewChild,
+  inject,
 } from '@angular/core';
 import { SkyLibResourcesService } from '@skyux/i18n';
 
@@ -109,19 +110,12 @@ export class SkyVerticalTabsetComponent
   #ngUnsubscribe = new Subject<void>();
   #_ariaRole = 'tablist';
 
-  #resources: SkyLibResourcesService;
-  #changeRef: ChangeDetectorRef;
+  readonly #resources = inject(SkyLibResourcesService);
+  readonly #changeRef = inject(ChangeDetectorRef);
 
-  constructor(
-    public adapterService: SkyVerticalTabsetAdapterService,
-    public tabService: SkyVerticalTabsetService,
-    resources: SkyLibResourcesService,
-    changeRef: ChangeDetectorRef,
-    public tabIdSvc: SkyTabIdService,
-  ) {
-    this.#resources = resources;
-    this.#changeRef = changeRef;
-  }
+  public readonly adapterService = inject(SkyVerticalTabsetAdapterService);
+  public readonly tabService = inject(SkyVerticalTabsetService);
+  public readonly tabIdSvc = inject(SkyTabIdService);
 
   public ngOnInit(): void {
     this.tabService.maintainTabContent = this.maintainTabContent;

--- a/libs/components/text-editor/src/lib/modules/rich-text-display/rich-text-display.component.ts
+++ b/libs/components/text-editor/src/lib/modules/rich-text-display/rich-text-display.component.ts
@@ -1,4 +1,9 @@
-import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  Input,
+  inject,
+} from '@angular/core';
 import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
 
 import { SkyTextSanitizationService } from '../text-editor/services/text-sanitization.service';
@@ -35,14 +40,6 @@ export class SkyRichTextDisplayComponent {
 
   #_richText = '';
 
-  #sanitizer: DomSanitizer;
-  #sanitizationService: SkyTextSanitizationService;
-
-  constructor(
-    sanitizer: DomSanitizer,
-    sanitizationService: SkyTextSanitizationService,
-  ) {
-    this.#sanitizer = sanitizer;
-    this.#sanitizationService = sanitizationService;
-  }
+  readonly #sanitizer = inject(DomSanitizer);
+  readonly #sanitizationService = inject(SkyTextSanitizationService);
 }

--- a/libs/components/text-editor/src/lib/modules/text-editor/services/text-editor-adapter.service.ts
+++ b/libs/components/text-editor/src/lib/modules/text-editor/services/text-editor-adapter.service.ts
@@ -21,19 +21,9 @@ import { SkyTextEditorService } from './text-editor.service';
 @Injectable()
 export class SkyTextEditorAdapterService {
   readonly #resourceSvc = inject(SkyLibResourcesService);
-  #selectionService: SkyTextEditorSelectionService;
-  #textEditorService: SkyTextEditorService;
-  #windowRef: SkyAppWindowRef;
-
-  constructor(
-    selectionService: SkyTextEditorSelectionService,
-    textEditorService: SkyTextEditorService,
-    windowService: SkyAppWindowRef,
-  ) {
-    this.#selectionService = selectionService;
-    this.#textEditorService = textEditorService;
-    this.#windowRef = windowService;
-  }
+  readonly #selectionService = inject(SkyTextEditorSelectionService);
+  readonly #textEditorService = inject(SkyTextEditorService);
+  readonly #windowRef = inject(SkyAppWindowRef);
 
   /**
    * Creates a text editor inside the supplied iframe element.

--- a/libs/components/theme/src/lib/style-loader.spec.ts
+++ b/libs/components/theme/src/lib/style-loader.spec.ts
@@ -1,7 +1,23 @@
+import { TestBed } from '@angular/core/testing';
+
 import FontFaceObserver from 'fontfaceobserver';
 import { Subject } from 'rxjs';
 
 import { SkyAppStyleLoader } from './style-loader';
+import { SkyThemeService } from './theming/theme.service';
+
+function createStyleLoader(themeSvc?: SkyThemeService): SkyAppStyleLoader {
+  TestBed.configureTestingModule({
+    providers: themeSvc
+      ? [{ provide: SkyThemeService, useValue: themeSvc }]
+      : [],
+  });
+  const styleLoader = TestBed.runInInjectionContext(
+    () => new SkyAppStyleLoader(),
+  );
+  TestBed.resetTestingModule();
+  return styleLoader;
+}
 
 describe('Style loader', () => {
   it('should resolve a promise after loading fonts', async () => {
@@ -9,7 +25,7 @@ describe('Style loader', () => {
       Promise.resolve(),
     );
 
-    const styleLoader = new SkyAppStyleLoader();
+    const styleLoader = createStyleLoader();
 
     await styleLoader.loadStyles();
 
@@ -21,7 +37,7 @@ describe('Style loader', () => {
       return Promise.reject(new Error('Fonts not loaded.'));
     });
 
-    const styleLoader = new SkyAppStyleLoader();
+    const styleLoader = createStyleLoader();
     const response = await styleLoader.loadStyles();
 
     expect(response.error.message).toBe('Fonts not loaded.');
@@ -34,7 +50,7 @@ describe('Style loader', () => {
       return sampleObserver.load(undefined, 1);
     });
 
-    const styleLoader = new SkyAppStyleLoader();
+    const styleLoader = createStyleLoader();
     const result = await styleLoader.loadStyles();
 
     expect(result.error).toBeDefined();
@@ -45,7 +61,7 @@ describe('Style loader', () => {
       Promise.resolve(),
     );
 
-    const styleLoader = new SkyAppStyleLoader();
+    const styleLoader = createStyleLoader();
     styleLoader.isLoaded = true;
 
     await styleLoader.loadStyles();
@@ -61,7 +77,7 @@ describe('Style loader', () => {
       settingsChange: new Subject<any>(),
     };
 
-    const styleLoader = new SkyAppStyleLoader(mockThemeSvc);
+    const styleLoader = createStyleLoader(mockThemeSvc);
 
     const resolve = styleLoader.loadStyles();
     expect(styleLoader.isLoaded).toBe(false);

--- a/libs/components/theme/src/lib/style-loader.ts
+++ b/libs/components/theme/src/lib/style-loader.ts
@@ -1,4 +1,4 @@
-import { Injectable, Optional } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 
 import FontFaceObserver from 'fontfaceobserver';
 import { take } from 'rxjs/operators';
@@ -12,11 +12,7 @@ export class SkyAppStyleLoader {
   public static readonly LOAD_TIMEOUT = 3000;
   public isLoaded = false;
 
-  #themeSvc: SkyThemeService | undefined;
-
-  constructor(@Optional() themeSvc?: SkyThemeService) {
-    this.#themeSvc = themeSvc;
-  }
+  readonly #themeSvc = inject(SkyThemeService, { optional: true });
 
   public loadStyles(): Promise<any> {
     if (this.isLoaded) {

--- a/libs/components/theme/src/lib/theming/theme-class.directive.ts
+++ b/libs/components/theme/src/lib/theming/theme-class.directive.ts
@@ -3,8 +3,8 @@ import {
   ElementRef,
   Input,
   OnDestroy,
-  Optional,
   Renderer2,
+  inject,
 } from '@angular/core';
 
 import { Subject } from 'rxjs';
@@ -68,16 +68,11 @@ export class SkyThemeClassDirective implements OnDestroy {
   #initialClasses: string[] = [];
   #skyThemeClassMap: SkyThemeClassMap | undefined;
 
-  #ngEl: ElementRef;
-  #renderer: Renderer2;
+  readonly #ngEl = inject(ElementRef);
+  readonly #renderer = inject(Renderer2);
 
-  constructor(
-    ngEl: ElementRef,
-    renderer: Renderer2,
-    @Optional() themeSvc?: SkyThemeService,
-  ) {
-    this.#ngEl = ngEl;
-    this.#renderer = renderer;
+  constructor() {
+    const themeSvc = inject(SkyThemeService, { optional: true });
     if (themeSvc) {
       themeSvc.settingsChange
         .pipe(takeUntil(this.#ngUnsubscribe))

--- a/libs/components/theme/src/lib/theming/theme-if.directive.ts
+++ b/libs/components/theme/src/lib/theming/theme-if.directive.ts
@@ -3,9 +3,9 @@ import {
   Directive,
   Input,
   OnDestroy,
-  Optional,
   TemplateRef,
   ViewContainerRef,
+  inject,
 } from '@angular/core';
 
 import { Subject } from 'rxjs';
@@ -40,18 +40,13 @@ export class SkyThemeIfDirective implements OnDestroy {
   #ngUnsubscribe = new Subject<void>();
   #hasView = false;
 
-  #templateRef: TemplateRef<unknown>;
-  #viewContainer: ViewContainerRef;
+  readonly #templateRef = inject(TemplateRef<unknown>);
+  readonly #viewContainer = inject(ViewContainerRef);
 
-  constructor(
-    templateRef: TemplateRef<unknown>,
-    viewContainer: ViewContainerRef,
-    changeDetector: ChangeDetectorRef,
-    @Optional() themeSvc?: SkyThemeService,
-  ) {
-    this.#templateRef = templateRef;
-    this.#viewContainer = viewContainer;
+  constructor() {
+    const themeSvc = inject(SkyThemeService, { optional: true });
     if (themeSvc) {
+      const changeDetector = inject(ChangeDetectorRef);
       themeSvc.settingsChange
         .pipe(takeUntil(this.#ngUnsubscribe))
         .subscribe((settingsChange) => {

--- a/libs/components/theme/src/lib/theming/theme.directive.ts
+++ b/libs/components/theme/src/lib/theming/theme.directive.ts
@@ -5,6 +5,7 @@ import {
   OnDestroy,
   OnInit,
   Renderer2,
+  inject,
 } from '@angular/core';
 
 import { SkyTheme } from './theme';
@@ -40,19 +41,9 @@ export class SkyThemeDirective implements OnInit, OnDestroy {
 
   #initialized = false;
 
-  #elRef: ElementRef;
-  #renderer: Renderer2;
-  #themeSvc: SkyThemeService;
-
-  constructor(
-    elRef: ElementRef,
-    renderer: Renderer2,
-    themeSvc: SkyThemeService,
-  ) {
-    this.#elRef = elRef;
-    this.#renderer = renderer;
-    this.#themeSvc = themeSvc;
-  }
+  readonly #elRef = inject(ElementRef);
+  readonly #renderer = inject(Renderer2);
+  readonly #themeSvc = inject(SkyThemeService);
 
   public ngOnInit(): void {
     this.#themeSvc.init(

--- a/libs/components/tiles/src/lib/modules/tiles/tile-dashboard/fixtures/tile2.component.fixture.ts
+++ b/libs/components/tiles/src/lib/modules/tiles/tile-dashboard/fixtures/tile2.component.fixture.ts
@@ -1,8 +1,8 @@
 import {
   ChangeDetectionStrategy,
   Component,
-  Optional,
   ViewChild,
+  inject,
 } from '@angular/core';
 
 import { SkyTileComponent } from '../../tile/tile.component';
@@ -22,7 +22,7 @@ export class Tile2TestComponent {
   })
   public tile!: SkyTileComponent;
 
-  constructor(@Optional() public context: TileTestContext) {}
+  public context = inject(TileTestContext, { optional: true });
 
   public tileSettingsClick(): void {}
 }

--- a/libs/components/tiles/src/lib/modules/tiles/tile-dashboard/tile-dashboard.component.ts
+++ b/libs/components/tiles/src/lib/modules/tiles/tile-dashboard/tile-dashboard.component.ts
@@ -5,7 +5,6 @@ import {
   EventEmitter,
   Input,
   OnDestroy,
-  Optional,
   Output,
   QueryList,
   ViewChild,
@@ -124,19 +123,16 @@ export class SkyTileDashboardComponent implements AfterViewInit, OnDestroy {
   });
 
   #configSet = false;
-  #dashboardService: SkyTileDashboardService;
+  readonly #dashboardService = inject(SkyTileDashboardService);
   #ngUnsubscribe = new Subject<void>();
-  #resourcesService: SkyLibResourcesService | undefined;
+  readonly #resourcesService = inject(SkyLibResourcesService, {
+    optional: true,
+  });
   #viewReady = false;
   #viewReadyTimer: ReturnType<typeof setTimeout> | undefined;
   #_config: SkyTileDashboardConfig | undefined;
 
-  constructor(
-    dashboardService: SkyTileDashboardService,
-    @Optional() resourcesService?: SkyLibResourcesService,
-  ) {
-    this.#dashboardService = dashboardService;
-    this.#resourcesService = resourcesService;
+  constructor() {
     this.moveInstructionsId =
       this.#dashboardService.bagId + '-move-instructions';
 

--- a/libs/components/tiles/src/lib/modules/tiles/tile-dashboard/tile-dashboard.service.spec.ts
+++ b/libs/components/tiles/src/lib/modules/tiles/tile-dashboard/tile-dashboard.service.spec.ts
@@ -1,5 +1,12 @@
 import { DragDropRegistry, DragRef, DropListRef } from '@angular/cdk/drag-drop';
-import { EventEmitter } from '@angular/core';
+import {
+  ChangeDetectorRef,
+  ElementRef,
+  EnvironmentInjector,
+  EventEmitter,
+  Injector,
+  runInInjectionContext,
+} from '@angular/core';
 import {
   ComponentFixture,
   TestBed,
@@ -532,19 +539,29 @@ describe('Tile dashboard service', () => {
       .query(By.directive(SkyTileDashboardComponent))
       .injector.get(SkyTileDashboardService);
 
-    TestBed.runInInjectionContext(() => {
-      dashboardService.moveTileOnKeyDown(
-        new SkyTileComponent(
-          fixture.elementRef,
-          fixture.componentRef.changeDetectorRef,
-          {
+    const tileInjector = Injector.create({
+      providers: [
+        { provide: ElementRef, useValue: fixture.elementRef },
+        {
+          provide: ChangeDetectorRef,
+          useValue: fixture.componentRef.changeDetectorRef,
+        },
+        {
+          provide: SkyTileDashboardService,
+          useValue: {
             configChange: new EventEmitter<SkyTileDashboardConfig>(),
           } as SkyTileDashboardService,
-        ),
-        'left',
-        'Tile 1',
-      );
+        },
+        { provide: SKY_TILE_TITLE_ID, useValue: 'test-tile-title-id' },
+      ],
+      parent: TestBed.inject(EnvironmentInjector),
     });
+
+    dashboardService.moveTileOnKeyDown(
+      runInInjectionContext(tileInjector, () => new SkyTileComponent()),
+      'left',
+      'Tile 1',
+    );
 
     // Make sure everything is still in the same spot
     const columnEls = fixture.nativeElement.querySelectorAll(

--- a/libs/components/tiles/src/lib/modules/tiles/tile/tile.component.ts
+++ b/libs/components/tiles/src/lib/modules/tiles/tile/tile.component.ts
@@ -10,7 +10,6 @@ import {
   Input,
   OnChanges,
   OnDestroy,
-  Optional,
   Output,
   SimpleChanges,
   TemplateRef,
@@ -178,8 +177,12 @@ export class SkyTileComponent implements AfterViewInit, OnChanges, OnDestroy {
   @ContentChild(SkyTileTitleComponent, { read: ElementRef })
   protected titleRef: ElementRef | undefined;
 
-  #changeDetector: ChangeDetectorRef;
-  #dashboardService: SkyTileDashboardService | undefined;
+  public elementRef = inject(ElementRef);
+
+  readonly #changeDetector = inject(ChangeDetectorRef);
+  readonly #dashboardService = inject(SkyTileDashboardService, {
+    optional: true,
+  });
   #ngUnsubscribe = new Subject<void>();
   #_isCollapsed = false;
 
@@ -187,13 +190,7 @@ export class SkyTileComponent implements AfterViewInit, OnChanges, OnDestroy {
 
   readonly #logSvc = inject(SkyLogService);
 
-  constructor(
-    public elementRef: ElementRef,
-    changeDetector: ChangeDetectorRef,
-    @Optional() dashboardService?: SkyTileDashboardService,
-  ) {
-    this.#changeDetector = changeDetector;
-    this.#dashboardService = dashboardService;
+  constructor() {
     this.isInDashboardColumn = !!this.#dashboardService;
 
     if (this.#dashboardService) {

--- a/libs/components/toast/src/lib/modules/toast/fixtures/toast-body.component.fixture.ts
+++ b/libs/components/toast/src/lib/modules/toast/fixtures/toast-body.component.fixture.ts
@@ -1,5 +1,5 @@
 // #region imports
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
 
 import { SkyToastInstance } from '../toast-instance';
 
@@ -13,14 +13,9 @@ import { SkyToastBodyTestContext } from './toast-body-context';
   standalone: false,
 })
 export class SkyToastBodyTestComponent {
-  #instance: SkyToastInstance;
+  readonly #instance = inject(SkyToastInstance);
 
-  constructor(
-    public context: SkyToastBodyTestContext,
-    instance: SkyToastInstance,
-  ) {
-    this.#instance = instance;
-  }
+  public readonly context = inject(SkyToastBodyTestContext);
 
   public close(): void {
     this.#instance.close();

--- a/libs/components/toast/src/lib/modules/toast/fixtures/toast-with-toaster-service.component.fixture.ts
+++ b/libs/components/toast/src/lib/modules/toast/fixtures/toast-with-toaster-service.component.fixture.ts
@@ -1,5 +1,5 @@
 // #region imports
-import { Component, ViewChild } from '@angular/core';
+import { Component, ViewChild, inject } from '@angular/core';
 
 import { SkyToastComponent } from '../toast.component';
 import { SkyToasterService } from '../toaster.service';
@@ -21,5 +21,5 @@ export class SkyToastWithToasterServiceTestComponent {
   })
   public toastComponent: SkyToastComponent | undefined;
 
-  constructor(public toasterService: SkyToasterService) {}
+  public readonly toasterService = inject(SkyToasterService);
 }

--- a/libs/components/toast/src/lib/modules/toast/toast-adapter.service.ts
+++ b/libs/components/toast/src/lib/modules/toast/toast-adapter.service.ts
@@ -1,4 +1,4 @@
-import { ElementRef, Injectable } from '@angular/core';
+import { ElementRef, Injectable, inject } from '@angular/core';
 import { SkyAppWindowRef } from '@skyux/core';
 
 /**
@@ -6,10 +6,7 @@ import { SkyAppWindowRef } from '@skyux/core';
  */
 @Injectable()
 export class SkyToastAdapterService {
-  #windowRef: SkyAppWindowRef;
-  constructor(windowRef: SkyAppWindowRef) {
-    this.#windowRef = windowRef;
-  }
+  readonly #windowRef = inject(SkyAppWindowRef);
 
   public scrollBottom(elementRef: ElementRef): void {
     const element = elementRef.nativeElement;

--- a/libs/components/toast/src/lib/modules/toast/toast.service.ts
+++ b/libs/components/toast/src/lib/modules/toast/toast.service.ts
@@ -39,6 +39,7 @@ export class SkyToastService implements OnDestroy {
   #dynamicComponentService: SkyDynamicComponentService;
   #environmentInjector = inject(EnvironmentInjector);
 
+  // eslint-disable-next-line @angular-eslint/prefer-inject -- constructor injection is required to maintain the public API for consumers who may instantiate this service directly (e.g. `new SkyToastService(...)`)
   constructor(dynamicComponentService: SkyDynamicComponentService) {
     this.#dynamicComponentService = dynamicComponentService;
     SkyToastService.toastStream = new BehaviorSubject<SkyToast[]>([]);
@@ -163,6 +164,7 @@ export class SkyToastService implements OnDestroy {
 })
 export class SkyToastLegacyService extends SkyToastService {
   /* istanbul ignore next */
+  // eslint-disable-next-line @angular-eslint/prefer-inject -- constructor injection is required to override the type of `dynamicComponentSvc` passed to the parent class's constructor.
   constructor(dynamicComponentSvc: SkyDynamicComponentLegacyService) {
     super(dynamicComponentSvc);
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated component and service dependency injection to use Angular’s modern injection pattern across the library.
  * Preserved existing component behavior, inputs, outputs, and lifecycle handling.
  * Maintained optional dependency support while simplifying internal construction.
* **Chores**
  * Updated linting guidance to encourage OnPush change detection in library components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->