### PR TITLE
chore: release 15.0.0-alpha.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,18 @@
 
 ### ⚠ BREAKING CHANGES
 
+* **components/theme:** update heading 5 color to use deemphasized text color (#4533)
 * **components/layout:** use number transform for fluid grid column size inputs (#4534)
 
 ### Features
 
 * **components/layout:** use number transform for fluid grid column size inputs ([#4534](https://github.com/blackbaud/skyux/issues/4534)) ([40241aa](https://github.com/blackbaud/skyux/commit/40241aa479f8223e213653dafec942707f08f584))
 * **components/popovers:** add Alt+ArrowUp/Alt+ArrowDown shortcuts to open and close popovers ([#4523](https://github.com/blackbaud/skyux/issues/4523)) ([#4529](https://github.com/blackbaud/skyux/issues/4529)) ([985dc41](https://github.com/blackbaud/skyux/commit/985dc41df2874853ba732d790010244f44cc596d)), closes [AB#4035677](https://dev.azure.com/blackbaud/Products/_workitems/edit/4035677)
+
+
+### Bug Fixes
+
+* **components/theme:** update heading 5 color to use deemphasized text color ([#4533](https://github.com/blackbaud/skyux/issues/4533)) ([fc08528](https://github.com/blackbaud/skyux/commit/fc08528f1c1f229c75053fb00257e90669b6fafe))
 
 ## [15.0.0-alpha.1](https://github.com/blackbaud/skyux/compare/15.0.0-alpha.0...15.0.0-alpha.1) (2026-07-20)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 
-## [15.0.0-alpha.2](https://github.com/blackbaud/skyux/compare/15.0.0-alpha.1...15.0.0-alpha.2) (2026-07-21)
+## [15.0.0-alpha.2](https://github.com/blackbaud/skyux/compare/15.0.0-alpha.1...15.0.0-alpha.2) (2026-07-22)
 
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,13 @@
 ## [15.0.0-alpha.2](https://github.com/blackbaud/skyux/compare/15.0.0-alpha.1...15.0.0-alpha.2) (2026-07-22)
 
 
+### ⚠ BREAKING CHANGES
+
+* **components/layout:** use number transform for fluid grid column size inputs (#4534)
+
 ### Features
 
+* **components/layout:** use number transform for fluid grid column size inputs ([#4534](https://github.com/blackbaud/skyux/issues/4534)) ([40241aa](https://github.com/blackbaud/skyux/commit/40241aa479f8223e213653dafec942707f08f584))
 * **components/popovers:** add Alt+ArrowUp/Alt+ArrowDown shortcuts to open and close popovers ([#4523](https://github.com/blackbaud/skyux/issues/4523)) ([#4529](https://github.com/blackbaud/skyux/issues/4529)) ([985dc41](https://github.com/blackbaud/skyux/commit/985dc41df2874853ba732d790010244f44cc596d)), closes [AB#4035677](https://dev.azure.com/blackbaud/Products/_workitems/edit/4035677)
 
 ## [15.0.0-alpha.1](https://github.com/blackbaud/skyux/compare/15.0.0-alpha.0...15.0.0-alpha.1) (2026-07-20)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
 
+## [15.0.0-alpha.2](https://github.com/blackbaud/skyux/compare/15.0.0-alpha.1...15.0.0-alpha.2) (2026-07-21)
+
+
+### Features
+
+* **components/popovers:** add Alt+ArrowUp/Alt+ArrowDown shortcuts to open and close popovers ([#4523](https://github.com/blackbaud/skyux/issues/4523)) ([#4529](https://github.com/blackbaud/skyux/issues/4529)) ([985dc41](https://github.com/blackbaud/skyux/commit/985dc41df2874853ba732d790010244f44cc596d)), closes [AB#4035677](https://dev.azure.com/blackbaud/Products/_workitems/edit/4035677)
+
 ## [15.0.0-alpha.1](https://github.com/blackbaud/skyux/compare/15.0.0-alpha.0...15.0.0-alpha.1) (2026-07-20)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "skyux",
-  "version": "15.0.0-alpha.1",
+  "version": "15.0.0-alpha.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "skyux",
-      "version": "15.0.0-alpha.1",
+      "version": "15.0.0-alpha.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skyux",
-  "version": "15.0.0-alpha.1",
+  "version": "15.0.0-alpha.2",
   "license": "MIT",
   "scripts": {
     "ng": "nx",


### PR DESCRIPTION
## [15.0.0-alpha.2](https://github.com/blackbaud/skyux/compare/15.0.0-alpha.1...15.0.0-alpha.2) (2026-07-22)


### ⚠ BREAKING CHANGES

* **components/theme:** update heading 5 color to use deemphasized text color (#4533)
* **components/layout:** use number transform for fluid grid column size inputs (#4534)

### Features

* **components/layout:** use number transform for fluid grid column size inputs ([#4534](https://github.com/blackbaud/skyux/issues/4534)) ([40241aa](https://github.com/blackbaud/skyux/commit/40241aa479f8223e213653dafec942707f08f584))
* **components/popovers:** add Alt+ArrowUp/Alt+ArrowDown shortcuts to open and close popovers ([#4523](https://github.com/blackbaud/skyux/issues/4523)) ([#4529](https://github.com/blackbaud/skyux/issues/4529)) ([985dc41](https://github.com/blackbaud/skyux/commit/985dc41df2874853ba732d790010244f44cc596d)), closes [AB#4035677](https://dev.azure.com/blackbaud/Products/_workitems/edit/4035677)


### Bug Fixes

* **components/theme:** update heading 5 color to use deemphasized text color ([#4533](https://github.com/blackbaud/skyux/issues/4533)) ([fc08528](https://github.com/blackbaud/skyux/commit/fc08528f1c1f229c75053fb00257e90669b6fafe))

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Updated heading 5 styling to use the deemphasized text color.
  * Fluid grid column size inputs now use numeric transformation, which may change existing sizing behavior.
* **New Features**
  * Added **Alt+ArrowUp** to open popovers and **Alt+ArrowDown** to close them.
* **Bug Fixes**
  * Corrected heading 5 color styling to consistently use deemphasized text color.
* **Release**
  * Bumped version to **15.0.0-alpha.2**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->