### PR TITLE
fix(components/ag-grid): update no-rows text (#4604)

### DIFF
--- a/libs/components/ag-grid/src/assets/locales/resources_en_US.json
+++ b/libs/components/ag-grid/src/assets/locales/resources_en_US.json
@@ -62,5 +62,13 @@
   "sky_ag_grid_column_group_header_collapse_aria_label": {
     "_description": "aria label for the collapse column group header button",
     "message": "Collapse column group {0}"
+  },
+  "sky_ag_grid_locale_no_rows_to_show": {
+    "_description": "ag-grid localeText override for the `noRowsToShow` empty-grid overlay message",
+    "message": "No data available"
+  },
+  "sky_ag_grid_locale_no_matching_rows": {
+    "_description": "ag-grid localeText override for the `noMatchingRows` empty-filter-results overlay message",
+    "message": "No matching rows"
   }
 }

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/ag-grid.service.spec.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/ag-grid.service.spec.ts
@@ -355,6 +355,43 @@ describe('SkyAgGridService', () => {
     });
   });
 
+  describe('localeText', () => {
+    it('should populate localeText with SKY UX resource strings', () => {
+      const gridOptions = agGridService.getGridOptions({ gridOptions: {} });
+
+      expect(gridOptions.localeText?.['noRowsToShow']).toEqual(
+        'No data available',
+      );
+      expect(gridOptions.localeText?.['noMatchingRows']).toEqual(
+        'No matching rows',
+      );
+    });
+
+    it('should prefer a consumer-provided localeText override over the default text', () => {
+      const gridOptions = agGridService.getGridOptions({
+        gridOptions: {
+          localeText: { noRowsToShow: 'Custom no rows text' },
+        },
+      });
+
+      expect(gridOptions.localeText?.['noRowsToShow']).toEqual(
+        'Custom no rows text',
+      );
+      expect(gridOptions.localeText?.['noMatchingRows']).toEqual(
+        'No matching rows',
+      );
+    });
+
+    it('should pass a consumer-provided getLocaleText callback through unchanged', () => {
+      const getLocaleText = jasmine.createSpy('getLocaleText');
+      const gridOptions = agGridService.getGridOptions({
+        gridOptions: { getLocaleText },
+      });
+
+      expect(gridOptions.getLocaleText).toBe(getLocaleText);
+    });
+  });
+
   describe('getEditableGridOptions', () => {
     it('should return the default gridOptions with the edit-specific property settings', () => {
       const editableGridOptions = agGridService.getEditableGridOptions({
@@ -1162,6 +1199,14 @@ describe('SkyAgGridService', () => {
           .skyComponentProperties.validatorMessage;
 
       expect(validatorMessage()).toEqual('Please enter a valid number');
+    });
+
+    it('should use fallback locale text', () => {
+      const options = serviceWithoutResources.getGridOptions({
+        gridOptions: {},
+      });
+
+      expect(options.localeText?.['noRowsToShow']).toEqual('No data available');
     });
   });
 });

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/ag-grid.service.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/ag-grid.service.ts
@@ -16,6 +16,7 @@ import {
   GridOptions,
   HeaderClassParams,
   ICellRendererParams,
+  LocaleText,
   RowClassParams,
   RowNode,
   RowSelectionOptions,
@@ -135,8 +136,27 @@ function getValidatorCellRendererSelector(
 
 let rowNodeId = -1;
 
+const skyAgGridLocaleTextDefaults = {
+  noRowsToShow: 'No data available',
+  noMatchingRows: 'No matching rows',
+} satisfies LocaleText;
+
+const skyAgGridLocaleTextResourceKeys: Record<
+  keyof typeof skyAgGridLocaleTextDefaults,
+  string
+> = {
+  noRowsToShow: 'sky_ag_grid_locale_no_rows_to_show',
+  noMatchingRows: 'sky_ag_grid_locale_no_matching_rows',
+};
+
 /**
  * `SkyAgGridService` provides methods to get AG Grid `gridOptions` to ensure grids match SKY UX functionality. The `gridOptions` can be overridden, and include registered SKY UX column types.
+ *
+ * Locale text is resolved once, when the grid options are created. [AG Grid does not re-read
+ * locale text after a grid is created](https://www.ag-grid.com/angular-data-grid/localisation/),
+ * so an application that changes locale at runtime must destroy and recreate the grid. Setting
+ * `gridOptions.getLocaleText` replaces SKY UX locale text entirely — use `gridOptions.localeText`
+ * to override individual strings instead.
  */
 @Injectable({
   providedIn: 'root',
@@ -173,9 +193,17 @@ export class SkyAgGridService {
       of('Row selection'),
     { initialValue: 'Row selection' },
   );
+  readonly #localeText = toSignal(
+    this.#resources?.getStrings(skyAgGridLocaleTextResourceKeys) ??
+      of(skyAgGridLocaleTextDefaults),
+    { initialValue: skyAgGridLocaleTextDefaults },
+  );
 
   /**
    * Returns [AG Grid `gridOptions`](https://www.ag-grid.com/angular-data-grid/grid-options/) with default SKY UX options, styling, and cell renderers registered for read-only grids.
+   *
+   * Locale text is resolved once, at call time. If the application's locale changes at
+   * runtime, destroy and recreate the grid to pick up the new locale text.
    * @param args
    * @returns
    */
@@ -193,6 +221,9 @@ export class SkyAgGridService {
 
   /**
    * Returns [AG Grid `gridOptions`](https://www.ag-grid.com/angular-data-grid/grid-options/) with default SKY UX options, styling, and cell editors registered for editable grids.
+   *
+   * Locale text is resolved once, at call time. If the application's locale changes at
+   * runtime, destroy and recreate the grid to pick up the new locale text.
    * @param args
    * @returns
    */
@@ -257,6 +288,10 @@ export class SkyAgGridService {
       context: {
         ...defaultGridOptions.context,
         ...providedGridOptions.context,
+      },
+      localeText: {
+        ...defaultGridOptions.localeText,
+        ...providedGridOptions.localeText,
       },
       columnTypes: {
         ...providedGridOptions.columnTypes,
@@ -582,6 +617,7 @@ export class SkyAgGridService {
           this.#getIconTemplate(iconKey as keyof IconMapType),
         ]),
       ),
+      localeText: this.#localeText(),
       loadingOverlayComponent: SkyAgGridLoadingComponent,
       onCellFocused: (event: CellFocusedEvent) => this.#onCellFocused(event),
       paginationPageSizeSelector: false,

--- a/libs/components/ag-grid/src/lib/modules/shared/sky-ag-grid-resources.module.ts
+++ b/libs/components/ag-grid/src/lib/modules/shared/sky-ag-grid-resources.module.ts
@@ -59,6 +59,8 @@ const RESOURCES: Record<string, SkyLibResources> = {
     sky_ag_grid_column_group_header_collapse_aria_label: {
       message: 'Collapse column group {0}',
     },
+    sky_ag_grid_locale_no_rows_to_show: { message: 'No data available' },
+    sky_ag_grid_locale_no_matching_rows: { message: 'No matching rows' },
   },
   'FR-CA': {
     sky_ag_grid_row_selector_aria_label: {


### PR DESCRIPTION
:cherries: Cherry picked from #4604 [fix(components/ag-grid): update no-rows text](https://github.com/blackbaud/skyux/pull/4604)

[AB#4079651](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/4079651) 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added localized AG Grid messages for empty data and no matching filtered rows.
  * Grid text now uses SKY UX localization by default while preserving custom text overrides.
  * Added fallback text for environments without localization resources.
  * Locale text is resolved when grid options are created; recreate grids after changing the application language.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->