### PR TITLE
feat(components/packages)!: add migration to remove @skyux/packages/polyfills from projects

### DIFF
--- a/apps/e2e/data-grid-storybook/project.json
+++ b/apps/e2e/data-grid-storybook/project.json
@@ -15,7 +15,7 @@
         },
         "index": "apps/e2e/data-grid-storybook/src/index.html",
         "browser": "apps/e2e/data-grid-storybook/src/main.ts",
-        "polyfills": ["zone.js", "libs/components/packages/src/polyfills.js"],
+        "polyfills": ["zone.js"],
         "tsConfig": "apps/e2e/data-grid-storybook/tsconfig.app.json",
         "inlineStyleLanguage": "scss",
         "stylePreprocessorOptions": {

--- a/libs/components/packages/migrations.json
+++ b/libs/components/packages/migrations.json
@@ -19,6 +19,11 @@
       "version": "0.0.0-PLACEHOLDER",
       "factory": "./src/schematics/migrations/all/workspace-check/workspace-check.schematic",
       "description": "Log warnings if the workspace is not configured correctly."
+    },
+    "migrate-dragula-polyfill": {
+      "version": "0.0.0-PLACEHOLDER",
+      "factory": "./src/schematics/migrations/all/migrate-dragula-polyfill/migrate-dragula-polyfill.schematic",
+      "description": "Remove the @skyux/packages/polyfills entry from project config, replacing it with a local copy when Dragula is still installed."
     }
   }
 }

--- a/libs/components/packages/package.json
+++ b/libs/components/packages/package.json
@@ -23,9 +23,6 @@
     },
     "./package.json": {
       "default": "./package.json"
-    },
-    "./polyfills": {
-      "default": "./src/polyfills.js"
     }
   },
   "schematics": "./collection.json",
@@ -114,6 +111,6 @@
     "parse5": "7.3.0",
     "tslib": "^2.8.1"
   },
-  "sideEffects": true,
+  "sideEffects": false,
   "main": "./src/index.js"
 }

--- a/libs/components/packages/project.json
+++ b/libs/components/packages/project.json
@@ -30,7 +30,6 @@
         "assets": [
           "libs/components/packages/collection.json",
           "libs/components/packages/migrations.json",
-          "libs/components/packages/src/polyfills.js",
           "libs/components/packages/src/schematics/**/schema.json",
           "libs/components/packages/src/schematics/**/*.template",
           "libs/components/packages/*.md"

--- a/libs/components/packages/src/polyfills.js
+++ b/libs/components/packages/src/polyfills.js
@@ -1,6 +1,0 @@
-'use strict';
-
-// Fix for crossvent `global is not defined` error. The crossvent library is used by Dragula,
-// which in turn is used by multiple SKY UX components.
-// https://github.com/bevacqua/dragula/issues/602
-window.global = window;

--- a/libs/components/packages/src/schematics/migrations/all/migrate-dragula-polyfill/migrate-dragula-polyfill.schematic.spec.ts
+++ b/libs/components/packages/src/schematics/migrations/all/migrate-dragula-polyfill/migrate-dragula-polyfill.schematic.spec.ts
@@ -139,7 +139,62 @@ describe('Migrations > Migrate Dragula polyfill', () => {
     expect(tree.exists(LOCAL_POLYFILL_PATH)).toBe(false);
   });
 
-  it('should warn and make no changes when package-lock.json is missing', async () => {
+  it('should migrate polyfills in build configurations', async () => {
+    const { runSchematic, tree } = await setup({
+      packageLock: { packages: { 'node_modules/dragula': {} } },
+    });
+
+    tree.overwrite(
+      '/angular.json',
+      JSON.stringify({
+        version: 1,
+        projects: {
+          app: {
+            projectType: 'application',
+            root: 'projects/app',
+            sourceRoot: 'projects/app/src',
+            architect: {
+              build: {
+                options: {
+                  polyfills: ['zone.js', '@skyux/packages/polyfills'],
+                },
+                configurations: {
+                  production: {
+                    polyfills: ['@skyux/packages/polyfills'],
+                  },
+                },
+              },
+            },
+          },
+        },
+      }),
+    );
+
+    await runSchematic();
+
+    const build = (
+      tree.readJson('/angular.json') as {
+        projects: {
+          app: {
+            architect: {
+              build: {
+                options: { polyfills: unknown };
+                configurations: { production: { polyfills: unknown } };
+              };
+            };
+          };
+        };
+      }
+    ).projects.app.architect.build;
+
+    expect(build.options.polyfills).toEqual(['zone.js', LOCAL_POLYFILL_PATH]);
+    expect(build.configurations.production.polyfills).toEqual([
+      LOCAL_POLYFILL_PATH,
+    ]);
+    expect(tree.exists(LOCAL_POLYFILL_PATH)).toBe(true);
+  });
+
+  it('should retain a local shim when package-lock.json is missing', async () => {
     const warnSpy = jest.fn();
     const { tree } = await setup({
       includeBuildOptions: true,
@@ -154,13 +209,38 @@ describe('Migrations > Migrate Dragula polyfill', () => {
 
     await runner.runSchematic('migrate-dragula-polyfill', {}, tree);
 
-    expect(getBuildPolyfills(tree)).toEqual(['@skyux/packages/polyfills']);
+    expect(getBuildPolyfills(tree)).toEqual([LOCAL_POLYFILL_PATH]);
+    expect(tree.exists(LOCAL_POLYFILL_PATH)).toBe(true);
     expect(warnSpy).toHaveBeenCalledWith(
       expect.stringContaining('package-lock.json" file was not found'),
     );
   });
 
-  it('should warn and make no changes for an unsupported lockfile version', async () => {
+  it('should retain a local shim when package-lock.json is malformed', async () => {
+    const warnSpy = jest.fn();
+    const { tree } = await setup({
+      includeBuildOptions: true,
+      polyfills: ['@skyux/packages/polyfills'],
+    });
+
+    tree.create('/package-lock.json', '{ invalid json');
+
+    runner.logger.subscribe((entry) => {
+      if (entry.level === 'warn') {
+        warnSpy(entry.message);
+      }
+    });
+
+    await runner.runSchematic('migrate-dragula-polyfill', {}, tree);
+
+    expect(getBuildPolyfills(tree)).toEqual([LOCAL_POLYFILL_PATH]);
+    expect(tree.exists(LOCAL_POLYFILL_PATH)).toBe(true);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('could not be parsed'),
+    );
+  });
+
+  it('should retain a local shim for an unsupported lockfile version', async () => {
     const warnSpy = jest.fn();
     const { tree } = await setup({
       packageLock: { dependencies: { dragula: {} } },
@@ -176,7 +256,8 @@ describe('Migrations > Migrate Dragula polyfill', () => {
 
     await runner.runSchematic('migrate-dragula-polyfill', {}, tree);
 
-    expect(getBuildPolyfills(tree)).toEqual(['@skyux/packages/polyfills']);
+    expect(getBuildPolyfills(tree)).toEqual([LOCAL_POLYFILL_PATH]);
+    expect(tree.exists(LOCAL_POLYFILL_PATH)).toBe(true);
     expect(warnSpy).toHaveBeenCalledWith(
       expect.stringContaining('unsupported lockfile version'),
     );

--- a/libs/components/packages/src/schematics/migrations/all/migrate-dragula-polyfill/migrate-dragula-polyfill.schematic.spec.ts
+++ b/libs/components/packages/src/schematics/migrations/all/migrate-dragula-polyfill/migrate-dragula-polyfill.schematic.spec.ts
@@ -1,0 +1,184 @@
+import {
+  SchematicTestRunner,
+  UnitTestTree,
+} from '@angular-devkit/schematics/testing';
+
+import path from 'node:path';
+
+import { createTestLibrary } from '../../../testing/scaffold';
+
+const LOCAL_POLYFILL_PATH = 'projects/app/src/dragula-polyfill.js';
+
+function getBuildPolyfills(tree: UnitTestTree): unknown {
+  const angularJson = tree.readJson('/angular.json') as {
+    projects: {
+      app: { architect: { build: { options?: { polyfills?: unknown } } } };
+    };
+  };
+
+  return angularJson.projects.app.architect.build.options?.polyfills;
+}
+
+describe('Migrations > Migrate Dragula polyfill', () => {
+  const runner = new SchematicTestRunner(
+    'migrations',
+    path.join(__dirname, '../../../../../migrations.json'),
+  );
+
+  async function setup(config: {
+    packageLock?: unknown;
+    polyfills?: unknown;
+    includeBuildOptions?: boolean;
+  }): Promise<{
+    runSchematic: () => Promise<UnitTestTree>;
+    tree: UnitTestTree;
+  }> {
+    const tree = await createTestLibrary(runner, {
+      projectName: 'foobar',
+    });
+
+    const build = config.includeBuildOptions
+      ? { options: { polyfills: config.polyfills } }
+      : {};
+
+    tree.overwrite(
+      '/angular.json',
+      JSON.stringify({
+        version: 1,
+        projects: {
+          app: {
+            projectType: 'application',
+            root: 'projects/app',
+            sourceRoot: 'projects/app/src',
+            architect: {
+              build,
+            },
+          },
+        },
+      }),
+    );
+
+    if (config.packageLock !== undefined) {
+      tree.create('/package-lock.json', JSON.stringify(config.packageLock));
+    }
+
+    return {
+      runSchematic: (): Promise<UnitTestTree> =>
+        runner.runSchematic('migrate-dragula-polyfill', {}, tree),
+      tree,
+    };
+  }
+
+  it('should remove the polyfill when Dragula is not installed', async () => {
+    const { runSchematic, tree } = await setup({
+      packageLock: { packages: { 'node_modules/zone.js': {} } },
+      includeBuildOptions: true,
+      polyfills: ['zone.js', '@skyux/packages/polyfills'],
+    });
+
+    await runSchematic();
+
+    expect(getBuildPolyfills(tree)).toEqual(['zone.js']);
+    expect(tree.exists(LOCAL_POLYFILL_PATH)).toBe(false);
+  });
+
+  it('should replace the polyfill with a local copy when Dragula is installed', async () => {
+    const { runSchematic, tree } = await setup({
+      packageLock: { packages: { 'node_modules/dragula': {} } },
+      includeBuildOptions: true,
+      polyfills: ['zone.js', '@skyux/packages/polyfills'],
+    });
+
+    await runSchematic();
+
+    expect(getBuildPolyfills(tree)).toEqual(['zone.js', LOCAL_POLYFILL_PATH]);
+    expect(tree.exists(LOCAL_POLYFILL_PATH)).toBe(true);
+    expect(tree.readText(LOCAL_POLYFILL_PATH)).toContain(
+      'window.global = window;',
+    );
+  });
+
+  it('should detect Dragula when installed transitively', async () => {
+    const { runSchematic, tree } = await setup({
+      packageLock: {
+        packages: { 'node_modules/some-lib/node_modules/dragula': {} },
+      },
+      includeBuildOptions: true,
+      polyfills: ['@skyux/packages/polyfills'],
+    });
+
+    await runSchematic();
+
+    expect(getBuildPolyfills(tree)).toEqual([LOCAL_POLYFILL_PATH]);
+    expect(tree.exists(LOCAL_POLYFILL_PATH)).toBe(true);
+  });
+
+  it('should leave projects without the polyfill entry untouched', async () => {
+    const { runSchematic, tree } = await setup({
+      packageLock: { packages: { 'node_modules/zone.js': {} } },
+      includeBuildOptions: true,
+      polyfills: ['zone.js'],
+    });
+
+    await runSchematic();
+
+    expect(getBuildPolyfills(tree)).toEqual(['zone.js']);
+    expect(tree.exists(LOCAL_POLYFILL_PATH)).toBe(false);
+  });
+
+  it('should ignore build targets without a polyfills array', async () => {
+    const { runSchematic, tree } = await setup({
+      packageLock: { packages: { 'node_modules/dragula': {} } },
+      includeBuildOptions: true,
+      polyfills: 'zone.js',
+    });
+
+    await runSchematic();
+
+    expect(getBuildPolyfills(tree)).toEqual('zone.js');
+    expect(tree.exists(LOCAL_POLYFILL_PATH)).toBe(false);
+  });
+
+  it('should warn and make no changes when package-lock.json is missing', async () => {
+    const warnSpy = jest.fn();
+    const { tree } = await setup({
+      includeBuildOptions: true,
+      polyfills: ['@skyux/packages/polyfills'],
+    });
+
+    runner.logger.subscribe((entry) => {
+      if (entry.level === 'warn') {
+        warnSpy(entry.message);
+      }
+    });
+
+    await runner.runSchematic('migrate-dragula-polyfill', {}, tree);
+
+    expect(getBuildPolyfills(tree)).toEqual(['@skyux/packages/polyfills']);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('package-lock.json" file was not found'),
+    );
+  });
+
+  it('should warn and make no changes for an unsupported lockfile version', async () => {
+    const warnSpy = jest.fn();
+    const { tree } = await setup({
+      packageLock: { dependencies: { dragula: {} } },
+      includeBuildOptions: true,
+      polyfills: ['@skyux/packages/polyfills'],
+    });
+
+    runner.logger.subscribe((entry) => {
+      if (entry.level === 'warn') {
+        warnSpy(entry.message);
+      }
+    });
+
+    await runner.runSchematic('migrate-dragula-polyfill', {}, tree);
+
+    expect(getBuildPolyfills(tree)).toEqual(['@skyux/packages/polyfills']);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('unsupported lockfile version'),
+    );
+  });
+});

--- a/libs/components/packages/src/schematics/migrations/all/migrate-dragula-polyfill/migrate-dragula-polyfill.schematic.spec.ts
+++ b/libs/components/packages/src/schematics/migrations/all/migrate-dragula-polyfill/migrate-dragula-polyfill.schematic.spec.ts
@@ -19,6 +19,16 @@ function getBuildPolyfills(tree: UnitTestTree): unknown {
   return angularJson.projects.app.architect.build.options?.polyfills;
 }
 
+function getTestPolyfills(tree: UnitTestTree): unknown {
+  const angularJson = tree.readJson('/angular.json') as {
+    projects: {
+      app: { architect: { test?: { options?: { polyfills?: unknown } } } };
+    };
+  };
+
+  return angularJson.projects.app.architect.test?.options?.polyfills;
+}
+
 describe('Migrations > Migrate Dragula polyfill', () => {
   const runner = new SchematicTestRunner(
     'migrations',
@@ -29,6 +39,7 @@ describe('Migrations > Migrate Dragula polyfill', () => {
     packageLock?: unknown;
     polyfills?: unknown;
     includeBuildOptions?: boolean;
+    testPolyfills?: unknown;
   }): Promise<{
     runSchematic: () => Promise<UnitTestTree>;
     tree: UnitTestTree;
@@ -41,6 +52,11 @@ describe('Migrations > Migrate Dragula polyfill', () => {
       ? { options: { polyfills: config.polyfills } }
       : {};
 
+    const test =
+      config.testPolyfills === undefined
+        ? undefined
+        : { options: { polyfills: config.testPolyfills } };
+
     tree.overwrite(
       '/angular.json',
       JSON.stringify({
@@ -52,6 +68,7 @@ describe('Migrations > Migrate Dragula polyfill', () => {
             sourceRoot: 'projects/app/src',
             architect: {
               build,
+              ...(test ? { test } : {}),
             },
           },
         },
@@ -136,6 +153,41 @@ describe('Migrations > Migrate Dragula polyfill', () => {
     await runSchematic();
 
     expect(getBuildPolyfills(tree)).toEqual('zone.js');
+    expect(tree.exists(LOCAL_POLYFILL_PATH)).toBe(false);
+  });
+
+  it('should migrate polyfills in the test target', async () => {
+    const { runSchematic, tree } = await setup({
+      packageLock: { packages: { 'node_modules/dragula': {} } },
+      includeBuildOptions: true,
+      polyfills: ['zone.js', '@skyux/packages/polyfills'],
+      testPolyfills: [
+        'zone.js',
+        'zone.js/testing',
+        '@skyux/packages/polyfills',
+      ],
+    });
+
+    await runSchematic();
+
+    expect(getBuildPolyfills(tree)).toEqual(['zone.js', LOCAL_POLYFILL_PATH]);
+    expect(getTestPolyfills(tree)).toEqual([
+      'zone.js',
+      'zone.js/testing',
+      LOCAL_POLYFILL_PATH,
+    ]);
+    expect(tree.exists(LOCAL_POLYFILL_PATH)).toBe(true);
+  });
+
+  it('should remove the test polyfill when Dragula is not installed', async () => {
+    const { runSchematic, tree } = await setup({
+      packageLock: { packages: { 'node_modules/zone.js': {} } },
+      testPolyfills: ['zone.js', '@skyux/packages/polyfills'],
+    });
+
+    await runSchematic();
+
+    expect(getTestPolyfills(tree)).toEqual(['zone.js']);
     expect(tree.exists(LOCAL_POLYFILL_PATH)).toBe(false);
   });
 

--- a/libs/components/packages/src/schematics/migrations/all/migrate-dragula-polyfill/migrate-dragula-polyfill.schematic.ts
+++ b/libs/components/packages/src/schematics/migrations/all/migrate-dragula-polyfill/migrate-dragula-polyfill.schematic.ts
@@ -1,0 +1,107 @@
+import { Rule, SchematicContext, Tree } from '@angular-devkit/schematics';
+import { updateWorkspace } from '@schematics/angular/utility';
+
+import { getSourceRoot } from '../../../utility/workspace';
+
+const PACKAGES_POLYFILL = '@skyux/packages/polyfills';
+const LOCAL_POLYFILL_FILENAME = 'dragula-polyfill.js';
+const LOCAL_POLYFILL_CONTENT = `'use strict';
+
+// Fix for crossvent \`global is not defined\` error. The crossvent library is used by Dragula,
+// which in turn is used by some third-party libraries.
+// https://github.com/bevacqua/dragula/issues/602
+window.global = window;
+`;
+
+/**
+ * Removes the \`@skyux/packages/polyfills\` entry from every project's build
+ * configuration. When Dragula is still installed (directly or transitively),
+ * the entry is replaced with a local copy of the polyfill so those consumers
+ * keep working without depending on \`@skyux/packages/polyfills\`.
+ */
+export default function migrateDragulaPolyfill(): Rule {
+  return (tree, context) => {
+    const packages = readLockFilePackages(tree, context);
+
+    if (!packages) {
+      return;
+    }
+
+    const dragulaInstalled = isDragulaInstalled(packages);
+
+    return updateWorkspace((workspace) => {
+      for (const project of workspace.projects.values()) {
+        const build = project.targets.get('build');
+        const polyfills = build?.options?.['polyfills'];
+
+        if (!Array.isArray(polyfills)) {
+          continue;
+        }
+
+        const index = polyfills.indexOf(PACKAGES_POLYFILL);
+
+        if (index === -1) {
+          continue;
+        }
+
+        if (dragulaInstalled) {
+          const localPolyfillPath = `${getSourceRoot(project)}/${LOCAL_POLYFILL_FILENAME}`;
+
+          tree.create(localPolyfillPath, LOCAL_POLYFILL_CONTENT);
+          polyfills.splice(index, 1, localPolyfillPath);
+        } else {
+          polyfills.splice(index, 1);
+        }
+      }
+    });
+  };
+}
+
+/**
+ * Reads the \`packages\` map from \`package-lock.json\`. Returns \`undefined\` (and
+ * logs a warning) when the lockfile is missing or predates lockfile version 2,
+ * because Dragula usage cannot be reliably determined in those cases.
+ */
+function readLockFilePackages(
+  tree: Tree,
+  context: SchematicContext,
+): Record<string, unknown> | undefined {
+  const buffer = tree.read('package-lock.json');
+
+  if (!buffer) {
+    context.logger.warn(
+      'A "package-lock.json" file was not found. Skipping migration of ' +
+        `"${PACKAGES_POLYFILL}" because Dragula usage could not be determined.`,
+    );
+
+    return undefined;
+  }
+
+  const lockFile = JSON.parse(buffer.toString()) as {
+    packages?: Record<string, unknown>;
+  };
+
+  if (!lockFile.packages) {
+    context.logger.warn(
+      'The "package-lock.json" file uses an unsupported lockfile version. ' +
+        `Skipping migration of "${PACKAGES_POLYFILL}" because Dragula usage ` +
+        'could not be determined.',
+    );
+
+    return undefined;
+  }
+
+  return lockFile.packages;
+}
+
+/**
+ * Determines whether Dragula is installed anywhere in the dependency tree by
+ * checking every package path recorded in the lockfile.
+ */
+function isDragulaInstalled(packages: Record<string, unknown>): boolean {
+  return Object.keys(packages).some(
+    (packagePath) =>
+      packagePath === 'node_modules/dragula' ||
+      packagePath.endsWith('/node_modules/dragula'),
+  );
+}

--- a/libs/components/packages/src/schematics/migrations/all/migrate-dragula-polyfill/migrate-dragula-polyfill.schematic.ts
+++ b/libs/components/packages/src/schematics/migrations/all/migrate-dragula-polyfill/migrate-dragula-polyfill.schematic.ts
@@ -1,5 +1,8 @@
 import { Rule, SchematicContext, Tree } from '@angular-devkit/schematics';
-import { updateWorkspace } from '@schematics/angular/utility';
+import {
+  ProjectDefinition,
+  updateWorkspace,
+} from '@schematics/angular/utility';
 
 import { getSourceRoot } from '../../../utility/workspace';
 
@@ -15,83 +18,111 @@ window.global = window;
 
 /**
  * Removes the \`@skyux/packages/polyfills\` entry from every project's build
- * configuration. When Dragula is still installed (directly or transitively),
- * the entry is replaced with a local copy of the polyfill so those consumers
- * keep working without depending on \`@skyux/packages/polyfills\`.
+ * options and build configurations. When Dragula is still installed (directly
+ * or transitively) — or when its usage cannot be determined — the entry is
+ * replaced with a local copy of the polyfill so those consumers keep working
+ * without depending on \`@skyux/packages/polyfills\`.
  */
 export default function migrateDragulaPolyfill(): Rule {
   return (tree, context) => {
-    const packages = readLockFilePackages(tree, context);
-
-    if (!packages) {
-      return;
-    }
-
-    const dragulaInstalled = isDragulaInstalled(packages);
+    const dragulaNeeded = isDragulaNeeded(tree, context);
 
     return updateWorkspace((workspace) => {
       for (const project of workspace.projects.values()) {
-        const build = project.targets.get('build');
-        const polyfills = build?.options?.['polyfills'];
-
-        if (!Array.isArray(polyfills)) {
-          continue;
-        }
-
-        const index = polyfills.indexOf(PACKAGES_POLYFILL);
-
-        if (index === -1) {
-          continue;
-        }
-
-        if (dragulaInstalled) {
-          const localPolyfillPath = `${getSourceRoot(project)}/${LOCAL_POLYFILL_FILENAME}`;
-
-          tree.create(localPolyfillPath, LOCAL_POLYFILL_CONTENT);
-          polyfills.splice(index, 1, localPolyfillPath);
-        } else {
-          polyfills.splice(index, 1);
-        }
+        migrateProjectPolyfills(tree, project, dragulaNeeded);
       }
     });
   };
 }
 
 /**
- * Reads the \`packages\` map from \`package-lock.json\`. Returns \`undefined\` (and
- * logs a warning) when the lockfile is missing or predates lockfile version 2,
- * because Dragula usage cannot be reliably determined in those cases.
+ * Migrates the \`@skyux/packages/polyfills\` entry out of a single project's build
+ * options and every build configuration.
  */
-function readLockFilePackages(
+function migrateProjectPolyfills(
   tree: Tree,
-  context: SchematicContext,
-): Record<string, unknown> | undefined {
+  project: ProjectDefinition,
+  dragulaNeeded: boolean,
+): void {
+  const build = project.targets.get('build');
+  const localPolyfillPath = `${getSourceRoot(project)}/${LOCAL_POLYFILL_FILENAME}`;
+
+  // Polyfills can be set on the build options and overridden per configuration.
+  const optionSets = [
+    build?.options,
+    ...Object.values(build?.configurations ?? {}),
+  ];
+
+  for (const options of optionSets) {
+    const polyfills = options?.['polyfills'];
+
+    if (!Array.isArray(polyfills)) {
+      continue;
+    }
+
+    const index = polyfills.indexOf(PACKAGES_POLYFILL);
+
+    if (index === -1) {
+      continue;
+    }
+
+    if (dragulaNeeded) {
+      if (!tree.exists(localPolyfillPath)) {
+        tree.create(localPolyfillPath, LOCAL_POLYFILL_CONTENT);
+      }
+
+      polyfills.splice(index, 1, localPolyfillPath);
+    } else {
+      polyfills.splice(index, 1);
+    }
+  }
+}
+
+/**
+ * Determines whether the local polyfill shim should be retained. Returns \`true\`
+ * when Dragula is installed, and — conservatively — also when its usage cannot
+ * be determined (missing, malformed, or unsupported \`package-lock.json\`), so a
+ * broken \`@skyux/packages/polyfills\` reference is never left behind.
+ */
+function isDragulaNeeded(tree: Tree, context: SchematicContext): boolean {
   const buffer = tree.read('package-lock.json');
 
   if (!buffer) {
     context.logger.warn(
-      'A "package-lock.json" file was not found. Skipping migration of ' +
+      'A "package-lock.json" file was not found; retaining a local copy of ' +
         `"${PACKAGES_POLYFILL}" because Dragula usage could not be determined.`,
     );
 
-    return undefined;
+    return true;
   }
 
-  const lockFile = JSON.parse(buffer.toString()) as {
-    packages?: Record<string, unknown>;
-  };
+  let lockFile: { packages?: Record<string, unknown> };
+
+  try {
+    lockFile = JSON.parse(buffer.toString()) as {
+      packages?: Record<string, unknown>;
+    };
+  } catch {
+    context.logger.warn(
+      'The "package-lock.json" file could not be parsed; retaining a local ' +
+        `copy of "${PACKAGES_POLYFILL}" because Dragula usage could not be ` +
+        'determined.',
+    );
+
+    return true;
+  }
 
   if (!lockFile.packages) {
     context.logger.warn(
-      'The "package-lock.json" file uses an unsupported lockfile version. ' +
-        `Skipping migration of "${PACKAGES_POLYFILL}" because Dragula usage ` +
-        'could not be determined.',
+      'The "package-lock.json" file uses an unsupported lockfile version; ' +
+        `retaining a local copy of "${PACKAGES_POLYFILL}" because Dragula ` +
+        'usage could not be determined.',
     );
 
-    return undefined;
+    return true;
   }
 
-  return lockFile.packages;
+  return isDragulaInstalled(lockFile.packages);
 }
 
 /**

--- a/libs/components/packages/src/schematics/migrations/all/migrate-dragula-polyfill/migrate-dragula-polyfill.schematic.ts
+++ b/libs/components/packages/src/schematics/migrations/all/migrate-dragula-polyfill/migrate-dragula-polyfill.schematic.ts
@@ -18,10 +18,10 @@ window.global = window;
 
 /**
  * Removes the \`@skyux/packages/polyfills\` entry from every project's build
- * options and build configurations. When Dragula is still installed (directly
- * or transitively) — or when its usage cannot be determined — the entry is
- * replaced with a local copy of the polyfill so those consumers keep working
- * without depending on \`@skyux/packages/polyfills\`.
+ * and test options and their configurations. When Dragula is still installed
+ * (directly or transitively) — or when its usage cannot be determined — the
+ * entry is replaced with a local copy of the polyfill so those consumers keep
+ * working without depending on \`@skyux/packages/polyfills\`.
  */
 export default function migrateDragulaPolyfill(): Rule {
   return (tree, context) => {
@@ -36,22 +36,22 @@ export default function migrateDragulaPolyfill(): Rule {
 }
 
 /**
- * Migrates the \`@skyux/packages/polyfills\` entry out of a single project's build
- * options and every build configuration.
+ * Migrates the \`@skyux/packages/polyfills\` entry out of a single project's
+ * build and test options and every configuration of each.
  */
 function migrateProjectPolyfills(
   tree: Tree,
   project: ProjectDefinition,
   dragulaNeeded: boolean,
 ): void {
-  const build = project.targets.get('build');
   const localPolyfillPath = `${getSourceRoot(project)}/${LOCAL_POLYFILL_FILENAME}`;
 
-  // Polyfills can be set on the build options and overridden per configuration.
-  const optionSets = [
-    build?.options,
-    ...Object.values(build?.configurations ?? {}),
-  ];
+  // Polyfills can be set on the target options and overridden per configuration.
+  const optionSets = ['build', 'test'].flatMap((targetName) => {
+    const target = project.targets.get(targetName);
+
+    return [target?.options, ...Object.values(target?.configurations ?? {})];
+  });
 
   for (const options of optionSets) {
     const polyfills = options?.['polyfills'];


### PR DESCRIPTION
[AB#3897818](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3897818)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an automatic migration for projects using Dragula, preserving required compatibility behavior with a local polyfill.
  * Projects without Dragula will have the obsolete polyfill configuration removed.

* **Bug Fixes**
  * Updated build configuration to prevent unnecessary polyfill inclusion.
  * Improved handling of missing, malformed, or unsupported project lockfiles with warnings and safe fallback behavior.
  * Preserved existing polyfill settings when project configuration uses unsupported formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->