### PR TITLE
ci: preserve translation partner commits during branch sync

### DIFF
--- a/.github/workflows/automated-translations.yml
+++ b/.github/workflows/automated-translations.yml
@@ -47,7 +47,13 @@ jobs:
   automated-translations:
     name: Sync translations
     needs: determine-lts
-    if: needs.determine-lts.outputs.should-sync == 'true'
+    # Skip runs triggered by this workflow's own push to automated-translations
+    # (it already syncs/opens a PR within the run that made the push), so LTS
+    # pushes don't trigger two runs and the partner has a smaller window
+    # between their push and the next sync.
+    if: |
+      needs.determine-lts.outputs.should-sync == 'true' &&
+      !(github.event_name == 'push' && github.ref_name == 'automated-translations' && github.actor == 'blackbaud-sky-build-user')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/scripts/automated-translations.ps1
+++ b/scripts/automated-translations.ps1
@@ -175,14 +175,29 @@ else
   Write-Output "`n::group::Check for changes`n"
   Write-Output "`n# git add -- '**/src/assets/locales/*.json' '**/*-resources.module.ts'"
   git add -- '**/src/assets/locales/*.json' '**/*-resources.module.ts'
+  if ($LASTEXITCODE -ne 0)
+  {
+    Write-Output "`n::error::git add failed (exit $LASTEXITCODE).`n"
+    exit $LASTEXITCODE
+  }
   Write-Output "`n# git diff --cached --stat"
   git diff --cached --stat
+  if ($LASTEXITCODE -ne 0)
+  {
+    Write-Output "`n::error::git diff --cached --stat failed (exit $LASTEXITCODE).`n"
+    exit $LASTEXITCODE
+  }
   Write-Output "#"
 
   # Only the staged locale/resource-module paths count as "changes" — anything
   # else touched by npm ci or nx format:write (e.g. lockfile drift) is left
   # unstaged and untouched, so it can never be committed here.
   $changes = git diff --cached --name-only
+  if ($LASTEXITCODE -ne 0)
+  {
+    Write-Output "`n::error::git diff --cached --name-only failed (exit $LASTEXITCODE).`n"
+    exit $LASTEXITCODE
+  }
 
   if ($changes)
   {
@@ -197,6 +212,11 @@ else
       Write-Output "`n::group::Push changes to $TranslationBranchName branch`n"
       Write-Output "`n# git commit -m '${CommitMessage}'"
       git commit -m "${CommitMessage}"
+      if ($LASTEXITCODE -ne 0)
+      {
+        Write-Output "`n::error::git commit failed (exit $LASTEXITCODE).`n"
+        exit $LASTEXITCODE
+      }
     }
   }
   else
@@ -229,6 +249,11 @@ else
   Write-Output "`n::endgroup::`n"
 
   $changesFromLts = git diff $LtsBranchName HEAD --name-only -- '**/src/assets/locales/*.json' '**/*-resources.module.ts'
+  if ($LASTEXITCODE -ne 0)
+  {
+    Write-Output "`n::error::git diff $LtsBranchName HEAD failed (exit $LASTEXITCODE).`n"
+    exit $LASTEXITCODE
+  }
   if ($changesFromLts)
   {
     Write-Output "`n::group::Pull request`n"

--- a/scripts/automated-translations.ps1
+++ b/scripts/automated-translations.ps1
@@ -103,8 +103,19 @@ else
   # Commits on this branch that are not yet on the LTS branch (e.g. translations
   # pushed directly by the translation partner) must never be rewritten or
   # force-pushed away, whether or not a pull request already exists for them.
-  $aheadCount = [int](git rev-list --count "$LtsBranchName..HEAD")
   Write-Output "`n# git rev-list --count $LtsBranchName..HEAD"
+  $aheadCountRaw = git rev-list --count "$LtsBranchName..HEAD"
+  if ($LASTEXITCODE -ne 0)
+  {
+    Write-Output "`n::error::git rev-list failed (exit $LASTEXITCODE).`n"
+    exit $LASTEXITCODE
+  }
+  $aheadCount = 0
+  if (-not [int]::TryParse("$aheadCountRaw", [ref]$aheadCount))
+  {
+    Write-Output "`n::error::git rev-list returned a non-numeric count ('$aheadCountRaw').`n"
+    exit 1
+  }
   Write-Output "$aheadCount"
 
   if ($aheadCount -gt 0)
@@ -217,7 +228,7 @@ else
   }
   Write-Output "`n::endgroup::`n"
 
-  $changesFromLts = git diff $LtsBranchName --name-only
+  $changesFromLts = git diff $LtsBranchName HEAD --name-only -- '**/src/assets/locales/*.json' '**/*-resources.module.ts'
   if ($changesFromLts)
   {
     Write-Output "`n::group::Pull request`n"

--- a/scripts/automated-translations.ps1
+++ b/scripts/automated-translations.ps1
@@ -1,5 +1,20 @@
 #!/usr/bin/env pwsh
 
+# Keeps the `automated-translations` branch in sync with the given LTS branch,
+# then opens (or updates) a pull request back to LTS when the branch has
+# content to deliver.
+#
+# The translation partner (Lingoport) pushes commits directly to
+# `automated-translations` with translated locale resources, and its watcher
+# does a plain, non-force `git pull` from that branch. To avoid ever orphaning
+# a partner commit:
+#   - If the branch has commits not yet on LTS (partner translations, or a
+#     previously-synced batch still pending in a PR), this script MERGES the
+#     LTS branch in (preserving those commits' SHAs) and pushes WITHOUT force.
+#   - Only when the branch has nothing unique to preserve does it REBASE onto
+#     LTS and push with `--force-with-lease`, keeping history linear.
+# See `-IsDryRun` to preview a sync without committing or pushing.
+
 [CmdletBinding()]
 param (
   [string]$LtsBranchName,
@@ -76,7 +91,7 @@ else
   Write-Output "`n# git pull"
   git pull --set-upstream origin $TranslationBranchName
 
-  $existingPr = gh pr list --state open --base $LtsBranchName `
+  $existingPr = gh pr list --state open --base $LtsBranchName --head $TranslationBranchName --limit 100 `
     --json title,url,headRefName,baseRefName `
     --jq ".[] | select(.headRefName == `"${TranslationBranchName}`" and .baseRefName == `"${LtsBranchName}`")"
   if ($LASTEXITCODE -ne 0)
@@ -85,51 +100,78 @@ else
     exit $LASTEXITCODE
   }
 
-  if ($existingPr)
+  # Commits on this branch that are not yet on the LTS branch (e.g. translations
+  # pushed directly by the translation partner) must never be rewritten or
+  # force-pushed away, whether or not a pull request already exists for them.
+  $aheadCount = [int](git rev-list --count "$LtsBranchName..HEAD")
+  Write-Output "`n# git rev-list --count $LtsBranchName..HEAD"
+  Write-Output "$aheadCount"
+
+  if ($aheadCount -gt 0)
   {
-    Write-Output "`n# git merge -X theirs --no-edit $LtsBranchName   (PR is open — preserving commit SHAs)"
-    git merge -X theirs --no-edit $LtsBranchName
+    Write-Output "`n# git merge --no-edit $LtsBranchName   ($aheadCount commit(s) ahead of $LtsBranchName — preserving them)"
+    git merge --no-edit $LtsBranchName
     if ($LASTEXITCODE -ne 0)
     {
-      Write-Output "`n::error::git merge failed (exit $LASTEXITCODE).`n"
+      Write-Output "`n::error::git merge failed (exit $LASTEXITCODE). Resolve conflicts manually so translation changes are not discarded.`n"
       exit $LASTEXITCODE
     }
+    $historyRewritten = $false
   }
   else
   {
-    Write-Output "`n# git rebase -X ours $LtsBranchName"
-    git rebase -X ours $LtsBranchName
+    Write-Output "`n# git rebase $LtsBranchName"
+    git rebase $LtsBranchName
     if ($LASTEXITCODE -ne 0)
     {
       Write-Output "`n::error::git rebase failed (exit $LASTEXITCODE).`n"
       exit $LASTEXITCODE
     }
+    $historyRewritten = $true
   }
   Write-Output "`n::endgroup::`n"
 
   Write-Output "`n::group::NPM Install`n"
   Write-Output "`n# npm ci"
   npm ci --no-audit --no-progress --no-fund
+  if ($LASTEXITCODE -ne 0)
+  {
+    Write-Output "`n::error::npm ci failed (exit $LASTEXITCODE).`n"
+    exit $LASTEXITCODE
+  }
   Write-Output "`n::endgroup::`n"
 
   Write-Output "`n::group::Update library resources`n"
   Write-Output "`n# npm run dev:create-library-resources"
   npm run dev:create-library-resources
+  if ($LASTEXITCODE -ne 0)
+  {
+    Write-Output "`n::error::dev:create-library-resources failed (exit $LASTEXITCODE).`n"
+    exit $LASTEXITCODE
+  }
   Write-Output "`n::endgroup::`n"
 
   Write-Output "`n::group::Prettier`n"
   Write-Output "`n# npx nx format:write"
   npx nx format:write
+  if ($LASTEXITCODE -ne 0)
+  {
+    Write-Output "`n::error::nx format:write failed (exit $LASTEXITCODE).`n"
+    exit $LASTEXITCODE
+  }
   Write-Output "`n::endgroup::`n"
 
   Write-Output "`n::group::Check for changes`n"
-  Write-Output "`n# git add -A"
-  git add -A
-  Write-Output "`n# git status"
-  git status
+  Write-Output "`n# git add -- '**/src/assets/locales/*.json' '**/*-resources.module.ts'"
+  git add -- '**/src/assets/locales/*.json' '**/*-resources.module.ts'
+  Write-Output "`n# git diff --cached --stat"
+  git diff --cached --stat
   Write-Output "#"
 
-  $changes = git status --porcelain
+  # Only the staged locale/resource-module paths count as "changes" — anything
+  # else touched by npm ci or nx format:write (e.g. lockfile drift) is left
+  # unstaged and untouched, so it can never be committed here.
+  $changes = git diff --cached --name-only
 
   if ($changes)
   {
@@ -153,15 +195,15 @@ else
 
   if (-not $IsDryRunBool)
   {
-    if ($existingPr)
-    {
-      Write-Output "`n# git push origin $TranslationBranchName"
-      git push origin $TranslationBranchName
-    }
-    else
+    if ($historyRewritten)
     {
       Write-Output "`n# git push --force-with-lease origin $TranslationBranchName"
       git push --force-with-lease origin $TranslationBranchName
+    }
+    else
+    {
+      Write-Output "`n# git push origin $TranslationBranchName"
+      git push origin $TranslationBranchName
     }
     if ($LASTEXITCODE -ne 0)
     {
@@ -196,7 +238,14 @@ else
         --body ":robot: This pull request was created by the automated translations script." `
         --label "risk level (author): 1" `
         --label "skip e2e"
-      $prForChanges = gh pr list --json title,url,headRefName --jq ".[] | select(.headRefName == `"${TranslationBranchName}`")"
+      if ($LASTEXITCODE -ne 0)
+      {
+        Write-Output "`n::error::gh pr create failed (exit $LASTEXITCODE).`n"
+        exit $LASTEXITCODE
+      }
+      $prForChanges = gh pr list --state open --base $LtsBranchName --head $TranslationBranchName --limit 100 `
+        --json title,url,headRefName,baseRefName `
+        --jq ".[] | select(.headRefName == `"${TranslationBranchName}`" and .baseRefName == `"${LtsBranchName}`")"
       if ($env:GITHUB_OUTPUT)
       {
         Write-Output "prCreated=true" >> $env:GITHUB_OUTPUT

--- a/scripts/automated-translations.ps1
+++ b/scripts/automated-translations.ps1
@@ -246,6 +246,11 @@ else
       $prForChanges = gh pr list --state open --base $LtsBranchName --head $TranslationBranchName --limit 100 `
         --json title,url,headRefName,baseRefName `
         --jq ".[] | select(.headRefName == `"${TranslationBranchName}`" and .baseRefName == `"${LtsBranchName}`")"
+      if ($LASTEXITCODE -ne 0)
+      {
+        Write-Output "`n::error::gh pr list failed (exit $LASTEXITCODE).`n"
+        exit $LASTEXITCODE
+      }
       if ($env:GITHUB_OUTPUT)
       {
         Write-Output "prCreated=true" >> $env:GITHUB_OUTPUT


### PR DESCRIPTION
## Summary

Evaluated `scripts/automated-translations.ps1` per a report that a translation
partner change might have been lost. Confirmed via the GitHub branch activity
log and a Lingoport `GIT_PULL` log that **no partner commit has actually been
lost** — the only partner push on record (Dec 2025) was preserved and merged
correctly. However, the script had a latent bug that could orphan a future
partner push, plus several smaller reliability issues. This PR fixes them.

## Problem

On the "no PR open" sync path, the script did:

```
git rebase -X ours $LtsBranchName
git push --force-with-lease origin automated-translations
```

If the translation partner pushes a commit to `automated-translations` and
any LTS commit lands before the next sync run (common — LTS is pushed to
several times a day, and each push triggers this workflow), the rebase
replays the partner's commit onto a new SHA and force-pushes it. The
partner's watcher does a plain, non-force `git pull`, so its local clone
would then hold an orphaned SHA and diverge from `origin/automated-translations`
on its next pull.

`-X ours`/`-X theirs` also resolved any content conflict in favor of the LTS
branch, which would silently discard an edited translation file rather than
the intended partner content.

## Changes

- **Preserve partner commits**: check `git rev-list --count $LtsBranchName..HEAD`
  before syncing. If the branch has commits not yet on LTS, merge (not
  rebase) so those SHAs are preserved, and push without force. Only rebase +
  `--force-with-lease` when there is nothing unique to preserve.
- **Fix conflict-resolution direction**: dropped `-X ours`/`-X theirs`; a
  genuine conflict now fails the script loudly instead of silently favoring
  either side.
- **Scope the auto-commit**: replaced `git add -A` with an explicit pathspec
  (`**/src/assets/locales/*.json`, `**/*-resources.module.ts`) so unrelated
  build/lockfile drift can never be swept into a translation PR (this is
  what produced empty PRs #4447/#4451/#4454).
- **Harden `gh pr list`**: added `--limit 100`, `--head`, `--base` to both
  lookups to avoid the implicit 30-item cap and cross-base false matches.
- **Exit-code guards**: added `$LASTEXITCODE` checks after `npm ci`,
  `dev:create-library-resources`, `nx format:write`, and `gh pr create` so a
  broken build/PR-create step can't silently report `success=true`.
- **Reduce the self-trigger loop**: the workflow now skips runs triggered by
  its own push to `automated-translations`, since that run already
  synced/opened a PR.
- Added a header comment documenting the merge-vs-rebase decision.

## Verification

- PowerShell syntax check passed; `nx format:check` passed with no changes.
- Ran the real script with `-IsDryRun true` against `14.x.x`/
  `automated-translations` (with the correct Node 20 toolchain) — output is
  unchanged from before this change (`No changes detected`,
  `No pull request`), confirming no behavioral regression for today's state
  (branch is currently level with LTS).
- Built a standalone git simulation with a partner commit ahead of a
  diverged LTS branch and confirmed the new logic merges (not rebases),
  preserves the partner's original commit SHA as an ancestor, and pushes via
  a plain fast-forward with no force required.

:robot: This pull request was generated with GitHub Copilot CLI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automated translation updates to preserve existing translation-branch history.
  * Prevented redundant workflow runs after automated translation updates.
  * Added safeguards to prevent incomplete updates when generation, formatting, or synchronization steps fail.
  * Improved pull request detection and validation for translation updates.

* **Chores**
  * Refined translation synchronization behavior for branches with or without new commits.
  * Improved handling of update and publishing failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->