### PR TITLE
fix(components/packages): skip sky-grid-column nested in sky-list-view-grid (#4562)

### DIFF
--- a/libs/components/packages/src/schematics/rules/convert-grid-to-data-grid/convert-grid-to-data-grid.spec.ts
+++ b/libs/components/packages/src/schematics/rules/convert-grid-to-data-grid/convert-grid-to-data-grid.spec.ts
@@ -197,6 +197,46 @@ describe('Convert Grid to Data Grid', () => {
     expect(hasLog('using the "columns" input was left unchanged')).toBe(true);
   });
 
+  it('should leave a sky-grid-column nested in sky-list-view-grid unchanged and warn', async () => {
+    const tree = await createTestApp(runner, { projectName: 'test-app' });
+    const input = stripIndents`
+      <sky-list-view-grid>
+        <sky-grid-column field="a" heading="A"></sky-grid-column>
+      </sky-list-view-grid>
+    `;
+    tree.create('src/app/test.component.html', input);
+    const result = await convert(tree);
+    expect(
+      stripIndents`${result.readText('src/app/test.component.html')}`,
+    ).toBe(input);
+    expect(hasLog('inside <sky-list-view-grid> was left unchanged')).toBe(true);
+  });
+
+  it('should convert a standalone grid while leaving a sky-list-view-grid block untouched', async () => {
+    const tree = await createTestApp(runner, { projectName: 'test-app' });
+    tree.create(
+      'src/app/test.component.html',
+      stripIndents`
+        <sky-grid [data]="data">
+          <sky-grid-column id="a" heading="A" />
+        </sky-grid>
+        <sky-list-view-grid>
+          <sky-grid-column field="b" heading="B"></sky-grid-column>
+        </sky-list-view-grid>
+      `,
+    );
+    const result = await convert(tree);
+    expect(stripIndents`${result.readText('src/app/test.component.html')}`)
+      .toBe(stripIndents`
+      <sky-data-grid [data]="data">
+        <sky-data-grid-column columnId="a" headingText="A" />
+      </sky-data-grid>
+      <sky-list-view-grid>
+        <sky-grid-column field="b" heading="B"></sky-grid-column>
+      </sky-list-view-grid>
+    `);
+  });
+
   it('should convert multiple self-closing columns', async () => {
     const tree = await createTestApp(runner, { projectName: 'test-app' });
     tree.create(
@@ -287,6 +327,198 @@ describe('Convert Grid to Data Grid', () => {
         })
         export class TestComponent {}
       `,
+    );
+  });
+
+  it('should remove a redundant SkyGridModule import covered by SkyListViewGridModule', async () => {
+    const tree = await createTestApp(runner, { projectName: 'test-app' });
+    const backtick = '`';
+    tree.create(
+      'src/app/test.component.ts',
+      stripIndents`
+        import { Component } from '@angular/core';
+        import { SkyGridModule } from '@skyux/grids';
+        import { SkyListViewGridModule } from '@skyux/list-builder-view-grids';
+
+        @Component({
+          selector: 'app-test',
+          template: ${backtick}
+            <sky-list-view-grid>
+              <sky-grid-column field="name" heading="Name"></sky-grid-column>
+            </sky-list-view-grid>
+          ${backtick},
+          imports: [SkyGridModule, SkyListViewGridModule],
+        })
+        export class TestComponent {}
+      `,
+    );
+    const result = await convert(tree);
+    expect(stripIndents`${result.readText('src/app/test.component.ts')}`).toBe(
+      stripIndents`
+        import { Component } from '@angular/core';
+
+        import { SkyListViewGridModule } from '@skyux/list-builder-view-grids';
+
+        @Component({
+          selector: 'app-test',
+          template: ${backtick}
+            <sky-list-view-grid>
+              <sky-grid-column field="name" heading="Name"></sky-grid-column>
+            </sky-list-view-grid>
+          ${backtick},
+          imports: [SkyListViewGridModule],
+        })
+        export class TestComponent {}
+      `,
+    );
+  });
+
+  it('should leave SkyGridModule unchanged and warn when SkyListViewGridModule cannot be confirmed', async () => {
+    const tree = await createTestApp(runner, { projectName: 'test-app' });
+    const backtick = '`';
+    const input = stripIndents`
+      import { Component } from '@angular/core';
+      import { SkyGridModule } from '@skyux/grids';
+
+      @Component({
+        selector: 'app-test',
+        template: ${backtick}
+          <sky-list-view-grid>
+            <sky-grid-column field="name" heading="Name"></sky-grid-column>
+          </sky-list-view-grid>
+        ${backtick},
+        imports: [SkyGridModule],
+      })
+      export class TestComponent {}
+    `;
+    tree.create('src/app/test.component.ts', input);
+    const result = await convert(tree);
+    expect(stripIndents`${result.readText('src/app/test.component.ts')}`).toBe(
+      input,
+    );
+    expect(hasLog('review it manually')).toBe(true);
+  });
+
+  it('should convert a real grid and remove the redundant SkyGridModule import in the same file', async () => {
+    const tree = await createTestApp(runner, { projectName: 'test-app' });
+    const backtick = '`';
+    tree.create(
+      'src/app/test.component.ts',
+      stripIndents`
+        import { Component } from '@angular/core';
+        import { SkyGridModule } from '@skyux/grids';
+        import { SkyListViewGridModule } from '@skyux/list-builder-view-grids';
+
+        @Component({
+          selector: 'app-test',
+          template: ${backtick}
+            <sky-grid [data]="data">
+              <sky-grid-column id="name" heading="Name" field="name" />
+            </sky-grid>
+            <sky-list-view-grid>
+              <sky-grid-column field="b" heading="B"></sky-grid-column>
+            </sky-list-view-grid>
+          ${backtick},
+          imports: [SkyGridModule, SkyListViewGridModule],
+        })
+        export class TestComponent {}
+      `,
+    );
+    const result = await convert(tree);
+    expect(stripIndents`${result.readText('src/app/test.component.ts')}`).toBe(
+      stripIndents`
+        import { Component } from '@angular/core';
+
+        import { SkyListViewGridModule } from '@skyux/list-builder-view-grids';
+        import { SkyDataGrid, SkyDataGridColumn } from '@skyux/data-grid';
+
+        @Component({
+          selector: 'app-test',
+          template: ${backtick}
+            <sky-data-grid [data]="data">
+              <sky-data-grid-column columnId="name" headingText="Name" field="name" />
+            </sky-data-grid>
+            <sky-list-view-grid>
+              <sky-grid-column field="b" heading="B"></sky-grid-column>
+            </sky-list-view-grid>
+          ${backtick},
+          imports: [SkyDataGrid, SkyDataGridColumn, SkyListViewGridModule],
+        })
+        export class TestComponent {}
+      `,
+    );
+  });
+
+  it('should convert a real grid even when a list-view-grid skip cannot confirm SkyListViewGridModule', async () => {
+    const tree = await createTestApp(runner, { projectName: 'test-app' });
+    const backtick = '`';
+    tree.create(
+      'src/app/test.component.ts',
+      stripIndents`
+        import { Component } from '@angular/core';
+        import { SkyGridModule } from '@skyux/grids';
+
+        @Component({
+          selector: 'app-test',
+          template: ${backtick}
+            <sky-grid [data]="data">
+              <sky-grid-column id="name" heading="Name" field="name" />
+            </sky-grid>
+            <sky-list-view-grid>
+              <sky-grid-column field="b" heading="B"></sky-grid-column>
+            </sky-list-view-grid>
+          ${backtick},
+          imports: [SkyGridModule],
+        })
+        export class TestComponent {}
+      `,
+    );
+    const result = await convert(tree);
+    expect(stripIndents`${result.readText('src/app/test.component.ts')}`).toBe(
+      stripIndents`
+        import { Component } from '@angular/core';
+
+        import { SkyDataGrid, SkyDataGridColumn } from '@skyux/data-grid';
+
+        @Component({
+          selector: 'app-test',
+          template: ${backtick}
+            <sky-data-grid [data]="data">
+              <sky-data-grid-column columnId="name" headingText="Name" field="name" />
+            </sky-data-grid>
+            <sky-list-view-grid>
+              <sky-grid-column field="b" heading="B"></sky-grid-column>
+            </sky-list-view-grid>
+          ${backtick},
+          imports: [SkyDataGrid, SkyDataGridColumn],
+        })
+        export class TestComponent {}
+      `,
+    );
+  });
+
+  it('should not touch imports when only SkyListViewGridModule is imported', async () => {
+    const tree = await createTestApp(runner, { projectName: 'test-app' });
+    const backtick = '`';
+    const input = stripIndents`
+      import { Component } from '@angular/core';
+      import { SkyListViewGridModule } from '@skyux/list-builder-view-grids';
+
+      @Component({
+        selector: 'app-test',
+        template: ${backtick}
+          <sky-list-view-grid>
+            <sky-grid-column field="name" heading="Name"></sky-grid-column>
+          </sky-list-view-grid>
+        ${backtick},
+        imports: [SkyListViewGridModule],
+      })
+      export class TestComponent {}
+    `;
+    tree.create('src/app/test.component.ts', input);
+    const result = await convert(tree);
+    expect(stripIndents`${result.readText('src/app/test.component.ts')}`).toBe(
+      input,
     );
   });
 });

--- a/libs/components/packages/src/schematics/rules/convert-grid-to-data-grid/convert-grid-to-data-grid.ts
+++ b/libs/components/packages/src/schematics/rules/convert-grid-to-data-grid/convert-grid-to-data-grid.ts
@@ -14,6 +14,7 @@ import {
   SwapTagCallback,
   getAttributeValueText,
   getElementsByTagName,
+  hasAncestorTag,
   parseTemplate,
   swapAttributes,
   swapTags,
@@ -23,14 +24,21 @@ import {
   isImportedFromPackage,
   parseSourceFile,
 } from '../../utility/typescript/ng-ast';
+import { removeClassReference } from '../../utility/typescript/remove-class-reference';
 import { swapImportedClass } from '../../utility/typescript/swap-imported-class';
 import { visitProjectFiles } from '../../utility/visit-project-files';
 
 const MIGRATION_DOC_URL =
   'https://developer.blackbaud.com/skyux/components/data-grid';
 
+const SKY_GRID_MODULE = 'SkyGridModule';
+const SKY_GRID_MODULE_PACKAGE = '@skyux/grids';
+const SKY_LIST_VIEW_GRID_MODULE = 'SkyListViewGridModule';
+const SKY_LIST_VIEW_GRID_MODULE_PACKAGE = '@skyux/list-builder-view-grids';
+
 const GRID_TAG: 'sky-grid'[] = ['sky-grid'];
 const COLUMN_TAG: 'sky-grid-column'[] = ['sky-grid-column'];
+const LIST_VIEW_GRID_TAG = 'sky-list-view-grid';
 
 /**
  * Attribute name swaps applied to `<sky-grid>`. A value of `''` drops the
@@ -337,19 +345,33 @@ function columnTagSwap(
   };
 }
 
+interface ConvertTemplateResult {
+  /** Number of `<sky-grid>`/`<sky-grid-column>` elements actually converted. */
+  converted: number;
+  /**
+   * Number of `<sky-grid>`/`<sky-grid-column>` elements left unchanged because
+   * they're nested inside `<sky-list-view-grid>`, which has no `<sky-data-grid>`
+   * equivalent in this migration.
+   */
+  listViewGridSkipped: number;
+}
+
 function convertTemplate(
   recorder: UpdateRecorder,
   content: string,
   context: SchematicContext,
   offset = 0,
-): void {
+): ConvertTemplateResult {
   const fragment = parseTemplate(content);
-  const grids = getElementsByTagName('sky-grid', fragment);
+  const grids = getElementsByTagName('sky-grid', fragment).filter(
+    (grid) => !hasAncestorTag(grid, LIST_VIEW_GRID_TAG),
+  );
 
   // Columns belonging to a skipped `[columns]` grid are excluded from the
   // column swap so we never leave `<sky-data-grid-column>` inside `<sky-grid>`.
   const skippedColumns = new Set<ElementWithLocation>();
   let converted = 0;
+  let listViewGridSkipped = 0;
 
   for (const grid of grids) {
     if (hasAttribute(grid, ['columns', '[columns]'])) {
@@ -371,9 +393,21 @@ function convertTemplate(
 
   // Collect columns from the whole fragment (getElementsByTagName traverses
   // unconditionally) and swap each individually for the same reason.
-  const columns = getElementsByTagName('sky-grid-column', fragment).filter(
-    (column) => !skippedColumns.has(column),
-  );
+  const allColumns = getElementsByTagName('sky-grid-column', fragment);
+  const columns = allColumns.filter((column) => {
+    if (hasAncestorTag(column, LIST_VIEW_GRID_TAG)) {
+      listViewGridSkipped++;
+      return false;
+    }
+    return !skippedColumns.has(column);
+  });
+  if (listViewGridSkipped > 0) {
+    logOnce(
+      context,
+      'warn',
+      'A <sky-grid-column> inside <sky-list-view-grid> was left unchanged. <sky-list-view-grid> has no <sky-data-grid> equivalent in this migration.',
+    );
+  }
   for (const column of columns) {
     swapTags(
       content,
@@ -402,6 +436,8 @@ function convertTemplate(
       'Some <sky-grid> features have no <sky-data-grid> equivalent (toolbar, text and row highlighting, custom per-column search, message-stream commands such as row delete, settingsKey persistence, and explicit width/height). Reimplement these manually as needed.',
     );
   }
+
+  return { converted, listViewGridSkipped };
 }
 
 function convertHtmlFile(
@@ -425,29 +461,60 @@ function convertTypescriptFile(
   const source = parseSourceFile(tree, filePath);
   const templates = getInlineTemplates(source);
   const recorder = tree.beginUpdate(filePath);
+  let converted = 0;
+  let listViewGridSkipped = 0;
   if (templates.length > 0) {
     const content = tree.readText(filePath);
     for (const template of templates) {
-      convertTemplate(
+      const result = convertTemplate(
         recorder,
         content.slice(template.start, template.end),
         context,
         template.start,
       );
+      converted += result.converted;
+      listViewGridSkipped += result.listViewGridSkipped;
     }
   }
-  if (isImportedFromPackage(source, 'SkyGridModule', '@skyux/grids')) {
-    swapImportedClass(recorder, filePath, source, [
-      {
-        classNames: {
-          SkyGridModule: ['SkyDataGrid', 'SkyDataGridColumn'],
+  if (isImportedFromPackage(source, SKY_GRID_MODULE, SKY_GRID_MODULE_PACKAGE)) {
+    if (listViewGridSkipped > 0 && converted === 0) {
+      const listViewGridModuleImported = isImportedFromPackage(
+        source,
+        SKY_LIST_VIEW_GRID_MODULE,
+        SKY_LIST_VIEW_GRID_MODULE_PACKAGE,
+      );
+      if (listViewGridModuleImported) {
+        // SkyListViewGridModule already re-exports SkyGridModule, and nothing
+        // in this file needs SkyDataGrid/SkyDataGridColumn; it's redundant.
+        removeClassReference(
+          recorder,
+          source,
+          SKY_GRID_MODULE,
+          SKY_GRID_MODULE_PACKAGE,
+        );
+      } else {
+        logOnce(
+          context,
+          'warn',
+          'The "SkyGridModule" import was left unchanged because a <sky-grid-column> inside <sky-list-view-grid> still depends on it and "SkyListViewGridModule" could not be found in this file\'s imports. If "SkyGridModule" is now unused, review it manually.',
+        );
+      }
+    } else {
+      // A real conversion needs SkyDataGrid/SkyDataGridColumn regardless of
+      // any list-view-grid skip in the same file, so this always runs when
+      // something was actually converted.
+      swapImportedClass(recorder, filePath, source, [
+        {
+          classNames: {
+            [SKY_GRID_MODULE]: ['SkyDataGrid', 'SkyDataGridColumn'],
+          },
+          moduleName: {
+            old: SKY_GRID_MODULE_PACKAGE,
+            new: '@skyux/data-grid',
+          },
         },
-        moduleName: {
-          old: '@skyux/grids',
-          new: '@skyux/data-grid',
-        },
-      },
-    ]);
+      ]);
+    }
   }
   tree.commitUpdate(recorder);
 }

--- a/libs/components/packages/src/schematics/utility/template.spec.ts
+++ b/libs/components/packages/src/schematics/utility/template.spec.ts
@@ -1,6 +1,7 @@
 import {
   getElementsByTagName,
   getText,
+  hasAncestorTag,
   isParentNode,
   parseTemplate,
   swapAttributes,
@@ -145,5 +146,25 @@ describe('template', () => {
     expect(() => getText(multipleDivElement.childNodes)).toThrow(
       'The element contains additional markup that cannot be processed.',
     );
+  });
+
+  it('should detect an ancestor tag', () => {
+    const template = `<sky-list-view-grid><sky-grid-column id="nested"></sky-grid-column></sky-list-view-grid><sky-grid-column id="sibling"></sky-grid-column>`;
+    const parsed = parseTemplate(template);
+    const columns = getElementsByTagName('sky-grid-column', parsed);
+    expect(columns).toHaveLength(2);
+    const nested = columns.find((column) =>
+      column.attrs.some(
+        (attr) => attr.name === 'id' && attr.value === 'nested',
+      ),
+    )!;
+    const sibling = columns.find((column) =>
+      column.attrs.some(
+        (attr) => attr.name === 'id' && attr.value === 'sibling',
+      ),
+    )!;
+    expect(hasAncestorTag(nested, 'sky-list-view-grid')).toBe(true);
+    expect(hasAncestorTag(sibling, 'sky-list-view-grid')).toBe(false);
+    expect(hasAncestorTag(nested, 'sky-grid')).toBe(false);
   });
 });

--- a/libs/components/packages/src/schematics/utility/template.ts
+++ b/libs/components/packages/src/schematics/utility/template.ts
@@ -30,6 +30,21 @@ export function isParentNode(node: unknown): node is ParentNode {
   return !!node && typeof node === 'object' && 'childNodes' in node;
 }
 
+export function hasAncestorTag(
+  node: ElementWithLocation,
+  tagName: string,
+): boolean {
+  const lowerTagName = tagName.toLowerCase();
+  let current = node.parentNode;
+  while (isElement(current)) {
+    if (current.tagName.toLowerCase() === lowerTagName) {
+      return true;
+    }
+    current = current.parentNode;
+  }
+  return false;
+}
+
 export function getElementsByTagName(
   tagName: string,
   node: Element | ParentNode,

--- a/libs/components/packages/src/schematics/utility/typescript/remove-class-reference.spec.ts
+++ b/libs/components/packages/src/schematics/utility/typescript/remove-class-reference.spec.ts
@@ -1,0 +1,81 @@
+import { Tree } from '@angular-devkit/schematics';
+import ts from '@schematics/angular/third_party/github.com/Microsoft/TypeScript/lib/typescript';
+
+import { removeClassReference } from './remove-class-reference';
+
+describe('remove-class-reference', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = Tree.empty();
+  });
+
+  function run(content: string): string {
+    const path = 'file.ts';
+    tree.create(path, content);
+    const sourceFile = ts.createSourceFile(
+      path,
+      content,
+      ts.ScriptTarget.Latest,
+      true,
+    );
+    const recorder = tree.beginUpdate(path);
+    removeClassReference(recorder, sourceFile, 'SkyGridModule', 'module');
+    tree.commitUpdate(recorder);
+    return tree.readText(path);
+  }
+
+  it('should remove the last entry in a decorator imports array and import', () => {
+    const content = `import { SkyListViewGridModule, SkyGridModule } from 'module';\n\n@Component({\n  imports: [SkyListViewGridModule, SkyGridModule],\n})\nclass Test {}`;
+    expect(run(content)).toBe(
+      `import { SkyListViewGridModule, } from 'module';\n\n@Component({\n  imports: [SkyListViewGridModule],\n})\nclass Test {}`,
+    );
+  });
+
+  it('should remove the first entry in a decorator imports array and import', () => {
+    const content = `import { SkyGridModule, SkyListViewGridModule } from 'module';\n\n@Component({\n  imports: [SkyGridModule, SkyListViewGridModule],\n})\nclass Test {}`;
+    expect(run(content)).toBe(
+      `import {  SkyListViewGridModule } from 'module';\n\n@Component({\n  imports: [SkyListViewGridModule],\n})\nclass Test {}`,
+    );
+  });
+
+  it('should leave an empty array when it is the only entry', () => {
+    const content = `import { SkyGridModule } from 'module';\n\n@Component({\n  imports: [SkyGridModule],\n})\nclass Test {}`;
+    expect(run(content)).toBe(
+      `\n\n@Component({\n  imports: [],\n})\nclass Test {}`,
+    );
+  });
+
+  it('should only remove the matching class from the import statement', () => {
+    const content = `import { SkyGridModule, SkyGridComponent } from 'module';\n\n@Component({\n  imports: [SkyGridModule],\n})\nclass Test {}`;
+    expect(run(content)).toBe(
+      `import {  SkyGridComponent } from 'module';\n\n@Component({\n  imports: [],\n})\nclass Test {}`,
+    );
+  });
+
+  it('should leave a direct non-array reference and its import untouched', () => {
+    const content = `import { SkyGridModule } from 'module';\n\nconst mod = SkyGridModule;`;
+    expect(run(content)).toBe(content);
+  });
+
+  it('should not modify an unrelated array that references the class name', () => {
+    const content = `import { SkyGridModule } from 'module';\n\nconst other = [SkyGridModule];\n\n@Component({\n  imports: [SkyGridModule],\n})\nclass Test {}`;
+    expect(run(content)).toBe(
+      `import { SkyGridModule } from 'module';\n\nconst other = [SkyGridModule];\n\n@Component({\n  imports: [],\n})\nclass Test {}`,
+    );
+  });
+
+  it('should not modify a reference shadowed by a parameter', () => {
+    const content = `import { SkyGridModule } from 'module';\n\nfunction makeConfig(SkyGridModule) {\n  return { imports: [SkyGridModule] };\n}\n\n@Component({\n  imports: [SkyGridModule],\n})\nclass Test {}`;
+    expect(run(content)).toBe(
+      `import { SkyGridModule } from 'module';\n\nfunction makeConfig(SkyGridModule) {\n  return { imports: [SkyGridModule] };\n}\n\n@Component({\n  imports: [],\n})\nclass Test {}`,
+    );
+  });
+
+  it('should not modify an imports array passed to a plain function call', () => {
+    const content = `import { SkyGridModule } from 'module';\n\nconst config = makeConfig({\n  imports: [SkyGridModule],\n});\n\n@Component({\n  imports: [SkyGridModule],\n})\nclass Test {}`;
+    expect(run(content)).toBe(
+      `import { SkyGridModule } from 'module';\n\nconst config = makeConfig({\n  imports: [SkyGridModule],\n});\n\n@Component({\n  imports: [],\n})\nclass Test {}`,
+    );
+  });
+});

--- a/libs/components/packages/src/schematics/utility/typescript/remove-class-reference.spec.ts
+++ b/libs/components/packages/src/schematics/utility/typescript/remove-class-reference.spec.ts
@@ -1,5 +1,5 @@
 import { Tree } from '@angular-devkit/schematics';
-import ts from '@schematics/angular/third_party/github.com/Microsoft/TypeScript/lib/typescript';
+import ts from 'typescript';
 
 import { removeClassReference } from './remove-class-reference';
 

--- a/libs/components/packages/src/schematics/utility/typescript/remove-class-reference.ts
+++ b/libs/components/packages/src/schematics/utility/typescript/remove-class-reference.ts
@@ -1,5 +1,5 @@
 import { UpdateRecorder } from '@angular-devkit/schematics';
-import ts from '@schematics/angular/third_party/github.com/Microsoft/TypeScript/lib/typescript';
+import ts from 'typescript';
 import { findNodes } from '@schematics/angular/utility/ast-utils';
 
 import { removeImport } from './remove-import';

--- a/libs/components/packages/src/schematics/utility/typescript/remove-class-reference.ts
+++ b/libs/components/packages/src/schematics/utility/typescript/remove-class-reference.ts
@@ -1,6 +1,6 @@
 import { UpdateRecorder } from '@angular-devkit/schematics';
-import ts from 'typescript';
 import { findNodes } from '@schematics/angular/utility/ast-utils';
+import ts from 'typescript';
 
 import { removeImport } from './remove-import';
 

--- a/libs/components/packages/src/schematics/utility/typescript/remove-class-reference.ts
+++ b/libs/components/packages/src/schematics/utility/typescript/remove-class-reference.ts
@@ -1,0 +1,84 @@
+import { UpdateRecorder } from '@angular-devkit/schematics';
+import ts from '@schematics/angular/third_party/github.com/Microsoft/TypeScript/lib/typescript';
+import { findNodes } from '@schematics/angular/utility/ast-utils';
+
+import { removeImport } from './remove-import';
+
+/**
+ * True if `array` is the value of an `imports: [...]` property on an object
+ * literal passed directly to a decorator (e.g. `@Component({ imports: [...] })`).
+ * A `PropertyAssignment`'s parent is always an `ObjectLiteralExpression` by
+ * grammar, so that link doesn't need its own check.
+ */
+function isDecoratorImportsArray(array: ts.ArrayLiteralExpression): boolean {
+  const property = array.parent;
+  if (
+    !ts.isPropertyAssignment(property) ||
+    property.name.getText() !== 'imports'
+  ) {
+    return false;
+  }
+  const call = property.parent.parent;
+  return ts.isCallExpression(call) && ts.isDecorator(call.parent);
+}
+
+/**
+ * Removes every reference to `className` from an Angular decorator's
+ * `imports: [...]` array, consuming the adjacent comma so the remaining
+ * entries stay well-formed, then removes the import of `className` from
+ * `moduleName` - but only if nothing else in the file still references it.
+ * References outside a decorator's `imports` array (unrelated arrays, a
+ * parameter that shadows the import, direct assignments, etc.) are left
+ * untouched, and the import is kept if any of those remain.
+ */
+export function removeClassReference(
+  recorder: UpdateRecorder,
+  sourceFile: ts.SourceFile,
+  className: string,
+  moduleName: string,
+): void {
+  const endOfImports = findNodes(
+    sourceFile,
+    ts.SyntaxKind.ImportDeclaration,
+  ).reduce((max, node) => Math.max(max, node.getEnd()), 0);
+
+  const references = findNodes(sourceFile, ts.SyntaxKind.Identifier).filter(
+    (node): node is ts.Identifier =>
+      ts.isIdentifier(node) &&
+      node.text === className &&
+      node.getStart() > endOfImports,
+  );
+
+  const decoratorArrayReferences = references.filter(
+    (
+      reference,
+    ): reference is ts.Identifier & { parent: ts.ArrayLiteralExpression } =>
+      ts.isArrayLiteralExpression(reference.parent) &&
+      isDecoratorImportsArray(reference.parent),
+  );
+  const hasUnhandledReference =
+    decoratorArrayReferences.length !== references.length;
+
+  decoratorArrayReferences.forEach((reference) => {
+    const parent = reference.parent;
+    const elements = Array.from(parent.elements);
+    const index = elements.indexOf(reference as unknown as ts.Expression);
+
+    if (elements.length === 1) {
+      recorder.remove(parent.getStart() + 1, parent.getWidth() - 2);
+    } else if (index === 0) {
+      const start = reference.getStart();
+      recorder.remove(start, elements[1].getStart() - start);
+    } else {
+      const start = elements[index - 1].getEnd();
+      recorder.remove(start, reference.getEnd() - start);
+    }
+  });
+
+  if (!hasUnhandledReference) {
+    removeImport(recorder, sourceFile, {
+      classNames: [className],
+      moduleName,
+    });
+  }
+}


### PR DESCRIPTION
:cherries: Cherry picked from #4562 [fix(components/packages): skip sky-grid-column nested in sky-list-view-grid](https://github.com/blackbaud/skyux/pull/4562)

[AB#4074210](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/4074210) 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved grid-to-data-grid migrations by preserving grids nested within list-view grids.
  - Updated module import handling to remove redundant imports when safe and retain them when coverage is uncertain.
  - Migrations now provide clearer reporting when elements are skipped.
  - Improved handling of files containing both convertible grids and preserved list-view grids.

- **Tests**
  - Added coverage for mixed grid scenarios, import handling, nested element detection, and safe cleanup of unused references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->