### PR TITLE
feat(components/charts): add pie and donut chart components

### DIFF
--- a/.github/skills/add-skyux-component/SKILL.md
+++ b/.github/skills/add-skyux-component/SKILL.md
@@ -84,23 +84,31 @@ for exact style; do not invent new patterns.
 8. **Update documentation.** Add the new doc IDs to the library's
    `documentation.json` (`development`, `testing`, and `codeExamples`
    sections) so the manifest picks them up.
-9. **Verify.** Run the affected tests, lint, and format before committing:
-   ```bash
-   npx nx test <library> --browsers=ChromeHeadless
-   npx nx test <library>-testing --browsers=ChromeHeadless
-   npx nx test code-examples --browsers=ChromeHeadless
-   npx nx build <library>-storybook
-   npm run lint:affected
-   nx format --files=<changed-file-paths>
-   ```
-10. **Commit.** Use a Conventional Commit with the matching
+9. **Add a playground page.** Create a page for manual testing under
+   `apps/playground/src/app/components/<library>/<component>/` and register
+   it in that library's `<library>.routes.ts` (set `name`, `icon`, and
+   `library` in the route `data`). Mirror a sibling playground page's
+   structure (a default-exported `*-playground.ts` component; larger pages
+   split scenarios into a `variants/` folder). Verify with
+   `npx nx serve playground`.
+10. **Verify.** Run the affected tests, lint, and format before committing:
+    ```bash
+    npx nx test <library> --browsers=ChromeHeadless
+    npx nx test <library>-testing --browsers=ChromeHeadless
+    npx nx test code-examples --browsers=ChromeHeadless
+    npx nx build <library>-storybook
+    npm run lint:affected
+    nx format --files=<changed-file-paths>
+    ```
+11. **Commit.** Use a Conventional Commit with the matching
     `components/<library>` scope per
     [commit-message.instructions.md](../../instructions/commit-message.instructions.md).
 
 ## Definition of Done
 
-- Component, module, spec, harness (+ spec), visual-test story, and code
-  example (+ spec) exist and follow a sibling component's structure.
+- Component, module, spec, harness (+ spec), visual-test story, code
+  example (+ spec), and playground page exist and follow a sibling
+  component's structure.
 - Public types are exported with the `sky`/`Sky` prefix from `src/index.ts`
   and `testing/src/public-api.ts`.
 - `documentation.json` lists the new development, testing, and code-example

--- a/apps/e2e/charts-storybook/src/app/chart-pie/chart-pie.component.html
+++ b/apps/e2e/charts-storybook/src/app/chart-pie/chart-pie.component.html
@@ -1,0 +1,27 @@
+<sky-chart headingText="Sales by region">
+  <sky-chart-pie
+    categoryLabelText="Region"
+    valueLabelText="Sales"
+    [displayMode]="displayMode"
+  >
+    @for (region of regions; track region.name) {
+      <sky-chart-pie-slice [labelText]="region.name" [value]="region.sales" />
+    }
+  </sky-chart-pie>
+</sky-chart>
+
+<sky-chart headingText="Revenue by channel">
+  <sky-chart-pie
+    categoryLabelText="Channel"
+    valueFormat="currency"
+    valueLabelText="Revenue"
+    [displayMode]="displayMode"
+  >
+    @for (channel of channels; track channel.name) {
+      <sky-chart-pie-slice
+        [labelText]="channel.name"
+        [value]="channel.revenue"
+      />
+    }
+  </sky-chart-pie>
+</sky-chart>

--- a/apps/e2e/charts-storybook/src/app/chart-pie/chart-pie.component.scss
+++ b/apps/e2e/charts-storybook/src/app/chart-pie/chart-pie.component.scss
@@ -1,0 +1,3 @@
+:host {
+  display: block;
+}

--- a/apps/e2e/charts-storybook/src/app/chart-pie/chart-pie.component.stories.ts
+++ b/apps/e2e/charts-storybook/src/app/chart-pie/chart-pie.component.stories.ts
@@ -1,0 +1,20 @@
+import type { Meta, StoryObj } from '@storybook/angular';
+
+import { ChartPieComponent } from './chart-pie.component';
+
+export default {
+  id: 'chart-piecomponent',
+  title: 'Components/Chart Pie',
+  component: ChartPieComponent,
+} as Meta<ChartPieComponent>;
+type Story = StoryObj<ChartPieComponent>;
+
+export const Pie: Story = {};
+Pie.args = {
+  displayMode: 'pie',
+};
+
+export const Donut: Story = {};
+Donut.args = {
+  displayMode: 'donut',
+};

--- a/apps/e2e/charts-storybook/src/app/chart-pie/chart-pie.component.ts
+++ b/apps/e2e/charts-storybook/src/app/chart-pie/chart-pie.component.ts
@@ -1,0 +1,32 @@
+import { CommonModule } from '@angular/common';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import {
+  SkyChart,
+  SkyChartPie,
+  type SkyChartPieDisplayMode,
+  SkyChartPieSlice,
+} from '@skyux/charts';
+
+@Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [CommonModule, SkyChart, SkyChartPie, SkyChartPieSlice],
+  selector: 'app-chart-pie',
+  templateUrl: './chart-pie.component.html',
+  styleUrls: ['./chart-pie.component.scss'],
+})
+export class ChartPieComponent {
+  public displayMode: SkyChartPieDisplayMode = 'pie';
+
+  protected readonly regions = [
+    { name: 'North', sales: 210 },
+    { name: 'South', sales: 175 },
+    { name: 'East', sales: 310 },
+    { name: 'West', sales: 260 },
+  ];
+
+  protected readonly channels = [
+    { name: 'In store', revenue: 412500 },
+    { name: 'Online', revenue: 618200 },
+    { name: 'Phone', revenue: 175300 },
+  ];
+}

--- a/apps/playground/src/app/components/charts/chart-pie/chart-pie-playground.html
+++ b/apps/playground/src/app/components/charts/chart-pie/chart-pie-playground.html
@@ -1,0 +1,37 @@
+<sky-page layout="blocks">
+  <sky-page-content>
+    <div class="sky-theme-margin-bottom-l">
+      <sky-toggle-switch
+        class="sky-margin-stacked-lg"
+        labelText="Donut display mode"
+        [checked]="isDonut()"
+        (toggleChange)="isDonut.set($event.checked)"
+      />
+    </div>
+    <sky-fluid-grid gutterSize="medium" [disableMargin]="true">
+      <sky-row>
+        <sky-column [screenSmall]="4">
+          <sky-box class="sky-margin-stacked-xl" headingText="Basic">
+            <sky-box-content>
+              <app-chart-pie-basic [displayMode]="displayMode()" />
+            </sky-box-content>
+          </sky-box>
+        </sky-column>
+        <sky-column [screenSmall]="4">
+          <sky-box class="sky-margin-stacked-xl" headingText="Currency values">
+            <sky-box-content>
+              <app-chart-pie-value-format [displayMode]="displayMode()" />
+            </sky-box-content>
+          </sky-box>
+        </sky-column>
+        <sky-column [screenSmall]="4">
+          <sky-box class="sky-margin-stacked-xl" headingText="Async data">
+            <sky-box-content>
+              <app-chart-pie-async [displayMode]="displayMode()" />
+            </sky-box-content>
+          </sky-box>
+        </sky-column>
+      </sky-row>
+    </sky-fluid-grid>
+  </sky-page-content>
+</sky-page>

--- a/apps/playground/src/app/components/charts/chart-pie/chart-pie-playground.ts
+++ b/apps/playground/src/app/components/charts/chart-pie/chart-pie-playground.ts
@@ -1,0 +1,35 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  signal,
+} from '@angular/core';
+import { type SkyChartPieDisplayMode } from '@skyux/charts';
+import { SkyToggleSwitchModule } from '@skyux/forms';
+import { SkyBoxModule, SkyFluidGridModule } from '@skyux/layout';
+import { SkyPageModule } from '@skyux/pages';
+
+import { ChartPieAsyncPlayground } from './variants/chart-pie-async-playground';
+import { ChartPieBasicPlayground } from './variants/chart-pie-basic-playground';
+import { ChartPieValueFormatPlayground } from './variants/chart-pie-value-format-playground';
+
+@Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [
+    ChartPieAsyncPlayground,
+    ChartPieBasicPlayground,
+    ChartPieValueFormatPlayground,
+    SkyBoxModule,
+    SkyFluidGridModule,
+    SkyPageModule,
+    SkyToggleSwitchModule,
+  ],
+  selector: 'app-chart-pie',
+  templateUrl: './chart-pie-playground.html',
+})
+export default class ChartPiePlayground {
+  protected readonly isDonut = signal(false);
+  protected readonly displayMode = computed<SkyChartPieDisplayMode>(() =>
+    this.isDonut() ? 'donut' : 'pie',
+  );
+}

--- a/apps/playground/src/app/components/charts/chart-pie/variants/chart-pie-async-playground.html
+++ b/apps/playground/src/app/components/charts/chart-pie/variants/chart-pie-async-playground.html
@@ -1,0 +1,22 @@
+<button
+  class="sky-btn sky-btn-default sky-margin-stacked-sm"
+  type="button"
+  [disabled]="donations.isLoading()"
+  (click)="donations.reload()"
+>
+  Reload data
+</button>
+<sky-chart headingText="Donations by channel" [loading]="donations.isLoading()">
+  @if (donations.value(); as data) {
+    <sky-chart-pie
+      categoryLabelText="Channel"
+      valueFormat="currency"
+      valueLabelText="Donations"
+      [displayMode]="displayMode()"
+    >
+      @for (slice of data.slices; track slice.label) {
+        <sky-chart-pie-slice [labelText]="slice.label" [value]="slice.value" />
+      }
+    </sky-chart-pie>
+  }
+</sky-chart>

--- a/apps/playground/src/app/components/charts/chart-pie/variants/chart-pie-async-playground.ts
+++ b/apps/playground/src/app/components/charts/chart-pie/variants/chart-pie-async-playground.ts
@@ -1,0 +1,47 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  input,
+  resource,
+} from '@angular/core';
+import {
+  SkyChart,
+  SkyChartPie,
+  type SkyChartPieDisplayMode,
+  SkyChartPieSlice,
+} from '@skyux/charts';
+
+interface ChartPieAsyncData {
+  slices: { label: string; value: number }[];
+}
+
+@Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [SkyChart, SkyChartPie, SkyChartPieSlice],
+  selector: 'app-chart-pie-async',
+  templateUrl: './chart-pie-async-playground.html',
+})
+export class ChartPieAsyncPlayground {
+  protected readonly displayMode = input<SkyChartPieDisplayMode>('pie');
+
+  // Demonstration resource: an actual SPA might use httpResource to load
+  // remote data. While reloading, the resource keeps its previous value, so
+  // the chart stays rendered beneath the wait overlay.
+  protected readonly donations = resource({
+    loader: () => fetchDonationsFromServer(),
+  });
+}
+
+/**
+ * Simulates a server-side call that returns the chart's data after a delay.
+ */
+async function fetchDonationsFromServer(): Promise<ChartPieAsyncData> {
+  await new Promise((resolve) => setTimeout(resolve, 1200));
+
+  return {
+    slices: ['Events', 'Direct mail', 'Online', 'Major gifts'].map((label) => ({
+      label,
+      value: Math.round(Math.random() * 90) + 10,
+    })),
+  };
+}

--- a/apps/playground/src/app/components/charts/chart-pie/variants/chart-pie-basic-playground.html
+++ b/apps/playground/src/app/components/charts/chart-pie/variants/chart-pie-basic-playground.html
@@ -1,0 +1,11 @@
+<sky-chart headingText="Sales by region">
+  <sky-chart-pie
+    categoryLabelText="Region"
+    valueLabelText="Sales"
+    [displayMode]="displayMode()"
+  >
+    @for (region of regions; track region.label) {
+      <sky-chart-pie-slice [labelText]="region.label" [value]="region.value" />
+    }
+  </sky-chart-pie>
+</sky-chart>

--- a/apps/playground/src/app/components/charts/chart-pie/variants/chart-pie-basic-playground.ts
+++ b/apps/playground/src/app/components/charts/chart-pie/variants/chart-pie-basic-playground.ts
@@ -1,0 +1,23 @@
+import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+import {
+  SkyChart,
+  SkyChartPie,
+  type SkyChartPieDisplayMode,
+  SkyChartPieSlice,
+} from '@skyux/charts';
+
+@Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [SkyChart, SkyChartPie, SkyChartPieSlice],
+  selector: 'app-chart-pie-basic',
+  templateUrl: './chart-pie-basic-playground.html',
+})
+export class ChartPieBasicPlayground {
+  protected readonly displayMode = input<SkyChartPieDisplayMode>('pie');
+  protected readonly regions = [
+    { label: 'North', value: 250 },
+    { label: 'South', value: 180 },
+    { label: 'East', value: 320 },
+    { label: 'West', value: 210 },
+  ];
+}

--- a/apps/playground/src/app/components/charts/chart-pie/variants/chart-pie-value-format-playground.html
+++ b/apps/playground/src/app/components/charts/chart-pie/variants/chart-pie-value-format-playground.html
@@ -1,0 +1,15 @@
+<sky-chart headingText="Revenue by channel">
+  <sky-chart-pie
+    categoryLabelText="Channel"
+    valueFormat="currency"
+    valueLabelText="Revenue"
+    [displayMode]="displayMode()"
+  >
+    @for (channel of channels; track channel.label) {
+      <sky-chart-pie-slice
+        [labelText]="channel.label"
+        [value]="channel.value"
+      />
+    }
+  </sky-chart-pie>
+</sky-chart>

--- a/apps/playground/src/app/components/charts/chart-pie/variants/chart-pie-value-format-playground.ts
+++ b/apps/playground/src/app/components/charts/chart-pie/variants/chart-pie-value-format-playground.ts
@@ -1,0 +1,22 @@
+import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+import {
+  SkyChart,
+  SkyChartPie,
+  type SkyChartPieDisplayMode,
+  SkyChartPieSlice,
+} from '@skyux/charts';
+
+@Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [SkyChart, SkyChartPie, SkyChartPieSlice],
+  selector: 'app-chart-pie-value-format',
+  templateUrl: './chart-pie-value-format-playground.html',
+})
+export class ChartPieValueFormatPlayground {
+  protected readonly displayMode = input<SkyChartPieDisplayMode>('pie');
+  protected readonly channels = [
+    { label: 'In store', value: 125000.5 },
+    { label: 'Online', value: 243500.75 },
+    { label: 'Phone', value: 58250.25 },
+  ];
+}

--- a/apps/playground/src/app/components/charts/charts.routes.ts
+++ b/apps/playground/src/app/components/charts/charts.routes.ts
@@ -19,6 +19,15 @@ const routes: Routes = [
       library: 'charts',
     },
   },
+  {
+    path: 'chart-pie',
+    loadComponent: () => import('./chart-pie/chart-pie-playground'),
+    data: {
+      name: 'Charts: Pie Chart',
+      icon: 'data-pie',
+      library: 'charts',
+    },
+  },
 ];
 
 export default routes;

--- a/libs/components/charts/documentation.json
+++ b/libs/components/charts/documentation.json
@@ -44,6 +44,36 @@
           "ChartsChartBarAsyncExample"
         ]
       }
+    },
+    "chart-pie": {
+      "development": {
+        "docsIds": [
+          "SkyChart",
+          "SkyChartPie",
+          "SkyChartPieSlice",
+          "SkyChartPieDisplayMode",
+          "SkyChartHeadingLevel",
+          "SkyChartHeadingStyle",
+          "SkyChartValueFormat"
+        ],
+        "primaryDocsId": "SkyChart"
+      },
+      "testing": {
+        "docsIds": [
+          "SkyChartPieHarness",
+          "SkyChartPieHarnessFilters",
+          "SkyChartHarness",
+          "SkyChartHarnessFilters",
+          "SkyChartTableModalHarness"
+        ]
+      },
+      "codeExamples": {
+        "docsIds": [
+          "ChartsChartPieBasicExample",
+          "ChartsChartPieDonutExample",
+          "ChartsChartPieAsyncExample"
+        ]
+      }
     }
   }
 }

--- a/libs/components/charts/src/assets/locales/resources_en_US.json
+++ b/libs/components/charts/src/assets/locales/resources_en_US.json
@@ -14,8 +14,13 @@
     "_description": "The label for the 'View data table' chart menu item",
     "message": "View data table"
   },
+  "skyux_charts.chart.donut.accessible_summary": {
+    "_description": "The accessible summary announced for a donut chart figure, describing its shape and noting that a data table alternative is available",
+    "message": "Donut chart. Number of slices: {0}. A data table is available from the chart's context menu.",
+    "_0": "The number of slices"
+  },
   "skyux_charts.chart.pie.accessible_summary": {
-    "_description": "The accessible summary announced for a pie or donut chart figure, describing its shape and noting that a data table alternative is available",
+    "_description": "The accessible summary announced for a pie chart figure, describing its shape and noting that a data table alternative is available",
     "message": "Pie chart. Number of slices: {0}. A data table is available from the chart's context menu.",
     "_0": "The number of slices"
   },

--- a/libs/components/charts/src/assets/locales/resources_en_US.json
+++ b/libs/components/charts/src/assets/locales/resources_en_US.json
@@ -14,6 +14,11 @@
     "_description": "The label for the 'View data table' chart menu item",
     "message": "View data table"
   },
+  "skyux_charts.chart.pie.accessible_summary": {
+    "_description": "The accessible summary announced for a pie or donut chart figure, describing its shape and noting that a data table alternative is available",
+    "message": "Pie chart. Number of slices: {0}. A data table is available from the chart's context menu.",
+    "_0": "The number of slices"
+  },
   "skyux_charts.data_table_modal.close_button": {
     "_description": "The label for the close button",
     "message": "Close"

--- a/libs/components/charts/src/index.ts
+++ b/libs/components/charts/src/index.ts
@@ -5,6 +5,9 @@ export type { SkyChartBarOrientation } from './lib/chart-bar/chart-bar-orientati
 export { SkyChartBarSeries } from './lib/chart-bar/chart-bar-series';
 export type { SkyChartBarSeriesLayout } from './lib/chart-bar/chart-bar-series-layout';
 export type { SkyChartBarSeriesValue } from './lib/chart-bar/chart-bar-series-value';
+export { SkyChartPie } from './lib/chart-pie/chart-pie';
+export type { SkyChartPieDisplayMode } from './lib/chart-pie/chart-pie-display-mode';
+export { SkyChartPieSlice } from './lib/chart-pie/chart-pie-slice';
 export { SkyChart } from './lib/chart/chart';
 export type { SkyChartHeadingLevel } from './lib/chart/chart-heading-level';
 export type { SkyChartHeadingStyle } from './lib/chart/chart-heading-style';

--- a/libs/components/charts/src/lib/chart-js/chart-js.ts
+++ b/libs/components/charts/src/lib/chart-js/chart-js.ts
@@ -9,6 +9,7 @@ import {
   viewChild,
 } from '@angular/core';
 import {
+  ArcElement,
   BarController,
   BarElement,
   CategoryScale,
@@ -18,16 +19,19 @@ import {
   Legend,
   LinearScale,
   LogarithmicScale,
+  PieController,
   Tooltip,
 } from 'chart.js';
 
 Chart.register(
+  ArcElement,
   BarController,
   BarElement,
   CategoryScale,
   LinearScale,
   LogarithmicScale,
   Legend,
+  PieController,
   Tooltip,
 );
 

--- a/libs/components/charts/src/lib/chart-pie/chart-pie-display-mode.ts
+++ b/libs/components/charts/src/lib/chart-pie/chart-pie-display-mode.ts
@@ -1,0 +1,7 @@
+/**
+ * How a pie chart renders its slices. `pie` renders a solid circle, and
+ * `donut` renders a ring with a hollow center.
+ *
+ * @preview
+ */
+export type SkyChartPieDisplayMode = 'pie' | 'donut';

--- a/libs/components/charts/src/lib/chart-pie/chart-pie-slice.ts
+++ b/libs/components/charts/src/lib/chart-pie/chart-pie-slice.ts
@@ -1,0 +1,32 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  input,
+  numberAttribute,
+} from '@angular/core';
+
+/**
+ * Defines a single slice of a pie chart. Slice sizes are proportional to
+ * their values.
+ *
+ * @preview
+ */
+@Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  selector: 'sky-chart-pie-slice',
+  template: '',
+})
+export class SkyChartPieSlice {
+  /**
+   * The text that identifies this slice in the legend, tooltips, and the
+   * data table.
+   */
+  public readonly labelText = input.required<string>();
+
+  /**
+   * The value of this slice.
+   */
+  public readonly value = input.required<number, unknown>({
+    transform: numberAttribute,
+  });
+}

--- a/libs/components/charts/src/lib/chart-pie/chart-pie.html
+++ b/libs/components/charts/src/lib/chart-pie/chart-pie.html
@@ -1,0 +1,3 @@
+@if (chartJsConfig(); as config) {
+  <sky-chart-js [config]="config" [style.height]="chartHeight()" />
+}

--- a/libs/components/charts/src/lib/chart-pie/chart-pie.spec.ts
+++ b/libs/components/charts/src/lib/chart-pie/chart-pie.spec.ts
@@ -151,6 +151,16 @@ describe('Chart pie component', () => {
     });
   });
 
+  it('should publish a donut accessible summary in the donut display mode', () => {
+    component.displayMode = 'donut';
+    fixture.detectChanges();
+
+    expect(tableSvc().summary()).toEqual({
+      resourceKey: 'skyux_charts.chart.donut.accessible_summary',
+      args: [2],
+    });
+  });
+
   it('should clear the accessible summary when the plot is destroyed', () => {
     fixture.detectChanges();
 
@@ -275,6 +285,14 @@ describe('Chart pie component', () => {
     expect(label(tooltipContext('North', 10))).toBe('North: $10.00');
   });
 
+  it('should format fractional tooltip values as percentages', () => {
+    component.valueFormat = 'percent';
+    fixture.detectChanges();
+
+    const label = getTooltipLabel(requireChart());
+    expect(label(tooltipContext('North', 0.25))).toBe('North: 25%');
+  });
+
   it('should apply the themed default height', () => {
     fixture.detectChanges();
 
@@ -315,6 +333,7 @@ describe('Chart pie component', () => {
 
   describe('a11y', () => {
     it('should be accessible as a pie', async () => {
+      fixture.detectChanges();
       await fixture.whenStable();
 
       await expectAsync(fixture.nativeElement).toBeAccessible();
@@ -322,6 +341,7 @@ describe('Chart pie component', () => {
 
     it('should be accessible as a donut', async () => {
       component.displayMode = 'donut';
+      fixture.detectChanges();
       await fixture.whenStable();
 
       await expectAsync(fixture.nativeElement).toBeAccessible();

--- a/libs/components/charts/src/lib/chart-pie/chart-pie.spec.ts
+++ b/libs/components/charts/src/lib/chart-pie/chart-pie.spec.ts
@@ -1,0 +1,451 @@
+import { Component, ViewChild } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { expect, expectAsync } from '@skyux-sdk/testing';
+import {
+  SkyTheme,
+  SkyThemeMode,
+  SkyThemeService,
+  SkyThemeSettings,
+  type SkyThemeSettingsChange,
+} from '@skyux/theme';
+import { Chart, type TooltipItem } from 'chart.js';
+import { ReplaySubject } from 'rxjs';
+
+import { SkyChartTableService } from '../chart-table/chart-table-service';
+import { SkyChart } from '../chart/chart';
+import { SkyChartValueFormat } from '../shared/value-format';
+
+import { SkyChartPie } from './chart-pie';
+import { SkyChartPieDisplayMode } from './chart-pie-display-mode';
+import { SkyChartPieSlice } from './chart-pie-slice';
+
+@Component({
+  imports: [SkyChart, SkyChartPie, SkyChartPieSlice],
+  template: `
+    <sky-chart headingText="Test chart">
+      @if (renderChart) {
+        <sky-chart-pie
+          categoryLabelText="Region"
+          valueLabelText="Sales"
+          [currencyCode]="currencyCode"
+          [digits]="digits"
+          [displayMode]="displayMode"
+          [valueFormat]="valueFormat"
+        >
+          @for (slice of slices; track slice.label) {
+            <sky-chart-pie-slice
+              [labelText]="slice.label"
+              [value]="slice.value"
+            />
+          }
+        </sky-chart-pie>
+      }
+    </sky-chart>
+  `,
+})
+class TestComponent {
+  @ViewChild(SkyChartPie)
+  public chartPie!: SkyChartPie;
+
+  public currencyCode: string | undefined;
+  public digits: number | undefined;
+  public displayMode: SkyChartPieDisplayMode = 'pie';
+  public renderChart = true;
+  public slices: { label: string; value: number }[] = [
+    { label: 'North', value: 10 },
+    { label: 'South', value: 20 },
+  ];
+  public valueFormat: SkyChartValueFormat | undefined;
+}
+
+describe('Chart pie component', () => {
+  let fixture: ComponentFixture<TestComponent>;
+  let component: TestComponent;
+  let destroyed: boolean;
+
+  // The plot publishes its table to the `SkyChartTableService` provided by
+  // the surrounding `sky-chart`, so the service is read from that injector.
+  function tableSvc(): SkyChartTableService {
+    return fixture.debugElement
+      .query(By.directive(SkyChart))
+      .injector.get(SkyChartTableService);
+  }
+
+  function getCanvas(): HTMLCanvasElement {
+    return fixture.nativeElement.querySelector('canvas');
+  }
+
+  function getChartContainerHeight(): string {
+    const container = fixture.nativeElement.querySelector(
+      'sky-chart-js',
+    ) as HTMLElement;
+
+    return container.style.height;
+  }
+
+  function getChart(): Chart<'pie'> | undefined {
+    return Chart.getChart(getCanvas()) as Chart<'pie'> | undefined;
+  }
+
+  function requireChart(): Chart<'pie'> {
+    const chart = getChart();
+
+    if (!chart) {
+      throw new Error('Expected a chart to have been created.');
+    }
+
+    return chart;
+  }
+
+  function getTooltipLabel(
+    chart: Chart<'pie'>,
+  ): (context: TooltipItem<'pie'>) => string {
+    return chart.options.plugins?.tooltip?.callbacks?.label as (
+      context: TooltipItem<'pie'>,
+    ) => string;
+  }
+
+  function tooltipContext(label: string, value: number): TooltipItem<'pie'> {
+    return { label, parsed: value } as unknown as TooltipItem<'pie'>;
+  }
+
+  beforeEach(() => {
+    // Karma loads the real modern theme stylesheet; applying the theme
+    // classes resolves the chart's themed tokens to concrete values.
+    document.body.classList.add('sky-theme-modern', 'sky-theme-brand-base');
+
+    TestBed.configureTestingModule({
+      imports: [TestComponent],
+    });
+
+    fixture = TestBed.createComponent(TestComponent);
+    component = fixture.componentInstance;
+    destroyed = false;
+  });
+
+  afterEach(() => {
+    document.body.classList.remove('sky-theme-modern', 'sky-theme-brand-base');
+
+    if (!destroyed) {
+      fixture.destroy();
+    }
+  });
+
+  it('should build the data table from the slices', () => {
+    fixture.detectChanges();
+
+    expect(tableSvc().table()).toEqual({
+      categoryLabel: 'Region',
+      categories: ['North', 'South'],
+      series: [{ label: 'Sales', values: ['10', '20'] }],
+    });
+  });
+
+  it('should publish an accessible summary from the slices', () => {
+    fixture.detectChanges();
+
+    expect(tableSvc().summary()).toEqual({
+      resourceKey: 'skyux_charts.chart.pie.accessible_summary',
+      args: [2],
+    });
+  });
+
+  it('should clear the accessible summary when the plot is destroyed', () => {
+    fixture.detectChanges();
+
+    const svc = tableSvc();
+    expect(svc.summary()).not.toBeUndefined();
+
+    fixture.destroy();
+    destroyed = true;
+
+    expect(svc.summary()).toBeUndefined();
+  });
+
+  it('should format the data table values using the value format', () => {
+    component.valueFormat = 'currency';
+    component.currencyCode = 'USD';
+    fixture.detectChanges();
+
+    expect(tableSvc().table()?.series[0].values).toEqual(['$10.00', '$20.00']);
+  });
+
+  it('should format the data table values with the given digits', () => {
+    component.digits = 1;
+    fixture.detectChanges();
+
+    expect(tableSvc().table()?.series[0].values).toEqual(['10.0', '20.0']);
+  });
+
+  it('should not build a table or chart without slices', () => {
+    component.slices = [];
+    fixture.detectChanges();
+
+    expect(tableSvc().table()).toBeUndefined();
+    expect(tableSvc().summary()).toBeUndefined();
+    expect(getCanvas()).toBeNull();
+
+    // Covers the destroy path when no chart was created.
+    fixture.destroy();
+    destroyed = true;
+  });
+
+  it('should create a pie chart from the slices', () => {
+    fixture.detectChanges();
+
+    const chart = requireChart();
+    expect(chart.data.labels).toEqual(['North', 'South']);
+    expect(chart.data.datasets[0].label).toBe('Sales');
+    expect(chart.data.datasets[0].data).toEqual([10, 20]);
+    expect(chart.options.cutout).toBe(0);
+  });
+
+  it('should cut out the center in the donut display mode', () => {
+    component.displayMode = 'donut';
+    fixture.detectChanges();
+
+    expect(requireChart().options.cutout).toBe('65%');
+  });
+
+  it('should assign each slice its own categorical data-visualization color', () => {
+    fixture.detectChanges();
+
+    const backgroundColor = requireChart().data.datasets[0]
+      .backgroundColor as string[];
+
+    expect(backgroundColor.length).toBe(2);
+    expect(backgroundColor[0]).not.toBe(backgroundColor[1]);
+
+    // Tokens are resolved to concrete values, never the raw property name.
+    expect(backgroundColor[0]).not.toContain('--sky');
+  });
+
+  it('should cycle the categorical palette when there are more slices than colors', () => {
+    component.slices = Array.from({ length: 9 }, (_, index) => ({
+      label: `Slice ${index}`,
+      value: index + 1,
+    }));
+    fixture.detectChanges();
+
+    const backgroundColor = requireChart().data.datasets[0]
+      .backgroundColor as string[];
+
+    // The palette has 8 categorical colors, so the ninth slice wraps.
+    expect(backgroundColor[8]).toBe(backgroundColor[0]);
+  });
+
+  it('should separate the slices with a themed arc border', () => {
+    fixture.detectChanges();
+
+    const arc = requireChart().options.elements?.arc;
+    expect(arc?.borderWidth).toBe(1);
+    expect(arc?.borderColor).not.toContain('--sky');
+    expect(arc?.borderColor).toBeTruthy();
+  });
+
+  it('should show the legend', () => {
+    fixture.detectChanges();
+
+    // A pie's legend identifies its slices, so it is never hidden.
+    expect(requireChart().options.plugins?.legend?.display).not.toBe(false);
+  });
+
+  it('should target the hovered slice for tooltips', () => {
+    fixture.detectChanges();
+
+    const tooltip = requireChart().options.plugins?.tooltip;
+    expect(tooltip?.mode).toBe('nearest');
+    expect(tooltip?.intersect).toBe(true);
+  });
+
+  it('should format the tooltip label with the slice label', () => {
+    fixture.detectChanges();
+
+    const label = getTooltipLabel(requireChart());
+    expect(label(tooltipContext('North', 10))).toBe('North: 10');
+  });
+
+  it('should format the tooltip value using the value format', () => {
+    component.valueFormat = 'currency';
+    component.currencyCode = 'USD';
+    fixture.detectChanges();
+
+    const label = getTooltipLabel(requireChart());
+    expect(label(tooltipContext('North', 10))).toBe('North: $10.00');
+  });
+
+  it('should apply the themed default height', () => {
+    fixture.detectChanges();
+
+    expect(getChartContainerHeight()).toMatch(/^clamp\(/);
+  });
+
+  it('should update an existing chart when inputs change', async () => {
+    fixture.detectChanges();
+
+    const chart = requireChart();
+    component.slices = [
+      { label: 'North', value: 30 },
+      { label: 'South', value: 40 },
+    ];
+    fixture.detectChanges();
+
+    // The chart updates in an `afterRenderEffect`, so wait for render
+    // effects to flush before asserting.
+    await fixture.whenStable();
+
+    expect(getChart()).toBe(chart);
+    expect(chart.data.datasets[0].data).toEqual([30, 40]);
+  });
+
+  it('should destroy the chart and clear the table when destroyed', () => {
+    fixture.detectChanges();
+
+    const canvas = getCanvas();
+    const svc = tableSvc();
+    expect(Chart.getChart(canvas)).toBeTruthy();
+
+    fixture.destroy();
+
+    expect(Chart.getChart(canvas)).toBeUndefined();
+    expect(svc.table()).toBeUndefined();
+    destroyed = true;
+  });
+
+  describe('a11y', () => {
+    it('should be accessible as a pie', async () => {
+      await fixture.whenStable();
+
+      await expectAsync(fixture.nativeElement).toBeAccessible();
+    });
+
+    it('should be accessible as a donut', async () => {
+      component.displayMode = 'donut';
+      await fixture.whenStable();
+
+      await expectAsync(fixture.nativeElement).toBeAccessible();
+    });
+  });
+});
+
+describe('Chart pie component in the default theme', () => {
+  @Component({
+    imports: [SkyChart, SkyChartPie, SkyChartPieSlice],
+    template: `
+      <sky-chart headingText="Sales">
+        <sky-chart-pie categoryLabelText="Region" valueLabelText="Sales">
+          <sky-chart-pie-slice labelText="North" [value]="10" />
+          <sky-chart-pie-slice labelText="South" [value]="20" />
+        </sky-chart-pie>
+      </sky-chart>
+    `,
+  })
+  class WrappedComponent {}
+
+  it('should theme the chart from the wrapper\u2019s default-theme overrides', async () => {
+    TestBed.configureTestingModule({
+      imports: [WrappedComponent],
+    });
+
+    // No modern theme classes: the default theme is active, and the
+    // `--sky-override-chart-*` values on `sky-chart` inherit to the plot.
+    const fixture = TestBed.createComponent(WrappedComponent);
+    fixture.detectChanges();
+
+    // The chart is created in an `afterRenderEffect`, so wait for render
+    // effects to flush before querying it.
+    await fixture.whenStable();
+
+    const canvas = fixture.nativeElement.querySelector('canvas');
+    const chart = Chart.getChart(canvas) as Chart<'pie'> | undefined;
+
+    if (!chart) {
+      throw new Error('Expected a chart to have been created.');
+    }
+
+    expect(chart.options.elements?.arc?.borderColor).toBe('#ffffff');
+
+    fixture.destroy();
+  });
+
+  it('should be accessible as a full sky-chart composition', async () => {
+    TestBed.configureTestingModule({ imports: [WrappedComponent] });
+
+    const fixture = TestBed.createComponent(WrappedComponent);
+
+    // Render, then re-render after the async library resources resolve so
+    // the context menu button receives its accessible name.
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    await expectAsync(fixture.nativeElement).toBeAccessible();
+
+    fixture.destroy();
+  });
+});
+
+describe('Chart pie component outside a sky-chart', () => {
+  @Component({
+    imports: [SkyChartPie, SkyChartPieSlice],
+    template: `
+      <sky-chart-pie categoryLabelText="Region" valueLabelText="Sales">
+        <sky-chart-pie-slice labelText="North" [value]="10" />
+      </sky-chart-pie>
+    `,
+  })
+  class StandaloneComponent {}
+
+  it('should throw when the plot is not inside a sky-chart', () => {
+    TestBed.configureTestingModule({ imports: [StandaloneComponent] });
+
+    expect(() => TestBed.createComponent(StandaloneComponent)).toThrowError(
+      'The <sky-chart-pie> component must be rendered inside a <sky-chart> ' +
+        'component.',
+    );
+  });
+});
+
+describe('Chart pie component with a theme service', () => {
+  it('should rebuild the chart when the theme settings change', async () => {
+    const currentSettings = new SkyThemeSettings(
+      SkyTheme.presets.default,
+      SkyThemeMode.presets.light,
+    );
+    const settingsChange = new ReplaySubject<SkyThemeSettingsChange>(1);
+    settingsChange.next({ currentSettings } as SkyThemeSettingsChange);
+
+    TestBed.configureTestingModule({
+      imports: [TestComponent],
+      providers: [{ provide: SkyThemeService, useValue: { settingsChange } }],
+    });
+
+    const fixture = TestBed.createComponent(TestComponent);
+    fixture.detectChanges();
+
+    const canvas = fixture.nativeElement.querySelector('canvas');
+    const chart = Chart.getChart(canvas);
+    expect(chart).toBeTruthy();
+
+    const updateSpy = spyOn(chart as Chart, 'update').and.callThrough();
+
+    // A new theme rebuilds the config, updating the existing chart in place
+    // rather than recreating it. A distinct settings instance is required —
+    // the theme signal skips reference-equal emissions — and the update runs
+    // in an `afterRenderEffect`, so wait for render effects to flush.
+    settingsChange.next({
+      currentSettings: new SkyThemeSettings(
+        SkyTheme.presets.modern,
+        SkyThemeMode.presets.light,
+      ),
+    } as SkyThemeSettingsChange);
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(updateSpy).toHaveBeenCalled();
+    expect(Chart.getChart(canvas)).toBe(chart);
+
+    fixture.destroy();
+  });
+});

--- a/libs/components/charts/src/lib/chart-pie/chart-pie.ts
+++ b/libs/components/charts/src/lib/chart-pie/chart-pie.ts
@@ -1,0 +1,218 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  contentChildren,
+  inject,
+  input,
+} from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { SkyAppLocaleProvider } from '@skyux/i18n';
+import { SkyThemeService } from '@skyux/theme';
+import { type ChartDataset, type TooltipItem } from 'chart.js';
+import { EMPTY, map } from 'rxjs';
+
+import { optionalNumberAttribute } from '../chart-axis/optional-number-attribute';
+import { SkyChartJs, type SkyChartJsConfig } from '../chart-js/chart-js';
+import { extendBaseChartJsConfig } from '../chart-js/chart-js-config-utils';
+import { SkyChartPlot } from '../chart-plot/chart-plot';
+import { SkyChartTable } from '../chart-table/chart-table';
+import { SkyChartAccessibleSummary } from '../chart-table/chart-table-service';
+import { SkyChartValueFormat } from '../shared/value-format';
+import { createSkyChartValueFormatter } from '../shared/value-formatter';
+import { SkyChartPieDisplayMode } from './chart-pie-display-mode';
+import { SkyChartPieSlice } from './chart-pie-slice';
+
+/**
+ * The fraction of the chart radius cut out of the center in the `donut`
+ * display mode.
+ */
+const DONUT_CUTOUT = '65%';
+
+/**
+ * Renders a pie chart from one or more slices. The `donut` display mode
+ * renders the same chart as a ring with a hollow center.
+ *
+ * @preview
+ */
+@Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [SkyChartJs],
+  selector: 'sky-chart-pie',
+  templateUrl: './chart-pie.html',
+})
+export class SkyChartPie extends SkyChartPlot {
+  readonly #localeProvider = inject(SkyAppLocaleProvider);
+
+  readonly #locale = toSignal(
+    this.#localeProvider.getLocaleInfo().pipe(map((info) => info.locale)),
+    { initialValue: this.#localeProvider.defaultLocale },
+  );
+
+  readonly #themeSettings = toSignal(
+    inject(SkyThemeService, { optional: true })?.settingsChange.pipe(
+      map((change) => change.currentSettings),
+    ) ?? EMPTY,
+    { initialValue: undefined },
+  );
+
+  /**
+   * The label that describes what the slices represent, shown as the
+   * category header of the chart's data table.
+   */
+  public readonly categoryLabelText = input.required<string>();
+
+  /**
+   * The ISO 4217 currency code used when `valueFormat` is `currency`. When
+   * unset, currency values format as `USD`.
+   */
+  public readonly currencyCode = input<string>();
+
+  /**
+   * The number of decimal places to display. When unset, the format's
+   * locale-aware default is used (for example, two places for most
+   * currencies).
+   */
+  public readonly digits = input(undefined, {
+    transform: optionalNumberAttribute,
+  });
+
+  /**
+   * How the chart renders its slices: a solid `pie` or a `donut` ring with a
+   * hollow center.
+   * @default 'pie'
+   */
+  public readonly displayMode = input<SkyChartPieDisplayMode>('pie');
+
+  /**
+   * How to format the slice values in tooltips and the data table. The
+   * `percent` format expects fractional values, so `0.25` displays as `25%`.
+   * @default 'number'
+   */
+  public readonly valueFormat = input<SkyChartValueFormat>('number');
+
+  /**
+   * The label that describes the plotted values, shown as the value column
+   * header of the chart's data table.
+   */
+  public readonly valueLabelText = input.required<string>();
+
+  protected readonly slices = contentChildren(SkyChartPieSlice);
+
+  protected readonly chartJsConfig = computed(() => this.#getChartJsConfig());
+
+  /**
+   * The height to apply to the rendered chart. Chart.js runs with
+   * `maintainAspectRatio: false`, so its container must be given an explicit
+   * height; pie charts always use the themed default.
+   */
+  protected readonly chartHeight = computed(() => {
+    // Read the theme signal so the height recomputes when the theme changes.
+    this.#themeSettings();
+
+    return this.getThemeStyles().height.default;
+  });
+
+  readonly #formatValue = computed<(value: number) => string>(() =>
+    createSkyChartValueFormatter({
+      format: this.valueFormat(),
+      currencyCode: this.currencyCode(),
+      digits: this.digits(),
+      locale: this.#locale(),
+    }),
+  );
+
+  protected override getChartTable(): SkyChartTable | undefined {
+    const slices = this.slices();
+
+    if (slices.length === 0) {
+      return undefined;
+    }
+
+    const formatValue = this.#formatValue();
+
+    return {
+      categoryLabel: this.categoryLabelText(),
+      categories: slices.map((slice) => slice.labelText()),
+      series: [
+        {
+          label: this.valueLabelText(),
+          values: slices.map((slice) => formatValue(slice.value())),
+        },
+      ],
+    };
+  }
+
+  protected override getAccessibleSummary():
+    | SkyChartAccessibleSummary
+    | undefined {
+    const slices = this.slices();
+
+    if (slices.length === 0) {
+      return undefined;
+    }
+
+    return {
+      resourceKey: 'skyux_charts.chart.pie.accessible_summary',
+      args: [slices.length],
+    };
+  }
+
+  #getChartJsConfig(): SkyChartJsConfig<'pie'> | undefined {
+    const slices = this.slices();
+
+    if (slices.length === 0) {
+      return undefined;
+    }
+
+    // Read the theme signal so the config rebuilds when the theme changes,
+    // then resolve the themed CSS custom properties to concrete values.
+    this.#themeSettings();
+
+    const themeStyles = this.getThemeStyles();
+    const categorical = themeStyles.series.categoricalPalette;
+    const formatValue = this.#formatValue();
+
+    const dataset: ChartDataset<'pie'> = {
+      label: this.valueLabelText(),
+      data: slices.map((slice) => slice.value()),
+      // Unlike a cartesian series, every slice gets its own categorical
+      // color, cycling through the palette when there are more slices than
+      // colors.
+      backgroundColor: slices.map(
+        (_, index) => categorical[index % categorical.length],
+      ),
+    };
+
+    return extendBaseChartJsConfig<'pie'>(themeStyles, {
+      type: 'pie',
+      data: {
+        labels: slices.map((slice) => slice.labelText()),
+        datasets: [dataset],
+      },
+      options: {
+        // A donut is a pie with its center cut out; the display mode only
+        // controls the cutout.
+        cutout: this.displayMode() === 'donut' ? DONUT_CUTOUT : 0,
+        elements: {
+          arc: {
+            borderWidth: 1,
+            borderColor: themeStyles.arc.borderColor,
+          },
+        },
+        plugins: {
+          tooltip: {
+            // The base config indexes tooltips along a cartesian axis; a pie
+            // has no axes, so tooltips target the hovered slice precisely.
+            mode: 'nearest',
+            intersect: true,
+            callbacks: {
+              label: (context: TooltipItem<'pie'>): string =>
+                `${context.label}: ${formatValue(context.parsed)}`,
+            },
+          },
+        },
+      },
+    });
+  }
+}

--- a/libs/components/charts/src/lib/chart-pie/chart-pie.ts
+++ b/libs/components/charts/src/lib/chart-pie/chart-pie.ts
@@ -153,7 +153,10 @@ export class SkyChartPie extends SkyChartPlot {
     }
 
     return {
-      resourceKey: 'skyux_charts.chart.pie.accessible_summary',
+      resourceKey:
+        this.displayMode() === 'donut'
+          ? 'skyux_charts.chart.donut.accessible_summary'
+          : 'skyux_charts.chart.pie.accessible_summary',
       args: [slices.length],
     };
   }

--- a/libs/components/charts/src/lib/shared/chart-theme-styles.ts
+++ b/libs/components/charts/src/lib/shared/chart-theme-styles.ts
@@ -93,6 +93,10 @@ export interface SkyChartThemeStyles {
       minCategoryGap: number;
     };
   };
+  /** The styling of pie and donut arcs (slices). */
+  arc: {
+    borderColor: string;
+  };
 }
 
 /**
@@ -274,6 +278,14 @@ export function resolveChartThemeStyles(
           maxBarThickness: remToPx('1rem', rootFontSize),
           minCategoryGap: remToPx('0.5rem', rootFontSize),
         },
+      },
+      arc: {
+        // Arcs are separated by the container background so adjacent slices
+        // read as distinct.
+        borderColor: readString(
+          styles,
+          '--sky-color-background-container-base',
+        ),
       },
     };
   } finally {

--- a/libs/components/charts/src/lib/shared/fixtures/theme-styles-fixture.ts
+++ b/libs/components/charts/src/lib/shared/fixtures/theme-styles-fixture.ts
@@ -58,6 +58,9 @@ export function createThemeStylesFixture(
         minCategoryGap: 8,
       },
     },
+    arc: {
+      borderColor: '#ffffff',
+    },
     ...overrides,
   };
 }

--- a/libs/components/charts/src/lib/shared/sky-charts-resources.module.ts
+++ b/libs/components/charts/src/lib/shared/sky-charts-resources.module.ts
@@ -25,6 +25,10 @@ const RESOURCES: Record<string, SkyLibResources> = {
     'skyux_charts.chart.controls.context_menu.view_data_table': {
       message: 'View data table',
     },
+    'skyux_charts.chart.donut.accessible_summary': {
+      message:
+        "Donut chart. Number of slices: {0}. A data table is available from the chart's context menu.",
+    },
     'skyux_charts.chart.pie.accessible_summary': {
       message:
         "Pie chart. Number of slices: {0}. A data table is available from the chart's context menu.",

--- a/libs/components/charts/src/lib/shared/sky-charts-resources.module.ts
+++ b/libs/components/charts/src/lib/shared/sky-charts-resources.module.ts
@@ -25,6 +25,10 @@ const RESOURCES: Record<string, SkyLibResources> = {
     'skyux_charts.chart.controls.context_menu.view_data_table': {
       message: 'View data table',
     },
+    'skyux_charts.chart.pie.accessible_summary': {
+      message:
+        "Pie chart. Number of slices: {0}. A data table is available from the chart's context menu.",
+    },
     'skyux_charts.data_table_modal.close_button': { message: 'Close' },
     'skyux_charts.data_table_modal.table_region_label': {
       message: 'Data table for {0}',

--- a/libs/components/charts/testing/src/modules/chart-pie/chart-pie-harness-filters.ts
+++ b/libs/components/charts/testing/src/modules/chart-pie/chart-pie-harness-filters.ts
@@ -1,0 +1,8 @@
+import { SkyHarnessFilters } from '@skyux/core/testing';
+
+/**
+ * A set of criteria for filtering `SkyChartPieHarness` instances.
+ * @preview
+ */
+// eslint-disable-next-line @typescript-eslint/no-empty-interface, @typescript-eslint/no-empty-object-type
+export interface SkyChartPieHarnessFilters extends SkyHarnessFilters {}

--- a/libs/components/charts/testing/src/modules/chart-pie/chart-pie-harness.spec.ts
+++ b/libs/components/charts/testing/src/modules/chart-pie/chart-pie-harness.spec.ts
@@ -1,0 +1,60 @@
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { Component } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { SkyChart, SkyChartPie, SkyChartPieSlice } from '@skyux/charts';
+
+import { SkyChartPieHarness } from './chart-pie-harness';
+
+@Component({
+  imports: [SkyChart, SkyChartPie, SkyChartPieSlice],
+  template: `
+    <sky-chart headingText="Complete chart">
+      <sky-chart-pie
+        data-sky-id="complete-chart"
+        categoryLabelText="Region"
+        valueLabelText="Sales"
+      >
+        <sky-chart-pie-slice labelText="North" [value]="10" />
+        <sky-chart-pie-slice labelText="South" [value]="20" />
+      </sky-chart-pie>
+    </sky-chart>
+    <sky-chart headingText="Empty chart">
+      <sky-chart-pie
+        data-sky-id="empty-chart"
+        categoryLabelText="Region"
+        valueLabelText="Sales"
+      />
+    </sky-chart>
+  `,
+})
+class TestComponent {}
+
+describe('Chart pie harness', () => {
+  async function setupTest(options: {
+    dataSkyId: string;
+  }): Promise<{ harness: SkyChartPieHarness }> {
+    const fixture = TestBed.createComponent(TestComponent);
+    const loader = TestbedHarnessEnvironment.loader(fixture);
+    const harness = await loader.getHarness(
+      SkyChartPieHarness.with({ dataSkyId: options.dataSkyId }),
+    );
+
+    return { harness };
+  }
+
+  it('should throw when no pie chart matches the filters', async () => {
+    await expectAsync(setupTest({ dataSkyId: 'no-such-chart' })).toBeRejected();
+  });
+
+  it('should indicate the plot is rendered', async () => {
+    const { harness } = await setupTest({ dataSkyId: 'complete-chart' });
+
+    await expectAsync(harness.isChartRendered()).toBeResolvedTo(true);
+  });
+
+  it('should indicate the plot is not rendered', async () => {
+    const { harness } = await setupTest({ dataSkyId: 'empty-chart' });
+
+    await expectAsync(harness.isChartRendered()).toBeResolvedTo(false);
+  });
+});

--- a/libs/components/charts/testing/src/modules/chart-pie/chart-pie-harness.ts
+++ b/libs/components/charts/testing/src/modules/chart-pie/chart-pie-harness.ts
@@ -1,0 +1,35 @@
+import { HarnessPredicate } from '@angular/cdk/testing';
+import { SkyComponentHarness } from '@skyux/core/testing';
+
+import { SkyChartPieHarnessFilters } from './chart-pie-harness-filters';
+
+/**
+ * Harness for interacting with a pie chart component in tests.
+ * @preview
+ */
+export class SkyChartPieHarness extends SkyComponentHarness {
+  /**
+   * @internal
+   */
+  public static readonly hostSelector = 'sky-chart-pie';
+
+  readonly #getCanvas = this.locatorForOptional('canvas');
+
+  /**
+   * Gets a `HarnessPredicate` that can be used to search for a
+   * `SkyChartPieHarness` that meets certain criteria.
+   */
+  public static with(
+    filters: SkyChartPieHarnessFilters,
+  ): HarnessPredicate<SkyChartPieHarness> {
+    return SkyChartPieHarness.getDataSkyIdPredicate(filters);
+  }
+
+  /**
+   * Whether the pie chart has rendered its plot. The plot renders once the
+   * chart is given at least one slice.
+   */
+  public async isChartRendered(): Promise<boolean> {
+    return (await this.#getCanvas()) !== null;
+  }
+}

--- a/libs/components/charts/testing/src/public-api.ts
+++ b/libs/components/charts/testing/src/public-api.ts
@@ -1,5 +1,7 @@
 export { SkyChartBarHarness } from './modules/chart-bar/chart-bar-harness';
 export type { SkyChartBarHarnessFilters } from './modules/chart-bar/chart-bar-harness-filters';
+export { SkyChartPieHarness } from './modules/chart-pie/chart-pie-harness';
+export type { SkyChartPieHarnessFilters } from './modules/chart-pie/chart-pie-harness-filters';
 export { SkyChartTableModalHarness } from './modules/chart-table/chart-table-modal-harness';
 export { SkyChartHarness } from './modules/chart/chart-harness';
 export type { SkyChartHarnessFilters } from './modules/chart/chart-harness-filters';

--- a/libs/components/code-examples/routes/src/index.ts
+++ b/libs/components/code-examples/routes/src/index.ts
@@ -263,6 +263,27 @@ export const routes: Routes = [
       ),
   },
   {
+    path: 'ChartsChartPieAsyncExample',
+    loadComponent: () =>
+      import('@skyux/code-examples').then(
+        ({ ChartsChartPieAsyncExample: c }) => c,
+      ),
+  },
+  {
+    path: 'ChartsChartPieBasicExample',
+    loadComponent: () =>
+      import('@skyux/code-examples').then(
+        ({ ChartsChartPieBasicExample: c }) => c,
+      ),
+  },
+  {
+    path: 'ChartsChartPieDonutExample',
+    loadComponent: () =>
+      import('@skyux/code-examples').then(
+        ({ ChartsChartPieDonutExample: c }) => c,
+      ),
+  },
+  {
     path: 'ColorpickerBasicExampleComponent',
     loadComponent: () =>
       import('@skyux/code-examples').then(

--- a/libs/components/code-examples/src/index.ts
+++ b/libs/components/code-examples/src/index.ts
@@ -34,6 +34,9 @@ export { ChartsChartBarMultipleSeriesExample } from './lib/modules/charts/chart-
 export { ChartsChartBarStackedExample } from './lib/modules/charts/chart-bar/stacked/example';
 export { ChartsChartBarValueBoundsExample } from './lib/modules/charts/chart-bar/value-bounds/example';
 export { ChartsChartBarValueFormatExample } from './lib/modules/charts/chart-bar/value-format/example';
+export { ChartsChartPieAsyncExample } from './lib/modules/charts/chart-pie/async/example';
+export { ChartsChartPieBasicExample } from './lib/modules/charts/chart-pie/basic/example';
+export { ChartsChartPieDonutExample } from './lib/modules/charts/chart-pie/donut/example';
 export { ColorpickerBasicExampleComponent } from './lib/modules/colorpicker/colorpicker/basic/example.component';
 export { ColorpickerHelpKeyExampleComponent } from './lib/modules/colorpicker/colorpicker/help-key/example.component';
 export { ColorpickerProgrammaticExampleComponent } from './lib/modules/colorpicker/colorpicker/programmatic/example.component';

--- a/libs/components/code-examples/src/lib/modules/charts/chart-pie/async/example.html
+++ b/libs/components/code-examples/src/lib/modules/charts/chart-pie/async/example.html
@@ -1,0 +1,21 @@
+<button
+  class="sky-btn sky-btn-default sky-theme-margin-bottom-s"
+  type="button"
+  [disabled]="sales.isLoading()"
+  (click)="sales.reload()"
+>
+  Reload data
+</button>
+<sky-chart
+  data-sky-id="sales-by-region"
+  headingText="Sales by region"
+  [loading]="sales.isLoading()"
+>
+  @if (sales.value(); as data) {
+    <sky-chart-pie categoryLabelText="Region" valueLabelText="Sales">
+      @for (slice of data.slices; track slice.label) {
+        <sky-chart-pie-slice [labelText]="slice.label" [value]="slice.value" />
+      }
+    </sky-chart-pie>
+  }
+</sky-chart>

--- a/libs/components/code-examples/src/lib/modules/charts/chart-pie/async/example.spec.ts
+++ b/libs/components/code-examples/src/lib/modules/charts/chart-pie/async/example.spec.ts
@@ -1,0 +1,95 @@
+import { manualChangeDetection } from '@angular/cdk/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { SkyChartHarness, SkyChartPieHarness } from '@skyux/charts/testing';
+import { provideNoopSkyAnimations } from '@skyux/core';
+
+import { ChartsChartPieAsyncExample } from './example';
+
+describe('Async pie chart example', () => {
+  // The harness loader waits for the fixture to stabilize, which resolves the
+  // example's simulated server call, so the chart is loaded by the time a
+  // harness is returned. The delay is set to 0 to keep the test fast.
+  async function setupTest(): Promise<{
+    fixture: ComponentFixture<ChartsChartPieAsyncExample>;
+    harness: SkyChartHarness;
+  }> {
+    TestBed.configureTestingModule({
+      providers: [provideNoopSkyAnimations()],
+    });
+
+    const fixture = TestBed.createComponent(ChartsChartPieAsyncExample);
+    fixture.componentRef.setInput('delay', 0);
+    const loader = TestbedHarnessEnvironment.loader(fixture);
+    fixture.detectChanges();
+    const harness = await loader.getHarness(
+      SkyChartHarness.with({ dataSkyId: 'sales-by-region' }),
+    );
+
+    return { fixture, harness };
+  }
+
+  it('should render the chart once the data resolves', async () => {
+    const { harness } = await setupTest();
+
+    await expectAsync(harness.getHeadingText()).toBeResolvedTo(
+      'Sales by region',
+    );
+    await expectAsync(harness.isLoading()).toBeResolvedTo(false);
+  });
+
+  it('should show the loading state until the request resolves', async () => {
+    TestBed.configureTestingModule({
+      providers: [provideNoopSkyAnimations()],
+    });
+
+    const fixture = TestBed.createComponent(ChartsChartPieAsyncExample);
+    fixture.componentRef.setInput('delay', 0);
+    const loader = TestbedHarnessEnvironment.loader(fixture);
+
+    // Drive change detection manually so the CDK does not auto-stabilize the
+    // fixture, which would resolve the simulated request before the loading
+    // state can be observed.
+    await manualChangeDetection(async () => {
+      fixture.detectChanges();
+
+      const harness = await loader.getHarness(
+        SkyChartHarness.with({ dataSkyId: 'sales-by-region' }),
+      );
+
+      await expectAsync(harness.isLoading()).toBeResolvedTo(true);
+
+      // A pending timer keeps the zone unstable, so `whenStable` waits for the
+      // simulated request to resolve without a fixed wall-clock delay.
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      await expectAsync(harness.isLoading()).toBeResolvedTo(false);
+    });
+  });
+
+  it('should render the pie chart plot', async () => {
+    const { harness } = await setupTest();
+
+    const pieHarness = await harness.queryHarness(SkyChartPieHarness);
+
+    await expectAsync(pieHarness.isChartRendered()).toBeResolvedTo(true);
+  });
+
+  it('should expose the loaded data through the data table modal', async () => {
+    const { harness } = await setupTest();
+
+    const dataTable = await harness.openDataTableModal();
+
+    await expectAsync(dataTable.getCategoryLabel()).toBeResolvedTo('Region');
+    await expectAsync(dataTable.getSeriesLabels()).toBeResolvedTo(['Sales']);
+    await expectAsync(dataTable.getCategories()).toBeResolvedTo([
+      'North',
+      'South',
+      'East',
+      'West',
+    ]);
+
+    await dataTable.close();
+  });
+});

--- a/libs/components/code-examples/src/lib/modules/charts/chart-pie/async/example.ts
+++ b/libs/components/code-examples/src/lib/modules/charts/chart-pie/async/example.ts
@@ -1,0 +1,49 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  input,
+  resource,
+} from '@angular/core';
+import { SkyChart, SkyChartPie, SkyChartPieSlice } from '@skyux/charts';
+
+interface ChartPieAsyncData {
+  slices: { label: string; value: number }[];
+}
+
+/**
+ * @title Pie chart with asynchronously loaded data
+ */
+@Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  selector: 'app-chart-pie-async-example',
+  templateUrl: './example.html',
+  imports: [SkyChart, SkyChartPie, SkyChartPieSlice],
+})
+export class ChartsChartPieAsyncExample {
+  // Simulate network latency.
+  public readonly delay = input(1200);
+
+  // A real SPA might use `httpResource` to load remote data. While reloading,
+  // the resource keeps its previous value, so the chart stays rendered
+  // beneath the wait overlay.
+  protected readonly sales = resource({
+    params: () => ({ delay: this.delay() }),
+    loader: ({ params }) => fetchSalesFromServer(params.delay),
+  });
+}
+
+/**
+ * Simulates a server-side call that returns the chart's data after a delay.
+ */
+async function fetchSalesFromServer(delay: number): Promise<ChartPieAsyncData> {
+  await new Promise((resolve) => setTimeout(resolve, delay));
+
+  return {
+    slices: [
+      { label: 'North', value: 250 },
+      { label: 'South', value: 180 },
+      { label: 'East', value: 320 },
+      { label: 'West', value: 210 },
+    ],
+  };
+}

--- a/libs/components/code-examples/src/lib/modules/charts/chart-pie/basic/example.html
+++ b/libs/components/code-examples/src/lib/modules/charts/chart-pie/basic/example.html
@@ -1,0 +1,11 @@
+<sky-chart data-sky-id="sales-by-region" headingText="Sales by region">
+  <sky-chart-pie
+    data-sky-id="sales-pie"
+    categoryLabelText="Region"
+    valueLabelText="Sales"
+  >
+    @for (region of regions; track region.name) {
+      <sky-chart-pie-slice [labelText]="region.name" [value]="region.sales" />
+    }
+  </sky-chart-pie>
+</sky-chart>

--- a/libs/components/code-examples/src/lib/modules/charts/chart-pie/basic/example.spec.ts
+++ b/libs/components/code-examples/src/lib/modules/charts/chart-pie/basic/example.spec.ts
@@ -1,0 +1,60 @@
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { SkyChartHarness, SkyChartPieHarness } from '@skyux/charts/testing';
+import { provideNoopSkyAnimations } from '@skyux/core';
+
+import { ChartsChartPieBasicExample } from './example';
+
+describe('Basic pie chart example', () => {
+  async function setupTest(): Promise<{
+    fixture: ComponentFixture<ChartsChartPieBasicExample>;
+    harness: SkyChartHarness;
+  }> {
+    TestBed.configureTestingModule({
+      providers: [provideNoopSkyAnimations()],
+    });
+
+    const fixture = TestBed.createComponent(ChartsChartPieBasicExample);
+    const loader = TestbedHarnessEnvironment.loader(fixture);
+    const harness = await loader.getHarness(
+      SkyChartHarness.with({ dataSkyId: 'sales-by-region' }),
+    );
+
+    return { fixture, harness };
+  }
+
+  it('should render the chart with the expected heading', async () => {
+    const { harness } = await setupTest();
+
+    await expectAsync(harness.getHeadingText()).toBeResolvedTo(
+      'Sales by region',
+    );
+  });
+
+  it('should render the pie chart plot', async () => {
+    const { harness } = await setupTest();
+
+    const pieHarness = await harness.queryHarness(
+      SkyChartPieHarness.with({ dataSkyId: 'sales-pie' }),
+    );
+
+    await expectAsync(pieHarness.isChartRendered()).toBeResolvedTo(true);
+  });
+
+  it('should expose the chart data through the data table modal', async () => {
+    const { harness } = await setupTest();
+
+    const dataTable = await harness.openDataTableModal();
+
+    await expectAsync(dataTable.getCategoryLabel()).toBeResolvedTo('Region');
+    await expectAsync(dataTable.getSeriesLabels()).toBeResolvedTo(['Sales']);
+    await expectAsync(dataTable.getCategories()).toBeResolvedTo([
+      'North',
+      'South',
+      'East',
+      'West',
+    ]);
+
+    await dataTable.close();
+  });
+});

--- a/libs/components/code-examples/src/lib/modules/charts/chart-pie/basic/example.ts
+++ b/libs/components/code-examples/src/lib/modules/charts/chart-pie/basic/example.ts
@@ -1,0 +1,20 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { SkyChart, SkyChartPie, SkyChartPieSlice } from '@skyux/charts';
+
+/**
+ * @title Basic pie chart
+ */
+@Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  selector: 'app-chart-pie-basic-example',
+  templateUrl: './example.html',
+  imports: [SkyChart, SkyChartPie, SkyChartPieSlice],
+})
+export class ChartsChartPieBasicExample {
+  protected readonly regions = [
+    { name: 'North', sales: 210 },
+    { name: 'South', sales: 175 },
+    { name: 'East', sales: 310 },
+    { name: 'West', sales: 260 },
+  ];
+}

--- a/libs/components/code-examples/src/lib/modules/charts/chart-pie/donut/example.html
+++ b/libs/components/code-examples/src/lib/modules/charts/chart-pie/donut/example.html
@@ -1,0 +1,16 @@
+<sky-chart data-sky-id="revenue-by-channel" headingText="Revenue by channel">
+  <sky-chart-pie
+    data-sky-id="revenue-donut"
+    categoryLabelText="Channel"
+    displayMode="donut"
+    valueFormat="currency"
+    valueLabelText="Revenue"
+  >
+    @for (channel of channels; track channel.name) {
+      <sky-chart-pie-slice
+        [labelText]="channel.name"
+        [value]="channel.revenue"
+      />
+    }
+  </sky-chart-pie>
+</sky-chart>

--- a/libs/components/code-examples/src/lib/modules/charts/chart-pie/donut/example.spec.ts
+++ b/libs/components/code-examples/src/lib/modules/charts/chart-pie/donut/example.spec.ts
@@ -1,0 +1,59 @@
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { SkyChartHarness, SkyChartPieHarness } from '@skyux/charts/testing';
+import { provideNoopSkyAnimations } from '@skyux/core';
+
+import { ChartsChartPieDonutExample } from './example';
+
+describe('Donut chart example', () => {
+  async function setupTest(): Promise<{
+    fixture: ComponentFixture<ChartsChartPieDonutExample>;
+    harness: SkyChartHarness;
+  }> {
+    TestBed.configureTestingModule({
+      providers: [provideNoopSkyAnimations()],
+    });
+
+    const fixture = TestBed.createComponent(ChartsChartPieDonutExample);
+    const loader = TestbedHarnessEnvironment.loader(fixture);
+    const harness = await loader.getHarness(
+      SkyChartHarness.with({ dataSkyId: 'revenue-by-channel' }),
+    );
+
+    return { fixture, harness };
+  }
+
+  it('should render the chart with the expected heading', async () => {
+    const { harness } = await setupTest();
+
+    await expectAsync(harness.getHeadingText()).toBeResolvedTo(
+      'Revenue by channel',
+    );
+  });
+
+  it('should render the donut chart plot', async () => {
+    const { harness } = await setupTest();
+
+    const pieHarness = await harness.queryHarness(
+      SkyChartPieHarness.with({ dataSkyId: 'revenue-donut' }),
+    );
+
+    await expectAsync(pieHarness.isChartRendered()).toBeResolvedTo(true);
+  });
+
+  it('should expose the formatted chart data through the data table modal', async () => {
+    const { harness } = await setupTest();
+
+    const dataTable = await harness.openDataTableModal();
+
+    await expectAsync(dataTable.getCategoryLabel()).toBeResolvedTo('Channel');
+    await expectAsync(dataTable.getSeriesLabels()).toBeResolvedTo(['Revenue']);
+    await expectAsync(dataTable.getCategories()).toBeResolvedTo([
+      'In store',
+      'Online',
+      'Phone',
+    ]);
+
+    await dataTable.close();
+  });
+});

--- a/libs/components/code-examples/src/lib/modules/charts/chart-pie/donut/example.ts
+++ b/libs/components/code-examples/src/lib/modules/charts/chart-pie/donut/example.ts
@@ -1,0 +1,19 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { SkyChart, SkyChartPie, SkyChartPieSlice } from '@skyux/charts';
+
+/**
+ * @title Donut chart
+ */
+@Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  selector: 'app-chart-pie-donut-example',
+  templateUrl: './example.html',
+  imports: [SkyChart, SkyChartPie, SkyChartPieSlice],
+})
+export class ChartsChartPieDonutExample {
+  protected readonly channels = [
+    { name: 'In store', revenue: 412500 },
+    { name: 'Online', revenue: 618200 },
+    { name: 'Phone', revenue: 175300 },
+  ];
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added pie and donut charts with configurable labels, values, formatting, currencies, tooltips, themes, and accessible summaries.
  * Added data-table access through the chart context menu.
  * Added basic, formatted-value, donut, and asynchronous chart examples with loading and reload states.
  * Added playground pages and documentation for the new chart options.

* **Testing**
  * Added testing harness support and comprehensive coverage for chart rendering, accessibility, formatting, themes, and empty states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->