### PR TITLE
fix: point dropdown docs to valid URL in JSDoc comments

### DIFF
--- a/libs/components/angular-tree-component/src/lib/modules/angular-tree/angular-tree-node.component.ts
+++ b/libs/components/angular-tree-component/src/lib/modules/angular-tree/angular-tree-node.component.ts
@@ -31,7 +31,7 @@ import { SkyAngularTreeWrapperComponent } from './angular-tree-wrapper.component
  * tag with the template reference variable `#treeNodeFullTemplate`. For information about tree node templates,
  * see the [Angular tree component documentation](https://angular2-tree.readme.io/docs/templates).
  * To display context menus with actions for individual items in hierarchical lists, place
- * [dropdowns](https://developer.blackbaud.com/skyux-popovers/docs/dropdown?docs-active-tab=design) inside the
+ * [dropdowns](https://developer.blackbaud.com/skyux/components/dropdown) inside the
  * Angular tree node component, which automatically handles styling and positioning for context menus.
  */
 @Component({

--- a/libs/components/lists/src/lib/modules/repeater/repeater-item-context-menu.component.ts
+++ b/libs/components/lists/src/lib/modules/repeater/repeater-item-context-menu.component.ts
@@ -2,7 +2,7 @@ import { Component } from '@angular/core';
 
 /**
  * Wraps and styles a
- * [`sky-dropdown` component](https://developer.blackbaud.com/skyux-popovers/docs/dropdown).
+ * [`sky-dropdown` component](https://developer.blackbaud.com/skyux/components/dropdown).
  */
 @Component({
   selector: 'sky-repeater-item-context-menu',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated dropdown component documentation links to point to the current SKY UX components documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->