### PR TITLE
feat(components/packages): add TypeScript 6 migration schematic

### DIFF
--- a/libs/components/packages/migrations.json
+++ b/libs/components/packages/migrations.json
@@ -19,6 +19,11 @@
       "version": "0.0.0-PLACEHOLDER",
       "factory": "./src/schematics/migrations/all/workspace-check/workspace-check.schematic",
       "description": "Log warnings if the workspace is not configured correctly."
+    },
+    "address-typescript-6-changes": {
+      "version": "0.0.0-PLACEHOLDER",
+      "factory": "./src/schematics/migrations/update-15/address-typescript-6-changes/address-typescript-6-changes",
+      "description": "Update TypeScript configuration and source files for TypeScript 6 breaking changes."
     }
   }
 }

--- a/libs/components/packages/src/schematics/migrations/update-15/address-typescript-6-changes/address-typescript-6-changes.spec.ts
+++ b/libs/components/packages/src/schematics/migrations/update-15/address-typescript-6-changes/address-typescript-6-changes.spec.ts
@@ -1,0 +1,137 @@
+import {
+  SchematicTestRunner,
+  UnitTestTree,
+} from '@angular-devkit/schematics/testing';
+
+import path from 'node:path';
+
+import { createTestApp, createTestLibrary } from '../../../testing/scaffold';
+import { JsonFile } from '../../../utility/json-file';
+
+const COLLECTION_PATH = path.join(__dirname, '../../../../../migrations.json');
+const SCHEMATIC_NAME = 'address-typescript-6-changes';
+
+function runSchematic(tree: UnitTestTree): Promise<UnitTestTree> {
+  const runner = new SchematicTestRunner('migrations', COLLECTION_PATH);
+
+  return runner.runSchematic(SCHEMATIC_NAME, {}, tree);
+}
+
+describe('address-typescript-6-changes', () => {
+  it('should convert an implicit-baseUrl import, remove baseUrl, and rebase paths', async () => {
+    const runner = new SchematicTestRunner('migrations', COLLECTION_PATH);
+    const tree = await createTestApp(runner, { projectName: 'test-app' });
+
+    const tsconfig = new JsonFile(tree, '/tsconfig.json');
+    tsconfig.modify(['compilerOptions', 'baseUrl'], './src');
+    tsconfig.modify(['compilerOptions', 'paths'], {
+      '@env/*': ['environments/*'],
+    });
+
+    tree.create('/src/app/shared.ts', 'export const shared = 1;');
+    tree.create('/src/app/consumer.ts', `import { shared } from 'app/shared';`);
+
+    const updatedTree = await runSchematic(tree);
+
+    expect(updatedTree.readText('/src/app/consumer.ts')).toBe(
+      `import { shared } from './shared';`,
+    );
+    expect(
+      new JsonFile(updatedTree, '/tsconfig.json').get([
+        'compilerOptions',
+        'baseUrl',
+      ]),
+    ).toBeUndefined();
+    expect(
+      new JsonFile(updatedTree, '/tsconfig.json').get([
+        'compilerOptions',
+        'paths',
+        '@env/*',
+      ]),
+    ).toEqual(['./src/environments/*']);
+  });
+
+  it('should convert an implicit-baseUrl import across a library project boundary', async () => {
+    const runner = new SchematicTestRunner('migrations', COLLECTION_PATH);
+    const tree = await createTestLibrary(runner, { projectName: 'my-lib' });
+
+    new JsonFile(tree, '/tsconfig.json').modify(
+      ['compilerOptions', 'baseUrl'],
+      './',
+    );
+    tree.create(
+      '/projects/my-lib/src/lib/helper.ts',
+      'export const helper = 1;',
+    );
+    tree.create(
+      '/projects/my-lib/src/lib/consumer.ts',
+      `import { helper } from 'projects/my-lib/src/lib/helper';`,
+    );
+
+    const updatedTree = await runSchematic(tree);
+
+    expect(updatedTree.readText('/projects/my-lib/src/lib/consumer.ts')).toBe(
+      `import { helper } from './helper';`,
+    );
+  });
+
+  it('should convert a legacy "module Foo {}" namespace declaration', async () => {
+    const runner = new SchematicTestRunner('migrations', COLLECTION_PATH);
+    const tree = await createTestApp(runner, { projectName: 'test-app' });
+
+    tree.create('/src/app/legacy.ts', `module Foo {\n  export const x = 1;\n}`);
+
+    const updatedTree = await runSchematic(tree);
+
+    expect(updatedTree.readText('/src/app/legacy.ts')).toBe(
+      `namespace Foo {\n  export const x = 1;\n}`,
+    );
+  });
+
+  it('should remove deprecated compiler options', async () => {
+    const runner = new SchematicTestRunner('migrations', COLLECTION_PATH);
+    const tree = await createTestApp(runner, { projectName: 'test-app' });
+
+    new JsonFile(tree, '/tsconfig.json').modify(
+      ['compilerOptions', 'downlevelIteration'],
+      true,
+    );
+
+    const updatedTree = await runSchematic(tree);
+
+    expect(
+      new JsonFile(updatedTree, '/tsconfig.json').get([
+        'compilerOptions',
+        'downlevelIteration',
+      ]),
+    ).toBeUndefined();
+  });
+
+  it('should remove an empty "types" array from a freshly-scaffolded app', async () => {
+    const runner = new SchematicTestRunner('migrations', COLLECTION_PATH);
+    const tree = await createTestApp(runner, { projectName: 'test-app' });
+
+    expect(
+      new JsonFile(tree, '/tsconfig.app.json').get([
+        'compilerOptions',
+        'types',
+      ]),
+    ).toEqual([]);
+
+    const updatedTree = await runSchematic(tree);
+
+    expect(
+      new JsonFile(updatedTree, '/tsconfig.app.json').get([
+        'compilerOptions',
+        'types',
+      ]),
+    ).toBeUndefined();
+  });
+
+  it('should succeed on a freshly-scaffolded app with no baseUrl', async () => {
+    const runner = new SchematicTestRunner('migrations', COLLECTION_PATH);
+    const tree = await createTestApp(runner, { projectName: 'test-app' });
+
+    await expect(runSchematic(tree)).resolves.toBeInstanceOf(UnitTestTree);
+  });
+});

--- a/libs/components/packages/src/schematics/migrations/update-15/address-typescript-6-changes/address-typescript-6-changes.ts
+++ b/libs/components/packages/src/schematics/migrations/update-15/address-typescript-6-changes/address-typescript-6-changes.ts
@@ -1,0 +1,20 @@
+import { Rule, SchematicContext, Tree } from '@angular-devkit/schematics';
+
+import { convertSourceFiles } from './lib/convert-source-files';
+import { buildTsconfigModel } from './lib/tsconfig-model';
+import { updateTsconfigFiles } from './lib/update-tsconfig-files';
+
+/**
+ * Prepares a workspace for TypeScript 6: converts implicit-`baseUrl` imports
+ * to relative imports and legacy `module Foo {}` namespaces before removing
+ * `baseUrl` (rebasing `paths`), and cleans up deprecated/default tsconfig
+ * compiler options.
+ */
+export default function addressTypescript6Changes(): Rule {
+  return (tree: Tree, context: SchematicContext): void => {
+    const model = buildTsconfigModel(tree);
+
+    convertSourceFiles(tree, model, context);
+    updateTsconfigFiles(tree, model, context);
+  };
+}

--- a/libs/components/packages/src/schematics/migrations/update-15/address-typescript-6-changes/lib/convert-source-files.spec.ts
+++ b/libs/components/packages/src/schematics/migrations/update-15/address-typescript-6-changes/lib/convert-source-files.spec.ts
@@ -1,0 +1,454 @@
+import { logging } from '@angular-devkit/core';
+import { HostTree, SchematicContext } from '@angular-devkit/schematics';
+
+import { convertSourceFiles } from './convert-source-files';
+import { buildTsconfigModel } from './tsconfig-model';
+
+function createContext(): {
+  context: SchematicContext;
+  warn: jest.SpyInstance;
+} {
+  const context: Pick<SchematicContext, 'logger'> = {
+    logger: new logging.NullLogger(),
+  };
+  const warn = jest.spyOn(context.logger, 'warn');
+
+  return { context: context as SchematicContext, warn };
+}
+
+function run(tree: HostTree, context: SchematicContext): void {
+  const model = buildTsconfigModel(tree);
+  convertSourceFiles(tree, model, context);
+}
+
+describe('convert-source-files', () => {
+  describe('import conversion', () => {
+    it('should convert a same-directory implicit-baseUrl import to relative', () => {
+      const tree = new HostTree();
+      tree.create(
+        '/tsconfig.json',
+        JSON.stringify({ compilerOptions: { baseUrl: './src' } }),
+      );
+      tree.create('/src/app/x.ts', 'export const x = 1;');
+      tree.create('/src/app/y.ts', `import { x } from 'app/x';`);
+
+      const { context } = createContext();
+      run(tree, context);
+
+      expect(tree.readText('/src/app/y.ts')).toBe(`import { x } from './x';`);
+    });
+
+    it('should convert a cross-directory implicit-baseUrl import to relative', () => {
+      const tree = new HostTree();
+      tree.create(
+        '/tsconfig.json',
+        JSON.stringify({ compilerOptions: { baseUrl: './src' } }),
+      );
+      tree.create('/src/shared/y.ts', 'export const y = 1;');
+      tree.create('/src/app/x.ts', `import { y } from 'shared/y';`);
+
+      const { context } = createContext();
+      run(tree, context);
+
+      expect(tree.readText('/src/app/x.ts')).toBe(
+        `import { y } from '../shared/y';`,
+      );
+    });
+
+    it('should resolve via a .d.ts candidate', () => {
+      const tree = new HostTree();
+      tree.create(
+        '/tsconfig.json',
+        JSON.stringify({ compilerOptions: { baseUrl: './src' } }),
+      );
+      tree.create('/src/app/x.d.ts', 'export declare const x: number;');
+      tree.create('/src/app/y.ts', `import { x } from 'app/x';`);
+
+      const { context } = createContext();
+      run(tree, context);
+
+      expect(tree.readText('/src/app/y.ts')).toBe(`import { x } from './x';`);
+    });
+
+    it('should resolve a directory import via an index.ts candidate and keep the directory form', () => {
+      const tree = new HostTree();
+      tree.create(
+        '/tsconfig.json',
+        JSON.stringify({ compilerOptions: { baseUrl: './src' } }),
+      );
+      tree.create('/src/shared/index.ts', 'export const shared = 1;');
+      tree.create('/src/app/x.ts', `import { shared } from 'shared';`);
+
+      const { context } = createContext();
+      run(tree, context);
+
+      expect(tree.readText('/src/app/x.ts')).toBe(
+        `import { shared } from '../shared';`,
+      );
+    });
+
+    it('should resolve a directory import via an index.d.ts candidate', () => {
+      const tree = new HostTree();
+      tree.create(
+        '/tsconfig.json',
+        JSON.stringify({ compilerOptions: { baseUrl: './src' } }),
+      );
+      tree.create(
+        '/src/shared/index.d.ts',
+        'export declare const shared: number;',
+      );
+      tree.create('/src/app/x.ts', `import { shared } from 'shared';`);
+
+      const { context } = createContext();
+      run(tree, context);
+
+      expect(tree.readText('/src/app/x.ts')).toBe(
+        `import { shared } from '../shared';`,
+      );
+    });
+
+    it('should convert an export-from specifier', () => {
+      const tree = new HostTree();
+      tree.create(
+        '/tsconfig.json',
+        JSON.stringify({ compilerOptions: { baseUrl: './src' } }),
+      );
+      tree.create('/src/app/x.ts', 'export const x = 1;');
+      tree.create('/src/app/y.ts', `export { x } from 'app/x';`);
+
+      const { context } = createContext();
+      run(tree, context);
+
+      expect(tree.readText('/src/app/y.ts')).toBe(`export { x } from './x';`);
+    });
+
+    it('should convert a re-export-all specifier', () => {
+      const tree = new HostTree();
+      tree.create(
+        '/tsconfig.json',
+        JSON.stringify({ compilerOptions: { baseUrl: './src' } }),
+      );
+      tree.create('/src/app/x.ts', 'export const x = 1;');
+      tree.create('/src/app/y.ts', `export * from 'app/x';`);
+
+      const { context } = createContext();
+      run(tree, context);
+
+      expect(tree.readText('/src/app/y.ts')).toBe(`export * from './x';`);
+    });
+
+    it('should convert a dynamic import specifier', () => {
+      const tree = new HostTree();
+      tree.create(
+        '/tsconfig.json',
+        JSON.stringify({ compilerOptions: { baseUrl: './src' } }),
+      );
+      tree.create('/src/app/x.ts', 'export const x = 1;');
+      tree.create('/src/app/y.ts', `const p = import('app/x');`);
+
+      const { context } = createContext();
+      run(tree, context);
+
+      expect(tree.readText('/src/app/y.ts')).toBe(`const p = import('./x');`);
+    });
+
+    it('should not touch a dynamic import with a non-literal argument', () => {
+      const tree = new HostTree();
+      tree.create(
+        '/tsconfig.json',
+        JSON.stringify({ compilerOptions: { baseUrl: './src' } }),
+      );
+      tree.create('/src/app/y.ts', `const p = import(someVar);`);
+
+      const { context } = createContext();
+      run(tree, context);
+
+      expect(tree.readText('/src/app/y.ts')).toBe(`const p = import(someVar);`);
+    });
+
+    it('should convert a "typeof import(...)" specifier', () => {
+      const tree = new HostTree();
+      tree.create(
+        '/tsconfig.json',
+        JSON.stringify({ compilerOptions: { baseUrl: './src' } }),
+      );
+      tree.create('/src/app/x.ts', 'export const x = 1;');
+      tree.create('/src/app/y.ts', `type T = typeof import('app/x');`);
+
+      const { context } = createContext();
+      run(tree, context);
+
+      expect(tree.readText('/src/app/y.ts')).toBe(
+        `type T = typeof import('./x');`,
+      );
+    });
+
+    it('should convert an import-equals require specifier', () => {
+      const tree = new HostTree();
+      tree.create(
+        '/tsconfig.json',
+        JSON.stringify({ compilerOptions: { baseUrl: './src' } }),
+      );
+      tree.create('/src/app/x.ts', 'export = 1;');
+      tree.create('/src/app/y.ts', `import x = require('app/x');`);
+
+      const { context } = createContext();
+      run(tree, context);
+
+      expect(tree.readText('/src/app/y.ts')).toBe(`import x = require('./x');`);
+    });
+
+    it('should not convert a specifier matching an exact paths alias', () => {
+      const tree = new HostTree();
+      tree.create(
+        '/tsconfig.json',
+        JSON.stringify({
+          compilerOptions: {
+            baseUrl: './',
+            paths: { '@app': ['src/app/index.ts'] },
+          },
+        }),
+      );
+      tree.create('/src/app/index.ts', 'export const x = 1;');
+      tree.create('/src/app/y.ts', `import { x } from '@app';`);
+
+      const { context } = createContext();
+      run(tree, context);
+
+      expect(tree.readText('/src/app/y.ts')).toBe(`import { x } from '@app';`);
+    });
+
+    it('should not convert a specifier matching a wildcard paths alias', () => {
+      const tree = new HostTree();
+      tree.create(
+        '/tsconfig.json',
+        JSON.stringify({
+          compilerOptions: {
+            baseUrl: './',
+            paths: { '@app/*': ['src/app/*'] },
+          },
+        }),
+      );
+      tree.create('/src/app/x.ts', 'export const x = 1;');
+      tree.create('/src/app/y.ts', `import { x } from '@app/x';`);
+
+      const { context } = createContext();
+      run(tree, context);
+
+      expect(tree.readText('/src/app/y.ts')).toBe(
+        `import { x } from '@app/x';`,
+      );
+    });
+
+    it('should not touch a specifier that has no baseUrl candidate (npm package)', () => {
+      const tree = new HostTree();
+      tree.create(
+        '/tsconfig.json',
+        JSON.stringify({ compilerOptions: { baseUrl: './src' } }),
+      );
+      tree.create(
+        '/src/app/y.ts',
+        `import { Component } from '@angular/core';`,
+      );
+
+      const { context } = createContext();
+      run(tree, context);
+
+      expect(tree.readText('/src/app/y.ts')).toBe(
+        `import { Component } from '@angular/core';`,
+      );
+    });
+
+    it('should not touch an already-relative specifier', () => {
+      const tree = new HostTree();
+      tree.create(
+        '/tsconfig.json',
+        JSON.stringify({ compilerOptions: { baseUrl: './src' } }),
+      );
+      tree.create('/src/app/x.ts', 'export const x = 1;');
+      tree.create('/src/app/y.ts', `import { x } from './x';`);
+
+      const { context } = createContext();
+      run(tree, context);
+
+      expect(tree.readText('/src/app/y.ts')).toBe(`import { x } from './x';`);
+    });
+
+    it('should not touch a rooted specifier', () => {
+      const tree = new HostTree();
+      tree.create(
+        '/tsconfig.json',
+        JSON.stringify({ compilerOptions: { baseUrl: './src' } }),
+      );
+      tree.create('/src/app/y.ts', `import { x } from '/absolute/x';`);
+
+      const { context } = createContext();
+      run(tree, context);
+
+      expect(tree.readText('/src/app/y.ts')).toBe(
+        `import { x } from '/absolute/x';`,
+      );
+    });
+
+    it('should leave every source file byte-identical when no config defines a baseUrl', () => {
+      const tree = new HostTree();
+      tree.create('/tsconfig.json', JSON.stringify({ compilerOptions: {} }));
+      const content = `import { Component } from '@angular/core';\nimport { x } from 'app/x';`;
+      tree.create('/src/app/y.ts', content);
+
+      const { context } = createContext();
+      run(tree, context);
+
+      expect(tree.readText('/src/app/y.ts')).toBe(content);
+    });
+
+    it('should warn once per directory when configs disagree on the effective baseUrl', () => {
+      const tree = new HostTree();
+      tree.create(
+        '/tsconfig.a.json',
+        JSON.stringify({ compilerOptions: { baseUrl: './a' } }),
+      );
+      tree.create(
+        '/tsconfig.b.json',
+        JSON.stringify({ compilerOptions: { baseUrl: './b' } }),
+      );
+      tree.create('/y.ts', `import { x } from '@angular/core';`);
+      tree.create('/z.ts', `import { x } from '@angular/core';`);
+
+      const { context, warn } = createContext();
+      run(tree, context);
+
+      expect(warn).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('module to namespace conversion', () => {
+    it('should convert "module Foo {}" to "namespace Foo {}"', () => {
+      const tree = new HostTree();
+      tree.create('/tsconfig.json', JSON.stringify({ compilerOptions: {} }));
+      tree.create('/y.ts', `module Foo {\n  export const x = 1;\n}`);
+
+      const { context } = createContext();
+      run(tree, context);
+
+      expect(tree.readText('/y.ts')).toBe(
+        `namespace Foo {\n  export const x = 1;\n}`,
+      );
+    });
+
+    it('should convert "declare module Foo {}" preserving "declare"', () => {
+      const tree = new HostTree();
+      tree.create('/tsconfig.json', JSON.stringify({ compilerOptions: {} }));
+      tree.create('/y.ts', `declare module Foo {\n  const x: number;\n}`);
+
+      const { context } = createContext();
+      run(tree, context);
+
+      expect(tree.readText('/y.ts')).toBe(
+        `declare namespace Foo {\n  const x: number;\n}`,
+      );
+    });
+
+    it('should convert "export module Foo {}"', () => {
+      const tree = new HostTree();
+      tree.create('/tsconfig.json', JSON.stringify({ compilerOptions: {} }));
+      tree.create('/y.ts', `export module Foo {\n  export const x = 1;\n}`);
+
+      const { context } = createContext();
+      run(tree, context);
+
+      expect(tree.readText('/y.ts')).toBe(
+        `export namespace Foo {\n  export const x = 1;\n}`,
+      );
+    });
+
+    it('should leave "namespace Foo {}" untouched', () => {
+      const tree = new HostTree();
+      tree.create('/tsconfig.json', JSON.stringify({ compilerOptions: {} }));
+      const content = `namespace Foo {\n  export const x = 1;\n}`;
+      tree.create('/y.ts', content);
+
+      const { context } = createContext();
+      run(tree, context);
+
+      expect(tree.readText('/y.ts')).toBe(content);
+    });
+
+    it('should leave an ambient string-named module declaration untouched', () => {
+      const tree = new HostTree();
+      tree.create('/tsconfig.json', JSON.stringify({ compilerOptions: {} }));
+      const content = `declare module 'some-package' {\n  export const x: number;\n}`;
+      tree.create('/y.ts', content);
+
+      const { context } = createContext();
+      run(tree, context);
+
+      expect(tree.readText('/y.ts')).toBe(content);
+    });
+
+    it('should leave "declare global {}" untouched', () => {
+      const tree = new HostTree();
+      tree.create('/tsconfig.json', JSON.stringify({ compilerOptions: {} }));
+      const content = `declare global {\n  interface Window {}\n}`;
+      tree.create('/y.ts', content);
+
+      const { context } = createContext();
+      run(tree, context);
+
+      expect(tree.readText('/y.ts')).toBe(content);
+    });
+
+    it('should only replace the outer keyword of a dotted module declaration', () => {
+      const tree = new HostTree();
+      tree.create('/tsconfig.json', JSON.stringify({ compilerOptions: {} }));
+      tree.create('/y.ts', `module A.B {\n  export const x = 1;\n}`);
+
+      const { context } = createContext();
+      run(tree, context);
+
+      expect(tree.readText('/y.ts')).toBe(
+        `namespace A.B {\n  export const x = 1;\n}`,
+      );
+    });
+
+    it('should convert a module declaration nested inside another module declaration', () => {
+      const tree = new HostTree();
+      tree.create('/tsconfig.json', JSON.stringify({ compilerOptions: {} }));
+      tree.create(
+        '/y.ts',
+        `module Outer {\n  module Inner {\n    export const x = 1;\n  }\n}`,
+      );
+
+      const { context } = createContext();
+      run(tree, context);
+
+      expect(tree.readText('/y.ts')).toBe(
+        `namespace Outer {\n  namespace Inner {\n    export const x = 1;\n  }\n}`,
+      );
+    });
+
+    it('should leave a sibling namespace declaration untouched when a module declaration triggers parsing', () => {
+      const tree = new HostTree();
+      tree.create('/tsconfig.json', JSON.stringify({ compilerOptions: {} }));
+      tree.create('/y.ts', `module Foo {}\nnamespace Bar {}`);
+
+      const { context } = createContext();
+      run(tree, context);
+
+      expect(tree.readText('/y.ts')).toBe(`namespace Foo {}\nnamespace Bar {}`);
+    });
+
+    it('should convert a module declaration inside a .d.ts file', () => {
+      const tree = new HostTree();
+      tree.create('/tsconfig.json', JSON.stringify({ compilerOptions: {} }));
+      tree.create('/y.d.ts', `declare module Foo {\n  const x: number;\n}`);
+
+      const { context } = createContext();
+      run(tree, context);
+
+      expect(tree.readText('/y.d.ts')).toBe(
+        `declare namespace Foo {\n  const x: number;\n}`,
+      );
+    });
+  });
+});

--- a/libs/components/packages/src/schematics/migrations/update-15/address-typescript-6-changes/lib/convert-source-files.ts
+++ b/libs/components/packages/src/schematics/migrations/update-15/address-typescript-6-changes/lib/convert-source-files.ts
@@ -1,0 +1,153 @@
+import {
+  SchematicContext,
+  Tree,
+  UpdateRecorder,
+} from '@angular-devkit/schematics';
+import { findNodes } from '@schematics/angular/utility/ast-utils';
+import { posix } from 'node:path';
+import ts from 'typescript';
+
+import { parseSourceFile } from '../../../../utility/typescript/ng-ast';
+import { visitProjectFiles } from '../../../../utility/visit-project-files';
+
+import { findModuleSpecifiers, matchesPathsPattern } from './module-specifiers';
+import { GoverningBaseUrl, TsconfigModel } from './tsconfig-model';
+
+const MODULE_KEYWORD_RE = /\bmodule\s+[A-Za-z_$]/;
+
+export function convertSourceFiles(
+  tree: Tree,
+  model: TsconfigModel,
+  context: SchematicContext,
+): void {
+  const warnedConflictDirs = new Set<string>();
+
+  visitProjectFiles(tree, '/', (filePath) => {
+    if (!filePath.endsWith('.ts')) {
+      return;
+    }
+
+    const content = tree.readText(filePath);
+    const governing = model.getGoverningBaseUrl(filePath);
+
+    if (!governing && !MODULE_KEYWORD_RE.test(content)) {
+      return;
+    }
+
+    if (governing?.conflictingConfigPaths) {
+      warnConflict(
+        context,
+        warnedConflictDirs,
+        filePath,
+        governing.conflictingConfigPaths,
+      );
+    }
+
+    const sourceFile = parseSourceFile(tree, filePath);
+    const recorder = tree.beginUpdate(filePath);
+
+    if (governing) {
+      convertImports(tree, filePath, sourceFile, governing, recorder);
+    }
+    convertNamespaces(sourceFile, recorder);
+
+    tree.commitUpdate(recorder);
+  });
+}
+
+function warnConflict(
+  context: SchematicContext,
+  warnedConflictDirs: Set<string>,
+  filePath: string,
+  conflictingConfigPaths: string[],
+): void {
+  const dir = posix.dirname(filePath);
+  if (warnedConflictDirs.has(dir)) {
+    return;
+  }
+  warnedConflictDirs.add(dir);
+
+  context.logger.warn(
+    `Multiple tsconfig files govern "${dir}" with different effective "baseUrl" values ` +
+      `(${conflictingConfigPaths.join(', ')}). Imports here were converted ` +
+      'using only one of them; verify the result.',
+  );
+}
+
+function convertImports(
+  tree: Tree,
+  filePath: string,
+  sourceFile: ts.SourceFile,
+  governing: GoverningBaseUrl,
+  recorder: UpdateRecorder,
+): void {
+  const fileDir = posix.dirname(filePath);
+
+  for (const specifier of findModuleSpecifiers(sourceFile)) {
+    const text = specifier.text;
+
+    if (text.startsWith('.') || text.startsWith('/')) {
+      continue;
+    }
+    if (matchesPathsPattern(text, governing.pathsPatterns)) {
+      continue;
+    }
+    if (!existsViaBaseUrl(tree, governing.baseUrlAbs, text)) {
+      continue;
+    }
+
+    let newSpecifier = posix.relative(
+      fileDir,
+      posix.join(governing.baseUrlAbs, text),
+    );
+    if (!newSpecifier.startsWith('.')) {
+      newSpecifier = `./${newSpecifier}`;
+    }
+
+    const innerStart = specifier.getStart(sourceFile) + 1;
+    const innerLength = specifier.getEnd() - innerStart - 1;
+    recorder.remove(innerStart, innerLength);
+    recorder.insertLeft(innerStart, newSpecifier);
+  }
+}
+
+function existsViaBaseUrl(
+  tree: Tree,
+  baseUrlAbs: string,
+  specifierText: string,
+): boolean {
+  const target = posix.join(baseUrlAbs, specifierText);
+
+  return (
+    tree.exists(`${target}.ts`) ||
+    tree.exists(`${target}.d.ts`) ||
+    tree.exists(`${target}/index.ts`) ||
+    tree.exists(`${target}/index.d.ts`)
+  );
+}
+
+function convertNamespaces(
+  sourceFile: ts.SourceFile,
+  recorder: UpdateRecorder,
+): void {
+  const declarations = findNodes(
+    sourceFile,
+    (node): node is ts.ModuleDeclaration =>
+      ts.isModuleDeclaration(node) && ts.isIdentifier(node.name),
+    Infinity,
+    true,
+  );
+
+  for (const declaration of declarations) {
+    const keyword = declaration
+      .getChildren(sourceFile)
+      .find((child) => child.kind === ts.SyntaxKind.ModuleKeyword);
+
+    if (!keyword) {
+      continue;
+    }
+
+    recorder.remove(keyword.getStart(sourceFile), keyword.getWidth(sourceFile));
+    recorder.insertLeft(keyword.getStart(sourceFile), 'namespace');
+  }
+}

--- a/libs/components/packages/src/schematics/migrations/update-15/address-typescript-6-changes/lib/module-specifiers.spec.ts
+++ b/libs/components/packages/src/schematics/migrations/update-15/address-typescript-6-changes/lib/module-specifiers.spec.ts
@@ -1,0 +1,110 @@
+import ts from 'typescript';
+
+import { findModuleSpecifiers, matchesPathsPattern } from './module-specifiers';
+
+function parse(content: string): ts.SourceFile {
+  return ts.createSourceFile('test.ts', content, ts.ScriptTarget.Latest, true);
+}
+
+function findSpecifierTexts(content: string): string[] {
+  return findModuleSpecifiers(parse(content)).map((node) => node.text);
+}
+
+describe('module-specifiers', () => {
+  describe('findModuleSpecifiers', () => {
+    it('should find an import declaration specifier', () => {
+      expect(findSpecifierTexts(`import { X } from 'app/x';`)).toEqual([
+        'app/x',
+      ]);
+    });
+
+    it('should find an export-from declaration specifier', () => {
+      expect(findSpecifierTexts(`export { X } from 'app/x';`)).toEqual([
+        'app/x',
+      ]);
+    });
+
+    it('should find a re-export-all specifier', () => {
+      expect(findSpecifierTexts(`export * from 'app/x';`)).toEqual(['app/x']);
+    });
+
+    it('should not error on an export declaration without a module specifier', () => {
+      expect(findSpecifierTexts(`const x = 1; export { x };`)).toEqual([]);
+    });
+
+    it('should find a dynamic import specifier', () => {
+      expect(findSpecifierTexts(`const p = import('app/x');`)).toEqual([
+        'app/x',
+      ]);
+    });
+
+    it('should not find a dynamic import with a non-literal argument', () => {
+      expect(findSpecifierTexts(`const p = import(someVar);`)).toEqual([]);
+    });
+
+    it('should not find a bare require() call', () => {
+      expect(findSpecifierTexts(`const x = require('app/x');`)).toEqual([]);
+    });
+
+    it('should find a "typeof import(...)" specifier', () => {
+      expect(findSpecifierTexts(`type X = typeof import('app/x');`)).toEqual([
+        'app/x',
+      ]);
+    });
+
+    it('should find an "import(...).Qualifier" type specifier', () => {
+      expect(findSpecifierTexts(`type X = import('app/x').Foo;`)).toEqual([
+        'app/x',
+      ]);
+    });
+
+    it('should find an import-equals require specifier', () => {
+      expect(findSpecifierTexts(`import x = require('app/x');`)).toEqual([
+        'app/x',
+      ]);
+    });
+
+    it('should not find the name of an ambient string-named module declaration', () => {
+      expect(findSpecifierTexts(`declare module 'app/x' {}`)).toEqual([]);
+    });
+
+    it('should find multiple specifiers in one file', () => {
+      expect(
+        findSpecifierTexts(`
+          import { A } from 'app/a';
+          import { B } from 'app/b';
+        `),
+      ).toEqual(['app/a', 'app/b']);
+    });
+  });
+
+  describe('matchesPathsPattern', () => {
+    it('should match an exact pattern', () => {
+      expect(matchesPathsPattern('@app', ['@app'])).toBe(true);
+    });
+
+    it('should not match a different exact pattern', () => {
+      expect(matchesPathsPattern('@app', ['@lib'])).toBe(false);
+    });
+
+    it('should match a wildcard prefix pattern', () => {
+      expect(matchesPathsPattern('@app/foo/bar', ['@app/*'])).toBe(true);
+    });
+
+    it('should not match when the wildcard prefix does not match', () => {
+      expect(matchesPathsPattern('@lib/foo', ['@app/*'])).toBe(false);
+    });
+
+    it('should match a wildcard pattern with a suffix', () => {
+      expect(matchesPathsPattern('bar/foo', ['*/foo'])).toBe(true);
+    });
+
+    it('should return false when there are no patterns', () => {
+      expect(matchesPathsPattern('@app/foo', [])).toBe(false);
+    });
+
+    it('should return true when any of multiple patterns match', () => {
+      expect(matchesPathsPattern('@lib/foo', ['@app/*', '@lib/*'])).toBe(true);
+    });
+  });
+});

--- a/libs/components/packages/src/schematics/migrations/update-15/address-typescript-6-changes/lib/module-specifiers.ts
+++ b/libs/components/packages/src/schematics/migrations/update-15/address-typescript-6-changes/lib/module-specifiers.ts
@@ -1,0 +1,110 @@
+import ts from 'typescript';
+
+type SpecifierExtractor = (node: ts.Node) => ts.StringLiteralLike | undefined;
+
+function getImportOrExportSpecifier(
+  node: ts.Node,
+): ts.StringLiteralLike | undefined {
+  if (
+    (ts.isImportDeclaration(node) || ts.isExportDeclaration(node)) &&
+    node.moduleSpecifier &&
+    ts.isStringLiteralLike(node.moduleSpecifier)
+  ) {
+    return node.moduleSpecifier;
+  }
+  return undefined;
+}
+
+function getDynamicImportSpecifier(
+  node: ts.Node,
+): ts.StringLiteralLike | undefined {
+  if (
+    ts.isCallExpression(node) &&
+    node.expression.kind === ts.SyntaxKind.ImportKeyword &&
+    node.arguments.length > 0 &&
+    ts.isStringLiteralLike(node.arguments[0])
+  ) {
+    return node.arguments[0];
+  }
+  return undefined;
+}
+
+function getImportTypeSpecifier(
+  node: ts.Node,
+): ts.StringLiteralLike | undefined {
+  if (
+    ts.isImportTypeNode(node) &&
+    ts.isLiteralTypeNode(node.argument) &&
+    ts.isStringLiteralLike(node.argument.literal)
+  ) {
+    return node.argument.literal;
+  }
+  return undefined;
+}
+
+function getImportEqualsSpecifier(
+  node: ts.Node,
+): ts.StringLiteralLike | undefined {
+  if (
+    ts.isExternalModuleReference(node) &&
+    ts.isStringLiteralLike(node.expression)
+  ) {
+    return node.expression;
+  }
+  return undefined;
+}
+
+const SPECIFIER_EXTRACTORS: SpecifierExtractor[] = [
+  getImportOrExportSpecifier,
+  getDynamicImportSpecifier,
+  getImportTypeSpecifier,
+  getImportEqualsSpecifier,
+];
+
+export function findModuleSpecifiers(
+  sourceFile: ts.SourceFile,
+): ts.StringLiteralLike[] {
+  const specifiers: ts.StringLiteralLike[] = [];
+
+  function visit(node: ts.Node): void {
+    for (const extract of SPECIFIER_EXTRACTORS) {
+      const specifier = extract(node);
+      if (specifier) {
+        specifiers.push(specifier);
+        break;
+      }
+    }
+
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile);
+
+  return specifiers;
+}
+
+/**
+ * Mirrors TypeScript's own `paths` pattern matching: a pattern with no `*`
+ * matches only an identical specifier, and a pattern with one `*` matches any
+ * specifier long enough to contain both its prefix and suffix.
+ */
+export function matchesPathsPattern(
+  specifier: string,
+  patterns: string[],
+): boolean {
+  return patterns.some((pattern) => {
+    const starIndex = pattern.indexOf('*');
+    if (starIndex === -1) {
+      return specifier === pattern;
+    }
+
+    const prefix = pattern.slice(0, starIndex);
+    const suffix = pattern.slice(starIndex + 1);
+
+    return (
+      specifier.length >= prefix.length + suffix.length &&
+      specifier.startsWith(prefix) &&
+      specifier.endsWith(suffix)
+    );
+  });
+}

--- a/libs/components/packages/src/schematics/migrations/update-15/address-typescript-6-changes/lib/tsconfig-model.spec.ts
+++ b/libs/components/packages/src/schematics/migrations/update-15/address-typescript-6-changes/lib/tsconfig-model.spec.ts
@@ -1,0 +1,392 @@
+import { HostTree } from '@angular-devkit/schematics';
+
+import {
+  buildTsconfigModel,
+  TsconfigInfo,
+  TsconfigModel,
+} from './tsconfig-model';
+
+function getConfig(model: TsconfigModel, path: string): TsconfigInfo {
+  const config = model.get(path);
+  if (!config) {
+    throw new Error(`Expected a config at "${path}".`);
+  }
+  return config;
+}
+
+describe('tsconfig-model', () => {
+  describe('discovery', () => {
+    it('should return no configs when the tree has no tsconfig files', () => {
+      const tree = new HostTree();
+      tree.create('/package.json', '{}');
+
+      const model = buildTsconfigModel(tree);
+
+      expect(model.getAll()).toHaveLength(0);
+    });
+
+    it('should discover a root tsconfig.json', () => {
+      const tree = new HostTree();
+      tree.create('/tsconfig.json', '{}');
+
+      const model = buildTsconfigModel(tree);
+
+      expect(model.get('/tsconfig.json')).toBeDefined();
+    });
+
+    it('should discover project-level tsconfig files', () => {
+      const tree = new HostTree();
+      tree.create('/tsconfig.json', '{}');
+      tree.create('/tsconfig.app.json', '{}');
+      tree.create('/tsconfig.spec.json', '{}');
+
+      const model = buildTsconfigModel(tree);
+
+      expect(
+        model
+          .getAll()
+          .map((c) => c.path)
+          .sort(),
+      ).toEqual([
+        '/tsconfig.app.json',
+        '/tsconfig.json',
+        '/tsconfig.spec.json',
+      ]);
+    });
+  });
+
+  describe('getEffectiveBaseUrl', () => {
+    it('should return the config own baseUrl', () => {
+      const tree = new HostTree();
+      tree.create(
+        '/tsconfig.json',
+        JSON.stringify({ compilerOptions: { baseUrl: './src' } }),
+      );
+
+      const model = buildTsconfigModel(tree);
+      const config = getConfig(model, '/tsconfig.json');
+      const effective = model.getEffectiveBaseUrl(config);
+
+      expect(effective?.value).toBe('./src');
+      expect(effective?.definedIn.path).toBe('/tsconfig.json');
+    });
+
+    it('should return undefined when no config defines a baseUrl', () => {
+      const tree = new HostTree();
+      tree.create('/tsconfig.json', JSON.stringify({ compilerOptions: {} }));
+
+      const model = buildTsconfigModel(tree);
+      const config = getConfig(model, '/tsconfig.json');
+
+      expect(model.getEffectiveBaseUrl(config)).toBeUndefined();
+    });
+
+    it('should walk an extends chain to find an inherited baseUrl', () => {
+      const tree = new HostTree();
+      tree.create(
+        '/tsconfig.json',
+        JSON.stringify({ compilerOptions: { baseUrl: './' } }),
+      );
+      tree.create(
+        '/tsconfig.app.json',
+        JSON.stringify({ extends: './tsconfig.json', compilerOptions: {} }),
+      );
+
+      const model = buildTsconfigModel(tree);
+      const child = getConfig(model, '/tsconfig.app.json');
+      const effective = model.getEffectiveBaseUrl(child);
+
+      expect(effective?.value).toBe('./');
+      expect(effective?.definedIn.path).toBe('/tsconfig.json');
+    });
+
+    it('should prefer the config own baseUrl over an inherited one', () => {
+      const tree = new HostTree();
+      tree.create(
+        '/tsconfig.json',
+        JSON.stringify({ compilerOptions: { baseUrl: './' } }),
+      );
+      tree.create(
+        '/tsconfig.app.json',
+        JSON.stringify({
+          extends: './tsconfig.json',
+          compilerOptions: { baseUrl: './src' },
+        }),
+      );
+
+      const model = buildTsconfigModel(tree);
+      const child = getConfig(model, '/tsconfig.app.json');
+      const effective = model.getEffectiveBaseUrl(child);
+
+      expect(effective?.value).toBe('./src');
+      expect(effective?.definedIn.path).toBe('/tsconfig.app.json');
+    });
+
+    it('should let the last entry of an extends array win', () => {
+      const tree = new HostTree();
+      tree.create(
+        '/tsconfig.a.json',
+        JSON.stringify({ compilerOptions: { baseUrl: './a' } }),
+      );
+      tree.create(
+        '/tsconfig.b.json',
+        JSON.stringify({ compilerOptions: { baseUrl: './b' } }),
+      );
+      tree.create(
+        '/tsconfig.json',
+        JSON.stringify({
+          extends: ['./tsconfig.a.json', './tsconfig.b.json'],
+          compilerOptions: {},
+        }),
+      );
+
+      const model = buildTsconfigModel(tree);
+      const config = getConfig(model, '/tsconfig.json');
+      const effective = model.getEffectiveBaseUrl(config);
+
+      expect(effective?.value).toBe('./b');
+      expect(effective?.definedIn.path).toBe('/tsconfig.b.json');
+    });
+
+    it('should gracefully ignore an extends reference to a missing file', () => {
+      const tree = new HostTree();
+      tree.create(
+        '/tsconfig.json',
+        JSON.stringify({
+          extends: './does-not-exist.json',
+          compilerOptions: {},
+        }),
+      );
+
+      const model = buildTsconfigModel(tree);
+      const config = getConfig(model, '/tsconfig.json');
+
+      expect(model.getEffectiveBaseUrl(config)).toBeUndefined();
+    });
+
+    it('should gracefully handle an extends cycle', () => {
+      const tree = new HostTree();
+      tree.create(
+        '/tsconfig.a.json',
+        JSON.stringify({ extends: './tsconfig.b.json', compilerOptions: {} }),
+      );
+      tree.create(
+        '/tsconfig.b.json',
+        JSON.stringify({ extends: './tsconfig.a.json', compilerOptions: {} }),
+      );
+
+      const model = buildTsconfigModel(tree);
+      const config = getConfig(model, '/tsconfig.a.json');
+
+      expect(model.getEffectiveBaseUrl(config)).toBeUndefined();
+    });
+
+    it('should resolve an extends reference to a node_modules package', () => {
+      const tree = new HostTree();
+      tree.create(
+        '/node_modules/@tsconfig/base/tsconfig.json',
+        JSON.stringify({ compilerOptions: { baseUrl: './' } }),
+      );
+      tree.create(
+        '/tsconfig.json',
+        JSON.stringify({
+          extends: '@tsconfig/base/tsconfig.json',
+          compilerOptions: {},
+        }),
+      );
+
+      const model = buildTsconfigModel(tree);
+      const config = getConfig(model, '/tsconfig.json');
+      const effective = model.getEffectiveBaseUrl(config);
+
+      expect(effective?.value).toBe('./');
+      expect(effective?.definedIn.inNodeModules).toBe(true);
+    });
+  });
+
+  describe('getEffectivePaths', () => {
+    it("should not merge a child's paths with an extended config's paths", () => {
+      const tree = new HostTree();
+      tree.create(
+        '/tsconfig.json',
+        JSON.stringify({
+          compilerOptions: { paths: { '@lib/*': ['projects/lib/src/*'] } },
+        }),
+      );
+      tree.create(
+        '/tsconfig.app.json',
+        JSON.stringify({
+          extends: './tsconfig.json',
+          compilerOptions: { paths: { '@app/*': ['src/app/*'] } },
+        }),
+      );
+
+      const model = buildTsconfigModel(tree);
+      const child = getConfig(model, '/tsconfig.app.json');
+      const effective = model.getEffectivePaths(child);
+
+      expect(effective?.value).toEqual({ '@app/*': ['src/app/*'] });
+    });
+
+    it('should inherit paths from an extended config when none are declared locally', () => {
+      const tree = new HostTree();
+      tree.create(
+        '/tsconfig.json',
+        JSON.stringify({
+          compilerOptions: { paths: { '@lib/*': ['projects/lib/src/*'] } },
+        }),
+      );
+      tree.create(
+        '/tsconfig.app.json',
+        JSON.stringify({ extends: './tsconfig.json', compilerOptions: {} }),
+      );
+
+      const model = buildTsconfigModel(tree);
+      const child = getConfig(model, '/tsconfig.app.json');
+      const effective = model.getEffectivePaths(child);
+
+      expect(effective?.value).toEqual({ '@lib/*': ['projects/lib/src/*'] });
+      expect(effective?.definedIn.path).toBe('/tsconfig.json');
+    });
+  });
+
+  describe('getEffectiveOption', () => {
+    it("should read the config's own compiler option", () => {
+      const tree = new HostTree();
+      tree.create(
+        '/tsconfig.json',
+        JSON.stringify({ compilerOptions: { module: 'preserve' } }),
+      );
+
+      const model = buildTsconfigModel(tree);
+      const config = getConfig(model, '/tsconfig.json');
+
+      expect(model.getEffectiveOption(config, 'module')).toBe('preserve');
+    });
+
+    it('should walk the extends chain for a compiler option', () => {
+      const tree = new HostTree();
+      tree.create(
+        '/tsconfig.json',
+        JSON.stringify({ compilerOptions: { module: 'preserve' } }),
+      );
+      tree.create(
+        '/tsconfig.app.json',
+        JSON.stringify({ extends: './tsconfig.json', compilerOptions: {} }),
+      );
+
+      const model = buildTsconfigModel(tree);
+      const child = getConfig(model, '/tsconfig.app.json');
+
+      expect(model.getEffectiveOption(child, 'module')).toBe('preserve');
+    });
+
+    it('should return undefined when no config in the chain defines the option', () => {
+      const tree = new HostTree();
+      tree.create('/tsconfig.json', JSON.stringify({ compilerOptions: {} }));
+
+      const model = buildTsconfigModel(tree);
+      const config = getConfig(model, '/tsconfig.json');
+
+      expect(model.getEffectiveOption(config, 'module')).toBeUndefined();
+    });
+  });
+
+  describe('getGoverningBaseUrl', () => {
+    it('should resolve the absolute baseUrl for a file in the same directory', () => {
+      const tree = new HostTree();
+      tree.create(
+        '/tsconfig.json',
+        JSON.stringify({ compilerOptions: { baseUrl: './src' } }),
+      );
+      tree.create('/src/app/foo.ts', '');
+
+      const model = buildTsconfigModel(tree);
+      const governing = model.getGoverningBaseUrl('/src/app/foo.ts');
+
+      expect(governing?.baseUrlAbs).toBe('/src');
+    });
+
+    it('should walk up directories to find a governing config', () => {
+      const tree = new HostTree();
+      tree.create(
+        '/tsconfig.json',
+        JSON.stringify({ compilerOptions: { baseUrl: './src' } }),
+      );
+      tree.create('/src/app/nested/deep/foo.ts', '');
+
+      const model = buildTsconfigModel(tree);
+      const governing = model.getGoverningBaseUrl(
+        '/src/app/nested/deep/foo.ts',
+      );
+
+      expect(governing?.baseUrlAbs).toBe('/src');
+    });
+
+    it('should return the effective paths patterns alongside the baseUrl', () => {
+      const tree = new HostTree();
+      tree.create(
+        '/tsconfig.json',
+        JSON.stringify({
+          compilerOptions: {
+            baseUrl: './',
+            paths: { '@app/*': ['src/app/*'] },
+          },
+        }),
+      );
+      tree.create('/src/foo.ts', '');
+
+      const model = buildTsconfigModel(tree);
+      const governing = model.getGoverningBaseUrl('/src/foo.ts');
+
+      expect(governing?.pathsPatterns).toEqual(['@app/*']);
+    });
+
+    it('should return undefined when no config in the tree defines a baseUrl', () => {
+      const tree = new HostTree();
+      tree.create('/tsconfig.json', JSON.stringify({ compilerOptions: {} }));
+      tree.create('/src/foo.ts', '');
+
+      const model = buildTsconfigModel(tree);
+
+      expect(model.getGoverningBaseUrl('/src/foo.ts')).toBeUndefined();
+    });
+
+    it('should prefer tsconfig.json over other configs in the same directory', () => {
+      const tree = new HostTree();
+      tree.create(
+        '/tsconfig.json',
+        JSON.stringify({ compilerOptions: { baseUrl: './src' } }),
+      );
+      tree.create(
+        '/tsconfig.other.json',
+        JSON.stringify({ compilerOptions: { baseUrl: './other' } }),
+      );
+      tree.create('/src/foo.ts', '');
+
+      const model = buildTsconfigModel(tree);
+      const governing = model.getGoverningBaseUrl('/src/foo.ts');
+
+      expect(governing?.baseUrlAbs).toBe('/src');
+    });
+
+    it('should flag conflicting effective baseUrls in the same directory', () => {
+      const tree = new HostTree();
+      tree.create(
+        '/tsconfig.a.json',
+        JSON.stringify({ compilerOptions: { baseUrl: './a' } }),
+      );
+      tree.create(
+        '/tsconfig.b.json',
+        JSON.stringify({ compilerOptions: { baseUrl: './b' } }),
+      );
+      tree.create('/foo.ts', '');
+
+      const model = buildTsconfigModel(tree);
+      const governing = model.getGoverningBaseUrl('/foo.ts');
+
+      expect(governing?.conflictingConfigPaths).toBeDefined();
+      expect(governing?.conflictingConfigPaths?.length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/libs/components/packages/src/schematics/migrations/update-15/address-typescript-6-changes/lib/tsconfig-model.ts
+++ b/libs/components/packages/src/schematics/migrations/update-15/address-typescript-6-changes/lib/tsconfig-model.ts
@@ -1,0 +1,233 @@
+import { Tree } from '@angular-devkit/schematics';
+import { posix } from 'node:path';
+
+import { JsonFile } from '../../../../utility/json-file';
+import { visitProjectFiles } from '../../../../utility/visit-project-files';
+
+const TSCONFIG_FILE_NAME_RE = /^tsconfig(\..+)?\.json$/;
+
+export interface TsconfigInfo {
+  path: string;
+  dir: string;
+  inNodeModules: boolean;
+  extends: TsconfigInfo[];
+  ownBaseUrl: string | undefined;
+  ownPaths: Record<string, string[]> | undefined;
+  json: JsonFile;
+}
+
+export interface EffectiveValue<T> {
+  value: T;
+  definedIn: TsconfigInfo;
+}
+
+export interface GoverningBaseUrl {
+  baseUrlAbs: string;
+  pathsPatterns: string[];
+  conflictingConfigPaths: string[] | undefined;
+}
+
+function basename(path: string): string {
+  return path.slice(path.lastIndexOf('/') + 1);
+}
+
+function isPathsRecord(value: unknown): value is Record<string, string[]> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function resolveExtendsRef(
+  tree: Tree,
+  ref: string,
+  fromDir: string,
+): string | undefined {
+  const candidates: string[] = ref.startsWith('.')
+    ? [posix.resolve(fromDir, ref), `${posix.resolve(fromDir, ref)}.json`]
+    : [
+        `/node_modules/${ref}`,
+        `/node_modules/${ref}.json`,
+        `/node_modules/${ref}/tsconfig.json`,
+      ];
+
+  return candidates.find((candidate) => tree.exists(candidate));
+}
+
+function loadConfig(
+  tree: Tree,
+  path: string,
+  configs: Map<string, TsconfigInfo>,
+): TsconfigInfo {
+  const existing = configs.get(path);
+  if (existing) {
+    return existing;
+  }
+
+  const json = new JsonFile(tree, path);
+  const dir = posix.dirname(path);
+  const ownBaseUrl = json.get(['compilerOptions', 'baseUrl']);
+  const ownPaths = json.get(['compilerOptions', 'paths']);
+  const rawExtends = json.get(['extends']);
+  const rawExtendsList: string[] = Array.isArray(rawExtends)
+    ? rawExtends
+    : typeof rawExtends === 'string'
+      ? [rawExtends]
+      : [];
+
+  const info: TsconfigInfo = {
+    path,
+    dir,
+    inNodeModules: path.includes('/node_modules/'),
+    extends: [],
+    ownBaseUrl: typeof ownBaseUrl === 'string' ? ownBaseUrl : undefined,
+    ownPaths: isPathsRecord(ownPaths) ? ownPaths : undefined,
+    json,
+  };
+  configs.set(path, info);
+
+  for (const ref of rawExtendsList) {
+    const resolvedPath = resolveExtendsRef(tree, ref, dir);
+    if (!resolvedPath) {
+      continue;
+    }
+
+    info.extends.push(loadConfig(tree, resolvedPath, configs));
+  }
+
+  return info;
+}
+
+function preferenceRank(config: TsconfigInfo): number {
+  return basename(config.path) === 'tsconfig.json' ? 0 : 1;
+}
+
+export class TsconfigModel {
+  readonly #configs: Map<string, TsconfigInfo>;
+
+  constructor(configs: Map<string, TsconfigInfo>) {
+    this.#configs = configs;
+  }
+
+  public getAll(): TsconfigInfo[] {
+    return [...this.#configs.values()];
+  }
+
+  public get(path: string): TsconfigInfo | undefined {
+    return this.#configs.get(path);
+  }
+
+  public getEffectiveBaseUrl(
+    config: TsconfigInfo,
+  ): EffectiveValue<string> | undefined {
+    return this.#resolveEffective(config, (c) => c.ownBaseUrl, new Set());
+  }
+
+  public getEffectivePaths(
+    config: TsconfigInfo,
+  ): EffectiveValue<Record<string, string[]>> | undefined {
+    return this.#resolveEffective(config, (c) => c.ownPaths, new Set());
+  }
+
+  public getEffectiveOption(config: TsconfigInfo, name: string): unknown {
+    const result = this.#resolveEffective(
+      config,
+      (c) => {
+        const value = c.json.get(['compilerOptions', name]);
+        return value === undefined ? undefined : value;
+      },
+      new Set(),
+    );
+
+    return result?.value;
+  }
+
+  public getGoverningBaseUrl(filePath: string): GoverningBaseUrl | undefined {
+    let dir = posix.dirname(filePath);
+
+    for (;;) {
+      const candidates = this.getAll()
+        .filter((c) => c.dir === dir)
+        .sort(
+          (a, b) =>
+            preferenceRank(a) - preferenceRank(b) ||
+            a.path.localeCompare(b.path),
+        );
+
+      const resolved = candidates
+        .map((config) => {
+          const effective = this.getEffectiveBaseUrl(config);
+          if (!effective) {
+            return undefined;
+          }
+
+          return {
+            config,
+            baseUrlAbs: posix.resolve(effective.definedIn.dir, effective.value),
+            paths: this.getEffectivePaths(config),
+          };
+        })
+        .filter((r): r is NonNullable<typeof r> => r !== undefined);
+
+      if (resolved.length > 0) {
+        const [first, ...rest] = resolved;
+        const conflicting = rest.filter(
+          (r) => r.baseUrlAbs !== first.baseUrlAbs,
+        );
+
+        return {
+          baseUrlAbs: first.baseUrlAbs,
+          pathsPatterns: Object.keys(first.paths?.value ?? {}),
+          conflictingConfigPaths: conflicting.length
+            ? conflicting.map((r) => r.config.path)
+            : undefined,
+        };
+      }
+
+      if (dir === '/') {
+        return undefined;
+      }
+
+      dir = posix.dirname(dir);
+    }
+  }
+
+  #resolveEffective<T>(
+    config: TsconfigInfo,
+    getOwn: (config: TsconfigInfo) => T | undefined,
+    visited: Set<string>,
+  ): EffectiveValue<T> | undefined {
+    const own = getOwn(config);
+    if (own !== undefined) {
+      return { value: own, definedIn: config };
+    }
+
+    if (visited.has(config.path)) {
+      return undefined;
+    }
+    visited.add(config.path);
+
+    for (let i = config.extends.length - 1; i >= 0; i--) {
+      const result = this.#resolveEffective(config.extends[i], getOwn, visited);
+      if (result) {
+        return result;
+      }
+    }
+
+    return undefined;
+  }
+}
+
+export function buildTsconfigModel(tree: Tree): TsconfigModel {
+  const discovered: string[] = [];
+
+  visitProjectFiles(tree, '/', (filePath) => {
+    if (TSCONFIG_FILE_NAME_RE.test(basename(filePath))) {
+      discovered.push(filePath);
+    }
+  });
+
+  const configs = new Map<string, TsconfigInfo>();
+  for (const path of discovered) {
+    loadConfig(tree, path, configs);
+  }
+
+  return new TsconfigModel(configs);
+}

--- a/libs/components/packages/src/schematics/migrations/update-15/address-typescript-6-changes/lib/update-tsconfig-files.spec.ts
+++ b/libs/components/packages/src/schematics/migrations/update-15/address-typescript-6-changes/lib/update-tsconfig-files.spec.ts
@@ -1,0 +1,504 @@
+import { logging } from '@angular-devkit/core';
+import { HostTree, SchematicContext } from '@angular-devkit/schematics';
+
+import { JsonFile } from '../../../../utility/json-file';
+
+import { buildTsconfigModel } from './tsconfig-model';
+import { updateTsconfigFiles } from './update-tsconfig-files';
+
+function createContext(): {
+  context: SchematicContext;
+  warn: jest.SpyInstance;
+} {
+  const context: Pick<SchematicContext, 'logger'> = {
+    logger: new logging.NullLogger(),
+  };
+  const warn = jest.spyOn(context.logger, 'warn');
+
+  return { context: context as SchematicContext, warn };
+}
+
+function run(tree: HostTree, context: SchematicContext): void {
+  const model = buildTsconfigModel(tree);
+  updateTsconfigFiles(tree, model, context);
+}
+
+describe('update-tsconfig-files', () => {
+  describe('baseUrl removal', () => {
+    it("should remove the config's own baseUrl", () => {
+      const tree = new HostTree();
+      tree.create(
+        '/tsconfig.json',
+        JSON.stringify({ compilerOptions: { baseUrl: './src' } }),
+      );
+
+      const { context } = createContext();
+      run(tree, context);
+
+      expect(
+        new JsonFile(tree, '/tsconfig.json').get([
+          'compilerOptions',
+          'baseUrl',
+        ]),
+      ).toBeUndefined();
+    });
+
+    it('should not throw when no config defines a baseUrl', () => {
+      const tree = new HostTree();
+      tree.create('/tsconfig.json', JSON.stringify({ compilerOptions: {} }));
+
+      const { context } = createContext();
+
+      expect(() => run(tree, context)).not.toThrow();
+    });
+
+    it('should warn and not edit when the effective baseUrl is inherited from node_modules', () => {
+      const tree = new HostTree();
+      tree.create(
+        '/node_modules/@tsconfig/base/tsconfig.json',
+        JSON.stringify({ compilerOptions: { baseUrl: './' } }),
+      );
+      tree.create(
+        '/tsconfig.json',
+        JSON.stringify({
+          extends: '@tsconfig/base/tsconfig.json',
+          compilerOptions: {},
+        }),
+      );
+
+      const { context, warn } = createContext();
+      run(tree, context);
+
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining('/tsconfig.json'),
+      );
+      expect(
+        new JsonFile(tree, '/tsconfig.json').get(['compilerOptions']),
+      ).toEqual({});
+    });
+  });
+
+  describe('paths rebasing', () => {
+    it('should rebase a paths value relative to the config directory', () => {
+      const tree = new HostTree();
+      tree.create(
+        '/tsconfig.json',
+        JSON.stringify({
+          compilerOptions: {
+            baseUrl: './',
+            paths: { '@lib/*': ['projects/lib/src/*'] },
+          },
+        }),
+      );
+
+      const { context } = createContext();
+      run(tree, context);
+
+      expect(
+        new JsonFile(tree, '/tsconfig.json').get([
+          'compilerOptions',
+          'paths',
+          '@lib/*',
+        ]),
+      ).toEqual(['./projects/lib/src/*']);
+    });
+
+    it('should rebase a paths value when baseUrl is a subdirectory', () => {
+      const tree = new HostTree();
+      tree.create(
+        '/tsconfig.json',
+        JSON.stringify({
+          compilerOptions: {
+            baseUrl: './src',
+            paths: { '@app/*': ['app/*'] },
+          },
+        }),
+      );
+
+      const { context } = createContext();
+      run(tree, context);
+
+      expect(
+        new JsonFile(tree, '/tsconfig.json').get([
+          'compilerOptions',
+          'paths',
+          '@app/*',
+        ]),
+      ).toEqual(['./src/app/*']);
+    });
+
+    it('should not change an already-relative value when the config dir already matches the baseUrl', () => {
+      const tree = new HostTree();
+      tree.create(
+        '/tsconfig.json',
+        JSON.stringify({
+          compilerOptions: {
+            baseUrl: './',
+            paths: { '@app/*': ['./src/app/*'] },
+          },
+        }),
+      );
+
+      const { context } = createContext();
+      run(tree, context);
+
+      expect(
+        new JsonFile(tree, '/tsconfig.json').get([
+          'compilerOptions',
+          'paths',
+          '@app/*',
+        ]),
+      ).toEqual(['./src/app/*']);
+    });
+
+    it('should re-relativize an already-relative value across directories using "../"', () => {
+      const tree = new HostTree();
+      tree.create(
+        '/tsconfig.json',
+        JSON.stringify({ compilerOptions: { baseUrl: './' } }),
+      );
+      tree.create(
+        '/projects/app/tsconfig.json',
+        JSON.stringify({
+          extends: '../../tsconfig.json',
+          compilerOptions: { paths: { '@lib/*': ['./projects/lib/src/*'] } },
+        }),
+      );
+
+      const { context } = createContext();
+      run(tree, context);
+
+      expect(
+        new JsonFile(tree, '/projects/app/tsconfig.json').get([
+          'compilerOptions',
+          'paths',
+          '@lib/*',
+        ]),
+      ).toEqual(['../lib/src/*']);
+    });
+
+    it('should not attempt to rebase paths when no config defines a baseUrl', () => {
+      const tree = new HostTree();
+      tree.create(
+        '/tsconfig.json',
+        JSON.stringify({
+          compilerOptions: { paths: { '@app/*': ['./src/app/*'] } },
+        }),
+      );
+
+      const { context } = createContext();
+      run(tree, context);
+
+      expect(
+        new JsonFile(tree, '/tsconfig.json').get([
+          'compilerOptions',
+          'paths',
+          '@app/*',
+        ]),
+      ).toEqual(['./src/app/*']);
+    });
+
+    it('should tolerate a non-array paths alias value', () => {
+      const tree = new HostTree();
+      tree.create(
+        '/tsconfig.json',
+        JSON.stringify({
+          compilerOptions: {
+            baseUrl: './',
+            paths: { '@app/*': 'not-an-array' },
+          },
+        }),
+      );
+
+      const { context } = createContext();
+
+      expect(() => run(tree, context)).not.toThrow();
+    });
+  });
+
+  describe('deprecated option removal', () => {
+    it.each([
+      ['downlevelIteration', true],
+      ['downlevelIteration', false],
+      ['outFile', './out.js'],
+    ])('should remove "%s" set to %p', (option, value) => {
+      const tree = new HostTree();
+      tree.create(
+        '/tsconfig.json',
+        JSON.stringify({ compilerOptions: { [option]: value } }),
+      );
+
+      const { context } = createContext();
+      run(tree, context);
+
+      expect(
+        new JsonFile(tree, '/tsconfig.json').get(['compilerOptions', option]),
+      ).toBeUndefined();
+    });
+
+    it.each([
+      'alwaysStrict',
+      'esModuleInterop',
+      'allowSyntheticDefaultImports',
+    ])('should remove "%s" when set to false', (option) => {
+      const tree = new HostTree();
+      tree.create(
+        '/tsconfig.json',
+        JSON.stringify({ compilerOptions: { [option]: false } }),
+      );
+
+      const { context } = createContext();
+      run(tree, context);
+
+      expect(
+        new JsonFile(tree, '/tsconfig.json').get(['compilerOptions', option]),
+      ).toBeUndefined();
+    });
+  });
+
+  describe('TS6-default option removal', () => {
+    it.each([
+      'strict',
+      'alwaysStrict',
+      'esModuleInterop',
+      'allowSyntheticDefaultImports',
+    ])('should remove "%s" when set to true', (option) => {
+      const tree = new HostTree();
+      tree.create(
+        '/tsconfig.json',
+        JSON.stringify({ compilerOptions: { [option]: true } }),
+      );
+
+      const { context } = createContext();
+      run(tree, context);
+
+      expect(
+        new JsonFile(tree, '/tsconfig.json').get(['compilerOptions', option]),
+      ).toBeUndefined();
+    });
+
+    it('should remove an empty "types" array', () => {
+      const tree = new HostTree();
+      tree.create(
+        '/tsconfig.json',
+        JSON.stringify({ compilerOptions: { types: [] } }),
+      );
+
+      const { context } = createContext();
+      run(tree, context);
+
+      expect(
+        new JsonFile(tree, '/tsconfig.json').get(['compilerOptions', 'types']),
+      ).toBeUndefined();
+    });
+
+    it('should keep a non-empty "types" array', () => {
+      const tree = new HostTree();
+      tree.create(
+        '/tsconfig.json',
+        JSON.stringify({ compilerOptions: { types: ['jasmine'] } }),
+      );
+
+      const { context } = createContext();
+      run(tree, context);
+
+      expect(
+        new JsonFile(tree, '/tsconfig.json').get(['compilerOptions', 'types']),
+      ).toEqual(['jasmine']);
+    });
+
+    it('should keep "strict: false"', () => {
+      const tree = new HostTree();
+      tree.create(
+        '/tsconfig.json',
+        JSON.stringify({ compilerOptions: { strict: false } }),
+      );
+
+      const { context } = createContext();
+      run(tree, context);
+
+      expect(
+        new JsonFile(tree, '/tsconfig.json').get(['compilerOptions', 'strict']),
+      ).toBe(false);
+    });
+
+    it('should remove "moduleResolution: bundler" when the effective module is "preserve"', () => {
+      const tree = new HostTree();
+      tree.create(
+        '/tsconfig.json',
+        JSON.stringify({
+          compilerOptions: { module: 'preserve', moduleResolution: 'bundler' },
+        }),
+      );
+
+      const { context } = createContext();
+      run(tree, context);
+
+      expect(
+        new JsonFile(tree, '/tsconfig.json').get([
+          'compilerOptions',
+          'moduleResolution',
+        ]),
+      ).toBeUndefined();
+    });
+
+    it('should remove "moduleResolution: bundler" when "module: preserve" is inherited', () => {
+      const tree = new HostTree();
+      tree.create(
+        '/tsconfig.json',
+        JSON.stringify({ compilerOptions: { module: 'preserve' } }),
+      );
+      tree.create(
+        '/tsconfig.app.json',
+        JSON.stringify({
+          extends: './tsconfig.json',
+          compilerOptions: { moduleResolution: 'bundler' },
+        }),
+      );
+
+      const { context } = createContext();
+      run(tree, context);
+
+      expect(
+        new JsonFile(tree, '/tsconfig.app.json').get([
+          'compilerOptions',
+          'moduleResolution',
+        ]),
+      ).toBeUndefined();
+    });
+
+    it('should keep "moduleResolution: bundler" when the effective module is not "preserve"', () => {
+      const tree = new HostTree();
+      tree.create(
+        '/tsconfig.json',
+        JSON.stringify({
+          compilerOptions: { module: 'ES2022', moduleResolution: 'bundler' },
+        }),
+      );
+
+      const { context } = createContext();
+      run(tree, context);
+
+      expect(
+        new JsonFile(tree, '/tsconfig.json').get([
+          'compilerOptions',
+          'moduleResolution',
+        ]),
+      ).toBe('bundler');
+    });
+
+    it('should never remove "target"', () => {
+      const tree = new HostTree();
+      tree.create(
+        '/tsconfig.json',
+        JSON.stringify({ compilerOptions: { target: 'ES2022' } }),
+      );
+
+      const { context } = createContext();
+      run(tree, context);
+
+      expect(
+        new JsonFile(tree, '/tsconfig.json').get(['compilerOptions', 'target']),
+      ).toBe('ES2022');
+    });
+  });
+
+  describe('deprecated-value warnings', () => {
+    it.each([
+      ['target', 'es3'],
+      ['target', 'es5'],
+      ['module', 'none'],
+      ['module', 'amd'],
+      ['module', 'umd'],
+      ['module', 'system'],
+      ['moduleResolution', 'node10'],
+      ['moduleResolution', 'classic'],
+      ['moduleResolution', 'node'],
+    ])('should warn when "%s" is "%s"', (option, value) => {
+      const tree = new HostTree();
+      tree.create(
+        '/tsconfig.json',
+        JSON.stringify({ compilerOptions: { [option]: value } }),
+      );
+
+      const { context, warn } = createContext();
+      run(tree, context);
+
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining('/tsconfig.json'),
+      );
+    });
+
+    it('should not warn for a clean workspace', () => {
+      const tree = new HostTree();
+      tree.create(
+        '/tsconfig.json',
+        JSON.stringify({
+          compilerOptions: { target: 'ES2022', module: 'preserve' },
+        }),
+      );
+
+      const { context, warn } = createContext();
+      run(tree, context);
+
+      expect(warn).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('comment preservation', () => {
+    it('should preserve file-leading comments after edits', () => {
+      const tree = new HostTree();
+      tree.create(
+        '/tsconfig.json',
+        [
+          '/* To learn more about Typescript configuration file: ... */',
+          '/* To learn more about Angular compiler options: ... */',
+          '{',
+          '  "compilerOptions": {',
+          '    "baseUrl": "./src",',
+          '    "target": "ES2022"',
+          '  }',
+          '}',
+        ].join('\n'),
+      );
+
+      const { context } = createContext();
+      run(tree, context);
+
+      const content = tree.readText('/tsconfig.json');
+      expect(content).toContain(
+        '/* To learn more about Typescript configuration file: ... */',
+      );
+      expect(content).toContain(
+        '/* To learn more about Angular compiler options: ... */',
+      );
+      expect(content).not.toContain('baseUrl');
+    });
+  });
+
+  describe('idempotency', () => {
+    it('should make no further changes on a second run', () => {
+      const tree = new HostTree();
+      tree.create(
+        '/tsconfig.json',
+        JSON.stringify({
+          compilerOptions: {
+            baseUrl: './src',
+            paths: { '@app/*': ['app/*'] },
+            strict: true,
+            downlevelIteration: true,
+          },
+        }),
+      );
+
+      const { context } = createContext();
+      run(tree, context);
+      const firstPass = tree.readText('/tsconfig.json');
+
+      run(tree, context);
+      const secondPass = tree.readText('/tsconfig.json');
+
+      expect(secondPass).toBe(firstPass);
+    });
+  });
+});

--- a/libs/components/packages/src/schematics/migrations/update-15/address-typescript-6-changes/lib/update-tsconfig-files.ts
+++ b/libs/components/packages/src/schematics/migrations/update-15/address-typescript-6-changes/lib/update-tsconfig-files.ts
@@ -1,0 +1,174 @@
+import { SchematicContext, Tree } from '@angular-devkit/schematics';
+import { posix } from 'node:path';
+
+import { JsonFile } from '../../../../utility/json-file';
+
+import { TsconfigInfo, TsconfigModel } from './tsconfig-model';
+
+const DEPRECATED_TARGETS = new Set(['es3', 'es5']);
+const DEPRECATED_MODULES = new Set(['none', 'amd', 'umd', 'system']);
+const DEPRECATED_MODULE_RESOLUTIONS = new Set(['node10', 'classic', 'node']);
+
+export function updateTsconfigFiles(
+  tree: Tree,
+  model: TsconfigModel,
+  context: SchematicContext,
+): void {
+  for (const config of model.getAll()) {
+    if (config.inNodeModules) {
+      continue;
+    }
+
+    warnAboutNodeModulesBaseUrl(context, model, config);
+    warnAboutDeprecatedValues(context, config);
+
+    const json = new JsonFile(tree, config.path);
+
+    rebasePaths(json, model, config);
+    removeBaseUrl(json, config);
+    removeDeprecatedOptions(json);
+    removeDefaultMatchingOptions(json, model, config);
+  }
+}
+
+function rebasePaths(
+  json: JsonFile,
+  model: TsconfigModel,
+  config: TsconfigInfo,
+): void {
+  if (!config.ownPaths) {
+    return;
+  }
+
+  const effectiveBaseUrl = model.getEffectiveBaseUrl(config);
+  if (!effectiveBaseUrl) {
+    return;
+  }
+
+  const baseUrlAbs = posix.resolve(
+    effectiveBaseUrl.definedIn.dir,
+    effectiveBaseUrl.value,
+  );
+
+  for (const [alias, values] of Object.entries(config.ownPaths)) {
+    if (!Array.isArray(values)) {
+      continue;
+    }
+
+    const newValues = values.map((value) =>
+      rebasePathValue(value, baseUrlAbs, config.dir),
+    );
+
+    if (JSON.stringify(newValues) !== JSON.stringify(values)) {
+      json.modify(['compilerOptions', 'paths', alias], newValues);
+    }
+  }
+}
+
+function rebasePathValue(
+  value: string,
+  baseUrlAbs: string,
+  configDir: string,
+): string {
+  const needsRewrite = !value.startsWith('.') || baseUrlAbs !== configDir;
+  if (!needsRewrite) {
+    return value;
+  }
+
+  const targetAbs = posix.resolve(baseUrlAbs, value);
+  const rebased = posix.relative(configDir, targetAbs);
+
+  return rebased.startsWith('.') ? rebased : `./${rebased}`;
+}
+
+function removeBaseUrl(json: JsonFile, config: TsconfigInfo): void {
+  if (config.ownBaseUrl !== undefined) {
+    json.remove(['compilerOptions', 'baseUrl']);
+  }
+}
+
+function removeDeprecatedOptions(json: JsonFile): void {
+  json.remove(['compilerOptions', 'downlevelIteration']);
+  json.remove(['compilerOptions', 'outFile']);
+  removeIfEquals(json, 'alwaysStrict', false);
+  removeIfEquals(json, 'esModuleInterop', false);
+  removeIfEquals(json, 'allowSyntheticDefaultImports', false);
+}
+
+function removeDefaultMatchingOptions(
+  json: JsonFile,
+  model: TsconfigModel,
+  config: TsconfigInfo,
+): void {
+  removeIfEquals(json, 'strict', true);
+  removeIfEquals(json, 'alwaysStrict', true);
+  removeIfEquals(json, 'esModuleInterop', true);
+  removeIfEquals(json, 'allowSyntheticDefaultImports', true);
+
+  const types = json.get(['compilerOptions', 'types']);
+  if (Array.isArray(types) && types.length === 0) {
+    json.remove(['compilerOptions', 'types']);
+  }
+
+  const moduleResolution = json.get(['compilerOptions', 'moduleResolution']);
+  if (
+    typeof moduleResolution === 'string' &&
+    moduleResolution.toLowerCase() === 'bundler'
+  ) {
+    const effectiveModule = model.getEffectiveOption(config, 'module');
+    if (
+      typeof effectiveModule === 'string' &&
+      effectiveModule.toLowerCase() === 'preserve'
+    ) {
+      json.remove(['compilerOptions', 'moduleResolution']);
+    }
+  }
+}
+
+function removeIfEquals(json: JsonFile, option: string, value: unknown): void {
+  if (json.get(['compilerOptions', option]) === value) {
+    json.remove(['compilerOptions', option]);
+  }
+}
+
+function warnAboutNodeModulesBaseUrl(
+  context: SchematicContext,
+  model: TsconfigModel,
+  config: TsconfigInfo,
+): void {
+  const effective = model.getEffectiveBaseUrl(config);
+  if (effective?.definedIn.inNodeModules) {
+    context.logger.warn(
+      `"${config.path}" inherits "baseUrl" from "${effective.definedIn.path}" in node_modules, ` +
+        `which cannot be edited automatically. Add "baseUrl": null to "${config.path}" or update its imports manually.`,
+    );
+  }
+}
+
+function warnAboutDeprecatedValues(
+  context: SchematicContext,
+  config: TsconfigInfo,
+): void {
+  warnIfDeprecated(context, config, 'target', DEPRECATED_TARGETS);
+  warnIfDeprecated(context, config, 'module', DEPRECATED_MODULES);
+  warnIfDeprecated(
+    context,
+    config,
+    'moduleResolution',
+    DEPRECATED_MODULE_RESOLUTIONS,
+  );
+}
+
+function warnIfDeprecated(
+  context: SchematicContext,
+  config: TsconfigInfo,
+  option: string,
+  deprecatedValues: Set<string>,
+): void {
+  const value = config.json.get(['compilerOptions', option]);
+  if (typeof value === 'string' && deprecatedValues.has(value.toLowerCase())) {
+    context.logger.warn(
+      `"${config.path}": "compilerOptions.${option}": "${value}" is deprecated in TypeScript 6 and should be updated manually.`,
+    );
+  }
+}


### PR DESCRIPTION
Adds an update-15 migration that prepares consumer workspaces for
TypeScript 6 by converting implicit-baseUrl imports to relative
imports, converting legacy `module Foo {}` namespaces, removing
`baseUrl` (while rebasing `paths`), and cleaning up deprecated and
default-matching tsconfig compiler options.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PoLAoPsvX7BD1yenuTywyX

[AB#4062933](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/4062933)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an automated migration to prepare Angular workspaces for TypeScript 6.
  * Updates imports and legacy namespace syntax for TypeScript 6 compatibility.
  * Cleans up deprecated and default TypeScript configuration options.
  * Rebases path mappings and warns about potentially incompatible settings.

* **Tests**
  * Added comprehensive coverage for source transformations, configuration inheritance, warnings, and repeatable migration results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->