### PR TITLE
feat(components/datetime): add `skyTimepickerRetainInvalidValues` to keep invalid timepicker entries

### DIFF
--- a/libs/components/datetime/src/lib/modules/timepicker/fixtures/timepicker-reactive-component.fixture.html
+++ b/libs/components/datetime/src/lib/modules/timepicker/fixtures/timepicker-reactive-component.fixture.html
@@ -6,6 +6,7 @@
       placeholder="Time"
       [returnFormat]="returnFormat"
       [skyTimepickerInput]="timePicker"
+      [skyTimepickerRetainInvalidValues]="retainInvalidValues"
       [timeFormat]="timeFormat"
     />
   </sky-timepicker>

--- a/libs/components/datetime/src/lib/modules/timepicker/fixtures/timepicker-reactive-component.fixture.ts
+++ b/libs/components/datetime/src/lib/modules/timepicker/fixtures/timepicker-reactive-component.fixture.ts
@@ -20,6 +20,8 @@ export class TimepickerReactiveTestComponent implements AfterViewInit, OnInit {
 
   public isDisabled: boolean | undefined;
 
+  public retainInvalidValues = false;
+
   public returnFormat: string | undefined;
 
   public selectedTime: SkyTimepickerTimeOutput | undefined;

--- a/libs/components/datetime/src/lib/modules/timepicker/timepicker.component.spec.ts
+++ b/libs/components/datetime/src/lib/modules/timepicker/timepicker.component.spec.ts
@@ -823,6 +823,75 @@ describe('Timepicker', () => {
       await fixture.whenStable();
       expect(component.timeControlValueAfterInit.local).toEqual('2:55 AM');
     }));
+
+    it('should clear an invalid value on blur by default', fakeAsync(() => {
+      detectChangesAndTick(fixture);
+
+      setInput('not a time', fixture);
+
+      expect(getInput(fixture).value).toBe('');
+    }));
+
+    describe('with retainInvalidValues', () => {
+      beforeEach(() => {
+        component.retainInvalidValues = true;
+      });
+
+      it('should retain an invalid value on blur and flag the control invalid', fakeAsync(() => {
+        detectChangesAndTick(fixture);
+
+        setInput('not a time', fixture);
+
+        expect(getInput(fixture).value).toBe('not a time');
+        expect(component.timeControl?.value).toBe('not a time');
+        expect(component.timeControl?.valid).toBeFalse();
+        expect(component.timeControl?.errors).toEqual({
+          skyTime: { invalid: 'not a time' },
+        });
+        expect(getInput(fixture)).toHaveCssClass('ng-invalid');
+      }));
+
+      it('should clear the invalid state once a valid value is entered', fakeAsync(() => {
+        detectChangesAndTick(fixture);
+
+        setInput('not a time', fixture);
+
+        expect(component.timeControl?.valid).toBeFalse();
+
+        setInput('2:55 AM', fixture);
+
+        expect(getInput(fixture).value).toBe('2:55 AM');
+        expect(component.timeControl?.value.local).toEqual('2:55 AM');
+        expect(component.timeControl?.valid).toBeTrue();
+        expect(getInput(fixture)).not.toHaveCssClass('ng-invalid');
+      }));
+
+      it('should retain an invalid value set programmatically', fakeAsync(() => {
+        detectChangesAndTick(fixture);
+
+        component.timeControl?.setValue('not a time');
+        detectChangesAndTick(fixture);
+
+        expect(getInput(fixture).value).toBe('not a time');
+        expect(component.timeControl?.valid).toBeFalse();
+        expect(component.timeControl?.errors).toEqual({
+          skyTime: { invalid: 'not a time' },
+        });
+        expect(getInput(fixture)).toHaveCssClass('ng-invalid');
+      }));
+
+      it('should still clear an empty value on blur', fakeAsync(() => {
+        detectChangesAndTick(fixture);
+
+        setInput('2:55 AM', fixture);
+        expect(getInput(fixture).value).toBe('2:55 AM');
+
+        setInput('', fixture);
+
+        expect(getInput(fixture).value).toBe('');
+        expect(component.timeControl?.valid).toBeTrue();
+      }));
+    });
   });
 
   describe('inside input box', () => {

--- a/libs/components/datetime/src/lib/modules/timepicker/timepicker.directive.ts
+++ b/libs/components/datetime/src/lib/modules/timepicker/timepicker.directive.ts
@@ -10,8 +10,10 @@ import {
   OnDestroy,
   OnInit,
   Renderer2,
+  booleanAttribute,
   forwardRef,
   inject,
+  input,
 } from '@angular/core';
 import {
   AbstractControl,
@@ -100,6 +102,18 @@ export class SkyTimepickerInputDirective
    */
   @Input()
   public returnFormat: string | undefined;
+
+  /**
+   * Whether to keep invalid entries in the input when it loses focus instead of
+   * clearing them. When set to `true`, an invalid value remains in the field and
+   * the associated form control is flagged with a `skyTime` error, matching the
+   * behavior of the datepicker. This is opt-in in this version and will become
+   * the default behavior in the next major version.
+   * @default false
+   */
+  public readonly skyTimepickerRetainInvalidValues = input(false, {
+    transform: booleanAttribute,
+  });
 
   /**
    * Whether to disable the timepicker on template-driven forms. Don't use this input on reactive forms because they may overwrite the input or leave the control out of sync.
@@ -203,6 +217,27 @@ export class SkyTimepickerInputDirective
   }
 
   public writeValue(value: any): void {
+    // When the consumer opts in, keep invalid entries in the input instead of
+    // clearing them so the user can see and correct their entry (matching the
+    // datepicker's behavior).
+    if (
+      this.skyTimepickerRetainInvalidValues() &&
+      typeof value === 'string' &&
+      value.length > 0
+    ) {
+      const formatted = this.#formatter(value);
+
+      if (formatted && formatted.local === 'Invalid date') {
+        this.#applyInvalidValue(value);
+
+        return;
+      }
+
+      this.#modelValue = formatted;
+
+      return;
+    }
+
     this.#modelValue = this.#formatter(value);
   }
 
@@ -216,12 +251,40 @@ export class SkyTimepickerInputDirective
       return null;
     }
 
+    // A raw string value only remains on the control when the consumer has
+    // opted in to retaining invalid values.
+    if (typeof value === 'string' && this.skyTimepickerRetainInvalidValues()) {
+      const formatted = this.#formatter(value);
+      /* istanbul ignore else */
+      if (formatted && formatted.local === 'Invalid date') {
+        // Mark as touched so the invalid CSS styles appear even when the value
+        // is set programmatically.
+        this.#control.markAsTouched();
+        return { skyTime: { invalid: value } };
+      }
+      /* istanbul ignore next */
+      return null;
+    }
+
     /* istanbul ignore next */
     if (value.local === 'Invalid date') {
       return { skyTime: { invalid: control.value } };
     }
 
     return null;
+  }
+
+  #applyInvalidValue(rawValue: string): void {
+    // There is no valid model value while an invalid entry is retained.
+    this.#_modelValue = undefined;
+
+    // Keep the user's raw entry in the input element.
+    this.#renderer.setProperty(this.#elRef.nativeElement, 'value', rawValue);
+
+    // Push the raw string to the form control and flag it as invalid.
+    this.#_onChange(rawValue);
+    this.#_validatorChange();
+    this.#control?.setErrors({ skyTime: { invalid: rawValue } });
   }
 
   #setInputValue(value: SkyTimepickerTimeOutput | undefined): void {


### PR DESCRIPTION
[AB#3955926](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3955926)