### PR TITLE
feat(components/datetime): add skyTimepickerRetainInvalidValues to keep invalid timepicker entries

### DIFF
--- a/apps/playground/src/app/components/datetime/timepicker/timepicker.component.html
+++ b/apps/playground/src/app/components/datetime/timepicker/timepicker.component.html
@@ -26,10 +26,10 @@
     >
       <sky-timepicker #timepickerRetain>
         <input
+          skyTimepickerRetainInvalidValues
           type="text"
           [formControl]="retainControl"
           [skyTimepickerInput]="timepickerRetain"
-          [skyTimepickerClearInvalidValues]="false"
         />
       </sky-timepicker>
     </sky-input-box>

--- a/apps/playground/src/app/components/datetime/timepicker/timepicker.component.html
+++ b/apps/playground/src/app/components/datetime/timepicker/timepicker.component.html
@@ -20,5 +20,26 @@
         />
       </sky-timepicker>
     </sky-input-box>
+    <sky-input-box
+      hintText="Enter an invalid value and focus out. The value stays in the field and the control is marked invalid instead of being cleared."
+      labelText="Retain invalid values"
+    >
+      <sky-timepicker #timepickerRetain>
+        <input
+          type="text"
+          [formControl]="retainControl"
+          [skyTimepickerInput]="timepickerRetain"
+          [skyTimepickerClearInvalidValues]="false"
+        />
+      </sky-timepicker>
+    </sky-input-box>
+    <dl>
+      <dt>Control value</dt>
+      <dd>{{ retainControl.value | json }}</dd>
+      <dt>Valid</dt>
+      <dd>{{ retainControl.valid }}</dd>
+      <dt>Errors</dt>
+      <dd>{{ retainControl.errors | json }}</dd>
+    </dl>
   </sky-page-content>
 </sky-page>

--- a/apps/playground/src/app/components/datetime/timepicker/timepicker.component.ts
+++ b/apps/playground/src/app/components/datetime/timepicker/timepicker.component.ts
@@ -1,11 +1,21 @@
+import { JsonPipe } from '@angular/common';
 import { Component } from '@angular/core';
+import { FormControl, ReactiveFormsModule } from '@angular/forms';
 import { SkyTimepickerModule } from '@skyux/datetime';
 import { SkyInputBoxModule } from '@skyux/forms';
 import { SkyPageModule } from '@skyux/pages';
 
 @Component({
   selector: 'app-timepicker',
-  imports: [SkyInputBoxModule, SkyPageModule, SkyTimepickerModule],
+  imports: [
+    JsonPipe,
+    ReactiveFormsModule,
+    SkyInputBoxModule,
+    SkyPageModule,
+    SkyTimepickerModule,
+  ],
   templateUrl: './timepicker.component.html',
 })
-export class TimepickerComponent {}
+export class TimepickerComponent {
+  protected retainControl = new FormControl<unknown>('');
+}

--- a/libs/components/code-examples/src/lib/modules/datetime/timepicker/basic/example.component.html
+++ b/libs/components/code-examples/src/lib/modules/datetime/timepicker/basic/example.component.html
@@ -11,7 +11,7 @@
           formControlName="time"
           timeFormat="hh"
           [skyTimepickerInput]="timepicker"
-          [skyTimepickerClearInvalidValues]="false"
+          skyTimepickerRetainInvalidValues
         />
       </sky-timepicker>
       @if (time.errors?.['invalidMinute']) {

--- a/libs/components/code-examples/src/lib/modules/datetime/timepicker/basic/example.component.html
+++ b/libs/components/code-examples/src/lib/modules/datetime/timepicker/basic/example.component.html
@@ -10,8 +10,8 @@
         <input
           formControlName="time"
           timeFormat="hh"
-          [skyTimepickerInput]="timepicker"
           skyTimepickerRetainInvalidValues
+          [skyTimepickerInput]="timepicker"
         />
       </sky-timepicker>
       @if (time.errors?.['invalidMinute']) {

--- a/libs/components/code-examples/src/lib/modules/datetime/timepicker/basic/example.component.html
+++ b/libs/components/code-examples/src/lib/modules/datetime/timepicker/basic/example.component.html
@@ -11,6 +11,7 @@
           formControlName="time"
           timeFormat="hh"
           [skyTimepickerInput]="timepicker"
+          [skyTimepickerClearInvalidValues]="false"
         />
       </sky-timepicker>
       @if (time.errors?.['invalidMinute']) {

--- a/libs/components/datetime/src/lib/modules/timepicker/fixtures/timepicker-reactive-component.fixture.html
+++ b/libs/components/datetime/src/lib/modules/timepicker/fixtures/timepicker-reactive-component.fixture.html
@@ -6,6 +6,7 @@
       placeholder="Time"
       [returnFormat]="returnFormat"
       [skyTimepickerInput]="timePicker"
+      [skyTimepickerClearInvalidValues]="clearInvalidValues"
       [timeFormat]="timeFormat"
     />
   </sky-timepicker>

--- a/libs/components/datetime/src/lib/modules/timepicker/fixtures/timepicker-reactive-component.fixture.html
+++ b/libs/components/datetime/src/lib/modules/timepicker/fixtures/timepicker-reactive-component.fixture.html
@@ -6,7 +6,7 @@
       placeholder="Time"
       [returnFormat]="returnFormat"
       [skyTimepickerInput]="timePicker"
-      [skyTimepickerClearInvalidValues]="clearInvalidValues"
+      [skyTimepickerRetainInvalidValues]="retainInvalidValues"
       [timeFormat]="timeFormat"
     />
   </sky-timepicker>

--- a/libs/components/datetime/src/lib/modules/timepicker/fixtures/timepicker-reactive-component.fixture.ts
+++ b/libs/components/datetime/src/lib/modules/timepicker/fixtures/timepicker-reactive-component.fixture.ts
@@ -22,6 +22,8 @@ export class TimepickerReactiveTestComponent implements AfterViewInit, OnInit {
 
   public clearInvalidValues = true;
 
+  public initialValue: string | undefined = '2:55 AM';
+
   public returnFormat: string | undefined;
 
   public selectedTime: SkyTimepickerTimeOutput | undefined;
@@ -39,7 +41,7 @@ export class TimepickerReactiveTestComponent implements AfterViewInit, OnInit {
   }
 
   public ngOnInit(): void {
-    this.timeControl = new UntypedFormControl('2:55 AM');
+    this.timeControl = new UntypedFormControl(this.initialValue);
     this.timepickerForm = new UntypedFormGroup({
       time: this.timeControl,
     });

--- a/libs/components/datetime/src/lib/modules/timepicker/fixtures/timepicker-reactive-component.fixture.ts
+++ b/libs/components/datetime/src/lib/modules/timepicker/fixtures/timepicker-reactive-component.fixture.ts
@@ -20,7 +20,7 @@ export class TimepickerReactiveTestComponent implements AfterViewInit, OnInit {
 
   public isDisabled: boolean | undefined;
 
-  public clearInvalidValues = true;
+  public retainInvalidValues = false;
 
   public initialValue: string | undefined = '2:55 AM';
 

--- a/libs/components/datetime/src/lib/modules/timepicker/fixtures/timepicker-reactive-component.fixture.ts
+++ b/libs/components/datetime/src/lib/modules/timepicker/fixtures/timepicker-reactive-component.fixture.ts
@@ -20,6 +20,8 @@ export class TimepickerReactiveTestComponent implements AfterViewInit, OnInit {
 
   public isDisabled: boolean | undefined;
 
+  public clearInvalidValues = true;
+
   public returnFormat: string | undefined;
 
   public selectedTime: SkyTimepickerTimeOutput | undefined;

--- a/libs/components/datetime/src/lib/modules/timepicker/timepicker.component.spec.ts
+++ b/libs/components/datetime/src/lib/modules/timepicker/timepicker.component.spec.ts
@@ -905,6 +905,29 @@ describe('Timepicker', () => {
         expect(getInput(fixture).value).toBe('');
         expect(component.timeControl?.valid).toBeTrue();
       }));
+
+      it('should clear a retained invalid value when the form control is reset', fakeAsync(() => {
+        detectChangesAndTick(fixture);
+
+        setInput('not a time', fixture);
+        expect(getInput(fixture).value).toBe('not a time');
+
+        component.timeControl?.reset();
+        detectChangesAndTick(fixture);
+
+        expect(getInput(fixture).value).toBe('');
+        expect(component.timeControl?.valid).toBeTrue();
+      }));
+
+      it('should not error when a valid string value is set programmatically', fakeAsync(() => {
+        detectChangesAndTick(fixture);
+
+        component.timeControl?.setValue('2:55 AM');
+        detectChangesAndTick(fixture);
+
+        expect(getInput(fixture).value).toBe('2:55 AM');
+        expect(component.timeControl?.valid).toBeTrue();
+      }));
     });
   });
 

--- a/libs/components/datetime/src/lib/modules/timepicker/timepicker.component.spec.ts
+++ b/libs/components/datetime/src/lib/modules/timepicker/timepicker.component.spec.ts
@@ -832,9 +832,9 @@ describe('Timepicker', () => {
       expect(getInput(fixture).value).toBe('');
     }));
 
-    describe('with clearInvalidValues disabled', () => {
+    describe('with retainInvalidValues enabled', () => {
       beforeEach(() => {
-        component.clearInvalidValues = false;
+        component.retainInvalidValues = true;
       });
 
       it('should retain an invalid value on blur and flag the control invalid', fakeAsync(() => {

--- a/libs/components/datetime/src/lib/modules/timepicker/timepicker.component.spec.ts
+++ b/libs/components/datetime/src/lib/modules/timepicker/timepicker.component.spec.ts
@@ -866,6 +866,20 @@ describe('Timepicker', () => {
         expect(getInput(fixture)).not.toHaveCssClass('ng-invalid');
       }));
 
+      it('should retain an invalid value provided by the initial form control', fakeAsync(() => {
+        component.initialValue = 'not a time';
+
+        detectChangesAndTick(fixture);
+
+        expect(getInput(fixture).value).toBe('not a time');
+        expect(component.timeControl?.value).toBe('not a time');
+        expect(component.timeControl?.valid).toBeFalse();
+        expect(component.timeControl?.errors).toEqual({
+          skyTime: { invalid: 'not a time' },
+        });
+        expect(getInput(fixture)).toHaveCssClass('ng-invalid');
+      }));
+
       it('should retain an invalid value set programmatically', fakeAsync(() => {
         detectChangesAndTick(fixture);
 

--- a/libs/components/datetime/src/lib/modules/timepicker/timepicker.component.spec.ts
+++ b/libs/components/datetime/src/lib/modules/timepicker/timepicker.component.spec.ts
@@ -823,6 +823,75 @@ describe('Timepicker', () => {
       await fixture.whenStable();
       expect(component.timeControlValueAfterInit.local).toEqual('2:55 AM');
     }));
+
+    it('should clear an invalid value on blur by default', fakeAsync(() => {
+      detectChangesAndTick(fixture);
+
+      setInput('not a time', fixture);
+
+      expect(getInput(fixture).value).toBe('');
+    }));
+
+    describe('with clearInvalidValues disabled', () => {
+      beforeEach(() => {
+        component.clearInvalidValues = false;
+      });
+
+      it('should retain an invalid value on blur and flag the control invalid', fakeAsync(() => {
+        detectChangesAndTick(fixture);
+
+        setInput('not a time', fixture);
+
+        expect(getInput(fixture).value).toBe('not a time');
+        expect(component.timeControl?.value).toBe('not a time');
+        expect(component.timeControl?.valid).toBeFalse();
+        expect(component.timeControl?.errors).toEqual({
+          skyTime: { invalid: 'not a time' },
+        });
+        expect(getInput(fixture)).toHaveCssClass('ng-invalid');
+      }));
+
+      it('should clear the invalid state once a valid value is entered', fakeAsync(() => {
+        detectChangesAndTick(fixture);
+
+        setInput('not a time', fixture);
+
+        expect(component.timeControl?.valid).toBeFalse();
+
+        setInput('2:55 AM', fixture);
+
+        expect(getInput(fixture).value).toBe('2:55 AM');
+        expect(component.timeControl?.value.local).toEqual('2:55 AM');
+        expect(component.timeControl?.valid).toBeTrue();
+        expect(getInput(fixture)).not.toHaveCssClass('ng-invalid');
+      }));
+
+      it('should retain an invalid value set programmatically', fakeAsync(() => {
+        detectChangesAndTick(fixture);
+
+        component.timeControl?.setValue('not a time');
+        detectChangesAndTick(fixture);
+
+        expect(getInput(fixture).value).toBe('not a time');
+        expect(component.timeControl?.valid).toBeFalse();
+        expect(component.timeControl?.errors).toEqual({
+          skyTime: { invalid: 'not a time' },
+        });
+        expect(getInput(fixture)).toHaveCssClass('ng-invalid');
+      }));
+
+      it('should still clear an empty value on blur', fakeAsync(() => {
+        detectChangesAndTick(fixture);
+
+        setInput('2:55 AM', fixture);
+        expect(getInput(fixture).value).toBe('2:55 AM');
+
+        setInput('', fixture);
+
+        expect(getInput(fixture).value).toBe('');
+        expect(component.timeControl?.valid).toBeTrue();
+      }));
+    });
   });
 
   describe('inside input box', () => {

--- a/libs/components/datetime/src/lib/modules/timepicker/timepicker.directive.ts
+++ b/libs/components/datetime/src/lib/modules/timepicker/timepicker.directive.ts
@@ -111,6 +111,7 @@ export class SkyTimepickerInputDirective
    * but will default to `false` in the next major version.
    * @default true
    */
+  // TODO: In a future breaking change - default this to `false`.
   public readonly skyTimepickerClearInvalidValues = input(true, {
     transform: booleanAttribute,
   });
@@ -138,10 +139,11 @@ export class SkyTimepickerInputDirective
   }
 
   set #modelValue(value: SkyTimepickerTimeOutput | undefined) {
-    if (value !== this.#_modelValue) {
+    // A retained invalid entry must be cleaned up even when the model value is
+    // unchanged (e.g. a form reset while `undefined` is the model value).
+    if (value !== this.#_modelValue || this.#hasRetainedInvalidValue) {
       this.#_modelValue = value;
-      // A model value takes over from any retained invalid entry.
-      this.#invalidValue = undefined;
+      this.#hasRetainedInvalidValue = false;
       this.#updateTimepickerInput();
       this.#setInputValue(value);
       this.#_validatorChange();
@@ -155,9 +157,9 @@ export class SkyTimepickerInputDirective
   #_modelValue: SkyTimepickerTimeOutput | undefined;
   #_skyTimepickerInput: SkyTimepickerComponent | undefined;
 
-  // The raw string retained on the control while an invalid entry is kept
-  // (only set when clearing invalid values is disabled).
-  #invalidValue: string | undefined;
+  // Set while an invalid entry is retained on the control instead of cleared
+  // (only when clearing invalid values is disabled).
+  #hasRetainedInvalidValue = false;
 
   readonly #renderer = inject(Renderer2);
   readonly #elRef = inject(ElementRef);
@@ -181,7 +183,7 @@ export class SkyTimepickerInputDirective
       // When an invalid entry is being retained, the raw string is already on
       // the control and flagged invalid by the validator; overwriting it with
       // the (undefined) model value would discard the entry and clear the error.
-      if (this.#invalidValue === undefined) {
+      if (!this.#hasRetainedInvalidValue) {
         this.#control.setValue(this.#modelValue, { emitEvent: false });
       }
 
@@ -229,28 +231,22 @@ export class SkyTimepickerInputDirective
   }
 
   public writeValue(value: any): void {
+    const formatted = this.#formatter(value);
+
     // When clearing is disabled, keep invalid entries in the input instead of
     // clearing them so the user can see and correct their entry (matching the
     // datepicker's behavior).
     if (
       !this.skyTimepickerClearInvalidValues() &&
       typeof value === 'string' &&
-      value.length > 0
+      value.length > 0 &&
+      formatted.local === 'Invalid date'
     ) {
-      const formatted = this.#formatter(value);
-
-      if (formatted && formatted.local === 'Invalid date') {
-        this.#applyInvalidValue(value);
-
-        return;
-      }
-
-      this.#modelValue = formatted;
-
+      this.#applyInvalidValue(value);
       return;
     }
 
-    this.#modelValue = this.#formatter(value);
+    this.#modelValue = formatted;
   }
 
   public validate(control: AbstractControl): ValidationErrors | null {
@@ -266,10 +262,7 @@ export class SkyTimepickerInputDirective
     // A raw string value only remains on the control when clearing invalid
     // values is disabled.
     if (typeof value === 'string' && !this.skyTimepickerClearInvalidValues()) {
-      const formatted = this.#formatter(value);
-
-      /* istanbul ignore else */
-      if (formatted && formatted.local === 'Invalid date') {
+      if (this.#formatter(value).local === 'Invalid date') {
         // Mark as touched so the invalid CSS styles appear even when the value
         // is set programmatically.
         this.#control.markAsTouched();
@@ -277,7 +270,6 @@ export class SkyTimepickerInputDirective
         return { skyTime: { invalid: value } };
       }
 
-      /* istanbul ignore next */
       return null;
     }
 
@@ -290,10 +282,9 @@ export class SkyTimepickerInputDirective
   }
 
   #applyInvalidValue(rawValue: string): void {
-    // There is no valid model value while an invalid entry is retained; hold on
-    // to the raw string so it survives initialization (see ngAfterContentInit).
+    // There is no valid model value while an invalid entry is retained.
     this.#_modelValue = undefined;
-    this.#invalidValue = rawValue;
+    this.#hasRetainedInvalidValue = true;
 
     // Keep the user's raw entry in the input element.
     this.#renderer.setProperty(this.#elRef.nativeElement, 'value', rawValue);

--- a/libs/components/datetime/src/lib/modules/timepicker/timepicker.directive.ts
+++ b/libs/components/datetime/src/lib/modules/timepicker/timepicker.directive.ts
@@ -104,15 +104,13 @@ export class SkyTimepickerInputDirective
   public returnFormat: string | undefined;
 
   /**
-   * Whether to clear invalid entries from the input when it loses focus. When
-   * set to `false`, an invalid value remains in the field and the associated
+   * Whether to retain invalid entries in the input when it loses focus. When
+   * set to `true`, an invalid value remains in the field and the associated
    * form control is flagged with a `skyTime` error, matching the behavior of
-   * the datepicker. This defaults to `true` to preserve the existing behavior,
-   * but will default to `false` in the next major version.
-   * @default true
+   * the datepicker.
+   * @default false
    */
-  // TODO: In a future breaking change - default this to `false`.
-  public readonly skyTimepickerClearInvalidValues = input(true, {
+  public readonly skyTimepickerRetainInvalidValues = input(false, {
     transform: booleanAttribute,
   });
 
@@ -233,11 +231,11 @@ export class SkyTimepickerInputDirective
   public writeValue(value: any): void {
     const formatted = this.#formatter(value);
 
-    // When clearing is disabled, keep invalid entries in the input instead of
+    // When retaining is enabled, keep invalid entries in the input instead of
     // clearing them so the user can see and correct their entry (matching the
     // datepicker's behavior).
     if (
-      !this.skyTimepickerClearInvalidValues() &&
+      this.skyTimepickerRetainInvalidValues() &&
       typeof value === 'string' &&
       value.length > 0 &&
       formatted.local === 'Invalid date'
@@ -259,9 +257,9 @@ export class SkyTimepickerInputDirective
       return null;
     }
 
-    // A raw string value only remains on the control when clearing invalid
-    // values is disabled.
-    if (typeof value === 'string' && !this.skyTimepickerClearInvalidValues()) {
+    // A raw string value only remains on the control when retaining invalid
+    // values is enabled.
+    if (typeof value === 'string' && this.skyTimepickerRetainInvalidValues()) {
       if (this.#formatter(value).local === 'Invalid date') {
         // Mark as touched so the invalid CSS styles appear even when the value
         // is set programmatically.

--- a/libs/components/datetime/src/lib/modules/timepicker/timepicker.directive.ts
+++ b/libs/components/datetime/src/lib/modules/timepicker/timepicker.directive.ts
@@ -10,8 +10,10 @@ import {
   OnDestroy,
   OnInit,
   Renderer2,
+  booleanAttribute,
   forwardRef,
   inject,
+  input,
 } from '@angular/core';
 import {
   AbstractControl,
@@ -100,6 +102,18 @@ export class SkyTimepickerInputDirective
    */
   @Input()
   public returnFormat: string | undefined;
+
+  /**
+   * Whether to clear invalid entries from the input when it loses focus. When
+   * set to `false`, an invalid value remains in the field and the associated
+   * form control is flagged with a `skyTime` error, matching the behavior of
+   * the datepicker. This defaults to `true` to preserve the existing behavior,
+   * but will default to `false` in the next major version.
+   * @default true
+   */
+  public readonly skyTimepickerClearInvalidValues = input(true, {
+    transform: booleanAttribute,
+  });
 
   /**
    * Whether to disable the timepicker on template-driven forms. Don't use this input on reactive forms because they may overwrite the input or leave the control out of sync.
@@ -203,6 +217,27 @@ export class SkyTimepickerInputDirective
   }
 
   public writeValue(value: any): void {
+    // When clearing is disabled, keep invalid entries in the input instead of
+    // clearing them so the user can see and correct their entry (matching the
+    // datepicker's behavior).
+    if (
+      !this.skyTimepickerClearInvalidValues() &&
+      typeof value === 'string' &&
+      value.length > 0
+    ) {
+      const formatted = this.#formatter(value);
+
+      if (formatted && formatted.local === 'Invalid date') {
+        this.#applyInvalidValue(value);
+
+        return;
+      }
+
+      this.#modelValue = formatted;
+
+      return;
+    }
+
     this.#modelValue = this.#formatter(value);
   }
 
@@ -216,12 +251,43 @@ export class SkyTimepickerInputDirective
       return null;
     }
 
+    // A raw string value only remains on the control when clearing invalid
+    // values is disabled.
+    if (typeof value === 'string' && !this.skyTimepickerClearInvalidValues()) {
+      const formatted = this.#formatter(value);
+
+      /* istanbul ignore else */
+      if (formatted && formatted.local === 'Invalid date') {
+        // Mark as touched so the invalid CSS styles appear even when the value
+        // is set programmatically.
+        this.#control.markAsTouched();
+
+        return { skyTime: { invalid: value } };
+      }
+
+      /* istanbul ignore next */
+      return null;
+    }
+
     /* istanbul ignore next */
     if (value.local === 'Invalid date') {
       return { skyTime: { invalid: control.value } };
     }
 
     return null;
+  }
+
+  #applyInvalidValue(rawValue: string): void {
+    // There is no valid model value while an invalid entry is retained.
+    this.#_modelValue = undefined;
+
+    // Keep the user's raw entry in the input element.
+    this.#renderer.setProperty(this.#elRef.nativeElement, 'value', rawValue);
+
+    // Push the raw string to the form control and flag it as invalid.
+    this.#_onChange(rawValue);
+    this.#_validatorChange();
+    this.#control?.setErrors({ skyTime: { invalid: rawValue } });
   }
 
   #setInputValue(value: SkyTimepickerTimeOutput | undefined): void {

--- a/libs/components/datetime/src/lib/modules/timepicker/timepicker.directive.ts
+++ b/libs/components/datetime/src/lib/modules/timepicker/timepicker.directive.ts
@@ -140,6 +140,8 @@ export class SkyTimepickerInputDirective
   set #modelValue(value: SkyTimepickerTimeOutput | undefined) {
     if (value !== this.#_modelValue) {
       this.#_modelValue = value;
+      // A model value takes over from any retained invalid entry.
+      this.#invalidValue = undefined;
       this.#updateTimepickerInput();
       this.#setInputValue(value);
       this.#_validatorChange();
@@ -152,6 +154,10 @@ export class SkyTimepickerInputDirective
   #_disabled = false;
   #_modelValue: SkyTimepickerTimeOutput | undefined;
   #_skyTimepickerInput: SkyTimepickerComponent | undefined;
+
+  // The raw string retained on the control while an invalid entry is kept
+  // (only set when clearing invalid values is disabled).
+  #invalidValue: string | undefined;
 
   readonly #renderer = inject(Renderer2);
   readonly #elRef = inject(ElementRef);
@@ -172,7 +178,13 @@ export class SkyTimepickerInputDirective
     // Watch for the control to be added and initialize the value immediately.
     /* istanbul ignore else */
     if (this.#control && this.#control.parent) {
-      this.#control.setValue(this.#modelValue, { emitEvent: false });
+      // When an invalid entry is being retained, the raw string is already on
+      // the control and flagged invalid by the validator; overwriting it with
+      // the (undefined) model value would discard the entry and clear the error.
+      if (this.#invalidValue === undefined) {
+        this.#control.setValue(this.#modelValue, { emitEvent: false });
+      }
+
       this.#changeDetector.markForCheck();
     }
   }
@@ -278,16 +290,19 @@ export class SkyTimepickerInputDirective
   }
 
   #applyInvalidValue(rawValue: string): void {
-    // There is no valid model value while an invalid entry is retained.
+    // There is no valid model value while an invalid entry is retained; hold on
+    // to the raw string so it survives initialization (see ngAfterContentInit).
     this.#_modelValue = undefined;
+    this.#invalidValue = rawValue;
 
     // Keep the user's raw entry in the input element.
     this.#renderer.setProperty(this.#elRef.nativeElement, 'value', rawValue);
 
-    // Push the raw string to the form control and flag it as invalid.
+    // Push the raw string to the form control and re-run validation. The
+    // validator supplies the `skyTime` error, so we avoid calling `setErrors`
+    // here to preserve any errors contributed by other validators.
     this.#_onChange(rawValue);
     this.#_validatorChange();
-    this.#control?.setErrors({ skyTime: { invalid: rawValue } });
   }
 
   #setInputValue(value: SkyTimepickerTimeOutput | undefined): void {


### PR DESCRIPTION
[AB#3955926](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3955926)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an option to retain invalid, non-empty time values instead of clearing them.
  * Retained invalid values are flagged and surfaced through reactive forms.
  * Added examples demonstrating retained input and validation status.
  * Valid time entries continue to be formatted normally and clear prior validation errors.

* **Bug Fixes**
  * Improved handling of invalid and programmatically assigned time values.
  * Empty values continue to be cleared and treated as valid.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->