### PR TITLE
chore: release 14.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Bug Fixes
 
+* **components/indicators:** spot illustration reflects dark mode and branding styles ([#4599](https://github.com/blackbaud/skyux/issues/4599)) ([c80de19](https://github.com/blackbaud/skyux/commit/c80de195af957667ba9600de8ad866c3c338b31e))
 * **components/packages:** add SkyDataGrid/SkyDataGridColumn to NgModule imports when only exports referenced SkyGridModule in convert-grid-to-data-grid ([#4600](https://github.com/blackbaud/skyux/issues/4600)) ([f1582d0](https://github.com/blackbaud/skyux/commit/f1582d096e3f4123199beef5b0438b0e6159a349))
 
 ## [14.11.0](https://github.com/blackbaud/skyux/compare/14.10.0...14.11.0) (2026-08-05)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,14 @@
 # Changelog
 
 
-## [14.11.1](https://github.com/blackbaud/skyux/compare/14.11.0...14.11.1) (2026-08-07)
+## [14.11.1](https://github.com/blackbaud/skyux/compare/14.11.0...14.11.1) (2026-08-10)
 
 
 ### Bug Fixes
 
 * **components/indicators:** spot illustration reflects dark mode and branding styles ([#4599](https://github.com/blackbaud/skyux/issues/4599)) ([c80de19](https://github.com/blackbaud/skyux/commit/c80de195af957667ba9600de8ad866c3c338b31e))
 * **components/packages:** add SkyDataGrid/SkyDataGridColumn to NgModule imports when only exports referenced SkyGridModule in convert-grid-to-data-grid ([#4600](https://github.com/blackbaud/skyux/issues/4600)) ([f1582d0](https://github.com/blackbaud/skyux/commit/f1582d096e3f4123199beef5b0438b0e6159a349))
+* point dropdown docs to valid URL in JSDoc comments ([#4592](https://github.com/blackbaud/skyux/issues/4592)) ([a6fa970](https://github.com/blackbaud/skyux/commit/a6fa97003e8f0a6645252716c501e50e2d900b83))
 
 ## [14.11.0](https://github.com/blackbaud/skyux/compare/14.10.0...14.11.0) (2026-08-05)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,12 @@
 # Changelog
 
 
-## [14.11.1](https://github.com/blackbaud/skyux/compare/14.11.0...14.11.1) (2026-08-10)
+## [14.12.0](https://github.com/blackbaud/skyux/compare/14.11.0...14.12.0) (2026-08-10)
+
+
+### Features
+
+* **components/ag-grid:** add `defineSkyAgGridColDef` to validate cell editor and renderer params against cell types ([#4582](https://github.com/blackbaud/skyux/issues/4582)) ([7c01fd2](https://github.com/blackbaud/skyux/commit/7c01fd2a96f3fefef0e42fc3934fd0098bf94ca5)), closes [AB#3928427](https://dev.azure.com/blackbaud/Products/_workitems/edit/3928427)
 
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
 
+## [14.11.1](https://github.com/blackbaud/skyux/compare/14.11.0...14.11.1) (2026-08-07)
+
+
+### Bug Fixes
+
+* **components/packages:** add SkyDataGrid/SkyDataGridColumn to NgModule imports when only exports referenced SkyGridModule in convert-grid-to-data-grid ([#4600](https://github.com/blackbaud/skyux/issues/4600)) ([f1582d0](https://github.com/blackbaud/skyux/commit/f1582d096e3f4123199beef5b0438b0e6159a349))
+
 ## [14.11.0](https://github.com/blackbaud/skyux/compare/14.10.0...14.11.0) (2026-08-05)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Bug Fixes
 
+* **components/ag-grid:** update no-rows text ([#4604](https://github.com/blackbaud/skyux/issues/4604)) ([da81925](https://github.com/blackbaud/skyux/commit/da81925b0e745e3504fd5e8543206137fbb7237b)), closes [AB#4079651](https://dev.azure.com/blackbaud/Products/_workitems/edit/4079651)
 * **components/indicators:** spot illustration reflects dark mode and branding styles ([#4599](https://github.com/blackbaud/skyux/issues/4599)) ([c80de19](https://github.com/blackbaud/skyux/commit/c80de195af957667ba9600de8ad866c3c338b31e))
 * **components/packages:** add SkyDataGrid/SkyDataGridColumn to NgModule imports when only exports referenced SkyGridModule in convert-grid-to-data-grid ([#4600](https://github.com/blackbaud/skyux/issues/4600)) ([f1582d0](https://github.com/blackbaud/skyux/commit/f1582d096e3f4123199beef5b0438b0e6159a349))
 * point dropdown docs to valid URL in JSDoc comments ([#4592](https://github.com/blackbaud/skyux/issues/4592)) ([a6fa970](https://github.com/blackbaud/skyux/commit/a6fa97003e8f0a6645252716c501e50e2d900b83))

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "skyux",
-  "version": "14.11.0",
+  "version": "14.11.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "skyux",
-      "version": "14.11.0",
+      "version": "14.11.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "skyux",
-  "version": "14.11.1",
+  "version": "14.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "skyux",
-      "version": "14.11.1",
+      "version": "14.12.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skyux",
-  "version": "14.11.1",
+  "version": "14.12.0",
   "license": "MIT",
   "scripts": {
     "ng": "nx",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skyux",
-  "version": "14.11.0",
+  "version": "14.11.1",
   "license": "MIT",
   "scripts": {
     "ng": "nx",


### PR DESCRIPTION
## [14.12.0](https://github.com/blackbaud/skyux/compare/14.11.0...14.12.0) (2026-08-10)


### Features

* **components/ag-grid:** add `defineSkyAgGridColDef` to validate cell editor and renderer params against cell types ([#4582](https://github.com/blackbaud/skyux/issues/4582)) ([7c01fd2](https://github.com/blackbaud/skyux/commit/7c01fd2a96f3fefef0e42fc3934fd0098bf94ca5)), closes [AB#3928427](https://dev.azure.com/blackbaud/Products/_workitems/edit/3928427)


### Bug Fixes

* **components/ag-grid:** update no-rows text ([#4604](https://github.com/blackbaud/skyux/issues/4604)) ([da81925](https://github.com/blackbaud/skyux/commit/da81925b0e745e3504fd5e8543206137fbb7237b)), closes [AB#4079651](https://dev.azure.com/blackbaud/Products/_workitems/edit/4079651)
* **components/indicators:** spot illustration reflects dark mode and branding styles ([#4599](https://github.com/blackbaud/skyux/issues/4599)) ([c80de19](https://github.com/blackbaud/skyux/commit/c80de195af957667ba9600de8ad866c3c338b31e))
* **components/packages:** add SkyDataGrid/SkyDataGridColumn to NgModule imports when only exports referenced SkyGridModule in convert-grid-to-data-grid ([#4600](https://github.com/blackbaud/skyux/issues/4600)) ([f1582d0](https://github.com/blackbaud/skyux/commit/f1582d096e3f4123199beef5b0438b0e6159a349))
* point dropdown docs to valid URL in JSDoc comments ([#4592](https://github.com/blackbaud/skyux/issues/4592)) ([a6fa970](https://github.com/blackbaud/skyux/commit/a6fa97003e8f0a6645252716c501e50e2d900b83))