### PR TITLE
chore: dock-item-visual null-safety + icon-storybook build budget

### DIFF
--- a/apps/e2e/core-storybook/src/app/dock/dock-item-visual.component.html
+++ b/apps/e2e/core-storybook/src/app/dock/dock-item-visual.component.html
@@ -1,7 +1,7 @@
 <div
   class="dock-item"
   [ngStyle]="{
-    'background-color': context.backgroundColor,
+    'background-color': context?.backgroundColor,
     height: height
   }"
 >

--- a/apps/e2e/icon-storybook/project.json
+++ b/apps/e2e/icon-storybook/project.json
@@ -17,6 +17,9 @@
         "polyfills": ["zone.js"],
         "tsConfig": "apps/e2e/icon-storybook/tsconfig.app.json",
         "inlineStyleLanguage": "scss",
+        "stylePreprocessorOptions": {
+          "includePaths": ["{workspaceRoot}"]
+        },
         "styles": [
           "apps/e2e/icon-storybook/src/styles.scss",
           "libs/components/theme/src/lib/styles/sky.scss",


### PR DESCRIPTION
## Summary
- Null-safe `context?.backgroundColor` in `dock-item-visual.component.html` (avoids a crash when `context` is undefined)
- Adds `stylePreprocessorOptions.includePaths` to `icon-storybook`'s build config

Split out of the AG Grid 36 upgrade branch — unrelated to that work, so it gets its own small PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability by safely handling missing context in the dock component.

* **Chores**
  * Updated build configuration to include workspace-root styling paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->