### PR TITLE
fix(components/layout): recalculate description list responsive layout on container resize (#4570)

### DIFF
--- a/apps/playground/src/app/components/layout/description-list/description-list-modal.component.html
+++ b/apps/playground/src/app/components/layout/description-list/description-list-modal.component.html
@@ -1,0 +1,30 @@
+<sky-modal headingText="Horizontal description list in a modal">
+  <sky-modal-content>
+    <p>
+      With the fix, this horizontal list renders on a single row (when wide
+      enough) on first open. Before the fix, it wrapped across multiple rows
+      until the window was resized.
+    </p>
+    <sky-description-list mode="horizontal">
+      @for (item of items; track item) {
+        <sky-description-list-content>
+          <sky-description-list-term>
+            {{ item.term }}
+          </sky-description-list-term>
+          <sky-description-list-description>
+            {{ item.description }}
+          </sky-description-list-description>
+        </sky-description-list-content>
+      }
+    </sky-description-list>
+  </sky-modal-content>
+  <sky-modal-footer>
+    <button
+      type="button"
+      class="sky-btn sky-btn-primary"
+      (click)="instance.close()"
+    >
+      Close
+    </button>
+  </sky-modal-footer>
+</sky-modal>

--- a/apps/playground/src/app/components/layout/description-list/description-list-modal.component.ts
+++ b/apps/playground/src/app/components/layout/description-list/description-list-modal.component.ts
@@ -1,0 +1,20 @@
+import { Component, inject } from '@angular/core';
+import { SkyHelpInlineModule } from '@skyux/help-inline';
+import { SkyDescriptionListModule } from '@skyux/layout';
+import { SkyModalInstance, SkyModalModule } from '@skyux/modals';
+
+@Component({
+  selector: 'app-description-list-modal',
+  templateUrl: './description-list-modal.component.html',
+  imports: [SkyDescriptionListModule, SkyHelpInlineModule, SkyModalModule],
+})
+export class DescriptionListModalComponent {
+  protected readonly instance = inject(SkyModalInstance);
+
+  protected items: { term: string; description: string }[] = [
+    { term: 'College', description: 'Humanities and Social Sciences' },
+    { term: 'Department', description: 'Anthropology' },
+    { term: 'Advisor', description: 'Cathy Green' },
+    { term: 'Class year', description: '2024' },
+  ];
+}

--- a/apps/playground/src/app/components/layout/description-list/description-list.component.html
+++ b/apps/playground/src/app/components/layout/description-list/description-list.component.html
@@ -38,3 +38,34 @@
 <button type="button" class="sky-btn sky-btn-default" (click)="toggleHelp()">
   Toggle help {{ showHelp }}
 </button>
+<button
+  type="button"
+  class="sky-btn sky-btn-default sky-margin-inline-sm"
+  (click)="openInModal()"
+>
+  Open horizontal list in modal
+</button>
+
+<div class="sky-theme-padding-inset-balanced-m">
+  <p>
+    Repro: the horizontal list below lives in "Tab 2", which is hidden (width 0)
+    on first render. Switch to Tab 2 and observe the layout.
+  </p>
+  <sky-tabset ariaLabel="Description list resize repro">
+    <sky-tab tabHeading="Tab 1"> Nothing to see here. </sky-tab>
+    <sky-tab tabHeading="Tab 2">
+      <sky-description-list mode="horizontal">
+        @for (item of items; track item) {
+          <sky-description-list-content>
+            <sky-description-list-term>
+              {{ item.term }}
+            </sky-description-list-term>
+            <sky-description-list-description>
+              {{ item.description }}
+            </sky-description-list-description>
+          </sky-description-list-content>
+        }
+      </sky-description-list>
+    </sky-tab>
+  </sky-tabset>
+</div>

--- a/apps/playground/src/app/components/layout/description-list/description-list.component.ts
+++ b/apps/playground/src/app/components/layout/description-list/description-list.component.ts
@@ -1,4 +1,7 @@
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
+import { SkyModalService } from '@skyux/modals';
+
+import { DescriptionListModalComponent } from './description-list-modal.component';
 
 @Component({
   selector: 'app-description-list',
@@ -6,6 +9,8 @@ import { Component } from '@angular/core';
   standalone: false,
 })
 export class DescriptionListComponent {
+  readonly #modalSvc = inject(SkyModalService);
+
   public items: { term: string; description: string; showHelp?: boolean }[] = [
     {
       term: 'College',
@@ -30,5 +35,9 @@ export class DescriptionListComponent {
 
   public toggleHelp(): void {
     this.showHelp = !this.showHelp;
+  }
+
+  protected openInModal(): void {
+    this.#modalSvc.open(DescriptionListModalComponent, { size: 'large' });
   }
 }

--- a/apps/playground/src/app/components/layout/description-list/description-list.module.ts
+++ b/apps/playground/src/app/components/layout/description-list/description-list.module.ts
@@ -1,6 +1,7 @@
 import { NgModule } from '@angular/core';
 import { SkyHelpInlineModule } from '@skyux/help-inline';
 import { SkyDescriptionListModule } from '@skyux/layout';
+import { SkyTabsModule } from '@skyux/tabs';
 
 import { DescriptionListRoutingModule } from './description-list-routing.module';
 import { DescriptionListComponent } from './description-list.component';
@@ -11,6 +12,7 @@ import { DescriptionListComponent } from './description-list.component';
     DescriptionListRoutingModule,
     SkyDescriptionListModule,
     SkyHelpInlineModule,
+    SkyTabsModule,
   ],
 })
 export class DescriptionListModule {

--- a/libs/components/layout/src/lib/modules/description-list/description-list.component.spec.ts
+++ b/libs/components/layout/src/lib/modules/description-list/description-list.component.spec.ts
@@ -4,7 +4,8 @@ import {
   fakeAsync,
   tick,
 } from '@angular/core/testing';
-import { SkyAppTestUtility, expect, expectAsync } from '@skyux-sdk/testing';
+import { expect, expectAsync } from '@skyux-sdk/testing';
+import { SkyResizeObserverService } from '@skyux/core';
 import {
   SkyTheme,
   SkyThemeMode,
@@ -13,7 +14,7 @@ import {
   SkyThemeSettingsChange,
 } from '@skyux/theme';
 
-import { BehaviorSubject, of } from 'rxjs';
+import { BehaviorSubject, Subject, of } from 'rxjs';
 
 import { SkyDescriptionListAdapterService } from './description-list-adapter-service';
 import { SkyDescriptionListComponent } from './description-list.component';
@@ -32,6 +33,7 @@ describe('Description list component', () => {
     settingsChange: BehaviorSubject<SkyThemeSettingsChange>;
   };
   let mockAdapter: MockAdapter;
+  let mockResize: Subject<void>;
 
   beforeEach(fakeAsync(() => {
     mockThemeSvc = {
@@ -44,6 +46,7 @@ describe('Description list component', () => {
       }),
     };
     mockAdapter = new MockAdapter();
+    mockResize = new Subject<void>();
 
     TestBed.configureTestingModule({
       imports: [SkyDescriptionListFixturesModule],
@@ -51,6 +54,12 @@ describe('Description list component', () => {
         {
           provide: SkyThemeService,
           useValue: mockThemeSvc,
+        },
+        {
+          provide: SkyResizeObserverService,
+          useValue: {
+            observe: (): Subject<void> => mockResize,
+          },
         },
       ],
     }).overrideComponent(SkyDescriptionListComponent, {
@@ -194,8 +203,10 @@ describe('Description list component', () => {
     expect(descriptionEls?.[2]).toHaveText('No information found');
   });
 
-  it('should call the adapter service when window is resized', fakeAsync(() => {
-    SkyAppTestUtility.fireDomEvent(window, 'resize');
+  it('should call the adapter service when the container is resized', fakeAsync(() => {
+    mockAdapter.setResponsiveClass.calls.reset();
+
+    mockResize.next();
     fixture.detectChanges();
 
     expect(mockAdapter.setResponsiveClass).toHaveBeenCalled();

--- a/libs/components/layout/src/lib/modules/description-list/description-list.component.ts
+++ b/libs/components/layout/src/lib/modules/description-list/description-list.component.ts
@@ -1,17 +1,18 @@
 import {
   AfterContentInit,
+  AfterViewInit,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   ContentChildren,
   ElementRef,
-  HostListener,
   Input,
   OnDestroy,
   QueryList,
   ViewChild,
   inject,
 } from '@angular/core';
+import { SkyResizeObserverService } from '@skyux/core';
 
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
@@ -33,7 +34,7 @@ import { SkyDescriptionListModeType } from './types/description-list-mode-type';
   standalone: false,
 })
 export class SkyDescriptionListComponent
-  implements AfterContentInit, OnDestroy
+  implements AfterContentInit, AfterViewInit, OnDestroy
 {
   /**
    * The default description to display when no description is provided
@@ -81,6 +82,7 @@ export class SkyDescriptionListComponent
   readonly #adapterService = inject(SkyDescriptionListAdapterService);
   readonly #changeDetector = inject(ChangeDetectorRef);
   readonly #descriptionListService = inject(SkyDescriptionListService);
+  readonly #resizeObserverSvc = inject(SkyResizeObserverService);
 
   public ngAfterContentInit(): void {
     // Wait for all content to render before detecting parent width.
@@ -98,14 +100,24 @@ export class SkyDescriptionListComponent
     }
   }
 
+  public ngAfterViewInit(): void {
+    // Recalculate the responsive class whenever the container size changes so
+    // the layout stays correct for containers that are hidden (width 0) or
+    // resized after the initial measurement, such as inactive tab content that
+    // is later revealed — not just on window resize.
+    if (this.elementRef) {
+      this.#resizeObserverSvc
+        .observe(this.elementRef)
+        .pipe(takeUntil(this.#ngUnsubscribe))
+        .subscribe(() => {
+          this.#updateResponsiveClass();
+        });
+    }
+  }
+
   public ngOnDestroy(): void {
     this.#ngUnsubscribe.next();
     this.#ngUnsubscribe.complete();
-  }
-
-  @HostListener('window:resize')
-  public onWindowResize(): void {
-    this.#updateResponsiveClass();
   }
 
   #updateResponsiveClass(): void {


### PR DESCRIPTION
:cherries: Cherry picked from #4570 [fix(components/layout): recalculate description list responsive layout on container resize](https://github.com/blackbaud/skyux/pull/4570)

[AB#4074075](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/4074075) 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added modal dialog functionality to display description lists in a larger, dedicated view
  * Introduced demonstration of description lists within tabbed layout configurations

* **Improvements**
  * Enhanced responsive behavior for description lists with improved size change detection and dynamic style recalculation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->