### PR TITLE
fix(components/packages): standalone schematic crash on SKY UX pipe in TestBed.configureTestingModule (#4524)

### DIFF
--- a/libs/components/packages/src/schematics/ng-generate/standalone/__snapshots__/standalone.schematic.spec.ts.snap
+++ b/libs/components/packages/src/schematics/ng-generate/standalone/__snapshots__/standalone.schematic.spec.ts.snap
@@ -178,6 +178,22 @@ import { SkyModalModule } from '@skyux/modals';
     "
 `;
 
+exports[`standalone should migrate a test with a SKY UX pipe used in TestBed.configureTestingModule 1`] = `
+"
+    import { TestBed } from '@angular/core/testing';
+import { SkyDatePipeModule } from '@skyux/datetime';
+    
+
+    describe('TestComponent', () => {
+      beforeEach(() => {
+        TestBed.configureTestingModule({
+          imports: [SkyDatePipeModule],
+        });
+      });
+    });
+    "
+`;
+
 exports[`standalone should provide for a pipe that is injected in a component 1`] = `
 "
     import { Component, Directive } from '@angular/core';

--- a/libs/components/packages/src/schematics/ng-generate/standalone/standalone.schematic.spec.ts
+++ b/libs/components/packages/src/schematics/ng-generate/standalone/standalone.schematic.spec.ts
@@ -256,6 +256,27 @@ describe('standalone', () => {
     expect(tree.readText('src/app/test.component.spec.ts')).toMatchSnapshot();
   });
 
+  it('should migrate a test with a SKY UX pipe used in TestBed.configureTestingModule', async () => {
+    const { tree } = await setup();
+    tree.create(
+      'src/app/test.component.spec.ts',
+      `
+    import { TestBed } from '@angular/core/testing';
+    import { SkyDatePipe } from '@skyux/datetime';
+
+    describe('TestComponent', () => {
+      beforeEach(() => {
+        TestBed.configureTestingModule({
+          imports: [SkyDatePipe],
+        });
+      });
+    });
+    `,
+    );
+    await runner.runSchematic('standalone-migration', {}, tree);
+    expect(tree.readText('src/app/test.component.spec.ts')).toMatchSnapshot();
+  });
+
   it('should do nothing on a component', async () => {
     const { tree } = await setup();
     tree.create(

--- a/libs/components/packages/src/schematics/ng-generate/standalone/standalone.schematic.ts
+++ b/libs/components/packages/src/schematics/ng-generate/standalone/standalone.schematic.ts
@@ -129,12 +129,12 @@ function getDecoratedClasses(sourceFile: ts.SourceFile): DecoratedClassData[] {
 
 function getDecoratedClassDeclaration(
   metadata: ts.ObjectLiteralExpression,
-): ts.ClassDeclaration {
+): ts.ClassDeclaration | undefined {
   let parent: ts.Node = metadata.parent;
   while (parent && !ts.isClassDeclaration(parent)) {
     parent = parent.parent;
   }
-  return parent as ts.ClassDeclaration;
+  return parent as ts.ClassDeclaration | undefined;
 }
 
 function getPackageTypeSourceFile(
@@ -391,7 +391,7 @@ function isReferencedOutsideDecorator(
             const classDeclaration = getDecoratedClassDeclaration(metadata);
             return {
               start: metadata.getEnd(),
-              end: classDeclaration.getEnd(),
+              end: (classDeclaration ?? sourceFile).getEnd(),
             };
           })
           .some(


### PR DESCRIPTION
:cherries: Cherry picked from #4524 [fix(components/packages): standalone schematic crash on SKY UX pipe in TestBed.configureTestingModule](https://github.com/blackbaud/skyux/pull/4524)

[AB#4046930](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/4046930) 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved standalone migration support for Angular tests that use SKY UX pipes.
  * Enhanced migration reliability when referenced classes cannot be identified in decorator metadata.

* **Tests**
  * Added coverage to verify that SKY UX pipe imports are migrated correctly in test configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->