### PR TITLE
chore: release 14.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
 
+## [14.13.0](https://github.com/blackbaud/skyux/compare/14.12.0...14.13.0) (2026-08-11)
+
+
+### Features
+
+* **components/lookup:** add testing method for getting a selection modal's heading text ([#4611](https://github.com/blackbaud/skyux/issues/4611)) ([a8d296c](https://github.com/blackbaud/skyux/commit/a8d296c1d96130f94312315531802eb5c815f74b))
+
 ## [14.12.0](https://github.com/blackbaud/skyux/compare/14.11.0...14.12.0) (2026-08-10)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,18 @@
 # Changelog
 
 
-## [14.13.0](https://github.com/blackbaud/skyux/compare/14.12.0...14.13.0) (2026-08-13)
+## [14.13.0](https://github.com/blackbaud/skyux/compare/14.12.0...14.13.0) (2026-08-14)
 
 
 ### Features
 
 * **components/lookup:** add testing method for getting a selection modal's heading text ([#4611](https://github.com/blackbaud/skyux/issues/4611)) ([a8d296c](https://github.com/blackbaud/skyux/commit/a8d296c1d96130f94312315531802eb5c815f74b))
 * tokenize the icon used by HTML select fields ([#4619](https://github.com/blackbaud/skyux/issues/4619)) ([c1a05d6](https://github.com/blackbaud/skyux/commit/c1a05d6221d4c0dc1da215e5a727abe8b01abbca))
+
+
+### Bug Fixes
+
+* **components/lookup:** autocomplete does not clear value on blur when all values are allowed ([#4626](https://github.com/blackbaud/skyux/issues/4626)) ([4c08ee4](https://github.com/blackbaud/skyux/commit/4c08ee42b79fba9b6294b1004caf715ed85b6353))
 
 ## [14.12.0](https://github.com/blackbaud/skyux/compare/14.11.0...14.12.0) (2026-08-10)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,13 @@
 # Changelog
 
 
-## [14.13.0](https://github.com/blackbaud/skyux/compare/14.12.0...14.13.0) (2026-08-11)
+## [14.13.0](https://github.com/blackbaud/skyux/compare/14.12.0...14.13.0) (2026-08-13)
 
 
 ### Features
 
 * **components/lookup:** add testing method for getting a selection modal's heading text ([#4611](https://github.com/blackbaud/skyux/issues/4611)) ([a8d296c](https://github.com/blackbaud/skyux/commit/a8d296c1d96130f94312315531802eb5c815f74b))
+* tokenize the icon used by HTML select fields ([#4619](https://github.com/blackbaud/skyux/issues/4619)) ([c1a05d6](https://github.com/blackbaud/skyux/commit/c1a05d6221d4c0dc1da215e5a727abe8b01abbca))
 
 ## [14.12.0](https://github.com/blackbaud/skyux/compare/14.11.0...14.12.0) (2026-08-10)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "skyux",
-  "version": "14.12.0",
+  "version": "14.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "skyux",
-      "version": "14.12.0",
+      "version": "14.13.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skyux",
-  "version": "14.12.0",
+  "version": "14.13.0",
   "license": "MIT",
   "scripts": {
     "ng": "nx",


### PR DESCRIPTION
## [14.13.0](https://github.com/blackbaud/skyux/compare/14.12.0...14.13.0) (2026-08-14)


### Features

* **components/lookup:** add testing method for getting a selection modal's heading text ([#4611](https://github.com/blackbaud/skyux/issues/4611)) ([a8d296c](https://github.com/blackbaud/skyux/commit/a8d296c1d96130f94312315531802eb5c815f74b))
* tokenize the icon used by HTML select fields ([#4619](https://github.com/blackbaud/skyux/issues/4619)) ([c1a05d6](https://github.com/blackbaud/skyux/commit/c1a05d6221d4c0dc1da215e5a727abe8b01abbca))


### Bug Fixes

* **components/lookup:** autocomplete does not clear value on blur when all values are allowed ([#4626](https://github.com/blackbaud/skyux/issues/4626)) ([4c08ee4](https://github.com/blackbaud/skyux/commit/4c08ee42b79fba9b6294b1004caf715ed85b6353))

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for testing lookup components.
  - Added tokenization for HTML select icons.
- **Bug Fixes**
  - Prevented autocomplete values from clearing on blur when all values are allowed.
- **Chores**
  - Updated the package version to 14.13.0.
  - Added release notes for the latest changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->