### PR TITLE
ci(sdk/e2e-schematics): support percy projects with suffixed slugs (#4560)

### DIFF
--- a/libs/sdk/e2e-schematics/src/workflow/percy-api/percy-api.spec.ts
+++ b/libs/sdk/e2e-schematics/src/workflow/percy-api/percy-api.spec.ts
@@ -102,7 +102,13 @@ describe('percy-api', () => {
     const fetchClient = jest.fn().mockImplementation((url: string) => {
       if (url.startsWith('https://percy.io/api/v1/projects')) {
         return Promise.resolve({
-          json: () => Promise.resolve({ data: { id: 'projectId' } }),
+          json: () =>
+            Promise.resolve({
+              data: {
+                id: 'projectId',
+                attributes: { slug: 'test-storybook-e2e' },
+              },
+            }),
         });
       }
       if (url.startsWith('https://percy.io/api/v1/builds')) {
@@ -141,7 +147,13 @@ describe('percy-api', () => {
     const fetchClient = jest.fn().mockImplementation((url: string) => {
       if (url.startsWith('https://percy.io/api/v1/projects')) {
         return Promise.resolve({
-          json: () => Promise.resolve({ data: { id: 'projectId' } }),
+          json: () =>
+            Promise.resolve({
+              data: {
+                id: 'projectId',
+                attributes: { slug: 'test-storybook-e2e' },
+              },
+            }),
         });
       }
       if (url.startsWith('https://percy.io/api/v1/builds')) {
@@ -192,7 +204,13 @@ describe('percy-api', () => {
     const fetchClient = jest.fn().mockImplementation((url: string) => {
       if (url.startsWith('https://percy.io/api/v1/projects')) {
         return Promise.resolve({
-          json: () => Promise.resolve({ data: { id: 'projectId' } }),
+          json: () =>
+            Promise.resolve({
+              data: {
+                id: 'projectId',
+                attributes: { slug: 'test-storybook-e2e' },
+              },
+            }),
         });
       }
       if (url.startsWith('https://percy.io/api/v1/builds')) {
@@ -231,7 +249,128 @@ describe('percy-api', () => {
       ),
     ).resolves.toEqual('');
     expect(logger.error).toHaveBeenCalledWith(
-      'Error checking Percy: Error: Error fetching Percy project ID',
+      'Error checking Percy: Error: Error fetching Percy project ID: Nope.',
+    );
+  });
+
+  it('should find project with a suffixed slug', async () => {
+    const logger = createLogger();
+    const fetchClient = jest.fn().mockImplementation((url: string) => {
+      if (url === 'https://percy.io/api/v1/projects') {
+        return Promise.resolve({
+          json: () =>
+            Promise.resolve({
+              data: {
+                id: 'projectId',
+                attributes: { slug: 'test-storybook-e2e-6342c271' },
+              },
+            }),
+        });
+      }
+      if (url.startsWith('https://percy.io/api/v1/builds')) {
+        return Promise.resolve({
+          json: () =>
+            Promise.resolve({
+              data: [
+                {
+                  id: 'buildId',
+                  type: 'builds',
+                  attributes: {
+                    'review-state': 'approved',
+                    state: 'finished',
+                    'commit-html-url': 'https://.../commitSha',
+                    'web-url': 'https://.../321',
+                  },
+                },
+              ],
+            }),
+        });
+      }
+      return Promise.reject(new Error('Unexpected URL'));
+    });
+    const result = await getLastGoodPercyBuild(
+      'test-storybook-e2e',
+      ['commitSha'],
+      true,
+      logger,
+      fetchClient,
+    );
+    expect(result).toEqual({ lastGoodCommit: 'commitSha', buildId: 321 });
+  });
+
+  it('should find project by exact slug in a project list', async () => {
+    const logger = createLogger();
+    const fetchClient = jest.fn().mockImplementation((url: string) => {
+      if (url === 'https://percy.io/api/v1/projects') {
+        return Promise.resolve({
+          json: () =>
+            Promise.resolve({
+              data: [
+                null,
+                { id: 'noAttributes' },
+                { id: 'noSlug', attributes: {} },
+                {
+                  id: 'projectId',
+                  attributes: { slug: 'test-storybook-e2e' },
+                },
+              ],
+            }),
+        });
+      }
+      if (url.startsWith('https://percy.io/api/v1/builds')) {
+        return Promise.resolve({
+          json: () =>
+            Promise.resolve({
+              data: [
+                {
+                  id: 'buildId',
+                  type: 'builds',
+                  attributes: {
+                    'review-state': 'approved',
+                    state: 'finished',
+                    'commit-html-url': 'https://.../commitSha',
+                    'web-url': 'https://.../321',
+                  },
+                },
+              ],
+            }),
+        });
+      }
+      return Promise.reject(new Error('Unexpected URL'));
+    });
+    const result = await getLastGoodPercyBuild(
+      'test-storybook-e2e',
+      ['commitSha'],
+      true,
+      logger,
+      fetchClient,
+    );
+    expect(result).toEqual({ lastGoodCommit: 'commitSha', buildId: 321 });
+  });
+
+  it('should reject when the project does not match the slug', async () => {
+    const logger = createLogger();
+    const fetchClient = jest.fn().mockImplementation((url: string) => {
+      if (url === 'https://percy.io/api/v1/projects') {
+        return Promise.resolve({
+          json: () =>
+            Promise.resolve({
+              data: { id: 'projectId', attributes: { slug: 'other-project' } },
+            }),
+        });
+      }
+      return Promise.reject(new Error('Unexpected URL'));
+    });
+    const result = await getLastGoodPercyBuild(
+      'test-storybook-e2e',
+      ['commitSha'],
+      true,
+      logger,
+      fetchClient,
+    );
+    expect(result).toEqual({ buildId: 0, lastGoodCommit: '' });
+    expect(logger.error).toHaveBeenCalledWith(
+      'Percy project ID response for test-storybook-e2e: {"id":"projectId","attributes":{"slug":"other-project"}}',
     );
   });
 
@@ -240,7 +379,13 @@ describe('percy-api', () => {
     const fetchClient = jest.fn().mockImplementation((url: string) => {
       if (url.startsWith('https://percy.io/api/v1/projects')) {
         return Promise.resolve({
-          json: () => Promise.resolve({ data: { id: 'projectId' } }),
+          json: () =>
+            Promise.resolve({
+              data: {
+                id: 'projectId',
+                attributes: { slug: 'test-storybook-e2e' },
+              },
+            }),
         });
       }
       if (url.startsWith('https://percy.io/api/v1/builds')) {
@@ -304,7 +449,13 @@ describe('percy-api', () => {
     const fetchClient = jest.fn().mockImplementation((url: string) => {
       if (url.startsWith('https://percy.io/api/v1/projects')) {
         return Promise.resolve({
-          json: () => Promise.resolve({ data: { id: 'projectId' } }),
+          json: () =>
+            Promise.resolve({
+              data: {
+                id: 'projectId',
+                attributes: { slug: 'test-storybook-e2e' },
+              },
+            }),
         });
       }
       if (url.startsWith('https://percy.io/api/v1/builds')) {

--- a/libs/sdk/e2e-schematics/src/workflow/percy-api/percy-api.ts
+++ b/libs/sdk/e2e-schematics/src/workflow/percy-api/percy-api.ts
@@ -59,6 +59,13 @@ interface Snapshot {
   };
 }
 
+interface Project {
+  id: string;
+  attributes?: {
+    slug?: string;
+  };
+}
+
 function getFetchJson(
   fetchClient: (input: RequestInfo | URL) => Promise<Response>,
 ): FetchJson {
@@ -75,8 +82,9 @@ function getFetchJson(
         }
       })
       .catch((error) => {
+        const reason = error instanceof Error ? error.message : error;
         return Promise.reject(
-          new Error(`Error fetching ${name}`, { cause: error }),
+          new Error(`Error fetching ${name}: ${reason}`, { cause: error }),
         );
       });
   };
@@ -247,21 +255,27 @@ async function getProjectId(
   logger: Logger,
   fetchJson: FetchJson,
 ): Promise<string> {
-  return await fetchJson<{ id: string }>(
-    `https://percy.io/api/v1/projects?project_slug=${slug}`,
+  // The API token is scoped to one project, and Percy may append a unique
+  // suffix to a new project's slug, so look up the token's project and match
+  // the slug prefix rather than querying by exact slug.
+  const response = await fetchJson<Project | Project[]>(
+    `https://percy.io/api/v1/projects`,
     'Percy project ID',
-  ).then((response) => {
-    if (response.id) {
-      return response.id;
-    } else {
-      logger.error(
-        `Percy project ID response for ${slug}: ${JSON.stringify(response)}`,
-      );
-      return Promise.reject(
-        `Percy project ID response for ${slug}: ${JSON.stringify(response)}`,
-      );
-    }
-  });
+  );
+  const project = (Array.isArray(response) ? response : [response]).find(
+    (project) =>
+      typeof project?.attributes?.slug === 'string' &&
+      (project.attributes.slug === slug ||
+        project.attributes.slug.startsWith(`${slug}-`)),
+  );
+  if (project?.id) {
+    return project.id;
+  }
+  const message = `Percy project ID response for ${slug}: ${JSON.stringify(
+    response,
+  )}`;
+  logger.error(message);
+  return await Promise.reject(message);
 }
 
 async function getBuilds(


### PR DESCRIPTION
:cherries: Cherry picked from #4560 [ci(sdk/e2e-schematics): support percy projects with suffixed slugs](https://github.com/blackbaud/skyux/pull/4560)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved project lookup reliability by matching exact project slugs and valid generated suffixes.
  * Prevented incorrect matches when project lists contain malformed or similarly named entries.
  * Enhanced project-fetch errors with the underlying failure details.
  * Added clearer handling when no matching project can be found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->