### PR TITLE
feat(components/popovers): add Alt+ArrowUp/Alt+ArrowDown shortcuts to open and close popovers

### DIFF
--- a/libs/components/popovers/src/lib/modules/popover/popover-keyboard-shortcut.service.spec.ts
+++ b/libs/components/popovers/src/lib/modules/popover/popover-keyboard-shortcut.service.spec.ts
@@ -1,0 +1,126 @@
+import { ElementRef } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+
+import { SkyPopoverKeyboardShortcutService } from './popover-keyboard-shortcut.service';
+
+describe('SkyPopoverKeyboardShortcutService', () => {
+  let service: SkyPopoverKeyboardShortcutService;
+  let cleanupEls: HTMLElement[];
+
+  function createFocusableElement(parent?: HTMLElement): HTMLButtonElement {
+    const el = document.createElement('button');
+    (parent ?? document.body).appendChild(el);
+    cleanupEls.push(el);
+    return el;
+  }
+
+  function fireAltArrowUp(altKey = true): KeyboardEvent {
+    const event = new KeyboardEvent('keydown', {
+      key: 'ArrowUp',
+      altKey,
+      bubbles: true,
+      cancelable: true,
+    });
+    document.dispatchEvent(event);
+    return event;
+  }
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(SkyPopoverKeyboardShortcutService);
+    cleanupEls = [];
+  });
+
+  afterEach(() => {
+    cleanupEls.forEach((el) => el.remove());
+  });
+
+  it('should call open() when exactly one registered element is within the focused element', () => {
+    const trigger = createFocusableElement();
+    const open = jasmine.createSpy('open');
+    service.register(new ElementRef(trigger), open);
+
+    trigger.focus();
+    fireAltArrowUp();
+
+    expect(open).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not call open() when no registered elements are within the focused element', () => {
+    const trigger = createFocusableElement();
+    const unrelated = createFocusableElement();
+    const open = jasmine.createSpy('open');
+    service.register(new ElementRef(trigger), open);
+
+    unrelated.focus();
+    fireAltArrowUp();
+
+    expect(open).not.toHaveBeenCalled();
+  });
+
+  it('should not call open() when multiple registered elements are within the focused element', () => {
+    const container = document.createElement('div');
+    container.tabIndex = -1;
+    document.body.appendChild(container);
+    cleanupEls.push(container);
+
+    const triggerA = createFocusableElement(container);
+    const triggerB = createFocusableElement(container);
+    const openA = jasmine.createSpy('openA');
+    const openB = jasmine.createSpy('openB');
+    service.register(new ElementRef(triggerA), openA);
+    service.register(new ElementRef(triggerB), openB);
+
+    container.focus();
+    fireAltArrowUp();
+
+    expect(openA).not.toHaveBeenCalled();
+    expect(openB).not.toHaveBeenCalled();
+  });
+
+  it('should not call open() for keys other than Alt+ArrowUp', () => {
+    const trigger = createFocusableElement();
+    const open = jasmine.createSpy('open');
+    service.register(new ElementRef(trigger), open);
+
+    trigger.focus();
+    fireAltArrowUp(false);
+
+    expect(open).not.toHaveBeenCalled();
+  });
+
+  it('should call preventDefault on the keyboard event when opening', () => {
+    const trigger = createFocusableElement();
+    service.register(new ElementRef(trigger), jasmine.createSpy('open'));
+
+    trigger.focus();
+    const event = fireAltArrowUp();
+
+    expect(event.defaultPrevented).toEqual(true);
+  });
+
+  it('should not call open() when there is no active element', () => {
+    const trigger = createFocusableElement();
+    const open = jasmine.createSpy('open');
+    service.register(new ElementRef(trigger), open);
+
+    trigger.focus();
+    spyOnProperty(document, 'activeElement').and.returnValue(null);
+
+    fireAltArrowUp();
+
+    expect(open).not.toHaveBeenCalled();
+  });
+
+  it('should stop calling open() once unregistered', () => {
+    const trigger = createFocusableElement();
+    const open = jasmine.createSpy('open');
+    const unregister = service.register(new ElementRef(trigger), open);
+
+    unregister();
+    trigger.focus();
+    fireAltArrowUp();
+
+    expect(open).not.toHaveBeenCalled();
+  });
+});

--- a/libs/components/popovers/src/lib/modules/popover/popover-keyboard-shortcut.service.ts
+++ b/libs/components/popovers/src/lib/modules/popover/popover-keyboard-shortcut.service.ts
@@ -1,0 +1,68 @@
+import { DOCUMENT } from '@angular/common';
+import { ElementRef, Injectable, OnDestroy, inject } from '@angular/core';
+
+import { Subscription, fromEvent as observableFromEvent } from 'rxjs';
+
+interface SkyPopoverKeyboardShortcutRegistration {
+  elementRef: ElementRef;
+  open: () => void;
+}
+
+/**
+ * Listens for the Alt+ArrowUp keyboard shortcut and opens the popover whose
+ * trigger element is the sole registered trigger within the focused element,
+ * so popovers whose triggers aren't reachable via Tab (e.g. because a parent
+ * element owns focus instead) can still be opened with the keyboard.
+ * @internal
+ */
+@Injectable({ providedIn: 'root' })
+export class SkyPopoverKeyboardShortcutService implements OnDestroy {
+  #registrations = new Set<SkyPopoverKeyboardShortcutRegistration>();
+
+  readonly #document = inject(DOCUMENT);
+
+  #subscription: Subscription;
+
+  constructor() {
+    this.#subscription = observableFromEvent<KeyboardEvent>(
+      this.#document,
+      'keydown',
+    ).subscribe((event) => this.#handleKeydown(event));
+  }
+
+  public ngOnDestroy(): void {
+    this.#subscription.unsubscribe();
+  }
+
+  public register(elementRef: ElementRef, open: () => void): () => void {
+    const registration: SkyPopoverKeyboardShortcutRegistration = {
+      elementRef,
+      open,
+    };
+
+    this.#registrations.add(registration);
+
+    return () => this.#registrations.delete(registration);
+  }
+
+  #handleKeydown(event: KeyboardEvent): void {
+    if (!event.altKey || event.key !== 'ArrowUp') {
+      return;
+    }
+
+    const activeElement = this.#document.activeElement;
+
+    if (!activeElement) {
+      return;
+    }
+
+    const candidates = Array.from(this.#registrations).filter((registration) =>
+      activeElement.contains(registration.elementRef.nativeElement),
+    );
+
+    if (candidates.length === 1) {
+      event.preventDefault();
+      candidates[0].open();
+    }
+  }
+}

--- a/libs/components/popovers/src/lib/modules/popover/popover.directive.spec.ts
+++ b/libs/components/popovers/src/lib/modules/popover/popover.directive.spec.ts
@@ -688,6 +688,209 @@ describe('Popover directive', () => {
 
       expect(popover).toBeNull();
     }));
+
+    it('should open the popover with alt+arrowup when the trigger is the sole popover trigger within the focused element', fakeAsync(() => {
+      detectChangesFakeAsync();
+
+      const button = getCallerElement();
+      button?.focus();
+
+      SkyAppTestUtility.fireDomEvent(document, 'keydown', {
+        keyboardEventInit: {
+          key: 'ArrowUp',
+          altKey: true,
+        },
+      });
+
+      detectChangesFakeAsync();
+
+      const popover = getPopoverElement();
+
+      expect(isElementVisible(popover)).toEqual(true);
+    }));
+
+    it('should not open a popover with alt+arrowup when multiple popover triggers are within the focused element', fakeAsync(() => {
+      detectChangesFakeAsync();
+
+      const canvas: HTMLElement =
+        fixture.nativeElement.querySelector('.canvas');
+      canvas.tabIndex = -1;
+      canvas.focus();
+
+      SkyAppTestUtility.fireDomEvent(document, 'keydown', {
+        keyboardEventInit: {
+          key: 'ArrowUp',
+          altKey: true,
+        },
+      });
+
+      detectChangesFakeAsync();
+
+      expect(getPopoverElement()).toBeNull();
+    }));
+
+    it('should not open a popover with alt+arrowup when the directive has no popover attached', fakeAsync(() => {
+      detectChangesFakeAsync();
+
+      fixture.componentInstance.skyPopover = undefined;
+      detectChangesFakeAsync();
+
+      const button = getCallerElement();
+      button?.focus();
+
+      SkyAppTestUtility.fireDomEvent(document, 'keydown', {
+        keyboardEventInit: {
+          key: 'ArrowUp',
+          altKey: true,
+        },
+      });
+
+      detectChangesFakeAsync();
+
+      expect(getPopoverElement()).toBeNull();
+    }));
+
+    describe('alt+arrowup focus management', function () {
+      function openViaAltArrowUp(): void {
+        const button = getCallerElement();
+        button?.focus();
+
+        SkyAppTestUtility.fireDomEvent(document, 'keydown', {
+          keyboardEventInit: {
+            key: 'ArrowUp',
+            altKey: true,
+          },
+        });
+
+        detectChangesFakeAsync();
+      }
+
+      function fireAltArrowDown(): void {
+        SkyAppTestUtility.fireDomEvent(document, 'keydown', {
+          keyboardEventInit: {
+            key: 'ArrowDown',
+            altKey: true,
+          },
+        });
+
+        detectChangesFakeAsync();
+      }
+
+      it('should move focus into the popover when it has focusable content', fakeAsync(() => {
+        fixture.componentInstance.showFocusableChildren = true;
+        detectChangesFakeAsync();
+
+        openViaAltArrowUp();
+
+        const focusableItems = getFocusableItems();
+
+        expect(isElementFocused(focusableItems?.item(0))).toEqual(true);
+      }));
+
+      it('should leave focus on the trigger when the popover has no focusable content', fakeAsync(() => {
+        detectChangesFakeAsync();
+
+        const button = getCallerElement();
+        openViaAltArrowUp();
+
+        expect(isElementFocused(button)).toEqual(true);
+      }));
+
+      it('should close the popover when focus moves to an element outside the trigger and the popover', fakeAsync(() => {
+        detectChangesFakeAsync();
+
+        openViaAltArrowUp();
+
+        expect(isElementVisible(getPopoverElement())).toEqual(true);
+
+        const unrelated = document.createElement('button');
+        document.body.appendChild(unrelated);
+
+        unrelated.focus();
+        detectChangesFakeAsync();
+
+        expect(getPopoverElement()).toBeNull();
+
+        unrelated.remove();
+      }));
+
+      it('should not close the popover when focus moves between focusable children within the popover', fakeAsync(() => {
+        fixture.componentInstance.showFocusableChildren = true;
+        detectChangesFakeAsync();
+
+        openViaAltArrowUp();
+
+        const focusableItems = getFocusableItems();
+        (focusableItems?.item(1) as HTMLElement | undefined)?.focus();
+        detectChangesFakeAsync();
+
+        expect(isElementVisible(getPopoverElement())).toEqual(true);
+      }));
+
+      it('should not error when focus moves elsewhere after the popover already closed via escape', fakeAsync(() => {
+        detectChangesFakeAsync();
+
+        const button = getCallerElement();
+        openViaAltArrowUp();
+
+        SkyAppTestUtility.fireDomEvent(button, 'keydown', {
+          keyboardEventInit: {
+            key: 'escape',
+          },
+        });
+        detectChangesFakeAsync();
+
+        expect(getPopoverElement()).toBeNull();
+
+        const unrelated = document.createElement('button');
+        document.body.appendChild(unrelated);
+
+        expect(() => {
+          unrelated.focus();
+          detectChangesFakeAsync();
+        }).not.toThrow();
+
+        unrelated.remove();
+      }));
+
+      it('should close the popover with alt+arrowdown after opening via alt+arrowup', fakeAsync(() => {
+        detectChangesFakeAsync();
+
+        openViaAltArrowUp();
+
+        expect(isElementVisible(getPopoverElement())).toEqual(true);
+
+        fireAltArrowDown();
+
+        expect(getPopoverElement()).toBeNull();
+      }));
+
+      it('should refocus the trigger when closed via alt+arrowdown', fakeAsync(() => {
+        fixture.componentInstance.showFocusableChildren = true;
+        detectChangesFakeAsync();
+
+        const button = getCallerElement();
+        openViaAltArrowUp();
+
+        fireAltArrowDown();
+
+        expect(isElementFocused(button)).toEqual(true);
+      }));
+
+      it('should not close a popover opened by click when alt+arrowdown is pressed', fakeAsync(() => {
+        detectChangesFakeAsync();
+
+        const button = getCallerElement();
+        button?.click();
+        detectChangesFakeAsync();
+
+        expect(isElementVisible(getPopoverElement())).toEqual(true);
+
+        fireAltArrowDown();
+
+        expect(isElementVisible(getPopoverElement())).toEqual(true);
+      }));
+    });
   });
 
   describe('message stream', function () {

--- a/libs/components/popovers/src/lib/modules/popover/popover.directive.spec.ts
+++ b/libs/components/popovers/src/lib/modules/popover/popover.directive.spec.ts
@@ -890,6 +890,42 @@ describe('Popover directive', () => {
 
         expect(isElementVisible(getPopoverElement())).toEqual(true);
       }));
+
+      it('should not error if the popover is unset before popoverOpened fires', fakeAsync(() => {
+        detectChangesFakeAsync();
+
+        const button = getCallerElement();
+        button?.focus();
+
+        SkyAppTestUtility.fireDomEvent(document, 'keydown', {
+          keyboardEventInit: {
+            key: 'ArrowUp',
+            altKey: true,
+          },
+        });
+
+        fixture.componentInstance.skyPopover = undefined;
+
+        expect(() => detectChangesFakeAsync()).not.toThrow();
+      }));
+
+      it('should close the popover if focus moves within it while its popoverId is falsy', fakeAsync(() => {
+        fixture.componentInstance.showFocusableChildren = true;
+        detectChangesFakeAsync();
+
+        openViaAltArrowUp();
+
+        const popoverRef = fixture.componentInstance.popoverRef;
+        if (popoverRef) {
+          popoverRef.popoverId = '';
+        }
+
+        const focusableItems = getFocusableItems();
+        (focusableItems?.item(1) as HTMLElement | undefined)?.focus();
+        detectChangesFakeAsync();
+
+        expect(getPopoverElement()).toBeNull();
+      }));
     });
   });
 

--- a/libs/components/popovers/src/lib/modules/popover/popover.directive.ts
+++ b/libs/components/popovers/src/lib/modules/popover/popover.directive.ts
@@ -1,3 +1,4 @@
+import { DOCUMENT } from '@angular/common';
 import {
   Directive,
   ElementRef,
@@ -9,8 +10,9 @@ import {
 } from '@angular/core';
 
 import { Subject, Subscription, fromEvent as observableFromEvent } from 'rxjs';
-import { takeUntil } from 'rxjs/operators';
+import { take, takeUntil } from 'rxjs/operators';
 
+import { SkyPopoverKeyboardShortcutService } from './popover-keyboard-shortcut.service';
 import { SkyPopoverSRPointerService } from './popover-sr-pointer.service';
 import { SkyPopoverComponent } from './popover.component';
 import { SkyPopoverAlignment } from './types/popover-alignment';
@@ -43,6 +45,7 @@ export class SkyPopoverDirective implements OnInit, OnDestroy {
     this.popoverId = value?.popoverId;
     this.#_popover = value;
     this.#updateSRPointer(value);
+    this.#updateKeyboardShortcut(value);
   }
 
   public get skyPopover(): SkyPopoverComponent | undefined {
@@ -101,10 +104,15 @@ export class SkyPopoverDirective implements OnInit, OnDestroy {
 
   #_trigger: SkyPopoverTrigger = 'click';
 
+  readonly #document = inject(DOCUMENT);
   readonly #elementRef = inject(ElementRef);
   #expanded = false;
   #popoverClosedSubscription: Subscription | undefined;
+  #shortcutFocusOutSubscription: Subscription | undefined;
+  #shortcutFocusSubscription: Subscription | undefined;
+  #unregisterKeyboardShortcut: (() => void) | undefined;
 
+  readonly #keyboardShortcutSvc = inject(SkyPopoverKeyboardShortcutService);
   readonly #srPointerSvc = inject(SkyPopoverSRPointerService);
 
   constructor() {
@@ -119,6 +127,9 @@ export class SkyPopoverDirective implements OnInit, OnDestroy {
     this.#removeEventListeners();
     this.#unsubscribeMessageStream();
     this.#popoverClosedSubscription?.unsubscribe();
+    this.#unregisterKeyboardShortcut?.();
+    this.#shortcutFocusSubscription?.unsubscribe();
+    this.#shortcutFocusOutSubscription?.unsubscribe();
   }
 
   public togglePopover(): void {
@@ -309,6 +320,83 @@ export class SkyPopoverDirective implements OnInit, OnDestroy {
       ariaExpanded: this.#expanded,
       ariaOwns: this.popoverId,
     });
+  }
+
+  #openViaKeyboardShortcut(): void {
+    this.#sendMessage(SkyPopoverMessageType.Open);
+    this.#focusPopoverWhenReady();
+  }
+
+  #focusPopoverWhenReady(): void {
+    this.#shortcutFocusSubscription?.unsubscribe();
+    this.#shortcutFocusSubscription = this.skyPopover?.popoverOpened
+      .pipe(take(1))
+      .subscribe(() => {
+        if (this.skyPopover?.hasFocusableContent()) {
+          this.#sendMessage(SkyPopoverMessageType.Focus);
+        }
+        this.#watchKeyboardShortcutSession();
+      });
+  }
+
+  #watchKeyboardShortcutSession(): void {
+    this.#shortcutFocusOutSubscription?.unsubscribe();
+
+    const popover = this.skyPopover;
+
+    if (!popover) {
+      return;
+    }
+
+    const stopWatching = new Subject<void>();
+
+    popover.popoverClosed.pipe(take(1)).subscribe(() => stopWatching.next());
+
+    const focusOutSubscription = new Subscription();
+
+    focusOutSubscription.add(
+      observableFromEvent(this.#document, 'focusin')
+        .pipe(takeUntil(stopWatching))
+        .subscribe(() => {
+          const activeElement = this.#document.activeElement;
+          const popoverEl = popover.popoverId
+            ? this.#document.getElementById(popover.popoverId)
+            : null;
+
+          const isWithin = (el: Element | null): boolean =>
+            !!activeElement && !!el && el.contains(activeElement);
+
+          if (
+            !isWithin(this.#elementRef.nativeElement) &&
+            !isWithin(popoverEl)
+          ) {
+            this.#sendMessage(SkyPopoverMessageType.Close);
+          }
+        }),
+    );
+
+    focusOutSubscription.add(
+      observableFromEvent<KeyboardEvent>(this.#document, 'keydown')
+        .pipe(takeUntil(stopWatching))
+        .subscribe((event) => {
+          if (event.altKey && event.key === 'ArrowDown') {
+            event.preventDefault();
+            this.#sendMessage(SkyPopoverMessageType.Close);
+            this.#elementRef.nativeElement.focus();
+          }
+        }),
+    );
+
+    this.#shortcutFocusOutSubscription = focusOutSubscription;
+  }
+
+  #updateKeyboardShortcut(popover: SkyPopoverComponent | undefined): void {
+    this.#unregisterKeyboardShortcut?.();
+    this.#unregisterKeyboardShortcut = popover
+      ? this.#keyboardShortcutSvc.register(this.#elementRef, () =>
+          this.#openViaKeyboardShortcut(),
+        )
+      : undefined;
   }
 
   #updateSRPointer(popover: SkyPopoverComponent | undefined): void {

--- a/libs/components/popovers/src/lib/modules/popover/popover.directive.ts
+++ b/libs/components/popovers/src/lib/modules/popover/popover.directive.ts
@@ -350,9 +350,11 @@ export class SkyPopoverDirective implements OnInit, OnDestroy {
 
     const stopWatching = new Subject<void>();
 
-    popover.popoverClosed.pipe(take(1)).subscribe(() => stopWatching.next());
-
     const focusOutSubscription = new Subscription();
+
+    focusOutSubscription.add(
+      popover.popoverClosed.pipe(take(1)).subscribe(() => stopWatching.next()),
+    );
 
     focusOutSubscription.add(
       observableFromEvent(this.#document, 'focusin')


### PR DESCRIPTION
## Summary
- Adds a shared `SkyPopoverKeyboardShortcutService` that lets Alt+ArrowUp open a popover whenever its trigger element is the sole popover trigger inside the currently focused element — this makes popovers reachable by keyboard even when the trigger itself isn't part of the tab order (e.g. an inline-help button inside an ag-Grid column header, where arrow keys move focus between cells instead of into cell contents).
- When such a shortcut-triggered open completes, focus moves into the popover's content if it has any focusable children; the popover then closes automatically if focus moves outside both the trigger and the popover by any means, or if Alt+ArrowDown is pressed (which also returns focus to the trigger).
- Both shortcuts are scoped to popovers opened this way, so existing click/hover/Tab-driven popover behavior is unchanged.
- No changes were needed in `@skyux/help-inline` or `@skyux/ag-grid` — the inline-help popover button already uses `[skyPopover]`, so it gets this behavior automatically.

Resolves [AB#4035677](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/4035677)

## Test plan
- [x] `nx run popovers:test --no-watch --browsers=ChromeHeadless` passes (new specs for the shortcut service and directive behavior)
- [x] `nx run popovers:lint` passes
- [x] `nx build popovers` passes
- [ ] Manual check on the data-grid docs demo: enable "Include inline help", Tab focus into a grid header cell, press Alt+ArrowUp to open the help popover, Alt+ArrowDown (or Tab/Escape/click elsewhere) to close it

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `Alt+ArrowUp` keyboard shortcut to open the popover tied to the currently focused trigger.
  * Added keyboard focus management for popovers, including restoring focus with `Alt+ArrowDown`.
* **Bug Fixes**
  * Popovers no longer open when the focused context is ambiguous (e.g., multiple triggers) or when a popover isn’t available.
  * Popovers close when focus leaves the trigger and popover content, with safer handling during rapid focus changes.
* **Tests**
  * Expanded keyboard and focus behavior coverage for popover directive/service behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->