### PR TITLE
fix(components/packages): add SkyDataGrid/SkyDataGridColumn to NgModule imports when only exports referenced SkyGridModule in convert-grid-to-data-grid

### DIFF
--- a/libs/components/packages/src/schematics/rules/convert-grid-to-data-grid/convert-grid-to-data-grid.spec.ts
+++ b/libs/components/packages/src/schematics/rules/convert-grid-to-data-grid/convert-grid-to-data-grid.spec.ts
@@ -1090,4 +1090,68 @@ describe('Convert Grid to Data Grid', () => {
       `,
     );
   });
+
+  it('should only add SkyDataGrid and SkyDataGridColumn to the NgModule that exports SkyGridModule without importing it, when a file declares multiple NgModules', async () => {
+    const tree = await createTestApp(runner, { projectName: 'test-app' });
+    tree.create(
+      'src/app/foo.component.html',
+      stripIndents`
+        <sky-grid [data]="data">
+          <sky-grid-column id="name" heading="Name" field="name" />
+        </sky-grid>
+      `,
+    );
+    createExternalTemplateComponent(tree, 'foo', 'FooComponent');
+    tree.create(
+      'src/app/foo.module.ts',
+      stripIndents`
+        import { NgModule } from '@angular/core';
+        import { SkyGridModule } from '@skyux/grids';
+
+        import { FooComponent } from './foo.component';
+
+        @NgModule({
+          declarations: [FooComponent],
+          imports: [SkyGridModule],
+          exports: [SkyGridModule],
+        })
+        export class FooModule {}
+
+        @NgModule({
+          exports: [SkyGridModule],
+        })
+        export class BarModule {}
+      `,
+    );
+    const result = await convert(tree);
+    const moduleOutput = result.readText('src/app/foo.module.ts');
+
+    // FooModule already imported SkyGridModule, so swapImportedClass alone
+    // handles it; it must not receive a second, duplicate imports edit.
+    const fooModuleBlock = moduleOutput.match(
+      /@NgModule\({[^{}]*}\)\s*export class FooModule \{\}/,
+    )?.[0];
+    expect(fooModuleBlock).toBeDefined();
+    expect(fooModuleBlock).toContain(
+      'imports: [SkyDataGrid, SkyDataGridColumn]',
+    );
+    expect(fooModuleBlock).toContain(
+      'exports: [SkyDataGrid, SkyDataGridColumn]',
+    );
+    expect(
+      fooModuleBlock?.match(/SkyDataGrid, SkyDataGridColumn/g),
+    ).toHaveLength(2);
+
+    // BarModule only exported SkyGridModule, so it needs the imports array added.
+    const barModuleBlock = moduleOutput.match(
+      /@NgModule\({[^{}]*}\)\s*export class BarModule \{\}/,
+    )?.[0];
+    expect(barModuleBlock).toBeDefined();
+    expect(barModuleBlock).toContain(
+      'exports: [SkyDataGrid, SkyDataGridColumn]',
+    );
+    expect(
+      barModuleBlock?.match(/SkyDataGrid, SkyDataGridColumn/g),
+    ).toHaveLength(2);
+  });
 });

--- a/libs/components/packages/src/schematics/rules/convert-grid-to-data-grid/convert-grid-to-data-grid.spec.ts
+++ b/libs/components/packages/src/schematics/rules/convert-grid-to-data-grid/convert-grid-to-data-grid.spec.ts
@@ -1008,4 +1008,86 @@ describe('Convert Grid to Data Grid', () => {
     ).toBe(true);
     expect(result.readText('package.json')).not.toContain('@skyux/data-grid');
   });
+
+  it('should add SkyDataGrid and SkyDataGridColumn to an NgModule imports array when only exports referenced SkyGridModule', async () => {
+    const tree = await createTestApp(runner, { projectName: 'test-app' });
+    tree.create(
+      'src/app/foo.component.html',
+      stripIndents`
+        <sky-grid [data]="data">
+          <sky-grid-column id="name" heading="Name" field="name" />
+        </sky-grid>
+      `,
+    );
+    createExternalTemplateComponent(tree, 'foo', 'FooComponent');
+    tree.create(
+      'src/app/foo.module.ts',
+      stripIndents`
+        import { NgModule } from '@angular/core';
+        import { SkyGridModule } from '@skyux/grids';
+
+        import { FooComponent } from './foo.component';
+
+        @NgModule({
+          declarations: [FooComponent],
+          exports: [SkyGridModule],
+        })
+        export class FooModule {}
+      `,
+    );
+    const result = await convert(tree);
+    const moduleOutput = result.readText('src/app/foo.module.ts');
+    expect(moduleOutput).toContain('exports: [SkyDataGrid, SkyDataGridColumn]');
+    expect(moduleOutput).toMatch(
+      /imports: \[\s*SkyDataGrid, SkyDataGridColumn\s*\]/,
+    );
+  });
+
+  it('should append SkyDataGrid and SkyDataGridColumn to an existing NgModule imports array when only exports referenced SkyGridModule', async () => {
+    const tree = await createTestApp(runner, { projectName: 'test-app' });
+    tree.create(
+      'src/app/foo.component.html',
+      stripIndents`
+        <sky-grid [data]="data">
+          <sky-grid-column id="name" heading="Name" field="name" />
+        </sky-grid>
+      `,
+    );
+    createExternalTemplateComponent(tree, 'foo', 'FooComponent');
+    tree.create(
+      'src/app/foo.module.ts',
+      stripIndents`
+        import { CommonModule } from '@angular/common';
+        import { NgModule } from '@angular/core';
+        import { SkyGridModule } from '@skyux/grids';
+
+        import { FooComponent } from './foo.component';
+
+        @NgModule({
+          declarations: [FooComponent],
+          imports: [CommonModule],
+          exports: [SkyGridModule],
+        })
+        export class FooModule {}
+      `,
+    );
+    const result = await convert(tree);
+    expect(stripIndents`${result.readText('src/app/foo.module.ts')}`).toBe(
+      stripIndents`
+        import { CommonModule } from '@angular/common';
+        import { NgModule } from '@angular/core';
+
+
+        import { FooComponent } from './foo.component';
+        import { SkyDataGrid, SkyDataGridColumn } from '@skyux/data-grid';
+
+        @NgModule({
+          declarations: [FooComponent],
+          imports: [CommonModule, SkyDataGrid, SkyDataGridColumn],
+          exports: [SkyDataGrid, SkyDataGridColumn],
+        })
+        export class FooModule {}
+      `,
+    );
+  });
 });

--- a/libs/components/packages/src/schematics/rules/convert-grid-to-data-grid/convert-grid-to-data-grid.ts
+++ b/libs/components/packages/src/schematics/rules/convert-grid-to-data-grid/convert-grid-to-data-grid.ts
@@ -618,12 +618,28 @@ function getAssociatedEvidence(
 }
 
 /**
- * True when an `@NgModule` in `source` exports `SkyGridModule` without also
- * importing it. `SkyDataGrid`/`SkyDataGridColumn` need to be added to that
- * NgModule's `imports` array as well, since a standalone class must be
- * imported before it can be exported.
+ * True for an `@NgModule` object literal that exports `SkyGridModule`
+ * without also importing it. `SkyDataGrid`/`SkyDataGridColumn` need to be
+ * added to that NgModule's `imports` array as well, since a standalone class
+ * must be imported before it can be exported. A source file may declare more
+ * than one `@NgModule`, so this must be checked per-node rather than
+ * file-wide to avoid touching NgModules that already import `SkyGridModule`
+ * or that don't reference it at all.
  */
 function ngModuleExportsGridModuleWithoutImportingIt(
+  node: ts.ObjectLiteralExpression,
+): boolean {
+  return (
+    isSymbolInClassMetadataFieldArray(node, 'exports', SKY_GRID_MODULE) &&
+    !isSymbolInClassMetadataFieldArray(node, 'imports', SKY_GRID_MODULE)
+  );
+}
+
+/**
+ * True when any `@NgModule` in `source` exports `SkyGridModule` without also
+ * importing it.
+ */
+function sourceHasNgModuleExportingGridModuleWithoutImportingIt(
   source: ts.SourceFile,
 ): boolean {
   if (!isImportedFromPackage(source, 'NgModule', '@angular/core')) {
@@ -632,8 +648,7 @@ function ngModuleExportsGridModuleWithoutImportingIt(
   return getDecoratorMetadata(source, 'NgModule', '@angular/core').some(
     (node) =>
       ts.isObjectLiteralExpression(node) &&
-      isSymbolInClassMetadataFieldArray(node, 'exports', SKY_GRID_MODULE) &&
-      !isSymbolInClassMetadataFieldArray(node, 'imports', SKY_GRID_MODULE),
+      ngModuleExportsGridModuleWithoutImportingIt(node),
   );
 }
 
@@ -680,7 +695,7 @@ function updateTypescriptImports(
     // skip stays safe because <sky-list-view-grid> requires
     // SkyListViewGridModule, which re-exports SkyGridModule.
     const needsGridImportForExport =
-      ngModuleExportsGridModuleWithoutImportingIt(source);
+      sourceHasNgModuleExportingGridModuleWithoutImportingIt(source);
     const recorder = tree.beginUpdate(filePath);
     swapImportedClass(recorder, filePath, source, [
       {
@@ -695,7 +710,9 @@ function updateTypescriptImports(
     ]);
     if (needsGridImportForExport) {
       // The import is already added by swapImportedClass above, so only the
-      // metadata array needs the symbols (importPath: null).
+      // metadata array needs the symbols (importPath: null). Restrict the
+      // edit to the NgModule(s) that actually need it, since a file can
+      // declare more than one NgModule.
       applyToUpdateRecorder(
         recorder,
         addSymbolToClassMetadata(
@@ -705,6 +722,7 @@ function updateTypescriptImports(
           'imports',
           DATA_GRID_CLASS_NAMES.join(', '),
           null,
+          ngModuleExportsGridModuleWithoutImportingIt,
         ),
       );
     }

--- a/libs/components/packages/src/schematics/rules/convert-grid-to-data-grid/convert-grid-to-data-grid.ts
+++ b/libs/components/packages/src/schematics/rules/convert-grid-to-data-grid/convert-grid-to-data-grid.ts
@@ -8,7 +8,11 @@ import {
 } from '@angular-devkit/schematics';
 import ts from '@schematics/angular/third_party/github.com/Microsoft/TypeScript/lib/typescript';
 import { ExistingBehavior, addDependency } from '@schematics/angular/utility';
-import { findNodes } from '@schematics/angular/utility/ast-utils';
+import {
+  findNodes,
+  getDecoratorMetadata,
+} from '@schematics/angular/utility/ast-utils';
+import { applyToUpdateRecorder } from '@schematics/angular/utility/change';
 
 import { logOnce } from '../../utility/log-once';
 import {
@@ -23,9 +27,11 @@ import {
   swapTags,
 } from '../../utility/template';
 import {
+  addSymbolToClassMetadata,
   getInlineTemplates,
   getTemplateUrls,
   isImportedFromPackage,
+  isSymbolInClassMetadataFieldArray,
   parseSourceFile,
 } from '../../utility/typescript/ng-ast';
 import { removeClassReference } from '../../utility/typescript/remove-class-reference';
@@ -39,6 +45,13 @@ const SKY_GRID_MODULE = 'SkyGridModule';
 const SKY_GRID_MODULE_PACKAGE = '@skyux/grids';
 const SKY_LIST_VIEW_GRID_MODULE = 'SkyListViewGridModule';
 const SKY_LIST_VIEW_GRID_MODULE_PACKAGE = '@skyux/list-builder-view-grids';
+
+/**
+ * `SkyDataGrid`/`SkyDataGridColumn` are standalone components that replace
+ * `SkyGridModule`. Unlike an NgModule, they must be present in an NgModule's
+ * `imports` array to also appear in that NgModule's `exports` array.
+ */
+const DATA_GRID_CLASS_NAMES = ['SkyDataGrid', 'SkyDataGridColumn'];
 
 const GRID_TAG: 'sky-grid'[] = ['sky-grid'];
 const COLUMN_TAG: 'sky-grid-column'[] = ['sky-grid-column'];
@@ -605,6 +618,26 @@ function getAssociatedEvidence(
 }
 
 /**
+ * True when an `@NgModule` in `source` exports `SkyGridModule` without also
+ * importing it. `SkyDataGrid`/`SkyDataGridColumn` need to be added to that
+ * NgModule's `imports` array as well, since a standalone class must be
+ * imported before it can be exported.
+ */
+function ngModuleExportsGridModuleWithoutImportingIt(
+  source: ts.SourceFile,
+): boolean {
+  if (!isImportedFromPackage(source, 'NgModule', '@angular/core')) {
+    return false;
+  }
+  return getDecoratorMetadata(source, 'NgModule', '@angular/core').some(
+    (node) =>
+      ts.isObjectLiteralExpression(node) &&
+      isSymbolInClassMetadataFieldArray(node, 'exports', SKY_GRID_MODULE) &&
+      !isSymbolInClassMetadataFieldArray(node, 'imports', SKY_GRID_MODULE),
+  );
+}
+
+/**
  * Second pass: decides what to do with a file's `SkyGridModule` import based
  * on the template evidence associated with the file — its own inline and
  * `templateUrl` templates plus, for NgModule and spec files, the templates of
@@ -646,11 +679,13 @@ function updateTypescriptImports(
     // A real conversion needs SkyDataGrid/SkyDataGridColumn. Any list-view-grid
     // skip stays safe because <sky-list-view-grid> requires
     // SkyListViewGridModule, which re-exports SkyGridModule.
+    const needsGridImportForExport =
+      ngModuleExportsGridModuleWithoutImportingIt(source);
     const recorder = tree.beginUpdate(filePath);
     swapImportedClass(recorder, filePath, source, [
       {
         classNames: {
-          [SKY_GRID_MODULE]: ['SkyDataGrid', 'SkyDataGridColumn'],
+          [SKY_GRID_MODULE]: DATA_GRID_CLASS_NAMES,
         },
         moduleName: {
           old: SKY_GRID_MODULE_PACKAGE,
@@ -658,6 +693,21 @@ function updateTypescriptImports(
         },
       },
     ]);
+    if (needsGridImportForExport) {
+      // The import is already added by swapImportedClass above, so only the
+      // metadata array needs the symbols (importPath: null).
+      applyToUpdateRecorder(
+        recorder,
+        addSymbolToClassMetadata(
+          source,
+          'NgModule',
+          filePath,
+          'imports',
+          DATA_GRID_CLASS_NAMES.join(', '),
+          null,
+        ),
+      );
+    }
     tree.commitUpdate(recorder);
   } else if (total.columnsSkipped > 0) {
     logOnce(

--- a/libs/components/packages/src/schematics/utility/typescript/ng-ast.ts
+++ b/libs/components/packages/src/schematics/utility/typescript/ng-ast.ts
@@ -172,6 +172,7 @@ export function addSymbolToClassMetadata(
   metadataField: string,
   symbolName: string,
   importPath: string | null = null,
+  nodeFilter?: (node: ts.ObjectLiteralExpression) => boolean,
 ): Change[] {
   const nodes =
     'TestBed.configureTestingModule' === decorator
@@ -179,7 +180,11 @@ export function addSymbolToClassMetadata(
       : getDecoratorMetadata(source, decorator, '@angular/core');
   let insertedImport = false;
   return nodes
-    .filter((node) => !!node && ts.isObjectLiteralExpression(node))
+    .filter(
+      (node): node is ts.ObjectLiteralExpression =>
+        !!node && ts.isObjectLiteralExpression(node),
+    )
+    .filter((node) => !nodeFilter || nodeFilter(node))
     .flatMap((node): Change[] => {
       if (
         importPath === '@angular/common' &&


### PR DESCRIPTION
Exporting a standalone class from an NgModule requires it to also be imported, unlike NgModule-to-NgModule re-exports, so the swap now adds the replacement classes to `imports` when the only reference to SkyGridModule was in `exports`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved grid-to-data-grid migrations for Angular modules that expose grid functionality through exports without directly importing it.
  * Migrations now correctly add the required data grid components to both imports and exports.
  * Existing module imports are preserved while the new data grid components are appended.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->