### PR TITLE
fix(components/packages): standalone schematic crash on SKY UX pipe in TestBed.configureTestingModule

### DIFF
--- a/libs/components/packages/src/schematics/ng-generate/standalone/__snapshots__/standalone.schematic.spec.ts.snap
+++ b/libs/components/packages/src/schematics/ng-generate/standalone/__snapshots__/standalone.schematic.spec.ts.snap
@@ -178,6 +178,22 @@ import { SkyModalModule } from '@skyux/modals';
     "
 `;
 
+exports[`standalone should migrate a test with a SKY UX pipe used in TestBed.configureTestingModule 1`] = `
+"
+    import { TestBed } from '@angular/core/testing';
+import { SkyDatePipeModule } from '@skyux/datetime';
+    
+
+    describe('TestComponent', () => {
+      beforeEach(() => {
+        TestBed.configureTestingModule({
+          imports: [SkyDatePipeModule],
+        });
+      });
+    });
+    "
+`;
+
 exports[`standalone should provide for a pipe that is injected in a component 1`] = `
 "
     import { Component, Directive } from '@angular/core';

--- a/libs/components/packages/src/schematics/ng-generate/standalone/standalone.schematic.spec.ts
+++ b/libs/components/packages/src/schematics/ng-generate/standalone/standalone.schematic.spec.ts
@@ -256,6 +256,27 @@ describe('standalone', () => {
     expect(tree.readText('src/app/test.component.spec.ts')).toMatchSnapshot();
   });
 
+  it('should migrate a test with a SKY UX pipe used in TestBed.configureTestingModule', async () => {
+    const { tree } = await setup();
+    tree.create(
+      'src/app/test.component.spec.ts',
+      `
+    import { TestBed } from '@angular/core/testing';
+    import { SkyDatePipe } from '@skyux/datetime';
+
+    describe('TestComponent', () => {
+      beforeEach(() => {
+        TestBed.configureTestingModule({
+          imports: [SkyDatePipe],
+        });
+      });
+    });
+    `,
+    );
+    await runner.runSchematic('standalone-migration', {}, tree);
+    expect(tree.readText('src/app/test.component.spec.ts')).toMatchSnapshot();
+  });
+
   it('should do nothing on a component', async () => {
     const { tree } = await setup();
     tree.create(

--- a/libs/components/packages/src/schematics/ng-generate/standalone/standalone.schematic.ts
+++ b/libs/components/packages/src/schematics/ng-generate/standalone/standalone.schematic.ts
@@ -129,12 +129,12 @@ function getDecoratedClasses(sourceFile: ts.SourceFile): DecoratedClassData[] {
 
 function getDecoratedClassDeclaration(
   metadata: ts.ObjectLiteralExpression,
-): ts.ClassDeclaration {
+): ts.ClassDeclaration | undefined {
   let parent: ts.Node = metadata.parent;
   while (parent && !ts.isClassDeclaration(parent)) {
     parent = parent.parent;
   }
-  return parent as ts.ClassDeclaration;
+  return parent as ts.ClassDeclaration | undefined;
 }
 
 function getPackageTypeSourceFile(
@@ -391,7 +391,7 @@ function isReferencedOutsideDecorator(
             const classDeclaration = getDecoratedClassDeclaration(metadata);
             return {
               start: metadata.getEnd(),
-              end: classDeclaration.getEnd(),
+              end: (classDeclaration ?? sourceFile).getEnd(),
             };
           })
           .some(


### PR DESCRIPTION
## Summary
- Fixes a crash in the `standalone-migration` schematic (`@skyux/packages:standalone-migration`) when a spec file imports a SKY UX pipe (e.g. a component test using `SkyDatePipe`) and passes it to `TestBed.configureTestingModule({...})` inside `beforeEach`.
- Root cause: `getDecoratedClassDeclaration()` walks up the AST looking for an enclosing `ClassDeclaration`, but a `TestBed.configureTestingModule` call in a spec has no enclosing class (it lives inside a `beforeEach` arrow function). The walk ran off the top of the file and returned `undefined`, and `isReferencedOutsideDecorator()` then crashed calling `.getEnd()` on it: `TypeError: Cannot read properties of undefined (reading 'getEnd')`.
- Fix: corrected the return type of `getDecoratedClassDeclaration` to `ts.ClassDeclaration | undefined`, and in `isReferencedOutsideDecorator` fall back to the source file's own end when no enclosing class exists.

[AB#4046930](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/4046930)

## Test plan
- [x] Added a failing test reproducing the exact crash (SKY UX pipe imported into `TestBed.configureTestingModule` inside `beforeEach`), confirmed it failed with the same stack trace as the reported issue, then confirmed it passes after the fix.
- [x] `nx test packages` — 181 tests passing, 100% coverage on `standalone.schematic.ts`.
- [x] `nx lint packages` — no new warnings/errors.
- [x] `nx build packages` — succeeds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved standalone component migration reliability when decorated class information is unavailable.
  - Prevented migration failures in edge cases involving standalone test configurations and imported framework pipes.

- **Tests**
  - Added coverage to verify that standalone component tests using SKY UX pipes are migrated to the appropriate import format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->