### PR TITLE
feat(components/lookup): add testing method for getting a selection modal's heading text (#4611)

### DIFF
--- a/libs/components/lookup/testing/src/modules/selection-modal/selection-modal-harness.spec.ts
+++ b/libs/components/lookup/testing/src/modules/selection-modal/selection-modal-harness.spec.ts
@@ -12,6 +12,7 @@ async function setupTest(options: {
   selectionDescriptor?: string;
   showAddButton?: boolean;
   addClick?: () => void;
+  title?: string;
 }): Promise<{
   fixture: ComponentFixture<SelectionModalHarnessTestComponent>;
   harness: SkySelectionModalHarness;
@@ -44,6 +45,7 @@ async function setupTest(options: {
     selectionDescriptor: options.selectionDescriptor,
     showAddButton: options.showAddButton,
     addClick: options.addClick,
+    title: options.title,
   });
 
   const loader = TestbedHarnessEnvironment.documentRootLoader(fixture);
@@ -73,6 +75,30 @@ describe('Selection modal harness', () => {
       });
 
       await expectAsync(harness.hasAddButton()).toBeResolvedTo(false);
+    });
+  });
+
+  describe('getHeadingText() method', () => {
+    it('should get the default heading text using the selection descriptor', async () => {
+      const { harness } = await setupTest({
+        selectMode: 'single',
+        selectionDescriptor: 'person',
+      });
+
+      await expectAsync(harness.getHeadingText()).toBeResolvedTo(
+        'Select person',
+      );
+    });
+
+    it('should get a custom heading text when a title is provided', async () => {
+      const { harness } = await setupTest({
+        selectMode: 'single',
+        title: 'Custom title',
+      });
+
+      await expectAsync(harness.getHeadingText()).toBeResolvedTo(
+        'Custom title',
+      );
     });
   });
 

--- a/libs/components/lookup/testing/src/modules/selection-modal/selection-modal-harness.ts
+++ b/libs/components/lookup/testing/src/modules/selection-modal/selection-modal-harness.ts
@@ -27,6 +27,8 @@ export class SkySelectionModalHarness extends ComponentHarness {
 
   #getCheckboxHarness = this.locatorFor(SkyCheckboxHarness);
 
+  #getHeading = this.locatorFor('.sky-modal-heading');
+
   #getInfiniteScroll = this.locatorFor(SkyInfiniteScrollHarness);
 
   #getSaveButton = this.locatorFor('button.sky-lookup-show-more-modal-save');
@@ -60,6 +62,13 @@ export class SkySelectionModalHarness extends ComponentHarness {
    */
   public async getSearchAriaLabel(): Promise<string | null> {
     return await (await this.#getSearchHarness()).getAriaLabel();
+  }
+
+  /**
+   * Gets the selection modal's heading text.
+   */
+  public async getHeadingText(): Promise<string | undefined> {
+    return await (await this.#getHeading()).text();
   }
 
   /**


### PR DESCRIPTION
:cherries: Cherry picked from #4611 [feat(components/lookup): add testing method for getting a selection modal's heading text](https://github.com/blackbaud/skyux/pull/4611)

[AB#4079758](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/4079758) 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a way for tests to read the selection modal’s heading text.
  * Added support for verifying both default and custom modal titles.

* **Tests**
  * Added coverage for headings generated from the selection descriptor and for provided custom titles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->