### PR TITLE
fix(components/data-grid): page not resetting to 1 when pageQueryParam is set (#4516)

### DIFF
--- a/libs/components/data-grid/src/lib/modules/data-grid/data-grid.spec.ts
+++ b/libs/components/data-grid/src/lib/modules/data-grid/data-grid.spec.ts
@@ -733,6 +733,34 @@ describe('SkyDataGrid', () => {
       await expectAsync(pagingHarness.getCurrentPage()).toBeResolvedTo(3);
     });
 
+    it('should update the page to 1 when the url query parameter is removed', async () => {
+      fixture.componentRef.setInput('pageSize', 2);
+      fixture.componentRef.setInput('pageQueryParam', 'page');
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      const router = TestBed.inject(Router);
+      await router.navigate([], {
+        queryParams: { page: 3 },
+      });
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      expect(component.page()).toBe(3);
+
+      await router.navigate([], {
+        queryParams: { page: null },
+        queryParamsHandling: 'merge',
+      });
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      expect(component.page()).toBe(1);
+
+      const pagingHarness = await loader.getHarness(SkyPagingHarness);
+      await expectAsync(pagingHarness.getCurrentPage()).toBeResolvedTo(1);
+    });
+
     it('should not use grid paging when autoPage is false', async () => {
       fixture.componentRef.setInput('autoPage', false);
       fixture.componentRef.setInput('pageSize', 200);

--- a/libs/components/data-grid/src/lib/modules/data-grid/data-grid.ts
+++ b/libs/components/data-grid/src/lib/modules/data-grid/data-grid.ts
@@ -440,7 +440,7 @@ export class SkyDataGrid {
             ? this.#activatedRoute.queryParamMap.pipe(
                 startWith(this.#activatedRoute.snapshot.queryParamMap),
                 map((params) =>
-                  coerceNumberProperty(params.get(pageQueryParam), NaN),
+                  coerceNumberProperty(params.get(pageQueryParam), 1),
                 ),
               )
             : [],
@@ -557,12 +557,20 @@ export class SkyDataGrid {
         this.currentPageChange(1);
       } else if (page > pageCount) {
         this.currentPageChange(pageCount);
-      } else {
-        if (untracked(this.autoPage)) {
-          api.paginationGoToPage(page - 1);
-        }
-        // When the page is set programmatically (rather than through the
-        // paging controls), sync the change to the URL query parameter.
+      } else if (untracked(this.autoPage)) {
+        api.paginationGoToPage(page - 1);
+      }
+    });
+    // Sync `page` to the URL query parameter when it changes, e.g. when set
+    // programmatically rather than through the paging controls (which
+    // already navigate directly). Tracks only `page` itself, not `gridApi`/
+    // `pageCount`, so a grid becoming ready does not push a `page` value
+    // that is still stale from an in-flight URL change onto the URL. Only
+    // syncs valid page numbers; out-of-range values are corrected by the
+    // effect above instead of being reflected in the URL.
+    effect(() => {
+      const page = this.page();
+      if (Number.isInteger(page) && page >= 1) {
         this.#syncPageQueryParam(page);
       }
     });


### PR DESCRIPTION
:cherries: Cherry picked from #4516 [fix(components/data-grid): page not resetting to 1 when pageQueryParam is set](https://github.com/blackbaud/skyux/pull/4516)

[AB#4046789](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/4046789) 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved data grid pagination when the page query parameter is missing or invalid.
  * Ensured the grid resets to page 1 and keeps the paging controls synchronized with the URL.
  * Prevented invalid page values from triggering incorrect pagination navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->