### PR TITLE
feat(components/ag-grid): add grid testing providers and deterministic render waits

### DIFF
--- a/libs/components/ag-grid/documentation.json
+++ b/libs/components/ag-grid/documentation.json
@@ -34,7 +34,11 @@
         "primaryDocsId": "SkyAgGridModule"
       },
       "testing": {
-        "docsIds": ["SkyAgGridWrapperHarness", "SkyAgGridWrapperHarnessFilters"]
+        "docsIds": [
+          "SkyAgGridWrapperHarness",
+          "SkyAgGridWrapperHarnessFilters",
+          "provideSkyAgGridTesting"
+        ]
       },
       "codeExamples": {
         "docsIds": [
@@ -82,7 +86,11 @@
         "primaryDocsId": "SkyAgGridModule"
       },
       "testing": {
-        "docsIds": ["SkyAgGridWrapperHarness", "SkyAgGridWrapperHarnessFilters"]
+        "docsIds": [
+          "SkyAgGridWrapperHarness",
+          "SkyAgGridWrapperHarnessFilters",
+          "provideSkyAgGridTesting"
+        ]
       },
       "codeExamples": {
         "docsIds": [

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/ag-grid-data-manager-adapter.directive.spec.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/ag-grid-data-manager-adapter.directive.spec.ts
@@ -54,7 +54,8 @@ describe('SkyAgGridDataManagerAdapterDirective', () => {
 
     agGridDataManagerFixture.detectChanges();
 
-    agGridComponent = agGridDataManagerFixtureComponent.agGrid as AgGridAngular;
+    agGridComponent =
+      agGridDataManagerFixtureComponent.agGrid() as AgGridAngular;
     dataViewEl = agGridDataManagerFixture.debugElement.query(
       By.directive(SkyAgGridDataManagerAdapterDirective),
     );
@@ -804,7 +805,7 @@ it('should move the horizontal scroll based on enableTopScroll check', async () 
     'ag-overlay',
   ]);
 
-  const agGrid = fixture.componentInstance.agGrid;
+  const agGrid = fixture.componentInstance.agGrid();
   expect(agGrid).toBeDefined();
   expect(agGrid!.api.getGridOption('context')?.enableTopScroll).toBeTrue();
 

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/ag-grid-data-manager-adapter.directive.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/ag-grid-data-manager-adapter.directive.ts
@@ -352,6 +352,8 @@ export class SkyAgGridDataManagerAdapterDirective implements OnDestroy {
           }
           this.#currentDataState = newState;
           this.#dataManagerSvc.updateDataState(newState, viewConfig.id);
+
+          this.#changeDetector.markForCheck();
         }
       });
     }
@@ -380,6 +382,8 @@ export class SkyAgGridDataManagerAdapterDirective implements OnDestroy {
         );
         this.#currentDataState = newDataState;
         this.#dataManagerSvc.updateDataState(newDataState, viewConfig.id);
+
+        this.#changeDetector.markForCheck();
       }
     }
   }
@@ -467,6 +471,8 @@ export class SkyAgGridDataManagerAdapterDirective implements OnDestroy {
       );
       this.#currentDataState = newDataState;
       this.#dataManagerSvc.updateDataState(newDataState, viewId);
+
+      this.#changeDetector.markForCheck();
     }
   }
 
@@ -491,6 +497,8 @@ export class SkyAgGridDataManagerAdapterDirective implements OnDestroy {
       );
       this.#currentDataState = newDataState;
       this.#dataManagerSvc.updateDataState(newDataState, viewId);
+
+      this.#changeDetector.markForCheck();
     }
   }
 

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/cell-renderers/cell-renderer-currency/cell-renderer-currency.component.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/cell-renderers/cell-renderer-currency/cell-renderer-currency.component.ts
@@ -1,4 +1,10 @@
-import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  Input,
+  inject,
+} from '@angular/core';
 import { SkyNumericModule, SkyNumericOptions } from '@skyux/core';
 
 import { ICellRendererAngularComp } from 'ag-grid-angular';
@@ -17,6 +23,8 @@ import { SkyAgGridValidatorProperties } from '../../types/validator-properties';
   imports: [SkyNumericModule],
 })
 export class SkyAgGridCellRendererCurrencyComponent implements ICellRendererAngularComp {
+  readonly #changeDetector = inject(ChangeDetectorRef);
+
   @Input()
   public set params(value: SkyCellRendererCurrencyParams) {
     this.agInit(value);
@@ -34,6 +42,7 @@ export class SkyAgGridCellRendererCurrencyComponent implements ICellRendererAngu
    */
   public agInit(params: SkyCellRendererCurrencyParams): void {
     this.#updateProperties(params);
+    this.#changeDetector.markForCheck();
   }
 
   /**

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/fixtures/ag-grid-data-manager.component.fixture.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/fixtures/ag-grid-data-manager.component.fixture.ts
@@ -1,10 +1,10 @@
 import {
   Component,
   OnInit,
-  ViewChild,
   ViewEncapsulation,
   inject,
   input,
+  viewChild,
 } from '@angular/core';
 import {
   SkyDataManagerModule,
@@ -28,6 +28,7 @@ import { SkyAgGridService } from '../ag-grid.service';
 import { SkyCellType } from '../types/cell-type';
 
 import { SKY_AG_GRID_DATA } from './ag-grid-data.fixture';
+import { AG_GRID_FIXTURE_TEST_OPTIONS } from './ag-grid-fixture-test-options';
 
 ModuleRegistry.registerModules([AllCommunityModule]);
 
@@ -44,8 +45,7 @@ ModuleRegistry.registerModules([AllCommunityModule]);
   ],
 })
 export class SkyAgGridDataManagerFixtureComponent implements OnInit {
-  @ViewChild(AgGridAngular)
-  public agGrid: AgGridAngular | undefined;
+  public readonly agGrid = viewChild(AgGridAngular);
 
   public columnDefs: ColDef[] = [
     {
@@ -79,6 +79,7 @@ export class SkyAgGridDataManagerFixtureComponent implements OnInit {
   public gridData = SKY_AG_GRID_DATA;
 
   public gridOptions: GridOptions = {
+    ...AG_GRID_FIXTURE_TEST_OPTIONS,
     columnDefs: this.columnDefs,
   };
 

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/fixtures/ag-grid-fixture-test-options.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/fixtures/ag-grid-fixture-test-options.ts
@@ -1,0 +1,12 @@
+import { GridOptions } from 'ag-grid-community';
+
+/**
+ * Grid options every ag-grid fixture applies so Karma specs render
+ * deterministically: no virtualization, scrollbars always present.
+ */
+export const AG_GRID_FIXTURE_TEST_OPTIONS: Partial<GridOptions> = {
+  alwaysShowHorizontalScroll: true,
+  alwaysShowVerticalScroll: true,
+  suppressColumnVirtualisation: true,
+  suppressRowVirtualisation: true,
+};

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/fixtures/ag-grid-minimal.component.fixture.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/fixtures/ag-grid-minimal.component.fixture.ts
@@ -17,6 +17,8 @@ import {
 import { SkyAgGridWrapperComponent } from '../ag-grid-wrapper.component';
 import { SkyAgGridService } from '../ag-grid.service';
 
+import { AG_GRID_FIXTURE_TEST_OPTIONS } from './ag-grid-fixture-test-options';
+
 ModuleRegistry.registerModules([AllCommunityModule]);
 
 export const MinimalColumnDefs = new InjectionToken<ColDef[]>(
@@ -57,6 +59,7 @@ export class SkyAgGridMinimalFixtureComponent {
   protected readonly gridOptionsFromService = this.editable
     ? this.#gridService.getEditableGridOptions({
         gridOptions: {
+          ...AG_GRID_FIXTURE_TEST_OPTIONS,
           columnDefs: this.columnDefs,
           domLayout: 'autoHeight' as DomLayoutType,
           context: {
@@ -66,6 +69,7 @@ export class SkyAgGridMinimalFixtureComponent {
       })
     : this.#gridService.getGridOptions({
         gridOptions: {
+          ...AG_GRID_FIXTURE_TEST_OPTIONS,
           columnDefs: this.columnDefs,
           domLayout: 'autoHeight' as DomLayoutType,
           context: {

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/header/header-group.component.html
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/header/header-group.component.html
@@ -1,19 +1,19 @@
-@if (params?.displayName) {
+@if (params()?.displayName) {
   <span
     class="header-group-text"
     role="presentation"
     [skyThemeClass]="{ 'sky-font-heading-4': 'modern' }"
-    >{{ params?.displayName }}</span
+    >{{ params()?.displayName }}</span
   >
 }
-@if (isExpandable$ | async) {
-  @if (isExpanded$ | async) {
+@if (isExpandable()) {
+  @if (isExpanded()) {
     <button
       class="sky-btn sky-btn-icon-borderless"
       type="button"
       [attr.aria-label]="
         'sky_ag_grid_column_group_header_collapse_aria_label'
-          | skyLibResources: params?.displayName
+          | skyLibResources: params()?.displayName
       "
       (click)="setExpanded(false)"
     >
@@ -25,7 +25,7 @@
       type="button"
       [attr.aria-label]="
         'sky_ag_grid_column_group_header_expand_aria_label'
-          | skyLibResources: params?.displayName
+          | skyLibResources: params()?.displayName
       "
       (click)="setExpanded(true)"
     >

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/header/header-group.component.spec.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/header/header-group.component.spec.ts
@@ -135,4 +135,34 @@ describe('SkyAgGridHeaderGroupComponent', () => {
     await fixture.whenStable();
     expect(expanded).toBeTruthy();
   });
+
+  it('should create the inline help component exactly once', async () => {
+    // Create a fresh fixture to ensure agInit and ngAfterViewInit both trigger #updateInlineHelp
+    const freshFixture = TestBed.createComponent(SkyAgGridHeaderGroupComponent);
+    const freshComponent = freshFixture.componentInstance;
+
+    // Call agInit before detectChanges so ngAfterViewInit hasn't been called yet
+    freshComponent.agInit({
+      ...baseParams,
+      columnGroup: {
+        ...baseParams.columnGroup,
+        getColGroupDef: () =>
+          ({
+            headerGroupComponent: SkyAgGridHeaderGroupComponent,
+            headerGroupComponentParams: {
+              inlineHelpComponent: TestHelpComponent,
+            },
+          }) as ColGroupDef,
+      } as ColumnGroup,
+    });
+
+    // Now detectChanges triggers ngAfterViewInit -> second #updateInlineHelp call
+    freshFixture.detectChanges();
+    await freshFixture.whenStable();
+
+    const helpComponents = freshFixture.debugElement.queryAll(
+      By.css('.test-help-component'),
+    );
+    expect(helpComponents.length).toBe(1);
+  });
 });

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/header/header-group.component.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/header/header-group.component.ts
@@ -1,14 +1,16 @@
-import { AsyncPipe } from '@angular/common';
 import {
   AfterViewInit,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
+  ComponentRef,
+  computed,
   ElementRef,
   EnvironmentInjector,
-  OnDestroy,
-  ViewChild,
   inject,
+  linkedSignal,
+  signal,
+  viewChild,
 } from '@angular/core';
 import {
   SkyDynamicComponentLocation,
@@ -20,8 +22,9 @@ import { SkyThemeModule } from '@skyux/theme';
 
 import { IHeaderGroupAngularComp } from 'ag-grid-angular';
 import { ProvidedColumnGroup } from 'ag-grid-community';
-import { BehaviorSubject, Observable, Subscription, takeUntil } from 'rxjs';
+import { EMPTY, switchMap } from 'rxjs';
 
+import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
 import { fromGridEvent } from '../ag-grid-event-utils';
 import { SkyAgGridHeaderGroupInfo } from '../types/header-group-info';
 import { SkyAgGridHeaderGroupParams } from '../types/header-group-params';
@@ -34,32 +37,52 @@ import { SkyAgGridHeaderGroupParams } from '../types/header-group-params';
   templateUrl: './header-group.component.html',
   styleUrls: ['./header-group.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [SkyThemeModule, SkyIconModule, AsyncPipe, SkyI18nModule],
+  imports: [SkyThemeModule, SkyIconModule, SkyI18nModule],
 })
 export class SkyAgGridHeaderGroupComponent
-  implements IHeaderGroupAngularComp, OnDestroy, AfterViewInit
+  implements IHeaderGroupAngularComp, AfterViewInit
 {
-  @ViewChild('inlineHelpContainer', { read: ElementRef, static: true })
-  public inlineHelpContainer: ElementRef | undefined;
+  public readonly inlineHelpContainer = viewChild('inlineHelpContainer', {
+    read: ElementRef,
+  });
 
-  protected params: SkyAgGridHeaderGroupParams | undefined = undefined;
-  protected isExpandable$: Observable<boolean>;
-  protected isExpanded$: Observable<boolean>;
+  protected readonly params = signal<SkyAgGridHeaderGroupParams | undefined>(
+    undefined,
+  );
+  protected readonly isExpandable = computed(() =>
+    this.#providedColumnGroup()?.isExpandable(),
+  );
+  protected readonly isExpanded = linkedSignal(() =>
+    this.#providedColumnGroup()?.isExpanded(),
+  );
 
-  #columnGroup: ProvidedColumnGroup | undefined = undefined;
-  #isExpandableSubject = new BehaviorSubject<boolean>(false);
-  #isExpandedSubject = new BehaviorSubject<boolean>(false);
-  #subscriptions = new Subscription();
-  #viewInitialized = false;
+  readonly #providedColumnGroup = computed<ProvidedColumnGroup | undefined>(
+    () => this.params()?.columnGroup?.getProvidedColumnGroup(),
+  );
+  readonly #gridApi = toObservable(computed(() => this.params()?.api));
+  readonly #columnGroupOpened = this.#gridApi.pipe(
+    switchMap((api) => (api ? fromGridEvent(api, 'columnGroupOpened') : EMPTY)),
+  );
+
   #agInitialized = false;
+  #viewInitialized = false;
+  #inlineHelpComponentRef: ComponentRef<unknown> | undefined;
 
   readonly #changeDetector = inject(ChangeDetectorRef);
   readonly #dynamicComponentService = inject(SkyDynamicComponentService);
   readonly #environmentInjector = inject(EnvironmentInjector);
 
   constructor() {
-    this.isExpandable$ = this.#isExpandableSubject.asObservable();
-    this.isExpanded$ = this.#isExpandedSubject.asObservable();
+    this.#columnGroupOpened.pipe(takeUntilDestroyed()).subscribe((event) => {
+      const columnGroup = this.#providedColumnGroup();
+      if (
+        columnGroup &&
+        columnGroup.isExpandable() &&
+        event.columnGroups.includes(columnGroup)
+      ) {
+        this.isExpanded.set(columnGroup.isExpanded());
+      }
+    });
   }
 
   public ngAfterViewInit(): void {
@@ -68,40 +91,15 @@ export class SkyAgGridHeaderGroupComponent
     this.#changeDetector.markForCheck();
   }
 
-  public ngOnDestroy(): void {
-    this.#subscriptions.unsubscribe();
-  }
-
   public agInit(params: SkyAgGridHeaderGroupParams | undefined): void {
+    this.params.set(params);
     this.#agInitialized = true;
-    this.params = params;
-    this.#subscriptions.unsubscribe();
-    if (!params) {
-      return;
-    }
-    this.#subscriptions = new Subscription();
-    this.#columnGroup = params.columnGroup.getProvidedColumnGroup();
-    this.#isExpandableSubject.next(!!this.#columnGroup?.isExpandable());
-    if (this.#isExpandableSubject.getValue()) {
-      this.#subscriptions.add(
-        fromGridEvent(params.api, 'columnGroupOpened')
-          .pipe(takeUntil(fromGridEvent(params.api, 'gridPreDestroyed')))
-          .subscribe((event) => {
-            if (
-              this.#columnGroup &&
-              event.columnGroups.includes(this.#columnGroup)
-            ) {
-              this.#isExpandedSubject.next(this.#columnGroup.isExpanded());
-            }
-          }),
-      );
-    }
     this.#updateInlineHelp();
     this.#changeDetector.markForCheck();
   }
 
   public setExpanded($event: boolean): void {
-    this.params?.setExpanded($event);
+    this.params()?.setExpanded($event);
   }
 
   #updateInlineHelp(): void {
@@ -109,27 +107,38 @@ export class SkyAgGridHeaderGroupComponent
       return;
     }
 
-    const colGroupDef = this.params?.columnGroup?.getColGroupDef();
+    const columnGroup = this.params()?.columnGroup;
+    const colGroupDef = columnGroup?.getColGroupDef();
     const inlineHelpComponent =
       colGroupDef?.headerGroupComponentParams?.inlineHelpComponent;
 
-    if (inlineHelpComponent) {
-      const headerGroupInfo = new SkyAgGridHeaderGroupInfo();
-      headerGroupInfo.columnGroup = this.params?.columnGroup;
-      headerGroupInfo.context = this.params?.context;
-      headerGroupInfo.displayName = this.params?.displayName;
+    if (
+      columnGroup &&
+      inlineHelpComponent &&
+      (!this.#inlineHelpComponentRef ||
+        this.#inlineHelpComponentRef.componentType !== inlineHelpComponent)
+    ) {
+      this.#dynamicComponentService.removeComponent(
+        this.#inlineHelpComponentRef,
+      );
 
-      this.#dynamicComponentService.createComponent(inlineHelpComponent, {
-        providers: [
-          {
-            provide: SkyAgGridHeaderGroupInfo,
-            useValue: headerGroupInfo,
-          },
-        ],
-        environmentInjector: this.#environmentInjector,
-        referenceEl: this.inlineHelpContainer?.nativeElement,
-        location: SkyDynamicComponentLocation.ElementBottom,
-      });
+      const headerGroupInfo = new SkyAgGridHeaderGroupInfo();
+      headerGroupInfo.columnGroup = columnGroup;
+      headerGroupInfo.context = this.params()?.context;
+      headerGroupInfo.displayName = this.params()?.displayName;
+
+      this.#inlineHelpComponentRef =
+        this.#dynamicComponentService.createComponent(inlineHelpComponent, {
+          providers: [
+            {
+              provide: SkyAgGridHeaderGroupInfo,
+              useValue: headerGroupInfo,
+            },
+          ],
+          environmentInjector: this.#environmentInjector,
+          referenceEl: this.inlineHelpContainer()?.nativeElement,
+          location: SkyDynamicComponentLocation.ElementBottom,
+        });
     }
   }
 }

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/header/header-row-selector/header-row-selector.component.spec.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/header/header-row-selector/header-row-selector.component.spec.ts
@@ -21,6 +21,7 @@ describe('SkyAgGridHeaderRowSelectorComponent', () => {
       | 'deselectAll'
       | 'getGridOption'
       | 'getSelectedNodes'
+      | 'isDestroyed'
       | 'removeEventListener'
       | 'selectAll'
     >
@@ -35,9 +36,11 @@ describe('SkyAgGridHeaderRowSelectorComponent', () => {
       'deselectAll',
       'getGridOption',
       'getSelectedNodes',
+      'isDestroyed',
       'removeEventListener',
       'selectAll',
     ]);
+    api.isDestroyed.and.returnValue(false);
   });
 
   it('should show checkbox and select all / deselect all', async () => {

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/header/header-row-selector/header-row-selector.component.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/header/header-row-selector/header-row-selector.component.ts
@@ -4,6 +4,7 @@ import {
   DestroyRef,
   RendererFactory2,
   computed,
+  effect,
   inject,
   model,
   signal,
@@ -11,10 +12,12 @@ import {
 import { SkyCheckboxChange, SkyCheckboxModule } from '@skyux/forms';
 
 import { IHeaderAngularComp } from 'ag-grid-angular';
-import { GridApi, IHeaderParams } from 'ag-grid-community';
+import {
+  GridApi,
+  IHeaderParams,
+  SelectionChangedEvent,
+} from 'ag-grid-community';
 import { Subscription } from 'rxjs';
-
-import { fromGridEvent } from '../../ag-grid-event-utils';
 
 @Component({
   selector: 'sky-ag-grid-row-selector-header',
@@ -31,7 +34,12 @@ export class SkyAgGridHeaderRowSelectorComponent implements IHeaderAngularComp {
   protected readonly checked = model(false);
   protected readonly indeterminate = signal(false);
   protected readonly multiSelect = signal(false);
-  protected readonly params = signal<IHeaderParams | undefined>(undefined);
+  protected readonly params = signal<IHeaderParams | undefined>(undefined, {
+    // Treat every `agInit()` call as a change (even if the params reference
+    // is reused) so the grid-event listener effects below always tear down
+    // and reattach rather than being skipped due to signal equality.
+    equal: () => false,
+  });
   protected readonly label = computed(() => {
     const params = this.params();
     return params?.displayName || params?.column.getColDef().field;
@@ -43,6 +51,46 @@ export class SkyAgGridHeaderRowSelectorComponent implements IHeaderAngularComp {
 
   constructor() {
     inject(DestroyRef).onDestroy(() => this.#subscriptions.unsubscribe());
+
+    // Selection changes, for multi-select grids.
+    effect((onCleanup) => {
+      const api = this.params()?.api;
+      if (!api || !this.multiSelect()) {
+        return;
+      }
+      const handler = (change: SelectionChangedEvent): void => {
+        if (api.isDestroyed()) {
+          return;
+        }
+        if (change.source.match(/selectall/i)) {
+          // Either select all or clear selection.
+          this.indeterminate.set(false);
+          this.checked.set(!!change.selectedNodes?.length);
+        } else {
+          this.indeterminate.set(!!change.selectedNodes?.length);
+          this.checked.set(false);
+        }
+      };
+      api.addEventListener('selectionChanged', handler);
+      onCleanup(() => api.removeEventListener('selectionChanged', handler));
+    });
+
+    // Clear selection state when row data is replaced, for multi-select grids.
+    effect((onCleanup) => {
+      const api = this.params()?.api;
+      if (!api || !this.multiSelect()) {
+        return;
+      }
+      const handler = (): void => {
+        if (api.isDestroyed()) {
+          return;
+        }
+        this.indeterminate.set(!!api.getSelectedNodes().length);
+        this.checked.set(false);
+      };
+      api.addEventListener('rowDataUpdated', handler);
+      onCleanup(() => api.removeEventListener('rowDataUpdated', handler));
+    });
   }
 
   public agInit(params: IHeaderParams): void {
@@ -60,26 +108,6 @@ export class SkyAgGridHeaderRowSelectorComponent implements IHeaderAngularComp {
     );
 
     if (this.multiSelect()) {
-      this.#subscriptions.add(
-        fromGridEvent(params.api, 'selectionChanged').subscribe((change) => {
-          if (change.source.match(/selectall/i)) {
-            // Either select all or clear selection.
-            this.indeterminate.set(false);
-            this.checked.set(!!change.selectedNodes?.length);
-          } else {
-            this.indeterminate.set(!!change.selectedNodes?.length);
-            this.checked.set(false);
-          }
-        }),
-      );
-
-      this.#subscriptions.add(
-        fromGridEvent(params.api, 'rowDataUpdated').subscribe(() => {
-          this.indeterminate.set(!!this.#api?.getSelectedNodes().length);
-          this.checked.set(false);
-        }),
-      );
-
       const el = params.eGridHeader;
       if (el) {
         this.#renderer.setAttribute(el, 'aria-keyshortcuts', 'Enter Space');

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/header/header.component.html
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/header/header.component.html
@@ -29,7 +29,7 @@
           >{{ displayName() }}</span
         >
       }
-      @if (filterEnabled$ | async) {
+      @if (filterEnabled()) {
         <span
           aria-hidden="true"
           class="ag-header-icon ag-header-label-icon ag-filter-icon"
@@ -37,7 +37,7 @@
         /></span>
       }
       @if (params()?.enableSorting) {
-        @if (sortOrder$ | async; as sortDirection) {
+        @if (sortOrder(); as sortDirection) {
           <button
             class="ag-sort-indicator-container sky-btn sky-btn-icon-borderless"
             type="button"
@@ -62,7 +62,7 @@
               >
             }
 
-            @if (sortIndexDisplay$ | async; as sortIndexDisplay) {
+            @if (sortIndexDisplay(); as sortIndexDisplay) {
               <span
                 aria-hidden="true"
                 class="ag-sort-indicator-icon ag-sort-order"

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/header/header.component.spec.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/header/header.component.spec.ts
@@ -185,7 +185,9 @@ describe('HeaderComponent', () => {
     fixture.detectChanges();
     await fixture.whenStable();
     expect(
-      fixture.debugElement.query(By.css('.ag-header-label-icon')),
+      fixture.debugElement.query(
+        By.css('.ag-sort-indicator-container .ag-header-label-icon'),
+      ),
     ).toBeFalsy();
     expect(document.querySelector('.ag-sort-indicator-container')).toBeNull();
 
@@ -263,6 +265,13 @@ describe('HeaderComponent', () => {
     component.agInit(params);
     fixture.detectChanges();
     await fixture.whenStable();
+    expect(component).toBeTruthy();
+    apiEvents['columnMoved'].forEach((listener) =>
+      listener({
+        column: params.column,
+        source: 'uiColumnMoved',
+      }),
+    );
     expect(component).toBeTruthy();
   });
 

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/header/header.component.spec.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/header/header.component.spec.ts
@@ -190,13 +190,10 @@ describe('HeaderComponent', () => {
     expect(document.querySelector('.ag-sort-indicator-container')).toBeNull();
 
     columnEvents['filterChanged'].forEach((listener) => listener());
-    expect(component.filterEnabled$.getValue()).toBe(true);
+    expect(component.filterEnabled()).toBe(true);
     fixture.detectChanges();
     await fixture.whenStable();
     expect(fixture.debugElement.query(By.css('.ag-filter-icon'))).toBeTruthy();
-
-    apiEvents['gridPreDestroyed'].forEach((listener) => listener());
-    expect(component).toBeTruthy();
   });
 
   it('should not show sort button when sort is disabled', () => {

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/header/header.component.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/header/header.component.ts
@@ -1,4 +1,3 @@
-import { AsyncPipe } from '@angular/common';
 import {
   AfterViewInit,
   ChangeDetectionStrategy,
@@ -7,12 +6,14 @@ import {
   ComponentRef,
   ElementRef,
   EnvironmentInjector,
-  OnDestroy,
-  ViewChild,
   computed,
+  effect,
   inject,
+  linkedSignal,
   signal,
+  viewChild,
 } from '@angular/core';
+import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
 import {
   SkyDynamicComponentLocation,
   SkyDynamicComponentService,
@@ -22,7 +23,7 @@ import { SkyIconModule } from '@skyux/icon';
 import { SkyThemeModule } from '@skyux/theme';
 
 import { IHeaderAngularComp } from 'ag-grid-angular';
-import { BehaviorSubject, Subscription } from 'rxjs';
+import { EMPTY, switchMap } from 'rxjs';
 
 import { fromGridEvent } from '../ag-grid-event-utils';
 import { SkyAgGridHeaderInfo } from '../types/header-info';
@@ -41,12 +42,12 @@ import { SkyAgGridHeaderParams } from '../types/header-params';
     '[attr.aria-label]': 'displayName() || accessibleHeaderText()',
     '[attr.role]': '"note"',
   },
-  imports: [SkyIconModule, SkyThemeModule, AsyncPipe, SkyI18nModule],
+  imports: [SkyIconModule, SkyThemeModule, SkyI18nModule],
 })
 export class SkyAgGridHeaderComponent
-  implements IHeaderAngularComp, OnDestroy, AfterViewInit
+  implements IHeaderAngularComp, AfterViewInit
 {
-  public readonly filterEnabled$ = new BehaviorSubject<boolean>(false);
+  public readonly filterEnabled = signal(false);
 
   // For accessibility, we need to set the title attribute on the header element if there is no visible header text.
   // https://dequeuniversity.com/rules/axe/4.5/empty-table-header?application=axeAPI
@@ -62,17 +63,20 @@ export class SkyAgGridHeaderComponent
     }
   });
 
-  @ViewChild('inlineHelpContainer', { read: ElementRef, static: true })
-  protected inlineHelpContainer: ElementRef | undefined;
+  protected readonly inlineHelpContainer = viewChild('inlineHelpContainer', {
+    read: ElementRef,
+  });
 
   protected readonly params = signal<SkyAgGridHeaderParams | undefined>(
     undefined,
   );
   protected sorted = '';
-  protected readonly sortOrder$ = new BehaviorSubject<
-    'asc' | 'desc' | undefined
-  >(undefined);
-  protected readonly sortIndexDisplay$ = new BehaviorSubject<string>('');
+  protected readonly sortOrder = linkedSignal<'asc' | 'desc' | undefined>(
+    () => this.params()?.column.getSort() || undefined,
+  );
+  protected readonly sortIndexDisplay = linkedSignal(() =>
+    this.#computeSortIndexDisplay(),
+  );
 
   protected displayName = computed<string | undefined>(() => {
     const params = this.params();
@@ -86,7 +90,6 @@ export class SkyAgGridHeaderComponent
     }
   });
 
-  #subscriptions = new Subscription();
   #inlineHelpComponentRef: ComponentRef<unknown> | undefined;
   #viewInitialized = false;
   #agInitialized = false;
@@ -96,76 +99,78 @@ export class SkyAgGridHeaderComponent
   readonly #dynamicComponentService = inject(SkyDynamicComponentService);
   readonly #environmentInjector = inject(EnvironmentInjector);
 
+  readonly #paramsChanges = toObservable(this.params);
+  readonly #sortChanged = this.#paramsChanges.pipe(
+    switchMap((params) =>
+      params?.enableSorting && params.api
+        ? fromGridEvent(params.api, 'sortChanged')
+        : EMPTY,
+    ),
+  );
+  readonly #columnMoved = this.#paramsChanges.pipe(
+    switchMap((params) =>
+      params?.api ? fromGridEvent(params.api, 'columnMoved') : EMPTY,
+    ),
+  );
+
+  constructor() {
+    // Column filter state changes
+    effect((onCleanup) => {
+      const column = this.params()?.column;
+      if (!column?.isFilterAllowed()) {
+        return;
+      }
+      const handler = (): void =>
+        this.filterEnabled.set(column.isFilterActive());
+      column.addEventListener('filterChanged', handler);
+      onCleanup(() => column.removeEventListener('filterChanged', handler));
+    });
+
+    // Column sort state changes
+    effect((onCleanup) => {
+      const params = this.params();
+      if (!params?.enableSorting) {
+        return;
+      }
+      const column = params.column;
+      const handler = (): void =>
+        this.sortOrder.set(column.getSort() || undefined);
+      column.addEventListener('sortChanged', handler);
+      onCleanup(() => column.removeEventListener('sortChanged', handler));
+    });
+
+    // Other column sort state changes, for multi-column sorting
+    this.#sortChanged.pipe(takeUntilDestroyed()).subscribe(() => {
+      this.sortIndexDisplay.set(this.#computeSortIndexDisplay());
+    });
+
+    // When the column is moved left via the keyboard, the element is detached
+    // and reattached to the DOM to maintain DOM order, and its focus is lost.
+    this.#columnMoved.pipe(takeUntilDestroyed()).subscribe((event) => {
+      const params = this.params();
+      const left = event.column?.getLeft() ?? 0;
+      const oldLeft = this.#leftPosition;
+      if (
+        params &&
+        event.column === params.column &&
+        event.source === 'uiColumnMoved' &&
+        left < oldLeft
+      ) {
+        params.eGridHeader.focus();
+      }
+      this.#leftPosition = left;
+    });
+  }
+
   public ngAfterViewInit(): void {
     this.#viewInitialized = true;
     this.#updateInlineHelp();
   }
 
-  public ngOnDestroy(): void {
-    this.#subscriptions.unsubscribe();
-  }
-
   public agInit(params: SkyAgGridHeaderParams | undefined): void {
     this.#agInitialized = true;
     this.params.set(params);
-    this.#subscriptions.unsubscribe();
-    if (!params) {
-      return;
-    }
-    this.#leftPosition = params.column.getLeft() ?? 0;
-    this.#subscriptions = new Subscription();
-    if (params.column.isFilterAllowed()) {
-      const handler = (): void => {
-        const isFilterActive = params.column.isFilterActive();
-        if (isFilterActive !== this.filterEnabled$.getValue()) {
-          this.filterEnabled$.next(isFilterActive);
-        }
-      };
-      params.column.addEventListener('filterChanged', handler);
-      this.#subscriptions.add(() =>
-        params.column.removeEventListener('filterChanged', handler),
-      );
-    }
-    if (params.enableSorting) {
-      // Column sort state changes
-      const handler = (): void => this.#updateSort();
-      params.column.addEventListener('sortChanged', handler);
-      this.#subscriptions.add(() =>
-        params.column.removeEventListener('sortChanged', handler),
-      );
-      // Other column sort state changes, for multi-column sorting
-      this.#subscriptions.add(
-        fromGridEvent(params.api, 'sortChanged').subscribe(() =>
-          this.#updateSortIndex(),
-        ),
-      );
-      this.#updateSort();
-      this.#updateSortIndex();
-    }
-
-    // When the column is moved left via the keyboard, the element is detached
-    // and reattached to the DOM to maintain DOM order, and its focus is lost.
-    this.#subscriptions.add(
-      fromGridEvent(params.api, 'columnMoved').subscribe((event) => {
-        const left = event.column?.getLeft() ?? 0;
-        const oldLeft = this.#leftPosition;
-        if (
-          event.column === params.column &&
-          event.source === 'uiColumnMoved' &&
-          left < oldLeft
-        ) {
-          params.eGridHeader.focus();
-        }
-        this.#leftPosition = left;
-      }),
-    );
-
-    this.#subscriptions.add(
-      fromGridEvent(params.api, 'gridPreDestroyed').subscribe(() =>
-        this.#subscriptions.unsubscribe(),
-      ),
-    );
-
+    this.#leftPosition = params?.column.getLeft() ?? 0;
     this.#updateInlineHelp();
     this.#changeDetector.markForCheck();
   }
@@ -215,7 +220,7 @@ export class SkyAgGridHeaderComponent
             },
           ],
           environmentInjector: this.#environmentInjector,
-          referenceEl: this.inlineHelpContainer?.nativeElement,
+          referenceEl: this.inlineHelpContainer()?.nativeElement,
           location: SkyDynamicComponentLocation.ElementBottom,
         });
     } else if (!inlineHelpComponent) {
@@ -225,23 +230,17 @@ export class SkyAgGridHeaderComponent
     }
   }
 
-  #updateSort(): void {
-    this.sortOrder$.next(this.params()?.column.getSort() || undefined);
-  }
-
-  #updateSortIndex(): void {
-    const sortIndex = this.params()?.column.getSortIndex();
-    const otherSortColumns = this.params()
-      ?.api?.getColumns()
+  #computeSortIndexDisplay(): string {
+    const params = this.params();
+    const sortIndex = params?.column.getSortIndex();
+    const otherSortColumns = params?.api
+      ?.getColumns()
       ?.some(
         (column) =>
-          column.getColId() !== this.params()?.column.getColId() &&
-          !!column.getSort(),
+          column.getColId() !== params?.column.getColId() && !!column.getSort(),
       );
-    if (sortIndex !== undefined && sortIndex !== null && otherSortColumns) {
-      this.sortIndexDisplay$.next(`${sortIndex + 1}`);
-    } else {
-      this.sortIndexDisplay$.next('');
-    }
+    return sortIndex !== undefined && sortIndex !== null && otherSortColumns
+      ? `${sortIndex + 1}`
+      : '';
   }
 }

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/header/header.component.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/header/header.component.ts
@@ -118,8 +118,10 @@ export class SkyAgGridHeaderComponent
     effect((onCleanup) => {
       const column = this.params()?.column;
       if (!column?.isFilterAllowed()) {
+        this.filterEnabled.set(false);
         return;
       }
+      this.filterEnabled.set(column.isFilterActive());
       const handler = (): void =>
         this.filterEnabled.set(column.isFilterActive());
       column.addEventListener('filterChanged', handler);
@@ -148,7 +150,7 @@ export class SkyAgGridHeaderComponent
     // and reattached to the DOM to maintain DOM order, and its focus is lost.
     this.#columnMoved.pipe(takeUntilDestroyed()).subscribe((event) => {
       const params = this.params();
-      const left = event.column?.getLeft() ?? 0;
+      const left = params?.column.getLeft() ?? 0;
       const oldLeft = this.#leftPosition;
       if (
         params &&

--- a/libs/components/ag-grid/testing/src/modules/ag-grid-wrapper/ag-grid-wrapper-harness.spec.ts
+++ b/libs/components/ag-grid/testing/src/modules/ag-grid-wrapper/ag-grid-wrapper-harness.spec.ts
@@ -3,6 +3,7 @@ import { Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { SkyAgGridModule } from '@skyux/ag-grid';
 
+import { provideSkyAgGridTesting } from '../ag-grid/provide-ag-grid-testing';
 import { SkyAgGridWrapperHarness } from './ag-grid-wrapper-harness';
 import { AgGridTestComponent } from './fixtures/ag-grid-test.component';
 
@@ -18,7 +19,9 @@ describe('SkyAgGridWrapperHarness', () => {
     let fixture: ComponentFixture<TestComponent>;
 
     beforeEach(() => {
-      TestBed.configureTestingModule({});
+      TestBed.configureTestingModule({
+        providers: [provideSkyAgGridTesting()],
+      });
       fixture = TestBed.createComponent(TestComponent);
       fixture.detectChanges();
     });
@@ -48,7 +51,9 @@ describe('SkyAgGridWrapperHarness', () => {
     let fixture: ComponentFixture<AgGridTestComponent>;
 
     beforeEach(() => {
-      TestBed.configureTestingModule({});
+      TestBed.configureTestingModule({
+        providers: [provideSkyAgGridTesting()],
+      });
       fixture = TestBed.createComponent(AgGridTestComponent);
     });
 
@@ -80,6 +85,64 @@ describe('SkyAgGridWrapperHarness', () => {
       await expectAsync(harness.getDisplayedColumnHeaderNames()).toBeResolvedTo(
         ['Name', ''],
       );
+    });
+
+    it('should get the current render count', async () => {
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      const harness = await TestbedHarnessEnvironment.loader(
+        fixture,
+      ).getHarness(
+        SkyAgGridWrapperHarness.with({ dataSkyId: 'ag-grid-wrapper' }),
+      );
+      await harness.waitUntilRendered();
+      expect(await harness.getRenderCount()).toBeGreaterThan(0);
+    });
+
+    it('should resolve waitUntilRendered() once the grid has rendered', async () => {
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      const harness = await TestbedHarnessEnvironment.loader(
+        fixture,
+      ).getHarness(
+        SkyAgGridWrapperHarness.with({ dataSkyId: 'ag-grid-wrapper' }),
+      );
+      await expectAsync(harness.waitUntilRendered()).toBeResolved();
+    });
+
+    it('should stop waiting after the bounded timeout if the grid never renders again', async () => {
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      const harness = await TestbedHarnessEnvironment.loader(
+        fixture,
+      ).getHarness(
+        SkyAgGridWrapperHarness.with({ dataSkyId: 'ag-grid-wrapper' }),
+      );
+      await expectAsync(
+        harness.waitUntilRendered(Number.MAX_SAFE_INTEGER),
+      ).toBeResolved();
+    });
+
+    it('should skip waiting when render tracking is not active', async () => {
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      const harness = await TestbedHarnessEnvironment.loader(
+        fixture,
+      ).getHarness(
+        SkyAgGridWrapperHarness.with({ dataSkyId: 'ag-grid-wrapper' }),
+      );
+
+      const originalValue = (window as any).AG_GRID_UNDER_TEST;
+      (window as any).AG_GRID_UNDER_TEST = undefined;
+      try {
+        await expectAsync(harness.waitUntilRendered()).toBeResolved();
+      } finally {
+        (window as any).AG_GRID_UNDER_TEST = originalValue;
+      }
     });
   });
 });

--- a/libs/components/ag-grid/testing/src/modules/ag-grid-wrapper/ag-grid-wrapper-harness.ts
+++ b/libs/components/ag-grid/testing/src/modules/ag-grid-wrapper/ag-grid-wrapper-harness.ts
@@ -4,10 +4,19 @@ import { SkyComponentHarness } from '@skyux/core/testing';
 
 import { GridApi, getGridApi } from 'ag-grid-community';
 
+import {
+  getMsSinceLastRender,
+  getRenderCount as getTrackedRenderCount,
+  isRenderTrackingActive,
+} from '../ag-grid/ag-grid-render-tracking';
+
 import { SkyAgGridWrapperHarnessFilters } from './ag-grid-wrapper-harness.filters';
 
 /**
  * Harness for interacting with SKY UX AG Grid components in tests.
+ * Add `provideSkyAgGridTesting()` to the spec's providers so the harness
+ * can wait for the grid to finish rendering; without it, render-readiness
+ * waits are skipped.
  */
 export class SkyAgGridWrapperHarness extends SkyComponentHarness {
   /**
@@ -66,7 +75,40 @@ export class SkyAgGridWrapperHarness extends SkyComponentHarness {
    * @internal
    */
   public async getGridApi(): Promise<GridApi> {
-    await this.waitForTasksOutsideAngular();
+    const api = await this.#locateGridApi();
+    if (isRenderTrackingActive()) {
+      await this.#waitForRenderCount(api, (count) => count > 0);
+    }
+    return api;
+  }
+
+  /**
+   * @internal
+   * The number of `modelUpdated` render passes AG Grid has completed for
+   * this grid so far. Callers that need to observe the *next* render (e.g.
+   * after triggering a sort) should capture this before acting, then pass it
+   * to `waitUntilRendered()`.
+   */
+  public async getRenderCount(): Promise<number> {
+    return getTrackedRenderCount(await this.#locateGridApi());
+  }
+
+  /**
+   * @internal
+   * Waits, on a bounded wall-clock poll, until the grid has completed more
+   * than `afterCount` render passes. Defaults to `0`, i.e. "has rendered at
+   * least once" - use this instead of `whenStable()`/`waitForTasksOutsideAngular()`,
+   * since AG Grid 36 schedules its render work outside the Angular zone.
+   */
+  public async waitUntilRendered(afterCount = 0): Promise<void> {
+    if (!isRenderTrackingActive()) {
+      return;
+    }
+    const api = await this.#locateGridApi();
+    await this.#waitForRenderCount(api, (count) => count > afterCount);
+  }
+
+  async #locateGridApi(): Promise<GridApi> {
     const locator = this.locatorFactory.locatorFor('ag-grid-angular');
     return await locator().then((grid) => {
       if (grid instanceof UnitTestElement) {
@@ -79,5 +121,28 @@ export class SkyAgGridWrapperHarness extends SkyComponentHarness {
       /* istanbul ignore next */
       throw new Error('Unable to get GridApi from AgGridAngular component.');
     });
+  }
+
+  // A grid that loads data asynchronously (e.g. an Angular `resource()`) can
+  // render an empty pass before its real data arrives, each firing its own
+  // `modelUpdated`. Waiting for the predicate to become true isn't enough -
+  // this also waits for the render count to stop moving for `settleMs`, so a
+  // read doesn't land on that intermediate empty pass.
+  async #waitForRenderCount(
+    api: GridApi,
+    predicate: (count: number) => boolean,
+    timeoutMs = 2000,
+    settleMs = 100,
+  ): Promise<void> {
+    const deadline = Date.now() + timeoutMs;
+    while (
+      !predicate(getTrackedRenderCount(api)) ||
+      getMsSinceLastRender(api) < settleMs
+    ) {
+      if (Date.now() >= deadline) {
+        return;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
   }
 }

--- a/libs/components/ag-grid/testing/src/modules/ag-grid/ag-grid-render-tracking.spec.ts
+++ b/libs/components/ag-grid/testing/src/modules/ag-grid/ag-grid-render-tracking.spec.ts
@@ -1,0 +1,68 @@
+import { GridApi } from 'ag-grid-community';
+
+import {
+  getMsSinceLastRender,
+  getRenderCount,
+  isRenderTrackingActive,
+  trackModelUpdate,
+} from './ag-grid-render-tracking';
+
+describe('ag-grid-render-tracking', () => {
+  it('starts a grid at a render count of 0', () => {
+    const api = {} as GridApi;
+
+    expect(getRenderCount(api)).toBe(0);
+  });
+
+  it('reports Infinity ms since last render for an untracked grid', () => {
+    const api = {} as GridApi;
+
+    expect(getMsSinceLastRender(api)).toBe(Infinity);
+  });
+
+  it('reports a finite ms since last render once a model update is tracked', () => {
+    const api = {} as GridApi;
+
+    trackModelUpdate(api);
+
+    expect(getMsSinceLastRender(api)).toBeLessThan(Infinity);
+  });
+
+  it('increments the render count on each tracked model update', () => {
+    const api = {} as GridApi;
+
+    trackModelUpdate(api);
+    expect(getRenderCount(api)).toBe(1);
+
+    trackModelUpdate(api);
+    expect(getRenderCount(api)).toBe(2);
+  });
+
+  it('tracks render counts independently per grid', () => {
+    const apiA = {} as GridApi;
+    const apiB = {} as GridApi;
+
+    trackModelUpdate(apiA);
+
+    expect(getRenderCount(apiA)).toBe(1);
+    expect(getRenderCount(apiB)).toBe(0);
+  });
+
+  describe('isRenderTrackingActive', () => {
+    const originalValue = (window as any).AG_GRID_UNDER_TEST;
+
+    afterEach(() => {
+      (window as any).AG_GRID_UNDER_TEST = originalValue;
+    });
+
+    it('is false unless AG_GRID_UNDER_TEST has been explicitly set to false', () => {
+      (window as any).AG_GRID_UNDER_TEST = undefined;
+      expect(isRenderTrackingActive()).toBeFalse();
+    });
+
+    it('is true when AG_GRID_UNDER_TEST is explicitly false', () => {
+      (window as any).AG_GRID_UNDER_TEST = false;
+      expect(isRenderTrackingActive()).toBeTrue();
+    });
+  });
+});

--- a/libs/components/ag-grid/testing/src/modules/ag-grid/ag-grid-render-tracking.ts
+++ b/libs/components/ag-grid/testing/src/modules/ag-grid/ag-grid-render-tracking.ts
@@ -1,0 +1,55 @@
+import { GridApi } from 'ag-grid-community';
+
+interface RenderState {
+  count: number;
+  lastRenderedAt: number;
+}
+
+const renderStates = new WeakMap<GridApi, RenderState>();
+
+/**
+ * @internal
+ * Records that AG Grid finished a row-model render pass for the given grid
+ * (initial load, sort, filter, or pagination all trigger `modelUpdated`).
+ */
+export function trackModelUpdate(api: GridApi): void {
+  const previous = renderStates.get(api);
+  renderStates.set(api, {
+    count: (previous?.count ?? 0) + 1,
+    lastRenderedAt: Date.now(),
+  });
+}
+
+/**
+ * @internal
+ * The number of `modelUpdated` render passes recorded for the given grid.
+ */
+export function getRenderCount(api: GridApi): number {
+  return renderStates.get(api)?.count ?? 0;
+}
+
+/**
+ * @internal
+ * Milliseconds since the last recorded render pass, or `Infinity` if none
+ * has been recorded yet. A grid that loads data asynchronously (e.g. an
+ * Angular `resource()`) can render an empty pass before its real data
+ * arrives, each firing its own `modelUpdated` - this lets callers wait for
+ * the render count to stop moving, not just for it to move once.
+ */
+export function getMsSinceLastRender(api: GridApi): number {
+  const state = renderStates.get(api);
+  return state ? Date.now() - state.lastRenderedAt : Infinity;
+}
+
+/**
+ * @internal
+ * Whether AG Grid is currently opted out of Angular's test zone (i.e.
+ * `provideSkyAgGridTesting()` is active), meaning render counts are actually
+ * being recorded and it's safe to wait on them. Consumers of
+ * `SkyAgGridWrapperHarness` that don't use `provideSkyAgGridTesting()` get no
+ * tracking at all, so waiting on a render count that will never move would
+ * just burn the full poll timeout on every read.
+ */
+export function isRenderTrackingActive(): boolean {
+  return (window as any).AG_GRID_UNDER_TEST === false;
+}

--- a/libs/components/ag-grid/testing/src/modules/ag-grid/ag-grid-testing.service.ts
+++ b/libs/components/ag-grid/testing/src/modules/ag-grid/ag-grid-testing.service.ts
@@ -34,6 +34,19 @@ function withRenderTracking<T>(options: GridOptions<T>): GridOptions<T> {
 }
 
 /**
+ * Tracks how many live `SkyAgGridTestingService` instances currently want
+ * `AG_GRID_UNDER_TEST` forced to `false`, and the value it held before the
+ * first of them activated it. `provideSkyAgGridTesting()` can be added to
+ * `TestBed.configureTestingModule()`'s providers *and/or* to one or more
+ * component `providers` arrays within the same spec, so multiple instances
+ * can be alive at once and destroyed in any order - the flag must stay forced
+ * while any instance is alive, and the pre-existing value must only be
+ * restored once the last one is destroyed.
+ */
+let activeInstanceCount = 0;
+let restoreValue: unknown;
+
+/**
  * @internal
  * Configures every grid with disabled row/column virtualization and opts out
  * of AG Grid's Angular test-zone detection. Specs that create and destroy many
@@ -42,8 +55,9 @@ function withRenderTracking<T>(options: GridOptions<T>): GridOptions<T> {
  * which surfaces as a `whenStable()` timeout unrelated to the code under test.
  * Without zone opt-out, AG Grid schedules its internal scroll/viewport work
  * inside the Angular zone under Karma, which can keep the zone from ever
- * reaching stable. The flag is restored to its prior value once the service is
- * destroyed, so specs that don't opt in aren't affected by ones that do.
+ * reaching stable. The flag is restored to its prior value once the last live
+ * instance is destroyed, so specs that don't opt in aren't affected by ones
+ * that do.
  *
  * Note: `provideSkyAgGridTesting()` can be added to `TestBed.configureTestingModule()`'s
  * providers *or* to a component's own `providers` array, so this can't rely on
@@ -56,10 +70,16 @@ function withRenderTracking<T>(options: GridOptions<T>): GridOptions<T> {
 export class SkyAgGridTestingService extends SkyAgGridService {
   constructor() {
     super();
-    const previousValue = (window as any).AG_GRID_UNDER_TEST;
+    if (activeInstanceCount === 0) {
+      restoreValue = (window as any).AG_GRID_UNDER_TEST;
+    }
+    activeInstanceCount++;
     (window as any).AG_GRID_UNDER_TEST = false;
     inject(DestroyRef).onDestroy(() => {
-      (window as any).AG_GRID_UNDER_TEST = previousValue;
+      activeInstanceCount--;
+      if (activeInstanceCount === 0) {
+        (window as any).AG_GRID_UNDER_TEST = restoreValue;
+      }
     });
   }
 

--- a/libs/components/ag-grid/testing/src/modules/ag-grid/ag-grid-testing.service.ts
+++ b/libs/components/ag-grid/testing/src/modules/ag-grid/ag-grid-testing.service.ts
@@ -1,0 +1,83 @@
+import { DestroyRef, Injectable, inject } from '@angular/core';
+import { SkyAgGridService, SkyGetGridOptionsArgs } from '@skyux/ag-grid';
+
+import { GridOptions, ModelUpdatedEvent } from 'ag-grid-community';
+
+import { trackModelUpdate } from './ag-grid-render-tracking';
+
+/**
+ * `GridOptions` applied to every grid built through `SkyAgGridService` while
+ * `provideSkyAgGridTesting()` is in effect. AG Grid recommends disabling
+ * row/column virtualization in tests so the whole grid is DOM-queryable
+ * regardless of a consumer's own layout/scroll settings.
+ */
+const SKY_AG_GRID_TESTING_OPTIONS: Partial<GridOptions> = {
+  suppressColumnVirtualisation: true,
+  suppressRowVirtualisation: true,
+};
+
+/**
+ * Records every `modelUpdated` render pass so `SkyAgGridWrapperHarness` can
+ * poll for a real, non-zone-dependent readiness signal instead of relying on
+ * `whenStable()`, which no longer waits for AG Grid once it runs outside the
+ * Angular zone (see `provideSkyAgGridTesting()`).
+ */
+function withRenderTracking<T>(options: GridOptions<T>): GridOptions<T> {
+  const onModelUpdated = options.onModelUpdated;
+  return {
+    ...options,
+    onModelUpdated: (event: ModelUpdatedEvent<T>): void => {
+      trackModelUpdate(event.api);
+      onModelUpdated?.(event);
+    },
+  };
+}
+
+/**
+ * @internal
+ * Configures every grid with disabled row/column virtualization and opts out
+ * of AG Grid's Angular test-zone detection. Specs that create and destroy many
+ * grids can otherwise see AG Grid's own internal timers and animation frames
+ * occasionally leave a `requestAnimationFrame` callback pending indefinitely,
+ * which surfaces as a `whenStable()` timeout unrelated to the code under test.
+ * Without zone opt-out, AG Grid schedules its internal scroll/viewport work
+ * inside the Angular zone under Karma, which can keep the zone from ever
+ * reaching stable. The flag is restored to its prior value once the service is
+ * destroyed, so specs that don't opt in aren't affected by ones that do.
+ *
+ * Note: `provideSkyAgGridTesting()` can be added to `TestBed.configureTestingModule()`'s
+ * providers *or* to a component's own `providers` array, so this can't rely on
+ * an environment-injector-only mechanism (like `ENVIRONMENT_INITIALIZER`) to
+ * set/restore the flag — a service constructor works at either injector level,
+ * and `DestroyRef` fires correctly for either a TestBed module teardown or a
+ * component destroy.
+ */
+@Injectable()
+export class SkyAgGridTestingService extends SkyAgGridService {
+  constructor() {
+    super();
+    const previousValue = (window as any).AG_GRID_UNDER_TEST;
+    (window as any).AG_GRID_UNDER_TEST = false;
+    inject(DestroyRef).onDestroy(() => {
+      (window as any).AG_GRID_UNDER_TEST = previousValue;
+    });
+  }
+
+  public override getGridOptions<T = any>(
+    args: SkyGetGridOptionsArgs<T>,
+  ): GridOptions<T> {
+    return withRenderTracking({
+      ...super.getGridOptions(args),
+      ...SKY_AG_GRID_TESTING_OPTIONS,
+    });
+  }
+
+  public override getEditableGridOptions<T = any>(
+    args: SkyGetGridOptionsArgs<T>,
+  ): GridOptions<T> {
+    return withRenderTracking({
+      ...super.getEditableGridOptions(args),
+      ...SKY_AG_GRID_TESTING_OPTIONS,
+    });
+  }
+}

--- a/libs/components/ag-grid/testing/src/modules/ag-grid/provide-ag-grid-testing.spec.ts
+++ b/libs/components/ag-grid/testing/src/modules/ag-grid/provide-ag-grid-testing.spec.ts
@@ -67,6 +67,11 @@ describe('provideSkyAgGridTesting', () => {
     it('should keep the flag active until the last of two independently-destroyed instances is torn down', () => {
       const win = window as unknown as { AG_GRID_UNDER_TEST?: boolean };
       const previous = win.AG_GRID_UNDER_TEST;
+      // Force a fixed, non-false ambient value before the instances activate,
+      // so the intermediate assertion below can only pass if the flag is
+      // genuinely being kept active by injector B - not by coincidence
+      // because the ambient value already happened to be non-false.
+      win.AG_GRID_UNDER_TEST = true;
 
       TestBed.configureTestingModule({});
       const parent = TestBed.inject(Injector);
@@ -78,16 +83,34 @@ describe('provideSkyAgGridTesting', () => {
         providers: [provideSkyAgGridTesting()],
         parent,
       });
+      let injectorADestroyed = false;
+      let injectorBDestroyed = false;
 
-      injectorA.get(SkyAgGridService); // instantiates the testing service
-      injectorB.get(SkyAgGridService); // instantiates a second, independent instance
-      expect(win.AG_GRID_UNDER_TEST).toBeFalse();
+      try {
+        injectorA.get(SkyAgGridService); // instantiates the testing service
+        injectorB.get(SkyAgGridService); // instantiates a second, independent instance
+        expect(win.AG_GRID_UNDER_TEST).toBeFalse();
 
-      injectorA.destroy();
-      expect(win.AG_GRID_UNDER_TEST).toBeFalse(); // injector B is still alive
+        injectorA.destroy();
+        injectorADestroyed = true;
+        expect(win.AG_GRID_UNDER_TEST).toBeFalse(); // injector B is still alive
 
-      injectorB.destroy();
-      expect(win.AG_GRID_UNDER_TEST).toBe(previous);
+        injectorB.destroy();
+        injectorBDestroyed = true;
+        expect(win.AG_GRID_UNDER_TEST).toBeTrue(); // restored to the forced sentinel
+      } finally {
+        if (!injectorADestroyed) {
+          injectorA.destroy();
+        }
+        if (!injectorBDestroyed) {
+          injectorB.destroy();
+        }
+        if (previous === undefined) {
+          delete win.AG_GRID_UNDER_TEST;
+        } else {
+          win.AG_GRID_UNDER_TEST = previous;
+        }
+      }
     });
   });
 });

--- a/libs/components/ag-grid/testing/src/modules/ag-grid/provide-ag-grid-testing.spec.ts
+++ b/libs/components/ag-grid/testing/src/modules/ag-grid/provide-ag-grid-testing.spec.ts
@@ -1,3 +1,4 @@
+import { Injector } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { SkyAgGridService } from '@skyux/ag-grid';
 
@@ -61,6 +62,32 @@ describe('provideSkyAgGridTesting', () => {
       } finally {
         delete win.AG_GRID_UNDER_TEST;
       }
+    });
+
+    it('should keep the flag active until the last of two independently-destroyed instances is torn down', () => {
+      const win = window as unknown as { AG_GRID_UNDER_TEST?: boolean };
+      const previous = win.AG_GRID_UNDER_TEST;
+
+      TestBed.configureTestingModule({});
+      const parent = TestBed.inject(Injector);
+      const injectorA = Injector.create({
+        providers: [provideSkyAgGridTesting()],
+        parent,
+      });
+      const injectorB = Injector.create({
+        providers: [provideSkyAgGridTesting()],
+        parent,
+      });
+
+      injectorA.get(SkyAgGridService); // instantiates the testing service
+      injectorB.get(SkyAgGridService); // instantiates a second, independent instance
+      expect(win.AG_GRID_UNDER_TEST).toBeFalse();
+
+      injectorA.destroy();
+      expect(win.AG_GRID_UNDER_TEST).toBeFalse(); // injector B is still alive
+
+      injectorB.destroy();
+      expect(win.AG_GRID_UNDER_TEST).toBe(previous);
     });
   });
 });

--- a/libs/components/ag-grid/testing/src/modules/ag-grid/provide-ag-grid-testing.spec.ts
+++ b/libs/components/ag-grid/testing/src/modules/ag-grid/provide-ag-grid-testing.spec.ts
@@ -1,0 +1,66 @@
+import { TestBed } from '@angular/core/testing';
+import { SkyAgGridService } from '@skyux/ag-grid';
+
+import { provideSkyAgGridTesting } from './provide-ag-grid-testing';
+
+describe('provideSkyAgGridTesting', () => {
+  describe('grid options', () => {
+    beforeEach(() => {
+      TestBed.configureTestingModule({
+        providers: [provideSkyAgGridTesting()],
+      });
+    });
+
+    it('should disable virtualization for read-only grids', () => {
+      const gridOptions = TestBed.inject(SkyAgGridService).getGridOptions({
+        gridOptions: {},
+      });
+
+      expect(gridOptions.suppressColumnVirtualisation).toBeTrue();
+      expect(gridOptions.suppressRowVirtualisation).toBeTrue();
+    });
+
+    it('should disable virtualization for editable grids', () => {
+      const gridOptions = TestBed.inject(
+        SkyAgGridService,
+      ).getEditableGridOptions({
+        gridOptions: {},
+      });
+
+      expect(gridOptions.suppressColumnVirtualisation).toBeTrue();
+      expect(gridOptions.suppressRowVirtualisation).toBeTrue();
+    });
+  });
+
+  describe('AG_GRID_UNDER_TEST flag', () => {
+    it('should set AG_GRID_UNDER_TEST to false while active and restore it after teardown', () => {
+      const win = window as unknown as { AG_GRID_UNDER_TEST?: boolean };
+      const previous = win.AG_GRID_UNDER_TEST;
+
+      TestBed.configureTestingModule({
+        providers: [provideSkyAgGridTesting()],
+      });
+      TestBed.inject(SkyAgGridService); // instantiates the testing service
+      expect(win.AG_GRID_UNDER_TEST).toBeFalse();
+
+      TestBed.resetTestingModule(); // destroys the injector
+      expect(win.AG_GRID_UNDER_TEST).toBe(previous); // undefined restored as undefined
+    });
+
+    it('should restore a pre-existing AG_GRID_UNDER_TEST value', () => {
+      const win = window as unknown as { AG_GRID_UNDER_TEST?: boolean };
+      win.AG_GRID_UNDER_TEST = true;
+      try {
+        TestBed.configureTestingModule({
+          providers: [provideSkyAgGridTesting()],
+        });
+        TestBed.inject(SkyAgGridService);
+        expect(win.AG_GRID_UNDER_TEST).toBeFalse();
+        TestBed.resetTestingModule();
+        expect(win.AG_GRID_UNDER_TEST).toBeTrue();
+      } finally {
+        delete win.AG_GRID_UNDER_TEST;
+      }
+    });
+  });
+});

--- a/libs/components/ag-grid/testing/src/modules/ag-grid/provide-ag-grid-testing.ts
+++ b/libs/components/ag-grid/testing/src/modules/ag-grid/provide-ag-grid-testing.ts
@@ -1,0 +1,24 @@
+import { Provider } from '@angular/core';
+import { SkyAgGridService } from '@skyux/ag-grid';
+
+import { SkyAgGridTestingService } from './ag-grid-testing.service';
+
+/**
+ * Configures every grid built through `SkyAgGridService` to disable AG Grid's
+ * row/column virtualization and to opt out of AG Grid's Angular test-zone
+ * detection while the test is running, so grid work completes without hanging
+ * `whenStable()`. The previous test-zone setting is restored when the test's
+ * injector is destroyed, so specs that don't opt in aren't affected by ones
+ * that do. Add to the spec's `TestBed.configureTestingModule` providers.
+ *
+ * @example
+ * ```typescript
+ * TestBed.configureTestingModule({
+ *   providers: [provideSkyAgGridTesting()],
+ * });
+ * ```
+ * @preview
+ */
+export function provideSkyAgGridTesting(): Provider[] {
+  return [{ provide: SkyAgGridService, useClass: SkyAgGridTestingService }];
+}

--- a/libs/components/ag-grid/testing/src/public-api.ts
+++ b/libs/components/ag-grid/testing/src/public-api.ts
@@ -1,2 +1,3 @@
 export { SkyAgGridWrapperHarness } from './modules/ag-grid-wrapper/ag-grid-wrapper-harness';
 export { SkyAgGridWrapperHarnessFilters } from './modules/ag-grid-wrapper/ag-grid-wrapper-harness.filters';
+export { provideSkyAgGridTesting } from './modules/ag-grid/provide-ag-grid-testing';

--- a/libs/components/code-examples/src/lib/modules/data-grid/basic/example.component.spec.ts
+++ b/libs/components/code-examples/src/lib/modules/data-grid/basic/example.component.spec.ts
@@ -1,7 +1,10 @@
 import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { SkyDataGridHarness } from '@skyux/data-grid/testing';
+import {
+  SkyDataGridHarness,
+  provideSkyDataGridTesting,
+} from '@skyux/data-grid/testing';
 import {
   SkyDropdownHarness,
   SkyDropdownMenuHarness,
@@ -17,6 +20,7 @@ describe('Basic data grid example', () => {
   }> {
     await TestBed.configureTestingModule({
       imports: [DataGridBasicExampleComponent],
+      providers: [provideSkyDataGridTesting()],
     }).compileComponents();
     const fixture = TestBed.createComponent(DataGridBasicExampleComponent);
     const loader = TestbedHarnessEnvironment.loader(fixture);

--- a/libs/components/code-examples/src/lib/modules/data-grid/loading/data.ts
+++ b/libs/components/code-examples/src/lib/modules/data-grid/loading/data.ts
@@ -1,10 +1,58 @@
+import { InjectionToken, ResourceLoader } from '@angular/core';
+
 import { SkyDataGridSort } from '@skyux/data-grid';
+
+export type DemoBehavior = 'data' | 'empty' | 'loading';
+
+/**
+ * An injection token that can be overridden in a test.
+ */
+export const DATA_LOADER = new InjectionToken('DATA_LOADER', {
+  providedIn: 'root',
+  factory: (): ResourceLoader<DataGridServerPage, DataGridServerParams> => {
+    return async ({
+      params,
+      abortSignal,
+    }: {
+      params: DataGridServerParams;
+      abortSignal: AbortSignal;
+    }): Promise<DataGridServerPage> => {
+      switch (params.behavior) {
+        case 'data':
+          await new Promise((resolve) => setTimeout(resolve, params.delay));
+          return getServerPage(params);
+        case 'empty':
+          await new Promise((resolve) => setTimeout(resolve, params.delay));
+          return { items: [], totalCount: 0 };
+        case 'loading':
+          return await new Promise((resolve) => {
+            abortSignal.addEventListener('abort', () => {
+              resolve({ items: [], totalCount: 0 });
+            });
+          });
+        default:
+          throw new Error();
+      }
+    };
+  },
+});
 
 export interface DataGridLoadingRow {
   id: string;
   name: string;
   age: number;
   startDate: Date;
+}
+
+/**
+ * Parameters available to the loader.
+ */
+export interface DataGridServerParams {
+  behavior: DemoBehavior;
+  delay: number;
+  page: number;
+  pageSize: number;
+  sort: SkyDataGridSort | undefined;
 }
 
 /**

--- a/libs/components/code-examples/src/lib/modules/data-grid/loading/example.component.spec.ts
+++ b/libs/components/code-examples/src/lib/modules/data-grid/loading/example.component.spec.ts
@@ -1,18 +1,33 @@
 import { HarnessLoader, manualChangeDetection } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { SkyDataGridHarness } from '@skyux/data-grid/testing';
+import {
+  provideSkyDataGridTesting,
+  SkyDataGridHarness,
+} from '@skyux/data-grid/testing';
 
+import { Provider, ResourceLoader } from '@angular/core';
+import { DATA_LOADER, DataGridServerPage, DataGridServerParams } from './data';
 import { DataGridLoadingExampleComponent } from './example.component';
 
 describe('Data grid loading example', () => {
-  async function setupTest(): Promise<{
+  async function setupTest(options?: {
+    dataLoader?: ResourceLoader<DataGridServerPage, DataGridServerParams>;
+  }): Promise<{
     fixture: ComponentFixture<DataGridLoadingExampleComponent>;
     loader: HarnessLoader;
     gridHarness: SkyDataGridHarness;
   }> {
+    const providers: Provider[] = [provideSkyDataGridTesting()];
+    if (options?.dataLoader) {
+      providers.push({
+        provide: DATA_LOADER,
+        useValue: options.dataLoader,
+      });
+    }
     await TestBed.configureTestingModule({
       imports: [DataGridLoadingExampleComponent],
+      providers,
     }).compileComponents();
     const fixture = TestBed.createComponent(DataGridLoadingExampleComponent);
     fixture.componentRef.setInput('delay', 0);
@@ -25,6 +40,13 @@ describe('Data grid loading example', () => {
     return { fixture, loader, gridHarness };
   }
 
+  async function settle(fixture: ComponentFixture<unknown>): Promise<void> {
+    await fixture.whenStable();
+    fixture.detectChanges();
+    await new Promise((resolve) => setTimeout(resolve));
+    fixture.detectChanges();
+  }
+
   async function clickButton(
     fixture: ComponentFixture<DataGridLoadingExampleComponent>,
     dataSkyId: string,
@@ -32,10 +54,7 @@ describe('Data grid loading example', () => {
     (fixture.nativeElement as HTMLElement)
       .querySelector<HTMLButtonElement>(`[data-sky-id="${dataSkyId}"]`)
       ?.click();
-    await fixture.whenStable();
-    fixture.detectChanges();
-    await new Promise((resolve) => setTimeout(resolve));
-    fixture.detectChanges();
+    await settle(fixture);
   }
 
   it('should create the component and show the first page of data', async () => {
@@ -55,10 +74,7 @@ describe('Data grid loading example', () => {
     await expectAsync(paging.getCurrentPage()).toBeResolvedTo(1);
 
     await paging.clickNextButton();
-    await fixture.whenStable();
-    fixture.detectChanges();
-    await new Promise((resolve) => setTimeout(resolve));
-    fixture.detectChanges();
+    await settle(fixture);
 
     await expectAsync(paging.getCurrentPage()).toBeResolvedTo(2);
     expect(await gridHarness.getDisplayedRowCount()).toBe(5);
@@ -72,22 +88,67 @@ describe('Data grid loading example', () => {
   });
 
   it('should show the loading overlay for the loading state', async () => {
-    const { fixture, gridHarness } = await setupTest();
+    const emptyPage: DataGridServerPage = { items: [], totalCount: 0 };
+    // The production loader's "loading" behavior never resolves until
+    // aborted, so use a spy that mirrors that: resolve immediately for
+    // every behavior except "loading", which hangs forever to keep the
+    // grid in a sustained loading state for the assertion below.
+    const loader = jasmine
+      .createSpy('loader')
+      .and.callFake((args: { params: DataGridServerParams }) =>
+        args.params.behavior === 'loading'
+          ? new Promise<DataGridServerPage>(() => {
+              // never resolves: sustained loading
+            })
+          : Promise.resolve(emptyPage),
+      );
+    const { fixture, gridHarness } = await setupTest({ dataLoader: loader });
 
-    // The loading state uses a resource that never resolves, so the app never
-    // reaches zone stability. Drive change detection manually (rather than
-    // through `clickButton`, which awaits `whenStable`) and query the harness
-    // under `manualChangeDetection` so the CDK does not auto-stabilize, which
-    // would otherwise hang until the test times out.
-    (fixture.nativeElement as HTMLElement)
-      .querySelector<HTMLButtonElement>('[data-sky-id="show-loading-button"]')
-      ?.click();
-    fixture.detectChanges();
-    await Promise.resolve();
-    fixture.detectChanges();
+    // Confirm the grid's render-readiness handshake has already completed
+    // before introducing a load that never resolves. The data grid also
+    // renders its own render-readiness wait through `SkyWaitHarness`
+    // (separate from the loading overlay under test below); settling here,
+    // while the initial "data" load still resolves immediately, ensures
+    // that wait has already cleared before `manualChangeDetection` disables
+    // further automatic stabilization.
+    await settle(fixture);
+    const readyWait = await gridHarness.getWait();
+    await expectAsync(readyWait.isWaiting()).toBeResolvedTo(false);
 
+    // The "loading" behavior's resource load never resolves, so it leaves
+    // an Angular `PendingTasks` entry open indefinitely. `fixture.whenStable()`
+    // - used by `clickButton`/`settle`, and internally by every CDK harness
+    // query via `forceStabilize()` - awaits that same pending-task signal,
+    // so it would hang forever here. `manualChangeDetection()` suspends the
+    // harness environment's automatic stabilization for its duration, so
+    // change detection must be driven manually below.
     await manualChangeDetection(async () => {
+      (fixture.nativeElement as HTMLElement)
+        .querySelector<HTMLButtonElement>('[data-sky-id="show-loading-button"]')
+        ?.click();
+      fixture.detectChanges();
+
+      // AG Grid mounts its loading overlay component outside the Angular
+      // zone, so poll on a bounded, real-time basis (not zone/PendingTasks
+      // stability) to give it a chance to appear.
+      const deadline = Date.now() + 2000;
+      while (!(await gridHarness.isLoading()) && Date.now() < deadline) {
+        await new Promise((resolve) => setTimeout(resolve, 25));
+        fixture.detectChanges();
+      }
+
       await expectAsync(gridHarness.isLoading()).toBeResolvedTo(true);
+    });
+
+    expect(loader).toHaveBeenCalledWith({
+      params: jasmine.objectContaining({
+        behavior: 'loading',
+        delay: 0,
+        pageSize: 5,
+        page: 1,
+      }),
+      abortSignal: jasmine.any(AbortSignal),
+      previous: { status: 'resolved' },
     });
   });
 

--- a/libs/components/code-examples/src/lib/modules/data-grid/loading/example.component.ts
+++ b/libs/components/code-examples/src/lib/modules/data-grid/loading/example.component.ts
@@ -3,6 +3,7 @@ import {
   ChangeDetectionStrategy,
   Component,
   effect,
+  inject,
   input,
   resource,
   signal,
@@ -13,9 +14,7 @@ import {
   SkyDataGridSort,
 } from '@skyux/data-grid';
 
-import { DataGridServerPage, getServerPage } from './data';
-
-type DemoBehavior = 'data' | 'empty' | 'loading';
+import { DATA_LOADER, DemoBehavior } from './data';
 
 /**
  * @title Data grid with a server-side resource data source
@@ -53,24 +52,7 @@ export class DataGridLoadingExampleComponent {
       pageSize: this.pageSize,
       sort: this.sort(),
     }),
-    loader: async ({ params, abortSignal }): Promise<DataGridServerPage> => {
-      switch (params.behavior) {
-        case 'data':
-          await new Promise((resolve) => setTimeout(resolve, params.delay));
-          return getServerPage(params);
-        case 'empty':
-          await new Promise((resolve) => setTimeout(resolve, params.delay));
-          return { items: [], totalCount: 0 };
-        case 'loading':
-          return await new Promise((resolve) => {
-            abortSignal.addEventListener('abort', () => {
-              resolve({ items: [], totalCount: 0 });
-            });
-          });
-        default:
-          throw new Error();
-      }
-    },
+    loader: inject(DATA_LOADER),
   });
 
   readonly #behavior = signal<DemoBehavior>('data');

--- a/libs/components/code-examples/src/lib/modules/data-grid/paging/example.component.spec.ts
+++ b/libs/components/code-examples/src/lib/modules/data-grid/paging/example.component.spec.ts
@@ -2,7 +2,10 @@ import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideRouter } from '@angular/router';
-import { SkyDataGridHarness } from '@skyux/data-grid/testing';
+import {
+  provideSkyDataGridTesting,
+  SkyDataGridHarness,
+} from '@skyux/data-grid/testing';
 
 import { DataGridPagingExampleComponent } from './example.component';
 
@@ -13,7 +16,7 @@ describe('Data grid paging example', () => {
   }> {
     await TestBed.configureTestingModule({
       imports: [DataGridPagingExampleComponent],
-      providers: [provideRouter([])],
+      providers: [provideRouter([]), provideSkyDataGridTesting()],
     }).compileComponents();
     const fixture = TestBed.createComponent(DataGridPagingExampleComponent);
     const loader = TestbedHarnessEnvironment.loader(fixture);

--- a/libs/components/code-examples/src/lib/modules/data-grid/sorting/example.component.spec.ts
+++ b/libs/components/code-examples/src/lib/modules/data-grid/sorting/example.component.spec.ts
@@ -1,7 +1,10 @@
 import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { SkyDataGridHarness } from '@skyux/data-grid/testing';
+import {
+  provideSkyDataGridTesting,
+  SkyDataGridHarness,
+} from '@skyux/data-grid/testing';
 
 import { DataGridSortingExampleComponent } from './example.component';
 
@@ -12,6 +15,7 @@ describe('Data grid sorting example', () => {
   }> {
     await TestBed.configureTestingModule({
       imports: [DataGridSortingExampleComponent],
+      providers: [provideSkyDataGridTesting()],
     }).compileComponents();
     const fixture = TestBed.createComponent(DataGridSortingExampleComponent);
     const loader = TestbedHarnessEnvironment.loader(fixture);

--- a/libs/components/code-examples/src/lib/modules/data-manager/data-manager/basic/example.component.spec.ts
+++ b/libs/components/code-examples/src/lib/modules/data-manager/data-manager/basic/example.component.spec.ts
@@ -4,6 +4,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { SkyDataManagerHarness } from '@skyux/data-manager/testing';
 import { SkyRepeaterHarness } from '@skyux/lists/testing';
 
+import { provideSkyAgGridTesting } from '@skyux/ag-grid/testing';
 import { DataManagerBasicExampleComponent } from './example.component';
 
 describe('Data manager basic example', () => {
@@ -14,6 +15,7 @@ describe('Data manager basic example', () => {
   }> {
     await TestBed.configureTestingModule({
       imports: [DataManagerBasicExampleComponent],
+      providers: [provideSkyAgGridTesting()],
     }).compileComponents();
 
     const fixture = TestBed.createComponent(DataManagerBasicExampleComponent);

--- a/libs/components/code-examples/src/lib/modules/pages/page/list-page-list-layout-demo/example.component.spec.ts
+++ b/libs/components/code-examples/src/lib/modules/pages/page/list-page-list-layout-demo/example.component.spec.ts
@@ -6,6 +6,7 @@ import {
 } from '@skyux/core/testing';
 import { SkyPageHarness } from '@skyux/pages/testing';
 
+import { provideSkyAgGridTesting } from '@skyux/ag-grid/testing';
 import { PagesPageListPageListLayoutExampleComponent } from './example.component';
 
 describe('List page list layout example', () => {
@@ -31,6 +32,7 @@ describe('List page list layout example', () => {
         PagesPageListPageListLayoutExampleComponent,
         SkyHelpTestingModule,
       ],
+      providers: [provideSkyAgGridTesting()],
     });
   });
 

--- a/libs/components/code-examples/src/lib/modules/pages/page/list-page-tabs-layout-demo/example.component.spec.ts
+++ b/libs/components/code-examples/src/lib/modules/pages/page/list-page-tabs-layout-demo/example.component.spec.ts
@@ -1,6 +1,7 @@
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideRouter } from '@angular/router';
+import { provideSkyAgGridTesting } from '@skyux/ag-grid/testing';
 import {
   SkyHelpTestingController,
   SkyHelpTestingModule,
@@ -32,7 +33,7 @@ describe('List page tabs layout example', () => {
         PagesPageListPageTabsLayoutExampleComponent,
         SkyHelpTestingModule,
       ],
-      providers: [provideRouter([])],
+      providers: [provideRouter([]), provideSkyAgGridTesting()],
     });
   });
 

--- a/libs/components/code-examples/src/lib/modules/pages/page/record-page-tabs-layout-demo/example.component.spec.ts
+++ b/libs/components/code-examples/src/lib/modules/pages/page/record-page-tabs-layout-demo/example.component.spec.ts
@@ -7,6 +7,7 @@ import {
 } from '@skyux/core/testing';
 import { SkyPageHarness } from '@skyux/pages/testing';
 
+import { provideSkyAgGridTesting } from '@skyux/ag-grid/testing';
 import { PagesPageRecordPageTabsLayoutExampleComponent } from './example.component';
 
 describe('Record page tabs layout example', () => {
@@ -32,7 +33,7 @@ describe('Record page tabs layout example', () => {
         PagesPageRecordPageTabsLayoutExampleComponent,
         SkyHelpTestingModule,
       ],
-      providers: [provideRouter([])],
+      providers: [provideRouter([]), provideSkyAgGridTesting()],
     });
   });
 

--- a/libs/components/data-grid/documentation.json
+++ b/libs/components/data-grid/documentation.json
@@ -7,7 +7,11 @@
         "primaryDocsId": "SkyDataGrid"
       },
       "testing": {
-        "docsIds": ["SkyDataGridHarness", "SkyDataGridHarnessFilters"]
+        "docsIds": [
+          "SkyDataGridHarness",
+          "SkyDataGridHarnessFilters",
+          "provideSkyDataGridTesting"
+        ]
       },
       "codeExamples": {
         "docsIds": [

--- a/libs/components/data-grid/src/lib/modules/data-grid/data-grid.spec.ts
+++ b/libs/components/data-grid/src/lib/modules/data-grid/data-grid.spec.ts
@@ -40,16 +40,6 @@ function getGridApiSync(agGridAngularElement: Element | null) {
 }
 
 /**
- * `ResourceDataTestComponent`'s grid goes through an async resource state
- * transition (rather than a synchronous, client-side action). This no longer
- * changes `flushAgGridWork`'s behavior (it settles deterministically off AG
- * Grid's own render-count signal rather than a fixed iteration budget), but
- * `getGridApi` still accepts it for call-site compatibility.
- */
-const DEFAULT_FLUSH_ITERATIONS = 15;
-const RESOURCE_DATA_SOURCE_ITERATIONS = 30;
-
-/**
  * `provideSkyAgGridTesting()` sets `window.AG_GRID_UNDER_TEST = false`,
  * which makes AG Grid schedule its internal work outside the Angular zone
  * (matching AG Grid's own production default). That means
@@ -79,7 +69,6 @@ async function flushAgGridWork<T>(fixture: ComponentFixture<T>): Promise<void> {
 async function getGridApi<T>(
   agGridAngularElement: Element | null,
   fixture: ComponentFixture<T>,
-  iterations = DEFAULT_FLUSH_ITERATIONS,
 ) {
   const api = getGridApiSync(agGridAngularElement);
   await flushAgGridWork(fixture);
@@ -1273,7 +1262,6 @@ describe('SkyDataGrid', () => {
           '[data-sky-id="resource-grid"] ag-grid-angular',
         ),
         resourceFixture,
-        RESOURCE_DATA_SOURCE_ITERATIONS,
       );
       expect(api).toBeTruthy();
       // No rows render while the resource is still loading.
@@ -1327,7 +1315,6 @@ describe('SkyDataGrid', () => {
           '[data-sky-id="resource-grid"] ag-grid-angular',
         ),
         resourceFixture,
-        RESOURCE_DATA_SOURCE_ITERATIONS,
       );
       expect(resourceFixture.componentInstance.selectedRowIds()).toEqual([
         '1',
@@ -1353,7 +1340,6 @@ describe('SkyDataGrid', () => {
           '[data-sky-id="resource-columns-grid"] ag-grid-angular',
         ),
         resourceFixture,
-        RESOURCE_DATA_SOURCE_ITERATIONS,
       );
       expect(api?.getColumnState().map((col) => col.colId)).toEqual([
         'name',
@@ -1376,7 +1362,6 @@ describe('SkyDataGrid', () => {
           '[data-sky-id="resource-columns-grid"] ag-grid-angular',
         ),
         resourceFixture,
-        RESOURCE_DATA_SOURCE_ITERATIONS,
       );
       expect(api?.getGridOption('pagination')).toBeTrue();
       expect(api?.getGridOption('paginationPageSize')).toBe(1);

--- a/libs/components/data-grid/src/lib/modules/data-grid/data-grid.spec.ts
+++ b/libs/components/data-grid/src/lib/modules/data-grid/data-grid.spec.ts
@@ -1,7 +1,13 @@
 import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { provideLocationMocks } from '@angular/common/testing';
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import {
+  ComponentFixture,
+  discardPeriodicTasks,
+  fakeAsync,
+  TestBed,
+  tick,
+} from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { ActivatedRoute, provideRouter, Router } from '@angular/router';
 import { expectAsync, SkyAppTestUtility } from '@skyux-sdk/testing';
@@ -13,13 +19,72 @@ import { SkyWaitHarness } from '@skyux/indicators/testing';
 // eslint-disable-next-line @nx/enforce-module-boundaries
 import { SkyPagingHarness } from '@skyux/lists/testing';
 
-import { getGridApi } from 'ag-grid-community';
+import { getGridApi as getAgGridApi } from 'ag-grid-community';
 import { SkyDataGrid } from './data-grid';
+import { ColumnFitTestComponent } from './fixtures/column-fit-test.component';
 import { ColumnWidthTestComponent } from './fixtures/column-width-test.component';
 import { DataGridTestComponent } from './fixtures/data-grid-test.component';
 import { FlexWidthTestComponent } from './fixtures/flex-width-test.component';
+import { ResourceColumnsTestComponent } from './fixtures/resource-columns-test.component';
 import { ResourceDataTestComponent } from './fixtures/resource-data-test.component';
 import { TemplateColumnTestComponent } from './fixtures/template-column-test.component';
+
+/**
+ * Synchronous on purpose: used directly only by the `fakeAsync` "columnFit"
+ * tests below, which don't opt into `provideSkyAgGridTesting()` and so don't
+ * need (and, inside `fakeAsync`, can't easily use) the real-macrotask flush
+ * that `getGridApi()` performs.
+ */
+function getGridApiSync(agGridAngularElement: Element | null) {
+  return getAgGridApi(agGridAngularElement);
+}
+
+/**
+ * `ResourceDataTestComponent`'s grid goes through an async resource state
+ * transition (rather than a synchronous, client-side action). This no longer
+ * changes `flushAgGridWork`'s behavior (it settles deterministically off AG
+ * Grid's own render-count signal rather than a fixed iteration budget), but
+ * `getGridApi` still accepts it for call-site compatibility.
+ */
+const DEFAULT_FLUSH_ITERATIONS = 15;
+const RESOURCE_DATA_SOURCE_ITERATIONS = 30;
+
+/**
+ * `provideSkyAgGridTesting()` sets `window.AG_GRID_UNDER_TEST = false`,
+ * which makes AG Grid schedule its internal work outside the Angular zone
+ * (matching AG Grid's own production default). That means
+ * `fixture.whenStable()` no longer waits for AG Grid's rendering to finish,
+ * so reading grid state (or state derived from it, like the paging harness
+ * or a rendered cell) immediately after triggering a change can race AG
+ * Grid's out-of-zone work.
+ *
+ * `SkyAgGridWrapperHarness.waitUntilRendered()` settles deterministically by
+ * polling AG Grid's `modelUpdated` render-count signal until it stops moving,
+ * instead of burning a fixed wall-clock budget.
+ */
+async function flushAgGridWork<T>(fixture: ComponentFixture<T>): Promise<void> {
+  // Let any just-triggered render begin before waiting for it to settle.
+  fixture.detectChanges();
+  await fixture.whenStable();
+  await new Promise((resolve) => setTimeout(resolve));
+
+  const loader = TestbedHarnessEnvironment.loader(fixture);
+  const wrapper = await loader.getHarnessOrNull(SkyAgGridWrapperHarness);
+  await wrapper?.waitUntilRendered(); // settles when modelUpdated stops moving
+
+  fixture.detectChanges();
+  await fixture.whenStable();
+}
+
+async function getGridApi<T>(
+  agGridAngularElement: Element | null,
+  fixture: ComponentFixture<T>,
+  iterations = DEFAULT_FLUSH_ITERATIONS,
+) {
+  const api = getGridApiSync(agGridAngularElement);
+  await flushAgGridWork(fixture);
+  return api;
+}
 
 describe('SkyDataGrid', () => {
   describe('without data manager', () => {
@@ -45,8 +110,7 @@ describe('SkyDataGrid', () => {
       fixture.componentRef.setInput('labelText', 'My test grid');
       fixture.detectChanges();
       await fixture.whenStable();
-      fixture.detectChanges();
-      await fixture.whenStable();
+      await flushAgGridWork(fixture);
 
       const gridWrapper = fixture.nativeElement.querySelector(
         'sky-ag-grid-wrapper',
@@ -164,6 +228,10 @@ describe('SkyDataGrid', () => {
       fixture.componentRef.setInput('dataForSimpleGrid', undefined);
       fixture.detectChanges();
       expect(component).toBeTruthy();
+      // Wait for the grid's initial render before reading its loading state
+      // below: with AG Grid's out-of-zone scheduling, `whenStable()` alone
+      // doesn't guarantee the grid has finished its first render pass.
+      await flushAgGridWork(fixture);
       const waitHarness =
         await TestbedHarnessEnvironment.loader(fixture).getHarness(
           SkyWaitHarness,
@@ -181,10 +249,11 @@ describe('SkyDataGrid', () => {
     it('should handle data changing from populated to undefined', async () => {
       fixture.detectChanges();
       await fixture.whenStable();
-      const api = getGridApi(
+      const api = await getGridApi(
         fixture.nativeElement.querySelector(
           '[data-sky-id="grid"] ag-grid-angular',
         ),
+        fixture,
       );
       expect(api).toBeTruthy();
       expect(api?.getDisplayedRowCount()).toBe(7);
@@ -199,10 +268,11 @@ describe('SkyDataGrid', () => {
       fixture.componentRef.setInput('dataForSimpleGrid', undefined);
       fixture.detectChanges();
       await fixture.whenStable();
-      const api = getGridApi(
+      const api = await getGridApi(
         fixture.nativeElement.querySelector(
           '[data-sky-id="grid"] ag-grid-angular',
         ),
+        fixture,
       );
       expect(api).toBeTruthy();
       expect(api?.getDisplayedRowCount()).toBe(0);
@@ -222,7 +292,7 @@ describe('SkyDataGrid', () => {
       const gridElement = fixture.nativeElement.querySelector(
         '[data-sky-id="grid"] ag-grid-angular',
       );
-      const api = getGridApi(gridElement);
+      const api = await getGridApi(gridElement, fixture);
       expect(api).toBeTruthy();
       expect(api?.getState()?.sort?.sortModel).toBeUndefined();
 
@@ -287,7 +357,7 @@ describe('SkyDataGrid', () => {
       const gridElement = fixture.nativeElement.querySelector(
         '[data-sky-id="grid"] ag-grid-angular',
       );
-      const api = getGridApi(gridElement);
+      const api = await getGridApi(gridElement, fixture);
       expect(api).toBeTruthy();
       expect(api?.getColumnState().map((col) => col.colId)).toEqual([
         'column1',
@@ -345,10 +415,11 @@ describe('SkyDataGrid', () => {
       });
       fixture.detectChanges();
       await fixture.whenStable();
-      const api = getGridApi(
+      const api = await getGridApi(
         fixture.nativeElement.querySelector(
           '[data-sky-id="grid"] ag-grid-angular',
         ),
+        fixture,
       );
       expect(api?.getState()?.sort?.sortModel).toEqual([
         { colId: 'column1', sort: 'desc', type: 'default' },
@@ -362,10 +433,11 @@ describe('SkyDataGrid', () => {
       });
       fixture.detectChanges();
       await fixture.whenStable();
-      const api = getGridApi(
+      const api = await getGridApi(
         fixture.nativeElement.querySelector(
           '[data-sky-id="grid"] ag-grid-angular',
         ),
+        fixture,
       );
       expect(api?.getState()?.sort?.sortModel).toEqual([
         { colId: 'column2', sort: 'asc', type: 'default' },
@@ -375,10 +447,11 @@ describe('SkyDataGrid', () => {
     it('should update grid options when pageSize changes', async () => {
       fixture.detectChanges();
       await fixture.whenStable();
-      const api = getGridApi(
+      const api = await getGridApi(
         fixture.nativeElement.querySelector(
           '[data-sky-id="grid"] ag-grid-angular',
         ),
+        fixture,
       );
       expect(api).toBeTruthy();
       expect(api?.getGridOption('pagination')).toBeFalsy();
@@ -400,8 +473,9 @@ describe('SkyDataGrid', () => {
       component.page.set(2);
       fixture.detectChanges();
       await fixture.whenStable();
-      const gridApi = getGridApi(
+      const gridApi = await getGridApi(
         fixture.nativeElement.querySelector('ag-grid-angular'),
+        fixture,
       );
       expect(gridApi?.paginationGetCurrentPage()).toBe(1); // zero-based
       fixture.componentRef.setInput('pageSize', 10);
@@ -413,10 +487,11 @@ describe('SkyDataGrid', () => {
     it('should update grid options when multiselect changes', async () => {
       fixture.detectChanges();
       await fixture.whenStable();
-      const api = getGridApi(
+      const api = await getGridApi(
         fixture.nativeElement.querySelector(
           '[data-sky-id="grid"] ag-grid-angular',
         ),
+        fixture,
       );
       expect(api).toBeTruthy();
       expect(api?.getGridOption('rowSelection')).toEqual(
@@ -431,26 +506,33 @@ describe('SkyDataGrid', () => {
       fixture.componentRef.setInput('multiselect', true);
       fixture.detectChanges();
       await fixture.whenStable();
-      expect(api?.getGridOption('rowSelection')).toEqual({
-        mode: 'multiRow',
-        checkboxes: true,
-        headerCheckbox: true,
-        checkboxLocation: 'selectionColumn',
-      });
+      expect(api?.getGridOption('rowSelection')).toEqual(
+        jasmine.objectContaining({
+          mode: 'multiRow',
+          checkboxes: true,
+          headerCheckbox: true,
+          checkboxLocation: 'selectionColumn',
+        }),
+      );
     });
 
     it('should select all rows', async () => {
       fixture.detectChanges();
       expect(component).toBeTruthy();
+      // Wait for the grids' initial render before reading their loading
+      // state below: with AG Grid 36's out-of-zone scheduling, `whenStable()`
+      // alone doesn't guarantee the grid has finished its first render pass.
+      await flushAgGridWork(fixture);
       const waitHarness =
         await TestbedHarnessEnvironment.loader(fixture).getHarness(
           SkyWaitHarness,
         );
       await expectAsync(waitHarness.isWaiting()).toBeResolvedTo(false);
-      const api = getGridApi(
+      const api = await getGridApi(
         fixture.nativeElement.querySelector(
           '[data-sky-id="multiselect-grid"] ag-grid-angular',
         ),
+        fixture,
       );
       expect(api).toBeTruthy();
       expect(api?.getSelectedNodes()).toHaveSize(0);
@@ -463,6 +545,10 @@ describe('SkyDataGrid', () => {
       expect(component).toBeTruthy();
       fixture.detectChanges();
       await fixture.whenStable();
+      // Wait for the grids' initial render before reading their loading
+      // state below: with AG Grid 36's out-of-zone scheduling, `whenStable()`
+      // alone doesn't guarantee the grid has finished its first render pass.
+      await flushAgGridWork(fixture);
       const waitHarnesses =
         await TestbedHarnessEnvironment.loader(fixture).getAllHarnesses(
           SkyWaitHarness,
@@ -472,10 +558,11 @@ describe('SkyDataGrid', () => {
           waitHarnesses.map((waitHarness) => waitHarness.isWaiting()),
         ),
       ).toBeResolvedTo([false, false, false]);
-      const api = getGridApi(
+      const api = await getGridApi(
         fixture.nativeElement.querySelector(
           '[data-sky-id="multiselect-grid"] ag-grid-angular',
         ),
+        fixture,
       );
       expect(api).toBeTruthy();
       expect(api?.getSelectedNodes()).toHaveSize(0);
@@ -488,10 +575,11 @@ describe('SkyDataGrid', () => {
     it('should deselect rows when selectedRowIds is reduced programmatically', async () => {
       fixture.detectChanges();
       await fixture.whenStable();
-      const api = getGridApi(
+      const api = await getGridApi(
         fixture.nativeElement.querySelector(
           '[data-sky-id="multiselect-grid"] ag-grid-angular',
         ),
+        fixture,
       );
       expect(api).toBeTruthy();
       component.selectedRowIds.set(['2', '4', '6']);
@@ -541,10 +629,11 @@ describe('SkyDataGrid', () => {
 
       // selectedRowIds should be updated to only include IDs still in the data
       expect(component.selectedRowIds()).toEqual(['1', '3', '5']);
-      const api = getGridApi(
+      const api = await getGridApi(
         fixture.nativeElement.querySelector(
           '[data-sky-id="multiselect-grid"] ag-grid-angular',
         ),
+        fixture,
       );
       expect(api).toBeTruthy();
       api?.getRowNode('3')?.setSelected(false);
@@ -607,6 +696,7 @@ describe('SkyDataGrid', () => {
       fixture.componentRef.setInput('pageSize', 4);
       fixture.detectChanges();
       await fixture.whenStable();
+      await flushAgGridWork(fixture);
       expect(component).toBeTruthy();
       const pagingHarness =
         await TestbedHarnessEnvironment.loader(fixture).getHarness(
@@ -626,6 +716,7 @@ describe('SkyDataGrid', () => {
       const navSpy = spyOn(router, 'navigate');
       fixture.detectChanges();
       await fixture.whenStable();
+      await flushAgGridWork(fixture);
       expect(component).toBeTruthy();
       const pagingHarness =
         await TestbedHarnessEnvironment.loader(fixture).getHarness(
@@ -729,6 +820,7 @@ describe('SkyDataGrid', () => {
 
       expect(component.page()).toBe(3);
 
+      await flushAgGridWork(fixture);
       const pagingHarness = await loader.getHarness(SkyPagingHarness);
       await expectAsync(pagingHarness.getCurrentPage()).toBeResolvedTo(3);
     });
@@ -757,6 +849,7 @@ describe('SkyDataGrid', () => {
 
       expect(component.page()).toBe(1);
 
+      await flushAgGridWork(fixture);
       const pagingHarness = await loader.getHarness(SkyPagingHarness);
       await expectAsync(pagingHarness.getCurrentPage()).toBeResolvedTo(1);
     });
@@ -767,6 +860,7 @@ describe('SkyDataGrid', () => {
       fixture.componentRef.setInput('rowCount', 1000);
       fixture.detectChanges();
       await fixture.whenStable();
+      await flushAgGridWork(fixture);
       expect(component).toBeTruthy();
       const pagingHarness =
         await TestbedHarnessEnvironment.loader(fixture).getHarness(
@@ -777,10 +871,11 @@ describe('SkyDataGrid', () => {
       await expectAsync(pagingHarness.getCurrentPage()).toBeResolvedTo(2);
       await pagingHarness.clickPreviousButton();
       await expectAsync(pagingHarness.getCurrentPage()).toBeResolvedTo(1);
-      const api = getGridApi(
+      const api = await getGridApi(
         fixture.nativeElement.querySelector(
           '[data-sky-id="grid"] ag-grid-angular',
         ),
+        fixture,
       );
       expect(api).toBeTruthy();
       expect(api?.getGridOption('pagination')).toBeFalsy();
@@ -792,10 +887,11 @@ describe('SkyDataGrid', () => {
       fixture.componentRef.setInput('pageSize', 2);
       fixture.detectChanges();
       await fixture.whenStable();
-      const api = getGridApi(
+      const api = await getGridApi(
         fixture.nativeElement.querySelector(
           '[data-sky-id="grid"] ag-grid-angular',
         ),
+        fixture,
       );
       expect(api).toBeTruthy();
       // `dataForSimpleGrid` has 7 rows; only `pageSize` rows should render.
@@ -859,6 +955,7 @@ describe('SkyDataGrid', () => {
         ),
       );
 
+      await flushAgGridWork(noRouterFixture);
       const pagingHarness =
         await TestbedHarnessEnvironment.loader(noRouterFixture).getHarness(
           SkyPagingHarness,
@@ -873,8 +970,9 @@ describe('SkyDataGrid', () => {
       const flexFixture = TestBed.createComponent(FlexWidthTestComponent);
       flexFixture.detectChanges();
       await flexFixture.whenStable();
-      const api = getGridApi(
+      const api = await getGridApi(
         flexFixture.nativeElement.querySelector('ag-grid-angular'),
+        flexFixture,
       );
       expect(api).toBeTruthy();
       const colDef = api?.getColumn('column1')?.getColDef();
@@ -887,7 +985,7 @@ describe('SkyDataGrid', () => {
       );
       templateFixture.detectChanges();
       await templateFixture.whenStable();
-      templateFixture.detectChanges();
+      await flushAgGridWork(templateFixture);
       const cells = Array.from(
         templateFixture.nativeElement.querySelectorAll(
           '.custom-cell',
@@ -904,8 +1002,9 @@ describe('SkyDataGrid', () => {
       );
       templateFixture.detectChanges();
       await templateFixture.whenStable();
-      const api = getGridApi(
+      const api = await getGridApi(
         templateFixture.nativeElement.querySelector('ag-grid-angular'),
+        templateFixture,
       );
       expect(api).toBeTruthy();
       const colDef = api?.getColumn('actions')?.getColDef();
@@ -923,8 +1022,9 @@ describe('SkyDataGrid', () => {
       const flexFixture = TestBed.createComponent(FlexWidthTestComponent);
       flexFixture.detectChanges();
       await flexFixture.whenStable();
-      const api = getGridApi(
+      const api = await getGridApi(
         flexFixture.nativeElement.querySelector('ag-grid-angular'),
+        flexFixture,
       );
       expect(api).toBeTruthy();
       const colDef = api?.getColumn('column3')?.getColDef();
@@ -938,8 +1038,9 @@ describe('SkyDataGrid', () => {
       const flexFixture = TestBed.createComponent(ColumnWidthTestComponent);
       flexFixture.detectChanges();
       await flexFixture.whenStable();
-      const api = getGridApi(
+      const api = await getGridApi(
         flexFixture.nativeElement.querySelector('ag-grid-angular'),
+        flexFixture,
       );
       expect(api).toBeTruthy();
       const colDef = api?.getColumn('column2')?.getColDef();
@@ -951,8 +1052,9 @@ describe('SkyDataGrid', () => {
       const flexFixture = TestBed.createComponent(ColumnWidthTestComponent);
       flexFixture.detectChanges();
       await flexFixture.whenStable();
-      const api = getGridApi(
+      const api = await getGridApi(
         flexFixture.nativeElement.querySelector('ag-grid-angular'),
+        flexFixture,
       );
       expect(api).toBeTruthy();
       expect(api?.getGridOption('autoSizeStrategy')).toBeFalsy();
@@ -962,10 +1064,11 @@ describe('SkyDataGrid', () => {
       fixture.componentRef.setInput('autoSort', false);
       fixture.detectChanges();
       await fixture.whenStable();
-      const api = getGridApi(
+      const api = await getGridApi(
         fixture.nativeElement.querySelector(
           '[data-sky-id="grid"] ag-grid-angular',
         ),
+        fixture,
       );
       expect(api).toBeTruthy();
       const comparator = api?.getColumn('column1')?.getColDef().comparator as
@@ -979,10 +1082,11 @@ describe('SkyDataGrid', () => {
     it('should not set a comparator on columns when autoSort is true', async () => {
       fixture.detectChanges();
       await fixture.whenStable();
-      const api = getGridApi(
+      const api = await getGridApi(
         fixture.nativeElement.querySelector(
           '[data-sky-id="grid"] ag-grid-angular',
         ),
+        fixture,
       );
       expect(api).toBeTruthy();
       expect(api?.getColumn('column1')?.getColDef().comparator).toBeUndefined();
@@ -994,21 +1098,35 @@ describe('SkyDataGrid', () => {
       );
       templateFixture.detectChanges();
       await templateFixture.whenStable();
-      const api = getGridApi(
+      const api = await getGridApi(
         templateFixture.nativeElement.querySelector('ag-grid-angular'),
+        templateFixture,
       );
       expect(api).toBeTruthy();
       const colDef = api?.getColumn('date')?.getColDef();
       expect(colDef?.cellDataType).toBe('dateString');
     });
 
-    it('should size columns to their content when columnFit is "content"', async () => {
-      fixture.detectChanges();
-      await fixture.whenStable();
-      // The default "grid" uses the default columnFit ("container").
-      const containerApi = getGridApi(
-        fixture.nativeElement.querySelector(
-          '[data-sky-id="grid"] ag-grid-angular',
+    it('should size columns to their content when columnFit is "content"', fakeAsync(() => {
+      // Uses a fixture without `provideSkyAgGridTesting()` so the real
+      // `autoSizeStrategy` grid option can be observed rather than the value
+      // the testing override suppresses. Only a single `tick()` is used
+      // (rather than `flush()`) because AG Grid's real auto-size
+      // measurement (which `provideSkyAgGridTesting()` would otherwise
+      // disable) reschedules its own `requestAnimationFrame` callback well
+      // beyond `flush()`'s 20-turn limit; the option's value is set
+      // synchronously at grid creation and doesn't require that
+      // measurement loop to fully settle. `discardPeriodicTasks()` clears
+      // the still-pending callback so the test doesn't fail on exit.
+      const fitFixture = TestBed.createComponent(ColumnFitTestComponent);
+      fitFixture.detectChanges();
+      tick();
+      fitFixture.detectChanges();
+
+      // The "container-fit-grid" uses the default columnFit ("container").
+      const containerApi = getGridApiSync(
+        fitFixture.nativeElement.querySelector(
+          '[data-sky-id="container-fit-grid"] ag-grid-angular',
         ),
       );
       expect(containerApi?.getGridOption('autoSizeStrategy')).toEqual({
@@ -1017,10 +1135,10 @@ describe('SkyDataGrid', () => {
         scaleUpToFitGridWidth: true,
       });
 
-      // The "multiselect-grid" sets columnFit="content" and has no flex columns.
-      const contentApi = getGridApi(
-        fixture.nativeElement.querySelector(
-          '[data-sky-id="multiselect-grid"] ag-grid-angular',
+      // The "content-fit-grid" sets columnFit="content" and has no flex columns.
+      const contentApi = getGridApiSync(
+        fitFixture.nativeElement.querySelector(
+          '[data-sky-id="content-fit-grid"] ag-grid-angular',
         ),
       );
       expect(contentApi?.getGridOption('autoSizeStrategy')).toEqual({
@@ -1028,7 +1146,9 @@ describe('SkyDataGrid', () => {
         skipHeader: true,
         scaleUpToFitGridWidth: false,
       });
-    });
+
+      discardPeriodicTasks();
+    }));
 
     it('should add the stacked margin class to the host when stacked is true', async () => {
       fixture.detectChanges();
@@ -1048,19 +1168,21 @@ describe('SkyDataGrid', () => {
       fixture.detectChanges();
       await fixture.whenStable();
       // The "multiselect-grid" sets topScrollEnabled; the default "grid" does not.
-      const topScrollApi = getGridApi(
+      const topScrollApi = await getGridApi(
         fixture.nativeElement.querySelector(
           '[data-sky-id="multiselect-grid"] ag-grid-angular',
         ),
+        fixture,
       );
       expect(
         topScrollApi?.getGridOption('context')?.enableTopScroll,
       ).toBeTrue();
 
-      const defaultApi = getGridApi(
+      const defaultApi = await getGridApi(
         fixture.nativeElement.querySelector(
           '[data-sky-id="grid"] ag-grid-angular',
         ),
+        fixture,
       );
       expect(defaultApi?.getGridOption('context')?.enableTopScroll).toBeFalsy();
     });
@@ -1111,10 +1233,11 @@ describe('SkyDataGrid', () => {
       fixture.detectChanges();
       await fixture.whenStable();
 
-      const api = getGridApi(
+      const api = await getGridApi(
         fixture.nativeElement.querySelector(
           '[data-sky-id="multiselect-grid"] ag-grid-angular',
         ),
+        fixture,
       );
       expect(component.selectedRowIds()).toEqual(['1', '2']);
       expect(api?.getSelectedNodes()).toHaveSize(2);
@@ -1123,10 +1246,11 @@ describe('SkyDataGrid', () => {
     it('should return null instead of NaN when a number column value getter receives a row without data', async () => {
       fixture.detectChanges();
       await fixture.whenStable();
-      const api = getGridApi(
+      const api = await getGridApi(
         fixture.nativeElement.querySelector(
           '[data-sky-id="multiselect-grid"] ag-grid-angular',
         ),
+        fixture,
       );
       const valueGetter = api?.getColumn('myId')?.getColDef().valueGetter as
         ((params: { data: unknown }) => number | null) | undefined;
@@ -1144,10 +1268,12 @@ describe('SkyDataGrid', () => {
       resourceFixture.detectChanges();
       await resourceFixture.whenStable();
 
-      const api = getGridApi(
+      const api = await getGridApi(
         resourceFixture.nativeElement.querySelector(
           '[data-sky-id="resource-grid"] ag-grid-angular',
         ),
+        resourceFixture,
+        RESOURCE_DATA_SOURCE_ITERATIONS,
       );
       expect(api).toBeTruthy();
       // No rows render while the resource is still loading.
@@ -1196,16 +1322,64 @@ describe('SkyDataGrid', () => {
       resourceFixture.detectChanges();
       await resourceFixture.whenStable();
 
-      const api = getGridApi(
+      const api = await getGridApi(
         resourceFixture.nativeElement.querySelector(
           '[data-sky-id="resource-grid"] ag-grid-angular',
         ),
+        resourceFixture,
+        RESOURCE_DATA_SOURCE_ITERATIONS,
       );
       expect(resourceFixture.componentInstance.selectedRowIds()).toEqual([
         '1',
         '2',
       ]);
       expect(api?.getSelectedNodes()).toHaveSize(2);
+    });
+
+    it('should apply column defs that settle before the grid is created', async () => {
+      const resourceFixture = TestBed.createComponent(
+        ResourceColumnsTestComponent,
+      );
+      resourceFixture.detectChanges();
+      // The resource settles synchronously, in the same tick that kicks off
+      // the grid's creation - before AG Grid's async `onGridReady` callback
+      // has a chance to fire - so this exercises the untracked-`gridApi`
+      // race rather than ordinary post-creation reactivity.
+      resourceFixture.componentInstance.showValueColumn.set(true);
+      resourceFixture.detectChanges();
+
+      const api = await getGridApi(
+        resourceFixture.nativeElement.querySelector(
+          '[data-sky-id="resource-columns-grid"] ag-grid-angular',
+        ),
+        resourceFixture,
+        RESOURCE_DATA_SOURCE_ITERATIONS,
+      );
+      expect(api?.getColumnState().map((col) => col.colId)).toEqual([
+        'name',
+        'value',
+      ]);
+    });
+
+    it('should apply a page size that settles before the grid is created', async () => {
+      const resourceFixture = TestBed.createComponent(
+        ResourceColumnsTestComponent,
+      );
+      resourceFixture.detectChanges();
+      // Same race as above, but for `pageSize`: it settles before AG Grid's
+      // async `onGridReady` callback fires.
+      resourceFixture.componentInstance.pageSize.set(1);
+      resourceFixture.detectChanges();
+
+      const api = await getGridApi(
+        resourceFixture.nativeElement.querySelector(
+          '[data-sky-id="resource-columns-grid"] ag-grid-angular',
+        ),
+        resourceFixture,
+        RESOURCE_DATA_SOURCE_ITERATIONS,
+      );
+      expect(api?.getGridOption('pagination')).toBeTrue();
+      expect(api?.getGridOption('paginationPageSize')).toBe(1);
     });
   });
 });

--- a/libs/components/data-grid/src/lib/modules/data-grid/data-grid.ts
+++ b/libs/components/data-grid/src/lib/modules/data-grid/data-grid.ts
@@ -326,7 +326,7 @@ export class SkyDataGrid {
         suppressMultiSort: true,
         suppressPaginationPanel: true,
         rowData,
-        rowSelection: untracked(() => this.#getRowSelection()),
+        rowSelection: untracked(() => this.#rowSelection()),
         autoSizeStrategy: untracked(() => this.#getAutoSizeStrategy()),
       },
     }) as GridOptions<SkyDataGridRowData>;
@@ -453,6 +453,30 @@ export class SkyDataGrid {
     ),
     { initialValue: NaN },
   );
+  readonly #rowSelection = computed<RowSelectionOptions<SkyDataGridRowData>>(
+    () => {
+      return this.multiselect()
+        ? {
+            checkboxes: true,
+            checkboxLocation: 'selectionColumn',
+            headerCheckbox: true,
+            mode: 'multiRow',
+          }
+        : {
+            checkboxes: false,
+            // `SkyAgGridService.getGridOptions()` only merges these defaults
+            // in when the grid is first created; spell them out here too so
+            // this effect's runtime `setGridOption('rowSelection', ...)` call
+            // (now that it tracks `gridApi`, it can run again as soon as the
+            // grid is created) re-applies the same value instead of one
+            // missing these defaulted fields.
+            enableClickSelection: false,
+            enableSelectionWithoutKeys: true,
+            mode: 'singleRow',
+          };
+    },
+    { equal: (a, b) => a.mode === b.mode },
+  );
 
   constructor() {
     // Update specific grid options after the grid has been loaded. Every
@@ -464,7 +488,7 @@ export class SkyDataGrid {
     // be stuck showing its pre-load, initial state forever. Tracking
     // `gridApi` means an effect can also re-run immediately once the grid is
     // created, re-applying its value even when nothing "real" changed; see
-    // `#getRowSelection()` for a case where that re-apply needed a fix of its
+    // `#rowSelection()` for a case where that re-apply needed a fix of its
     // own to stay equivalent to the grid's initial options.
     effect(() => {
       const api = this.gridApi();
@@ -489,7 +513,7 @@ export class SkyDataGrid {
     });
     effect(() => {
       const api = this.gridApi();
-      const rowSelection = this.#getRowSelection();
+      const rowSelection = this.#rowSelection();
       api?.setGridOption('rowSelection', rowSelection);
     });
 
@@ -816,27 +840,5 @@ export class SkyDataGrid {
       skipHeader: true,
       scaleUpToFitGridWidth: this.columnFit() === 'container',
     };
-  }
-
-  #getRowSelection(): RowSelectionOptions<SkyDataGridRowData> {
-    return this.multiselect()
-      ? {
-          checkboxes: true,
-          checkboxLocation: 'selectionColumn',
-          headerCheckbox: true,
-          mode: 'multiRow',
-        }
-      : {
-          checkboxes: false,
-          // `SkyAgGridService.getGridOptions()` only merges these defaults
-          // in when the grid is first created; spell them out here too so
-          // this effect's runtime `setGridOption('rowSelection', ...)` call
-          // (now that it tracks `gridApi`, it can run again as soon as the
-          // grid is created) re-applies the same value instead of one
-          // missing these defaulted fields.
-          enableClickSelection: false,
-          enableSelectionWithoutKeys: true,
-          mode: 'singleRow',
-        };
   }
 }

--- a/libs/components/data-grid/src/lib/modules/data-grid/data-grid.ts
+++ b/libs/components/data-grid/src/lib/modules/data-grid/data-grid.ts
@@ -6,6 +6,7 @@ import {
 } from '@angular/cdk/coercion';
 import {
   ChangeDetectionStrategy,
+  ChangeDetectorRef,
   Component,
   computed,
   contentChildren,
@@ -315,6 +316,10 @@ export class SkyDataGrid {
         onGridReady: (args) => {
           this.gridApi.set(args.api);
           this.gridReady.set(true);
+          // AG Grid dispatches `onGridReady` outside the Angular zone, so
+          // the `gridReady`/`gridApi` signal writes above aren't picked up
+          // by zone-triggered change detection on their own.
+          this.#changeDetector.markForCheck();
         },
         pagination,
         paginationPageSize,
@@ -379,6 +384,7 @@ export class SkyDataGrid {
   });
 
   readonly #activatedRoute = inject(ActivatedRoute, { optional: true });
+  readonly #changeDetector = inject(ChangeDetectorRef);
   readonly #gridService = inject(SkyAgGridService);
   readonly #logger = inject(SkyLogService);
   readonly #router = inject(Router, { optional: true });
@@ -449,33 +455,40 @@ export class SkyDataGrid {
   );
 
   constructor() {
-    // Update specific grid options after the grid has been loaded. These read
-    // `gridApi` untracked because a recreated grid rebuilds its options from the
-    // `gridOptions` computed; the selection and page effects below instead track
-    // `gridApi` so they re-apply their state to a freshly created grid.
+    // Update specific grid options after the grid has been loaded. Every
+    // effect tracks `gridApi`: a value backed by an async resource (e.g.
+    // Angular's `resource()`) can settle to its final value before
+    // `ngAfterViewInit` even creates the grid. With `gridApi` read untracked,
+    // that value would be silently dropped - this effect's *other*
+    // dependency never changes again to trigger a re-run, so the grid would
+    // be stuck showing its pre-load, initial state forever. Tracking
+    // `gridApi` means an effect can also re-run immediately once the grid is
+    // created, re-applying its value even when nothing "real" changed; see
+    // `#getRowSelection()` for a case where that re-apply needed a fix of its
+    // own to stay equivalent to the grid's initial options.
     effect(() => {
-      const api = untracked(() => this.gridApi());
+      const api = this.gridApi();
       const columnDefs = this.#columnDefs();
       api?.setGridOption('columnDefs', columnDefs);
     });
     effect(() => {
-      const api = untracked(() => this.gridApi());
+      const api = this.gridApi();
       const isLoading = this.loading() || !Array.isArray(this.data());
       api?.setGridOption('loading', isLoading);
     });
     effect(() => {
-      const api = untracked(() => this.gridApi());
+      const api = this.gridApi();
       const { pagination, paginationPageSize } = this.#paginationOptions();
       api?.setGridOption('pagination', pagination);
       api?.setGridOption('paginationPageSize', paginationPageSize);
     });
     effect(() => {
-      const api = untracked(() => this.gridApi());
+      const api = this.gridApi();
       const rowData = this.rowData();
       api?.setGridOption('rowData', rowData);
     });
     effect(() => {
-      const api = untracked(() => this.gridApi());
+      const api = this.gridApi();
       const rowSelection = this.#getRowSelection();
       api?.setGridOption('rowSelection', rowSelection);
     });
@@ -621,6 +634,7 @@ export class SkyDataGrid {
     this.#gridDestroyed.pipe(takeUntilDestroyed()).subscribe(() => {
       this.gridApi.set(undefined);
       this.gridReady.set(false);
+      this.#changeDetector.markForCheck();
     });
 
     // Emit updates from the grid.
@@ -812,6 +826,17 @@ export class SkyDataGrid {
           headerCheckbox: true,
           mode: 'multiRow',
         }
-      : { checkboxes: false, mode: 'singleRow' };
+      : {
+          checkboxes: false,
+          // `SkyAgGridService.getGridOptions()` only merges these defaults
+          // in when the grid is first created; spell them out here too so
+          // this effect's runtime `setGridOption('rowSelection', ...)` call
+          // (now that it tracks `gridApi`, it can run again as soon as the
+          // grid is created) re-applies the same value instead of one
+          // missing these defaulted fields.
+          enableClickSelection: false,
+          enableSelectionWithoutKeys: true,
+          mode: 'singleRow',
+        };
   }
 }

--- a/libs/components/data-grid/src/lib/modules/data-grid/fixtures/column-fit-test.component.ts
+++ b/libs/components/data-grid/src/lib/modules/data-grid/fixtures/column-fit-test.component.ts
@@ -1,0 +1,34 @@
+import { Component } from '@angular/core';
+import { SkyDataGrid } from '../data-grid';
+import { SkyDataGridColumn } from '../data-grid-column';
+
+/**
+ * Deliberately omits `provideSkyAgGridTesting()` so the grids in this fixture
+ * use the real `SkyAgGridService`, and so tests using it observe the real
+ * `autoSizeStrategy` grid option rather than the testing override that
+ * suppresses it.
+ */
+@Component({
+  selector: 'sky-column-fit-test',
+  imports: [SkyDataGrid, SkyDataGridColumn],
+  template: `
+    <sky-data-grid data-sky-id="container-fit-grid" [data]="data">
+      <sky-data-grid-column field="column1" headingText="Column1" />
+      <sky-data-grid-column field="column2" headingText="Column2" />
+    </sky-data-grid>
+    <sky-data-grid
+      data-sky-id="content-fit-grid"
+      columnFit="content"
+      [data]="data"
+    >
+      <sky-data-grid-column field="column1" headingText="Column1" />
+      <sky-data-grid-column field="column2" headingText="Column2" />
+    </sky-data-grid>
+  `,
+})
+export class ColumnFitTestComponent {
+  public data = [
+    { id: '1', column1: 'A', column2: 'B' },
+    { id: '2', column1: 'C', column2: 'D' },
+  ];
+}

--- a/libs/components/data-grid/src/lib/modules/data-grid/fixtures/column-width-test.component.ts
+++ b/libs/components/data-grid/src/lib/modules/data-grid/fixtures/column-width-test.component.ts
@@ -1,10 +1,12 @@
 import { Component } from '@angular/core';
+import { provideSkyAgGridTesting } from '@skyux/ag-grid/testing';
 import { SkyDataGrid } from '../data-grid';
 import { SkyDataGridColumn } from '../data-grid-column';
 
 @Component({
   selector: 'sky-column-width-test',
   imports: [SkyDataGrid, SkyDataGridColumn],
+  providers: [provideSkyAgGridTesting()],
   template: `
     <sky-data-grid [data]="data">
       <sky-data-grid-column

--- a/libs/components/data-grid/src/lib/modules/data-grid/fixtures/data-grid-test.component.ts
+++ b/libs/components/data-grid/src/lib/modules/data-grid/fixtures/data-grid-test.component.ts
@@ -1,13 +1,8 @@
 import { JsonPipe } from '@angular/common';
-import {
-  ChangeDetectorRef,
-  Component,
-  inject,
-  input,
-  model,
-} from '@angular/core';
+import { Component, input, model } from '@angular/core';
 import { SkyDropdownModule, SkyPopoverModule } from '@skyux/popovers';
 
+import { provideSkyAgGridTesting } from '@skyux/ag-grid/testing';
 import { SkyDataGridSort } from '../../types/data-grid-sort';
 import { SkyDataGrid } from '../data-grid';
 import { SkyDataGridColumn } from '../data-grid-column';
@@ -30,6 +25,7 @@ interface RowModel {
     SkyDropdownModule,
     JsonPipe,
   ],
+  providers: [provideSkyAgGridTesting()],
 })
 export class DataGridTestComponent {
   public readonly dataForSimpleGrid = input<RowModel[] | undefined>([
@@ -75,15 +71,12 @@ export class DataGridTestComponent {
   protected readonly showCol3 = input<boolean>(true);
   protected readonly showCol3HeaderText = input<boolean>(true);
 
-  readonly #cdr = inject(ChangeDetectorRef);
-
   public selectAll(): void {
     this.selectedRowIds.set(
       (this.dataForSimpleGridWithMultiselect() ?? []).map(
         (item) => item.myId as string,
       ),
     );
-    this.#cdr.markForCheck();
   }
 
   public clearAll(): void {

--- a/libs/components/data-grid/src/lib/modules/data-grid/fixtures/flex-width-test.component.ts
+++ b/libs/components/data-grid/src/lib/modules/data-grid/fixtures/flex-width-test.component.ts
@@ -1,10 +1,12 @@
 import { Component } from '@angular/core';
+import { provideSkyAgGridTesting } from '@skyux/ag-grid/testing';
 import { SkyDataGrid } from '../data-grid';
 import { SkyDataGridColumn } from '../data-grid-column';
 
 @Component({
   selector: 'sky-flex-width-test',
   imports: [SkyDataGrid, SkyDataGridColumn],
+  providers: [provideSkyAgGridTesting()],
   template: `
     <sky-data-grid [data]="data">
       <sky-data-grid-column

--- a/libs/components/data-grid/src/lib/modules/data-grid/fixtures/resource-columns-test.component.ts
+++ b/libs/components/data-grid/src/lib/modules/data-grid/fixtures/resource-columns-test.component.ts
@@ -1,0 +1,42 @@
+import { Component, signal } from '@angular/core';
+import { provideSkyAgGridTesting } from '@skyux/ag-grid/testing';
+
+import { SkyDataGrid } from '../data-grid';
+import { SkyDataGridColumn } from '../data-grid-column';
+
+interface ResourceRow {
+  id: string;
+  name: string;
+  value: number;
+}
+
+@Component({
+  selector: 'sky-resource-columns-test',
+  imports: [SkyDataGrid, SkyDataGridColumn],
+  providers: [provideSkyAgGridTesting()],
+  template: `
+    <sky-data-grid
+      data-sky-id="resource-columns-grid"
+      [data]="data()"
+      [pageSize]="pageSize()"
+    >
+      <sky-data-grid-column field="name" headingText="Name" />
+      @if (showValueColumn()) {
+        <sky-data-grid-column field="value" headingText="Value" />
+      }
+    </sky-data-grid>
+  `,
+})
+export class ResourceColumnsTestComponent {
+  public readonly data = signal<ResourceRow[]>([
+    { id: '1', name: 'Alice', value: 1 },
+    { id: '2', name: 'Bob', value: 2 },
+  ]);
+
+  // Signals resembling a `Resource`-shaped object so a test can flip the
+  // settled column set and page size exactly as a real resource() would as
+  // it resolves - synchronously, in the same tick that creates the grid, so
+  // the settled value lands before AG Grid's async `onGridReady` fires.
+  public readonly showValueColumn = signal(false);
+  public readonly pageSize = signal<number | undefined>(undefined);
+}

--- a/libs/components/data-grid/src/lib/modules/data-grid/fixtures/resource-data-test.component.ts
+++ b/libs/components/data-grid/src/lib/modules/data-grid/fixtures/resource-data-test.component.ts
@@ -1,4 +1,5 @@
 import { Component, model, signal } from '@angular/core';
+import { provideSkyAgGridTesting } from '@skyux/ag-grid/testing';
 import { SkyDataGrid } from '../data-grid';
 import { SkyDataGridColumn } from '../data-grid-column';
 
@@ -10,6 +11,7 @@ interface ResourceRow {
 @Component({
   selector: 'sky-resource-data-test',
   imports: [SkyDataGrid, SkyDataGridColumn],
+  providers: [provideSkyAgGridTesting()],
   template: `
     <sky-data-grid
       data-sky-id="resource-grid"

--- a/libs/components/data-grid/src/lib/modules/data-grid/fixtures/template-column-test.component.ts
+++ b/libs/components/data-grid/src/lib/modules/data-grid/fixtures/template-column-test.component.ts
@@ -1,10 +1,12 @@
 import { Component } from '@angular/core';
+import { provideSkyAgGridTesting } from '@skyux/ag-grid/testing';
 import { SkyDataGrid } from '../data-grid';
 import { SkyDataGridColumn } from '../data-grid-column';
 
 @Component({
   selector: 'sky-template-column-test',
   imports: [SkyDataGrid, SkyDataGridColumn],
+  providers: [provideSkyAgGridTesting()],
   template: `
     <sky-data-grid [data]="data">
       <sky-data-grid-column

--- a/libs/components/data-grid/testing/src/modules/data-grid/data-grid-harness.spec.ts
+++ b/libs/components/data-grid/testing/src/modules/data-grid/data-grid-harness.spec.ts
@@ -30,10 +30,17 @@ async function expectRenderWaitGatesResolution<T>(
   const renderWait = new Promise<void>((resolve) => {
     releaseRenderWait = resolve;
   });
+  let waitStarted!: () => void;
+  const waitStartedPromise = new Promise<void>((resolve) => {
+    waitStarted = resolve;
+  });
   const waitUntilRenderedSpy = spyOn(
     SkyAgGridWrapperHarness.prototype,
     'waitUntilRendered',
-  ).and.returnValue(renderWait);
+  ).and.callFake(() => {
+    waitStarted();
+    return renderWait;
+  });
 
   let resolved = false;
   const pending = runQuery().then((result) => {
@@ -41,10 +48,12 @@ async function expectRenderWaitGatesResolution<T>(
     return result;
   });
 
-  // Let any already-pending microtasks or timers (e.g. the grid wrapper
-  // harness lookup) run to completion. The query itself must still be
-  // pending, because it's blocked on the deferred render wait above.
-  await new Promise((resolve) => setTimeout(resolve, 50));
+  // Wait until `waitUntilRendered()` has actually been invoked (i.e. any
+  // pending microtasks/timers, like the grid wrapper harness lookup, have
+  // run to completion) rather than guessing a fixed delay. The query itself
+  // must still be pending, because it's blocked on the deferred render wait
+  // above.
+  await waitStartedPromise;
   expect(waitUntilRenderedSpy).toHaveBeenCalled();
   expect(resolved).toBe(false);
 

--- a/libs/components/data-grid/testing/src/modules/data-grid/data-grid-harness.spec.ts
+++ b/libs/components/data-grid/testing/src/modules/data-grid/data-grid-harness.spec.ts
@@ -1,10 +1,58 @@
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { SkyAgGridWrapperHarness } from '@skyux/ag-grid/testing';
 import { SkyWaitHarness } from '@skyux/indicators/testing';
 import { SkyPagingHarness } from '@skyux/lists/testing';
 
 import { SkyDataGridHarness } from './data-grid-harness';
 import { DataGridTestComponent } from './fixtures/data-grid-test.component';
+
+/**
+ * Deterministically proves that a query resolves only after the grid's
+ * render-readiness signal (`SkyAgGridWrapperHarness#waitUntilRendered`)
+ * settles, rather than merely happening to pass because the fixture's real
+ * render finished quickly. This is necessary because in ChromeHeadless the
+ * real AG Grid render for this small fixture completes fast enough that an
+ * unguarded query passes the vast majority of the time too - a plain
+ * "detectChanges then query" spec would not fail on an unguarded method and
+ * so would not actually prove the guard exists. Instead, this replaces
+ * `waitUntilRendered()` with a promise under test control: while it's
+ * pending, a guarded query must still be pending too; only after it's
+ * released may the query resolve. An unguarded query (i.e. the base
+ * `SkyQueryableComponentHarness` implementation, with no override) never
+ * calls `waitUntilRendered()` at all and resolves immediately, so it fails
+ * the "not yet resolved" assertion below.
+ */
+async function expectRenderWaitGatesResolution<T>(
+  runQuery: () => Promise<T>,
+): Promise<T> {
+  let releaseRenderWait!: () => void;
+  const renderWait = new Promise<void>((resolve) => {
+    releaseRenderWait = resolve;
+  });
+  const waitUntilRenderedSpy = spyOn(
+    SkyAgGridWrapperHarness.prototype,
+    'waitUntilRendered',
+  ).and.returnValue(renderWait);
+
+  let resolved = false;
+  const pending = runQuery().then((result) => {
+    resolved = true;
+    return result;
+  });
+
+  // Let any already-pending microtasks or timers (e.g. the grid wrapper
+  // harness lookup) run to completion. The query itself must still be
+  // pending, because it's blocked on the deferred render wait above.
+  await new Promise((resolve) => setTimeout(resolve, 50));
+  expect(waitUntilRenderedSpy).toHaveBeenCalled();
+  expect(resolved).toBe(false);
+
+  releaseRenderWait();
+  const result = await pending;
+  expect(resolved).toBe(true);
+  return result;
+}
 
 describe('data-grid-harness', () => {
   let fixture: ComponentFixture<DataGridTestComponent>;
@@ -177,6 +225,57 @@ describe('data-grid-harness', () => {
     await expectAsync(harness.getPaging()).toBeRejectedWithError(
       'Unable to retrieve paging. The data grid is not paged.',
     );
+  });
+
+  it('should not resolve querySelector until the grid finishes rendering', async () => {
+    fixture.detectChanges();
+
+    const harness = await TestbedHarnessEnvironment.loader(fixture).getHarness(
+      SkyDataGridHarness.with({ dataSkyId: 'grid' }),
+    );
+
+    const cell = await expectRenderWaitGatesResolution(() =>
+      harness.querySelector('.ag-cell'),
+    );
+    expect(cell).toBeTruthy();
+  });
+
+  it('should not resolve querySelectorOrNull until the grid finishes rendering', async () => {
+    fixture.detectChanges();
+
+    const harness = await TestbedHarnessEnvironment.loader(fixture).getHarness(
+      SkyDataGridHarness.with({ dataSkyId: 'grid' }),
+    );
+
+    const cell = await expectRenderWaitGatesResolution(() =>
+      harness.querySelectorOrNull('.ag-cell'),
+    );
+    expect(cell).toBeTruthy();
+  });
+
+  it('should resolve querySelectorOrNull to null when no element matches', async () => {
+    fixture.detectChanges();
+
+    const harness = await TestbedHarnessEnvironment.loader(fixture).getHarness(
+      SkyDataGridHarness.with({ dataSkyId: 'grid' }),
+    );
+
+    await expectAsync(
+      harness.querySelectorOrNull('.does-not-exist'),
+    ).toBeResolvedTo(null);
+  });
+
+  it('should not resolve querySelectorAll until the grid finishes rendering', async () => {
+    fixture.detectChanges();
+
+    const harness = await TestbedHarnessEnvironment.loader(fixture).getHarness(
+      SkyDataGridHarness.with({ dataSkyId: 'grid' }),
+    );
+
+    const cells = await expectRenderWaitGatesResolution(() =>
+      harness.querySelectorAll('.ag-cell'),
+    );
+    expect(cells.length).toBeGreaterThan(0);
   });
 
   it('should get the wait harness and reflect grid readiness', async () => {

--- a/libs/components/data-grid/testing/src/modules/data-grid/data-grid-harness.ts
+++ b/libs/components/data-grid/testing/src/modules/data-grid/data-grid-harness.ts
@@ -99,19 +99,20 @@ export class SkyDataGridHarness extends SkyQueryableComponentHarness {
     const grid = await this.#getGridWrapper();
     const api = await grid.getGridApi();
     const renderCountBeforeClick = await grid.getRenderCount();
+    const btn = await this.locatorFor(
+      `.ag-header-cell.ag-header-cell-sortable[col-id="${column}"] button.ag-header-cell-label-sortable`,
+    )();
     // AG Grid's `sortChanged` event (which `SkyDataGrid`'s own `[(sort)]`
     // binding listens for) is dispatched independently of the `modelUpdated`
     // render event `waitUntilRendered()` waits for below, so wait for it
     // explicitly instead of guessing how many stabilize passes are enough
-    // for it to have already fired.
+    // for it to have already fired. Registered only after `btn` resolves, so
+    // a failed locator lookup can't leave this listener attached.
     let handler!: () => void;
     const sortChanged = new Promise<void>((resolve) => {
       handler = (): void => resolve();
       api.addEventListener('sortChanged', handler);
     });
-    const btn = await this.locatorFor(
-      `.ag-header-cell.ag-header-cell-sortable[col-id="${column}"] button.ag-header-cell-label-sortable`,
-    )();
     let timeoutId: ReturnType<typeof setTimeout> | undefined;
     try {
       await btn.click();

--- a/libs/components/data-grid/testing/src/modules/data-grid/data-grid-harness.ts
+++ b/libs/components/data-grid/testing/src/modules/data-grid/data-grid-harness.ts
@@ -1,4 +1,9 @@
-import { HarnessPredicate } from '@angular/cdk/testing';
+import {
+  ComponentHarness,
+  HarnessPredicate,
+  HarnessQuery,
+  TestElement,
+} from '@angular/cdk/testing';
 import { SkyAgGridWrapperHarness } from '@skyux/ag-grid/testing';
 import { SkyQueryableComponentHarness } from '@skyux/core/testing';
 import { SkyWaitHarness } from '@skyux/indicators/testing';
@@ -8,6 +13,9 @@ import { SkyDataGridHarnessFilters } from './data-grid-harness.filters';
 
 /**
  * Harness for interacting with SKY UX data grid components in tests.
+ * Add `provideSkyDataGridTesting()` to the spec's providers so the harness
+ * can wait for the grid to finish rendering; without it, render-readiness
+ * waits are skipped.
  * @preview
  */
 export class SkyDataGridHarness extends SkyQueryableComponentHarness {
@@ -83,13 +91,36 @@ export class SkyDataGridHarness extends SkyQueryableComponentHarness {
   }
 
   /**
-   * Clicks the column header sort button.
+   * Clicks the column header sort button and waits for the grid to re-render
+   * the sorted rows, and for a consumer's own `[(sort)]` binding to reflect
+   * the change, before resolving.
    */
   public async clickColumnSortButton(column: string): Promise<void> {
+    const grid = await this.#getGridWrapper();
+    const renderCountBeforeClick = await grid.getRenderCount();
+    const api = await grid.getGridApi();
+    // AG Grid's `sortChanged` event (which `SkyDataGrid`'s own `[(sort)]`
+    // binding listens for) is dispatched independently of the `modelUpdated`
+    // render event `waitUntilRendered()` waits for below, so wait for it
+    // explicitly instead of guessing how many stabilize passes are enough
+    // for it to have already fired.
+    const sortChanged = new Promise<void>((resolve) => {
+      const handler = (): void => {
+        api.removeEventListener('sortChanged', handler);
+        resolve();
+      };
+      api.addEventListener('sortChanged', handler);
+    });
     const btn = await this.locatorFor(
       `.ag-header-cell.ag-header-cell-sortable[col-id="${column}"] button.ag-header-cell-label-sortable`,
     )();
     await btn.click();
+    await grid.waitUntilRendered(renderCountBeforeClick);
+    await Promise.race([
+      sortChanged,
+      new Promise((resolve) => setTimeout(resolve, 2000)),
+    ]);
+    await this.forceStabilize();
   }
 
   /**
@@ -119,7 +150,81 @@ export class SkyDataGridHarness extends SkyQueryableComponentHarness {
     return await this.queryHarness(SkyWaitHarness);
   }
 
+  /**
+   * Returns a child harness after the grid has finished rendering, or throws
+   * an error if the harness is not found.
+   */
+  public override async queryHarness<T extends ComponentHarness>(
+    query: HarnessQuery<T>,
+  ): Promise<T> {
+    await this.#waitForGridWrapperRendered();
+    return await super.queryHarness(query);
+  }
+
+  /**
+   * Returns a child harness after the grid has finished rendering, or `null`
+   * if not found.
+   */
+  public override async queryHarnessOrNull<T extends ComponentHarness>(
+    query: HarnessQuery<T>,
+  ): Promise<T | null> {
+    await this.#waitForGridWrapperRendered();
+    return await super.queryHarnessOrNull(query);
+  }
+
+  /**
+   * Returns all child harnesses that match after the grid has finished
+   * rendering.
+   */
+  public override async queryHarnesses<T extends ComponentHarness>(
+    query: HarnessQuery<T>,
+  ): Promise<T[]> {
+    await this.#waitForGridWrapperRendered();
+    return await super.queryHarnesses(query);
+  }
+
+  /**
+   * Returns a child test element after the grid has finished rendering, or
+   * throws an error if not found.
+   */
+  public override async querySelector(selector: string): Promise<TestElement> {
+    await this.#waitForGridWrapperRendered();
+    return await super.querySelector(selector);
+  }
+
+  /**
+   * Returns a child test element after the grid has finished rendering, or
+   * `null` if not found.
+   */
+  public override async querySelectorOrNull(
+    selector: string,
+  ): Promise<TestElement | null> {
+    await this.#waitForGridWrapperRendered();
+    return await super.querySelectorOrNull(selector);
+  }
+
+  /**
+   * Returns all child test elements that match after the grid has finished
+   * rendering.
+   */
+  public override async querySelectorAll(
+    selector: string,
+  ): Promise<TestElement[]> {
+    await this.#waitForGridWrapperRendered();
+    return await super.querySelectorAll(selector);
+  }
+
+  /**
+   * Bypasses the render-readiness wait to avoid recursing through it while
+   * checking readiness itself.
+   */
   async #getGridWrapper(): Promise<SkyAgGridWrapperHarness> {
-    return await this.queryHarness(SkyAgGridWrapperHarness);
+    return await super.queryHarness(SkyAgGridWrapperHarness);
+  }
+
+  async #waitForGridWrapperRendered(): Promise<void> {
+    await this.#getGridWrapper()
+      .then(async (grid) => await grid.waitUntilRendered())
+      .catch(() => undefined);
   }
 }

--- a/libs/components/data-grid/testing/src/modules/data-grid/data-grid-harness.ts
+++ b/libs/components/data-grid/testing/src/modules/data-grid/data-grid-harness.ts
@@ -97,29 +97,35 @@ export class SkyDataGridHarness extends SkyQueryableComponentHarness {
    */
   public async clickColumnSortButton(column: string): Promise<void> {
     const grid = await this.#getGridWrapper();
-    const renderCountBeforeClick = await grid.getRenderCount();
     const api = await grid.getGridApi();
+    const renderCountBeforeClick = await grid.getRenderCount();
     // AG Grid's `sortChanged` event (which `SkyDataGrid`'s own `[(sort)]`
     // binding listens for) is dispatched independently of the `modelUpdated`
     // render event `waitUntilRendered()` waits for below, so wait for it
     // explicitly instead of guessing how many stabilize passes are enough
     // for it to have already fired.
+    let handler!: () => void;
     const sortChanged = new Promise<void>((resolve) => {
-      const handler = (): void => {
-        api.removeEventListener('sortChanged', handler);
-        resolve();
-      };
+      handler = (): void => resolve();
       api.addEventListener('sortChanged', handler);
     });
     const btn = await this.locatorFor(
       `.ag-header-cell.ag-header-cell-sortable[col-id="${column}"] button.ag-header-cell-label-sortable`,
     )();
-    await btn.click();
-    await grid.waitUntilRendered(renderCountBeforeClick);
-    await Promise.race([
-      sortChanged,
-      new Promise((resolve) => setTimeout(resolve, 2000)),
-    ]);
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+    try {
+      await btn.click();
+      await grid.waitUntilRendered(renderCountBeforeClick);
+      await Promise.race([
+        sortChanged,
+        new Promise((resolve) => {
+          timeoutId = setTimeout(resolve, 2000);
+        }),
+      ]);
+    } finally {
+      clearTimeout(timeoutId);
+      api.removeEventListener('sortChanged', handler);
+    }
     await this.forceStabilize();
   }
 

--- a/libs/components/data-grid/testing/src/modules/data-grid/provide-data-grid-testing.spec.ts
+++ b/libs/components/data-grid/testing/src/modules/data-grid/provide-data-grid-testing.spec.ts
@@ -1,0 +1,32 @@
+import { TestBed } from '@angular/core/testing';
+import { SkyAgGridService } from '@skyux/ag-grid';
+
+import { provideSkyDataGridTesting } from './provide-data-grid-testing';
+
+describe('provideSkyDataGridTesting', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideSkyDataGridTesting()],
+    });
+  });
+
+  it('should disable virtualization for read-only grids', () => {
+    const gridOptions = TestBed.inject(SkyAgGridService).getGridOptions({
+      gridOptions: {},
+    });
+
+    expect(gridOptions.suppressColumnVirtualisation).toBeTrue();
+    expect(gridOptions.suppressRowVirtualisation).toBeTrue();
+  });
+
+  it('should disable virtualization for editable grids', () => {
+    const gridOptions = TestBed.inject(SkyAgGridService).getEditableGridOptions(
+      {
+        gridOptions: {},
+      },
+    );
+
+    expect(gridOptions.suppressColumnVirtualisation).toBeTrue();
+    expect(gridOptions.suppressRowVirtualisation).toBeTrue();
+  });
+});

--- a/libs/components/data-grid/testing/src/modules/data-grid/provide-data-grid-testing.ts
+++ b/libs/components/data-grid/testing/src/modules/data-grid/provide-data-grid-testing.ts
@@ -1,0 +1,13 @@
+import { Provider } from '@angular/core';
+import { provideSkyAgGridTesting } from '@skyux/ag-grid/testing';
+
+/**
+ * Configures every data grid in the test to disable AG Grid's row/column
+ * virtualization and to opt out of AG Grid's Angular test-zone detection so
+ * `SkyDataGridHarness` can reliably wait for the grid to finish rendering.
+ * Add to the spec's `TestBed.configureTestingModule` providers.
+ * @preview
+ */
+export function provideSkyDataGridTesting(): Provider[] {
+  return [provideSkyAgGridTesting()];
+}

--- a/libs/components/data-grid/testing/src/public-api.ts
+++ b/libs/components/data-grid/testing/src/public-api.ts
@@ -1,2 +1,3 @@
 export { SkyDataGridHarness } from './modules/data-grid/data-grid-harness';
 export { SkyDataGridHarnessFilters } from './modules/data-grid/data-grid-harness.filters';
+export { provideSkyDataGridTesting } from './modules/data-grid/provide-data-grid-testing';


### PR DESCRIPTION
[AB#4045248](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/4045248)

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved data-grid rendering and change detection after sorting, column changes, and grid recreation.
  * Fixed header filter, sort, expansion, inline-help, and selection updates.
  * Improved asynchronous loading and loading-state handling.

* **New Features**
  * Added render-aware data-grid testing support and harness utilities.
  * Enhanced loading examples with data, empty, and continuously loading scenarios.

* **Tests**
  * Expanded coverage for rendering, sorting, selection, column sizing, and asynchronous behavior.
  * Added stable testing configurations for predictable grid rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->