### PR TITLE
fix: rename docs groups to match docs URL slugs

### DIFF
--- a/libs/components/data-grid/documentation.json
+++ b/libs/components/data-grid/documentation.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../manifest-generator/documentation-schema.json",
   "groups": {
-    "data-grid-package": {
+    "data-grid-component": {
       "development": {
         "docsIds": ["SkyDataGrid", "SkyDataGridColumn", "SkyDataGridSort"],
         "primaryDocsId": "SkyDataGrid"

--- a/libs/components/forms/documentation.json
+++ b/libs/components/forms/documentation.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../manifest-generator/documentation-schema.json",
   "groups": {
-    "character-counter": {
+    "character-count": {
       "development": {
         "docsIds": [
           "SkyCharacterCounterModule",

--- a/libs/components/tabs/documentation.json
+++ b/libs/components/tabs/documentation.json
@@ -61,7 +61,7 @@
         ]
       }
     },
-    "vertical-tabset": {
+    "vertical-tabs": {
       "development": {
         "docsIds": [
           "SkyVerticalTabsetModule",
@@ -91,7 +91,7 @@
         ]
       }
     },
-    "wizard": {
+    "tabs-wizard": {
       "development": {
         "docsIds": [
           "SkyTabsModule",


### PR DESCRIPTION
The docs wiki scraper expects the documentation page's slug to match the documentation.json group name.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated documentation labels for data grid, character count, vertical tabs, and tabs wizard components.
  - Improved naming consistency without changing the documented examples or content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->