### PR TITLE
fix(components/ag-grid): update no-rows text

### DIFF
--- a/libs/components/ag-grid/src/assets/locales/resources_en_US.json
+++ b/libs/components/ag-grid/src/assets/locales/resources_en_US.json
@@ -62,5 +62,13 @@
   "sky_ag_grid_column_group_header_collapse_aria_label": {
     "_description": "aria label for the collapse column group header button",
     "message": "Collapse column group {0}"
+  },
+  "sky_ag_grid_locale_no_rows_to_show": {
+    "_description": "ag-grid localeText override for the `noRowsToShow` empty-grid overlay message",
+    "message": "No data available"
+  },
+  "sky_ag_grid_locale_no_matching_rows": {
+    "_description": "ag-grid localeText override for the `noMatchingRows` empty-filter-results overlay message",
+    "message": "No matching rows"
   }
 }

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/ag-grid.service.spec.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/ag-grid.service.spec.ts
@@ -362,6 +362,9 @@ describe('SkyAgGridService', () => {
       expect(gridOptions.localeText?.['noRowsToShow']).toEqual(
         'No data available',
       );
+      expect(gridOptions.localeText?.['noMatchingRows']).toEqual(
+        'No matching rows',
+      );
     });
 
     it('should prefer a consumer-provided localeText override over the default text', () => {
@@ -373,6 +376,9 @@ describe('SkyAgGridService', () => {
 
       expect(gridOptions.localeText?.['noRowsToShow']).toEqual(
         'Custom no rows text',
+      );
+      expect(gridOptions.localeText?.['noMatchingRows']).toEqual(
+        'No matching rows',
       );
     });
 

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/ag-grid.service.spec.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/ag-grid.service.spec.ts
@@ -355,6 +355,37 @@ describe('SkyAgGridService', () => {
     });
   });
 
+  describe('localeText', () => {
+    it('should populate localeText with SKY UX resource strings', () => {
+      const gridOptions = agGridService.getGridOptions({ gridOptions: {} });
+
+      expect(gridOptions.localeText?.['noRowsToShow']).toEqual(
+        'No data available',
+      );
+    });
+
+    it('should prefer a consumer-provided localeText override over the default text', () => {
+      const gridOptions = agGridService.getGridOptions({
+        gridOptions: {
+          localeText: { noRowsToShow: 'Custom no rows text' },
+        },
+      });
+
+      expect(gridOptions.localeText?.['noRowsToShow']).toEqual(
+        'Custom no rows text',
+      );
+    });
+
+    it('should pass a consumer-provided getLocaleText callback through unchanged', () => {
+      const getLocaleText = jasmine.createSpy('getLocaleText');
+      const gridOptions = agGridService.getGridOptions({
+        gridOptions: { getLocaleText },
+      });
+
+      expect(gridOptions.getLocaleText).toBe(getLocaleText);
+    });
+  });
+
   describe('getEditableGridOptions', () => {
     it('should return the default gridOptions with the edit-specific property settings', () => {
       const editableGridOptions = agGridService.getEditableGridOptions({
@@ -1164,6 +1195,14 @@ describe('SkyAgGridService', () => {
           .skyComponentProperties.validatorMessage;
 
       expect(validatorMessage()).toEqual('Please enter a valid number');
+    });
+
+    it('should use fallback locale text', () => {
+      const options = serviceWithoutResources.getGridOptions({
+        gridOptions: {},
+      });
+
+      expect(options.localeText?.['noRowsToShow']).toEqual('No data available');
     });
   });
 });

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/ag-grid.service.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/ag-grid.service.ts
@@ -16,6 +16,7 @@ import {
   GridOptions,
   HeaderClassParams,
   ICellRendererParams,
+  LocaleText,
   RowClassParams,
   RowNode,
   RowSelectionOptions,
@@ -135,8 +136,27 @@ function getValidatorCellRendererSelector(
 
 let rowNodeId = -1;
 
+const skyAgGridLocaleTextDefaults = {
+  noRowsToShow: 'No data available',
+  noMatchingRows: 'No matching rows',
+} satisfies LocaleText;
+
+const skyAgGridLocaleTextResourceKeys: Record<
+  keyof typeof skyAgGridLocaleTextDefaults,
+  string
+> = {
+  noRowsToShow: 'sky_ag_grid_locale_no_rows_to_show',
+  noMatchingRows: 'sky_ag_grid_locale_no_matching_rows',
+};
+
 /**
  * `SkyAgGridService` provides methods to get AG Grid `gridOptions` to ensure grids match SKY UX functionality. The `gridOptions` can be overridden, and include registered SKY UX column types.
+ *
+ * Locale text is resolved once, when the grid options are created. [AG Grid does not re-read
+ * locale text after a grid is created](https://www.ag-grid.com/angular-data-grid/localisation/),
+ * so an application that changes locale at runtime must destroy and recreate the grid. Setting
+ * `gridOptions.getLocaleText` replaces SKY UX locale text entirely — use `gridOptions.localeText`
+ * to override individual strings instead.
  */
 @Injectable({
   providedIn: 'root',
@@ -173,9 +193,17 @@ export class SkyAgGridService {
       of('Row selection'),
     { initialValue: 'Row selection' },
   );
+  readonly #localeText = toSignal(
+    this.#resources?.getStrings(skyAgGridLocaleTextResourceKeys) ??
+      of(skyAgGridLocaleTextDefaults),
+    { initialValue: skyAgGridLocaleTextDefaults },
+  );
 
   /**
    * Returns [AG Grid `gridOptions`](https://www.ag-grid.com/angular-data-grid/grid-options/) with default SKY UX options, styling, and cell renderers registered for read-only grids.
+   *
+   * Locale text is resolved once, at call time. If the application's locale changes at
+   * runtime, destroy and recreate the grid to pick up the new locale text.
    * @param args
    * @returns
    */
@@ -193,6 +221,9 @@ export class SkyAgGridService {
 
   /**
    * Returns [AG Grid `gridOptions`](https://www.ag-grid.com/angular-data-grid/grid-options/) with default SKY UX options, styling, and cell editors registered for editable grids.
+   *
+   * Locale text is resolved once, at call time. If the application's locale changes at
+   * runtime, destroy and recreate the grid to pick up the new locale text.
    * @param args
    * @returns
    */
@@ -257,6 +288,10 @@ export class SkyAgGridService {
       context: {
         ...defaultGridOptions.context,
         ...providedGridOptions.context,
+      },
+      localeText: {
+        ...defaultGridOptions.localeText,
+        ...providedGridOptions.localeText,
       },
       columnTypes: {
         ...providedGridOptions.columnTypes,
@@ -583,6 +618,7 @@ export class SkyAgGridService {
           this.#getIconTemplate(iconKey as keyof IconMapType),
         ]),
       ),
+      localeText: this.#localeText(),
       loadingOverlayComponent: SkyAgGridLoadingComponent,
       onCellFocused: (event: CellFocusedEvent) => this.#onCellFocused(event),
       rowModelType: 'clientSide',

--- a/libs/components/ag-grid/src/lib/modules/shared/sky-ag-grid-resources.module.ts
+++ b/libs/components/ag-grid/src/lib/modules/shared/sky-ag-grid-resources.module.ts
@@ -59,6 +59,8 @@ const RESOURCES: Record<string, SkyLibResources> = {
     sky_ag_grid_column_group_header_collapse_aria_label: {
       message: 'Collapse column group {0}',
     },
+    sky_ag_grid_locale_no_rows_to_show: { message: 'No data available' },
+    sky_ag_grid_locale_no_matching_rows: { message: 'No matching rows' },
   },
   'FR-CA': {
     sky_ag_grid_row_selector_aria_label: {


### PR DESCRIPTION
[AB#4079651](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/4079651)

The default AG Grid options used "No Rows To Show" and that text does not match the SKY UX style guide. The text has been updated and now loads via a `@skyux/i18n` resource string.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added English localization for AG Grid empty-grid and no-matching-row messages.
  * Grid locale text now updates automatically with resource changes while preserving consumer-provided overrides and callbacks.
* **Bug Fixes**
  * Added fallback text for empty-grid and no-matching-row states when localization resources are unavailable.
* **Tests**
  * Added coverage for default messages, consumer overrides, callbacks, and localization fallbacks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->