### PR TITLE
data grid with data manager

### DIFF
--- a/apps/e2e/data-grid-storybook/project.json
+++ b/apps/e2e/data-grid-storybook/project.json
@@ -39,7 +39,7 @@
             {
               "type": "anyComponentStyle",
               "maximumWarning": "6kb",
-              "maximumError": "10kb"
+              "maximumError": "150kb"
             }
           ],
           "outputHashing": "all"

--- a/libs/components/code-examples/routes/src/index.ts
+++ b/libs/components/code-examples/routes/src/index.ts
@@ -345,6 +345,13 @@ export const routes: Routes = [
       ),
   },
   {
+    path: 'DataManagerResourceExampleComponent',
+    loadComponent: () =>
+      import('@skyux/code-examples').then(
+        ({ DataManagerResourceExampleComponent: c }) => c,
+      ),
+  },
+  {
     path: 'DatetimeDatepickerBasicExampleComponent',
     loadComponent: () =>
       import('@skyux/code-examples').then(

--- a/libs/components/code-examples/routes/src/index.ts
+++ b/libs/components/code-examples/routes/src/index.ts
@@ -317,6 +317,13 @@ export const routes: Routes = [
       ),
   },
   {
+    path: 'DataGridDataManagerExampleComponent',
+    loadComponent: () =>
+      import('@skyux/code-examples').then(
+        ({ DataGridDataManagerExampleComponent: c }) => c,
+      ),
+  },
+  {
     path: 'DataGridLoadingExampleComponent',
     loadComponent: () =>
       import('@skyux/code-examples').then(

--- a/libs/components/code-examples/src/index.ts
+++ b/libs/components/code-examples/src/index.ts
@@ -42,6 +42,7 @@ export { CoreMediaQueryBasicExampleComponent } from './lib/modules/core/media-qu
 export { CoreMediaQueryResponsiveHostExampleComponent } from './lib/modules/core/media-query/responsive-host/example.component';
 export { CoreNumericBasicExampleComponent } from './lib/modules/core/numeric/basic/example.component';
 export { DataGridBasicExampleComponent } from './lib/modules/data-grid/basic/example.component';
+export { DataGridDataManagerExampleComponent } from './lib/modules/data-grid/data-manager/example.component';
 export { DataGridLoadingExampleComponent } from './lib/modules/data-grid/loading/example.component';
 export { DataGridPagingExampleComponent } from './lib/modules/data-grid/paging/example.component';
 export { DataGridSortingExampleComponent } from './lib/modules/data-grid/sorting/example.component';

--- a/libs/components/code-examples/src/index.ts
+++ b/libs/components/code-examples/src/index.ts
@@ -46,6 +46,7 @@ export { DataGridLoadingExampleComponent } from './lib/modules/data-grid/loading
 export { DataGridPagingExampleComponent } from './lib/modules/data-grid/paging/example.component';
 export { DataGridSortingExampleComponent } from './lib/modules/data-grid/sorting/example.component';
 export { DataManagerBasicExampleComponent } from './lib/modules/data-manager/data-manager/basic/example.component';
+export { DataManagerResourceExampleComponent } from './lib/modules/data-manager/data-manager/resource/example.component';
 export { DatetimeDatePipeBasicExampleComponent } from './lib/modules/datetime/date-pipe/basic/example.component';
 export { DatetimeDateRangePickerBasicExampleComponent } from './lib/modules/datetime/date-range-picker/basic/example.component';
 export { DatetimeDateRangePickerCustomCalculatorExampleComponent } from './lib/modules/datetime/date-range-picker/custom-calculator/example.component';

--- a/libs/components/code-examples/src/lib/modules/data-grid/data-manager/data.ts
+++ b/libs/components/code-examples/src/lib/modules/data-grid/data-manager/data.ts
@@ -1,0 +1,17 @@
+export interface DataGridDataManagerRow {
+  id: string;
+  name: string;
+  type: string;
+  color: string;
+  quantity: number;
+}
+
+export const DATA_GRID_DEMO_DATA: DataGridDataManagerRow[] = [
+  { id: '1', name: 'Apple', type: 'Pome', color: 'Red', quantity: 12 },
+  { id: '2', name: 'Banana', type: 'Berry', color: 'Yellow', quantity: 8 },
+  { id: '3', name: 'Cherry', type: 'Drupe', color: 'Red', quantity: 45 },
+  { id: '4', name: 'Daikon', type: 'Root', color: 'White', quantity: 3 },
+  { id: '5', name: 'Edamame', type: 'Legume', color: 'Green', quantity: 22 },
+  { id: '6', name: 'Fig', type: 'Syconium', color: 'Purple', quantity: 17 },
+  { id: '7', name: 'Grape', type: 'Berry', color: 'Green', quantity: 60 },
+];

--- a/libs/components/code-examples/src/lib/modules/data-grid/data-manager/example.component.html
+++ b/libs/components/code-examples/src/lib/modules/data-grid/data-manager/example.component.html
@@ -2,9 +2,15 @@
   <sky-data-manager-toolbar
     labelText="fruit"
     settingsKey="data-grid-data-manager-example"
+    searchEnabled
+    [(searchText)]="search"
   />
 
-  <sky-data-grid skyDataManagerColumnController labelText="Fruit" [data]="data">
+  <sky-data-grid
+    skyDataManagerColumnController
+    labelText="Fruit"
+    [data]="data()"
+  >
     <sky-data-grid-column field="name" headingText="Name" />
     <sky-data-grid-column
       field="type"

--- a/libs/components/code-examples/src/lib/modules/data-grid/data-manager/example.component.html
+++ b/libs/components/code-examples/src/lib/modules/data-grid/data-manager/example.component.html
@@ -1,0 +1,22 @@
+<sky-data-manager>
+  <sky-data-manager-toolbar
+    labelText="fruit"
+    settingsKey="data-grid-data-manager-example"
+  />
+
+  <sky-data-grid skyDataManagerColumnController labelText="Fruit" [data]="data">
+    <sky-data-grid-column field="name" headingText="Name" />
+    <sky-data-grid-column
+      field="type"
+      headingText="Type"
+      description="The botanical classification of the fruit."
+    />
+    <sky-data-grid-column field="color" headingText="Color" />
+    <sky-data-grid-column
+      field="quantity"
+      headingText="Quantity"
+      dataType="number"
+      columnHidden
+    />
+  </sky-data-grid>
+</sky-data-manager>

--- a/libs/components/code-examples/src/lib/modules/data-grid/data-manager/example.component.spec.ts
+++ b/libs/components/code-examples/src/lib/modules/data-grid/data-manager/example.component.spec.ts
@@ -1,0 +1,56 @@
+import { HarnessLoader } from '@angular/cdk/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { SkyDataGridHarness } from '@skyux/data-grid/testing';
+
+import { DataGridDataManagerExampleComponent } from './example.component';
+
+describe('Data grid data manager example', () => {
+  async function setupTest(): Promise<{
+    fixture: ComponentFixture<DataGridDataManagerExampleComponent>;
+    gridHarness: SkyDataGridHarness;
+  }> {
+    await TestBed.configureTestingModule({
+      imports: [DataGridDataManagerExampleComponent],
+    }).compileComponents();
+    const fixture = TestBed.createComponent(
+      DataGridDataManagerExampleComponent,
+    );
+    const loader: HarnessLoader = TestbedHarnessEnvironment.loader(fixture);
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const gridHarness = await loader.getHarness(SkyDataGridHarness);
+    await expectAsync(gridHarness.isGridReady()).toBeResolvedTo(true);
+
+    return { fixture, gridHarness };
+  }
+
+  it('should create the component', async () => {
+    const { fixture, gridHarness } = await setupTest();
+
+    expect(fixture.componentInstance).toBeDefined();
+    await expectAsync(gridHarness.getDisplayedRowCount()).toBeResolvedTo(7);
+  });
+
+  it('should hide the column marked columnHidden', async () => {
+    const { gridHarness } = await setupTest();
+
+    await expectAsync(gridHarness.getDisplayedColumnIds()).toBeResolvedTo([
+      'name',
+      'type',
+      'color',
+    ]);
+  });
+
+  it('should display a column picker button', async () => {
+    const { fixture } = await setupTest();
+
+    expect(
+      (fixture.nativeElement as HTMLElement).querySelector(
+        '.sky-col-picker-btn',
+      ),
+    ).toBeTruthy();
+  });
+});

--- a/libs/components/code-examples/src/lib/modules/data-grid/data-manager/example.component.ts
+++ b/libs/components/code-examples/src/lib/modules/data-grid/data-manager/example.component.ts
@@ -1,0 +1,23 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { SkyUIConfigService } from '@skyux/core';
+import { SkyDataGrid, SkyDataGridColumn } from '@skyux/data-grid';
+import {
+  SkyDataManagerModule,
+  SkyDataManagerService,
+} from '@skyux/data-manager';
+
+import { DATA_GRID_DEMO_DATA, DataGridDataManagerRow } from './data';
+
+/**
+ * @title Data grid in a data manager with a column picker
+ */
+@Component({
+  selector: 'app-data-grid-data-manager-example',
+  templateUrl: './example.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  providers: [SkyDataManagerService, SkyUIConfigService],
+  imports: [SkyDataGrid, SkyDataGridColumn, SkyDataManagerModule],
+})
+export class DataGridDataManagerExampleComponent {
+  protected readonly data: DataGridDataManagerRow[] = DATA_GRID_DEMO_DATA;
+}

--- a/libs/components/code-examples/src/lib/modules/data-grid/data-manager/example.component.ts
+++ b/libs/components/code-examples/src/lib/modules/data-grid/data-manager/example.component.ts
@@ -1,10 +1,11 @@
-import { ChangeDetectionStrategy, Component } from '@angular/core';
-import { SkyUIConfigService } from '@skyux/core';
-import { SkyDataGrid, SkyDataGridColumn } from '@skyux/data-grid';
 import {
-  SkyDataManagerModule,
-  SkyDataManagerService,
-} from '@skyux/data-manager';
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  signal,
+} from '@angular/core';
+import { SkyDataGrid, SkyDataGridColumn } from '@skyux/data-grid';
+import { SkyDataManagerModule } from '@skyux/data-manager';
 
 import { DATA_GRID_DEMO_DATA, DataGridDataManagerRow } from './data';
 
@@ -15,9 +16,20 @@ import { DATA_GRID_DEMO_DATA, DataGridDataManagerRow } from './data';
   selector: 'app-data-grid-data-manager-example',
   templateUrl: './example.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  providers: [SkyDataManagerService, SkyUIConfigService],
   imports: [SkyDataGrid, SkyDataGridColumn, SkyDataManagerModule],
 })
 export class DataGridDataManagerExampleComponent {
-  protected readonly data: DataGridDataManagerRow[] = DATA_GRID_DEMO_DATA;
+  protected readonly data = computed<DataGridDataManagerRow[]>(() => {
+    const data = DATA_GRID_DEMO_DATA.slice();
+    const searchValue = this.search().trim().normalize('NFD').toLowerCase();
+    if (searchValue) {
+      return data.filter(({ name, type, color }) =>
+        [name, type, color].some((value) =>
+          value.trim().normalize('NFD').toLowerCase().includes(searchValue),
+        ),
+      );
+    }
+    return data;
+  });
+  protected readonly search = signal('');
 }

--- a/libs/components/code-examples/src/lib/modules/data-manager/data-manager/resource/data.ts
+++ b/libs/components/code-examples/src/lib/modules/data-manager/data-manager/resource/data.ts
@@ -1,0 +1,50 @@
+export interface FruitServerItem {
+  id: string;
+  name: string;
+  color: string;
+}
+
+export interface FruitServerPage {
+  items: FruitServerItem[];
+  totalCount: number;
+}
+
+const ALL_FRUIT: FruitServerItem[] = [
+  { id: '1', name: 'Orange', color: 'orange' },
+  { id: '2', name: 'Mango', color: 'orange' },
+  { id: '3', name: 'Lime', color: 'green' },
+  { id: '4', name: 'Strawberry', color: 'red' },
+  { id: '5', name: 'Blueberry', color: 'blue' },
+  { id: '6', name: 'Banana', color: 'yellow' },
+];
+
+export interface FruitServerParams {
+  page: number;
+  pageSize: number;
+  searchText?: string;
+  sort?: { propertyName: string; descending: boolean };
+}
+
+export function getServerPage(params: FruitServerParams): FruitServerPage {
+  let items = ALL_FRUIT;
+
+  if (params.searchText) {
+    const search = params.searchText.toLowerCase();
+    items = items.filter((item) => item.name.toLowerCase().includes(search));
+  }
+
+  if (params.sort) {
+    const { propertyName, descending } = params.sort;
+    items = [...items].sort((a, b) => {
+      const result = (a as unknown as Record<string, string>)[
+        propertyName
+      ].localeCompare((b as unknown as Record<string, string>)[propertyName]);
+      return descending ? -result : result;
+    });
+  }
+
+  const totalCount = items.length;
+  const start = (params.page - 1) * params.pageSize;
+
+  return { items: items.slice(start, start + params.pageSize), totalCount };
+}

--- a/libs/components/code-examples/src/lib/modules/data-manager/data-manager/resource/example.component.html
+++ b/libs/components/code-examples/src/lib/modules/data-manager/data-manager/resource/example.component.html
@@ -1,0 +1,28 @@
+<sky-data-manager>
+  <sky-data-manager-toolbar
+    labelText="fruit"
+    [searchEnabled]="true"
+    [pageSize]="3"
+    [totalCount]="totalCount"
+  >
+    <sky-data-manager-sort-option
+      propertyName="name"
+      label="Name (A - Z)"
+      [id]="'az'"
+    />
+    <sky-data-manager-sort-option
+      propertyName="name"
+      label="Name (Z - A)"
+      [id]="'za'"
+      [descending]="true"
+    />
+  </sky-data-manager-toolbar>
+
+  <ul>
+    @for (item of data.value()?.items; track item.id) {
+      <li>{{ item.name }}</li>
+    } @empty {
+      <li>No fruit found.</li>
+    }
+  </ul>
+</sky-data-manager>

--- a/libs/components/code-examples/src/lib/modules/data-manager/data-manager/resource/example.component.spec.ts
+++ b/libs/components/code-examples/src/lib/modules/data-manager/data-manager/resource/example.component.spec.ts
@@ -1,0 +1,98 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideNoopSkyAnimations } from '@skyux/core';
+import { SkySortHarness } from '@skyux/lists/testing';
+import { SkySearchHarness } from '@skyux/lookup/testing';
+
+import { HarnessLoader } from '@angular/cdk/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+
+import { DataManagerResourceExampleComponent } from './example.component';
+
+async function setupTest(): Promise<{
+  fixture: ComponentFixture<DataManagerResourceExampleComponent>;
+  loader: HarnessLoader;
+}> {
+  await TestBed.configureTestingModule({
+    imports: [DataManagerResourceExampleComponent],
+    providers: [provideNoopSkyAnimations()],
+  }).compileComponents();
+
+  const fixture = TestBed.createComponent(DataManagerResourceExampleComponent);
+  const loader = TestbedHarnessEnvironment.loader(fixture);
+
+  return { fixture, loader };
+}
+
+describe('DataManagerResourceExampleComponent', () => {
+  it('creates the component and renders the first page of results', async () => {
+    const { fixture } = await setupTest();
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const el = fixture.nativeElement as HTMLElement;
+    const items = el.querySelectorAll('li');
+    expect(items.length).toBe(3);
+  });
+
+  it('filters results using the search box harness', async () => {
+    const { fixture, loader } = await setupTest();
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const search = await loader.getHarness(SkySearchHarness);
+    await search.enterText('lime');
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const el = fixture.nativeElement as HTMLElement;
+    const items = el.querySelectorAll('li');
+    expect(items.length).toBe(1);
+    expect(items[0].textContent).toContain('Lime');
+  });
+
+  it('sorts results using the sort harness', async () => {
+    const { fixture, loader } = await setupTest();
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const sort = await loader.getHarness(SkySortHarness);
+    await sort.click();
+    const item = await sort.getItem({ text: 'Name (Z - A)' });
+    await item.click();
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const el = fixture.nativeElement as HTMLElement;
+    const items = el.querySelectorAll('li');
+    expect(items[0].textContent).toContain('Strawberry');
+  });
+
+  it('shows an empty state when no fruit matches', async () => {
+    const { fixture, loader } = await setupTest();
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const search = await loader.getHarness(SkySearchHarness);
+    await search.enterText('nonexistent');
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const el = fixture.nativeElement as HTMLElement;
+    expect(el.textContent).toContain('No fruit found.');
+  });
+});

--- a/libs/components/code-examples/src/lib/modules/data-manager/data-manager/resource/example.component.spec.ts
+++ b/libs/components/code-examples/src/lib/modules/data-manager/data-manager/resource/example.component.spec.ts
@@ -47,9 +47,6 @@ describe('DataManagerResourceExampleComponent', () => {
 
     const search = await loader.getHarness(SkySearchHarness);
     await search.enterText('lime');
-    fixture.detectChanges();
-    await fixture.whenStable();
-    fixture.detectChanges();
 
     const el = fixture.nativeElement as HTMLElement;
     const items = el.querySelectorAll('li');
@@ -69,9 +66,6 @@ describe('DataManagerResourceExampleComponent', () => {
     await sort.click();
     const item = await sort.getItem({ text: 'Name (Z - A)' });
     await item.click();
-    fixture.detectChanges();
-    await fixture.whenStable();
-    fixture.detectChanges();
 
     const el = fixture.nativeElement as HTMLElement;
     const items = el.querySelectorAll('li');
@@ -88,9 +82,6 @@ describe('DataManagerResourceExampleComponent', () => {
 
     const search = await loader.getHarness(SkySearchHarness);
     await search.enterText('nonexistent');
-    fixture.detectChanges();
-    await fixture.whenStable();
-    fixture.detectChanges();
 
     const el = fixture.nativeElement as HTMLElement;
     expect(el.textContent).toContain('No fruit found.');

--- a/libs/components/code-examples/src/lib/modules/data-manager/data-manager/resource/example.component.ts
+++ b/libs/components/code-examples/src/lib/modules/data-manager/data-manager/resource/example.component.ts
@@ -1,0 +1,51 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  inject,
+  resource,
+} from '@angular/core';
+import { SkyUIConfigService } from '@skyux/core';
+import {
+  SkyDataManagerModule,
+  SkyDataManagerService,
+} from '@skyux/data-manager';
+
+import { getServerPage } from './data';
+
+/**
+ * @title Data manager with a server-side resource data source
+ */
+@Component({
+  selector: 'app-data-manager-resource-example',
+  templateUrl: './example.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [SkyDataManagerModule],
+  providers: [SkyDataManagerService, SkyUIConfigService],
+})
+export class DataManagerResourceExampleComponent {
+  protected readonly dataManager = inject(SkyDataManagerService);
+
+  protected readonly data = resource({
+    params: () => this.dataManager.state(),
+    loader: async ({ params }) => {
+      // Simulates an asynchronous server request.
+      await Promise.resolve();
+
+      return getServerPage({
+        page: params.page ?? 1,
+        pageSize: params.pageSize ?? 3,
+        searchText: params.searchText,
+        sort: params.activeSortOption
+          ? {
+              propertyName: params.activeSortOption.propertyName,
+              descending: params.activeSortOption.descending,
+            }
+          : undefined,
+      });
+    },
+  });
+
+  protected get totalCount(): number {
+    return this.data.value()?.totalCount ?? 0;
+  }
+}

--- a/libs/components/data-grid/documentation.json
+++ b/libs/components/data-grid/documentation.json
@@ -12,6 +12,7 @@
       "codeExamples": {
         "docsIds": [
           "DataGridBasicExampleComponent",
+          "DataGridDataManagerExampleComponent",
           "DataGridLoadingExampleComponent",
           "DataGridPagingExampleComponent",
           "DataGridSortingExampleComponent"

--- a/libs/components/data-grid/src/lib/modules/data-grid/data-grid-column-selection.spec.ts
+++ b/libs/components/data-grid/src/lib/modules/data-grid/data-grid-column-selection.spec.ts
@@ -1,0 +1,306 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { SkyDataColumnSource } from '@skyux/lists';
+
+import { GridApi, getGridApi } from 'ag-grid-community';
+
+import { SkyDataGrid } from './data-grid';
+import { ColumnSelectionTestComponent } from './fixtures/column-selection-test.component';
+
+function mouseEvent(type: string, x: number, y: number): MouseEvent {
+  return new MouseEvent(type, {
+    bubbles: true,
+    cancelable: true,
+    clientX: x,
+    clientY: y,
+    buttons: 1,
+  });
+}
+
+describe('SkyDataGrid column selection', () => {
+  let fixture: ComponentFixture<ColumnSelectionTestComponent>;
+
+  function getColumnSource(): SkyDataColumnSource {
+    return fixture.debugElement
+      .query((node) => node.componentInstance instanceof SkyDataGrid)
+      .injector.get(SkyDataColumnSource);
+  }
+
+  async function detect(): Promise<void> {
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+    await fixture.whenStable();
+  }
+
+  /**
+   * Drags one column header onto another, the way a user reorders columns.
+   */
+  function dragColumn(fromColumnId: string, toColumnId: string): void {
+    const el = fixture.nativeElement as HTMLElement;
+    const source = el.querySelector<HTMLElement>(
+      `.ag-header-cell[col-id="${fromColumnId}"]`,
+    );
+    const target = el.querySelector<HTMLElement>(
+      `.ag-header-cell[col-id="${toColumnId}"]`,
+    );
+
+    if (!source || !target) {
+      throw new Error(
+        `Could not find the column headers to drag from "${fromColumnId}" to "${toColumnId}".`,
+      );
+    }
+
+    const sourceRect = source.getBoundingClientRect();
+    const targetRect = target.getBoundingClientRect();
+    const y = sourceRect.top + sourceRect.height / 2;
+
+    source.dispatchEvent(
+      mouseEvent('mousedown', sourceRect.left + sourceRect.width / 2, y),
+    );
+
+    // Move past the drag threshold, then onto the target column.
+    for (const x of [
+      sourceRect.left + sourceRect.width / 2 - 10,
+      targetRect.left + targetRect.width,
+      targetRect.left + targetRect.width / 2,
+      targetRect.left + 2,
+    ]) {
+      document.dispatchEvent(mouseEvent('mousemove', x, y));
+    }
+
+    document.dispatchEvent(mouseEvent('mouseup', targetRect.left + 2, y));
+  }
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ColumnSelectionTestComponent);
+  });
+
+  it('should provide itself as a SkyDataColumnSource', async () => {
+    await detect();
+
+    expect(getColumnSource()).toBeInstanceOf(SkyDataGrid);
+  });
+
+  it('should derive the column catalog from the declared columns', async () => {
+    fixture.componentRef.setInput('lockedDescription', 'Always shown.');
+    await detect();
+
+    expect(getColumnSource().dataColumns()).toEqual([
+      {
+        alwaysDisplayed: true,
+        description: 'Always shown.',
+        id: 'locked',
+        initialHide: false,
+        labelText: 'Locked',
+      },
+      {
+        alwaysDisplayed: false,
+        description: undefined,
+        id: 'name',
+        initialHide: false,
+        labelText: 'Name',
+      },
+      {
+        alwaysDisplayed: false,
+        description: undefined,
+        id: 'age',
+        initialHide: false,
+        labelText: 'Age',
+      },
+      {
+        alwaysDisplayed: false,
+        description: undefined,
+        id: 'extra',
+        initialHide: false,
+        labelText: 'Extra',
+      },
+    ]);
+  });
+
+  it('should omit columns that have neither a columnId nor a field', async () => {
+    fixture.componentRef.setInput('showInvalid', true);
+    await detect();
+
+    expect(
+      getColumnSource()
+        .dataColumns()
+        .map((col) => col.id),
+    ).toEqual(['locked', 'name', 'age', 'extra']);
+  });
+
+  it('should display every column in declaration order by default', async () => {
+    await detect();
+
+    expect(getColumnSource().displayedColumnIds()).toEqual([
+      'locked',
+      'name',
+      'age',
+      'extra',
+    ]);
+  });
+
+  it('should hide columns marked columnHidden by default', async () => {
+    fixture.componentRef.setInput('extraHidden', true);
+    await detect();
+
+    expect(getColumnSource().displayedColumnIds()).toEqual([
+      'locked',
+      'name',
+      'age',
+    ]);
+    expect(getColumnSource().dataColumns()[3].initialHide).toBeTrue();
+  });
+
+  it('should display the columns named by selectedColumnIds, in order', async () => {
+    fixture.componentInstance.selectedColumnIds.set(['locked', 'age', 'name']);
+    await detect();
+
+    expect(getColumnSource().displayedColumnIds()).toEqual([
+      'locked',
+      'age',
+      'name',
+    ]);
+  });
+
+  it('should drop IDs for columns that do not exist', async () => {
+    fixture.componentInstance.selectedColumnIds.set([
+      'locked',
+      'nonexistent',
+      'name',
+    ]);
+    await detect();
+
+    expect(getColumnSource().displayedColumnIds()).toEqual(['locked', 'name']);
+  });
+
+  it('should display locked columns first even when they are omitted', async () => {
+    fixture.componentInstance.selectedColumnIds.set(['age', 'name']);
+    await detect();
+
+    expect(getColumnSource().displayedColumnIds()).toEqual([
+      'locked',
+      'age',
+      'name',
+    ]);
+  });
+
+  it('should update the displayed columns when setDisplayedColumnIds is called', async () => {
+    await detect();
+
+    getColumnSource().setDisplayedColumnIds(['locked', 'name']);
+    await detect();
+
+    expect(getColumnSource().displayedColumnIds()).toEqual(['locked', 'name']);
+    expect(fixture.componentInstance.selectedColumnIds()).toEqual([
+      'locked',
+      'name',
+    ]);
+  });
+
+  it('should not emit when setDisplayedColumnIds matches what displays', async () => {
+    await detect();
+
+    const before = fixture.componentInstance.selectedColumnIds();
+    getColumnSource().setDisplayedColumnIds(['locked', 'name', 'age', 'extra']);
+    await detect();
+
+    // The model is untouched, so it keeps its empty declarative default.
+    expect(fixture.componentInstance.selectedColumnIds()).toBe(before);
+  });
+
+  it('should keep hidden columns defined so they can be shown again', async () => {
+    fixture.componentInstance.selectedColumnIds.set(['locked', 'name']);
+    await detect();
+
+    const grid = fixture.debugElement.query(
+      (node) => node.componentInstance instanceof SkyDataGrid,
+    ).componentInstance as SkyDataGrid;
+    const columnState = (
+      grid as unknown as {
+        gridApi: () => {
+          getColumnState: () => { colId: string; hide?: boolean | null }[];
+        };
+      }
+    )
+      .gridApi()
+      .getColumnState();
+
+    expect(
+      columnState.map((state) => ({ id: state.colId, hide: !!state.hide })),
+    ).toEqual([
+      { id: 'locked', hide: false },
+      { id: 'name', hide: false },
+      { id: 'age', hide: true },
+      { id: 'extra', hide: true },
+    ]);
+  });
+
+  it('should store the new order when the user drags a column header', async () => {
+    await detect();
+
+    dragColumn('age', 'name');
+    await detect();
+
+    expect(fixture.componentInstance.selectedColumnIds()).toEqual([
+      'locked',
+      'age',
+      'name',
+      'extra',
+    ]);
+    expect(getColumnSource().displayedColumnIds()).toEqual([
+      'locked',
+      'age',
+      'name',
+      'extra',
+    ]);
+  });
+
+  it('should not store a new order when applying a layout moves columns', async () => {
+    await detect();
+
+    // Applying a layout moves columns in the grid, which must not be mistaken
+    // for a move the user made.
+    getColumnSource().setDisplayedColumnIds(['locked', 'age', 'name']);
+    await detect();
+
+    expect(fixture.componentInstance.selectedColumnIds()).toEqual([
+      'locked',
+      'age',
+      'name',
+    ]);
+  });
+
+  it('should apply the column order to the grid', async () => {
+    await detect();
+
+    fixture.componentInstance.selectedColumnIds.set(['locked', 'age', 'name']);
+    await detect();
+
+    const api = getGridApi(
+      fixture.nativeElement.querySelector('ag-grid-angular'),
+    ) as GridApi;
+
+    expect(
+      api
+        .getColumnState()
+        .filter((state) => !state.hide)
+        .map((state) => state.colId),
+    ).toEqual(['locked', 'age', 'name']);
+  });
+
+  it('should drop a column from the display when it is removed from the template', async () => {
+    fixture.componentInstance.selectedColumnIds.set([
+      'locked',
+      'name',
+      'extra',
+    ]);
+    await detect();
+
+    expect(getColumnSource().displayedColumnIds()).toContain('extra');
+
+    fixture.componentRef.setInput('showExtra', false);
+    await detect();
+
+    expect(getColumnSource().displayedColumnIds()).toEqual(['locked', 'name']);
+  });
+});

--- a/libs/components/data-grid/src/lib/modules/data-grid/data-grid-column-selection.spec.ts
+++ b/libs/components/data-grid/src/lib/modules/data-grid/data-grid-column-selection.spec.ts
@@ -212,18 +212,11 @@ describe('SkyDataGrid column selection', () => {
     fixture.componentInstance.selectedColumnIds.set(['locked', 'name']);
     await detect();
 
-    const grid = fixture.debugElement.query(
-      (node) => node.componentInstance instanceof SkyDataGrid,
-    ).componentInstance as SkyDataGrid;
     const columnState = (
-      grid as unknown as {
-        gridApi: () => {
-          getColumnState: () => { colId: string; hide?: boolean | null }[];
-        };
-      }
-    )
-      .gridApi()
-      .getColumnState();
+      getGridApi(
+        fixture.nativeElement.querySelector('ag-grid-angular'),
+      ) as GridApi
+    ).getColumnState();
 
     expect(
       columnState.map((state) => ({ id: state.colId, hide: !!state.hide })),

--- a/libs/components/data-grid/src/lib/modules/data-grid/data-grid-column.ts
+++ b/libs/components/data-grid/src/lib/modules/data-grid/data-grid-column.ts
@@ -47,6 +47,13 @@ export class SkyDataGridColumn {
   );
 
   /**
+   * The description of the column to display beneath the column label in a
+   * column picker. This applies only when the grid participates in a column
+   * picker, such as when it is used inside a data manager.
+   */
+  public readonly description = input<string>();
+
+  /**
    * The property to retrieve cell information from an entry on the grid `data` array.
    * You must provide either the `columnId` or `field` property for every column,
    * but do not provide both. When a column maps directly to a property on the data,

--- a/libs/components/data-grid/src/lib/modules/data-grid/data-grid.ts
+++ b/libs/components/data-grid/src/lib/modules/data-grid/data-grid.ts
@@ -57,6 +57,7 @@ import {
   RowSelectionModule,
   RowSelectionOptions,
   RowStyleModule,
+  SELECTION_COLUMN_ID,
   ValidationModule,
 } from 'ag-grid-community';
 import {
@@ -82,7 +83,9 @@ import { fromGridEvent } from './data-grid-event-utils';
 // the grid/column state and event APIs the component and its harness rely on,
 // and dev-time validation messaging. `ColumnMoveModule` enables users to drag
 // column headers to reorder columns; it is not part of `AllCommunityModule`
-// and is only exported under an underscore-prefixed name.
+// and is only exported under an underscore-prefixed name, so this package's
+// `ag-grid-community` peer dependency is restricted to the minor version known
+// to export it.
 ModuleRegistry.registerModules([
   CellStyleModule,
   ClientSideRowModelApiModule,
@@ -111,7 +114,7 @@ function arraysEqual(a: readonly string[], b: readonly string[]): boolean {
 
 // Columns AG Grid creates and manages itself, which are never offered to a
 // column picker and never included in the displayed column IDs.
-const RESERVED_COLUMN_IDS = ['ag-Grid-SelectionColumn'];
+const RESERVED_COLUMN_IDS: string[] = [SELECTION_COLUMN_ID];
 
 /**
  * Displays tabular data in a grid using a declarative set of columns and inputs.

--- a/libs/components/data-grid/src/lib/modules/data-grid/data-grid.ts
+++ b/libs/components/data-grid/src/lib/modules/data-grid/data-grid.ts
@@ -28,7 +28,11 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { SkyAgGridModule, SkyAgGridService, SkyCellType } from '@skyux/ag-grid';
 import { SkyLogService, SkyViewkeeperModule } from '@skyux/core';
 import { SkyWaitModule } from '@skyux/indicators';
-import { SkyPagingModule } from '@skyux/lists';
+import {
+  SkyDataColumnOption,
+  SkyDataColumnSource,
+  SkyPagingModule,
+} from '@skyux/lists';
 
 import { AgGridAngular } from 'ag-grid-angular';
 import {
@@ -39,6 +43,7 @@ import {
   ColDef,
   ColumnApiModule,
   ColumnAutoSizeModule,
+  _ColumnMoveModule as ColumnMoveModule,
   EventApiModule,
   GridApi,
   GridOptions,
@@ -73,15 +78,18 @@ import { fromGridEvent } from './data-grid-event-utils';
 // Register only the AG Grid community modules this component actually uses,
 // rather than `AllCommunityModule`, to keep the consumer's bundle lean. This
 // covers the client-side row model, sorting, pagination, row selection, cell
-// and row styling, column auto-sizing, auto-height (text wrap), the grid/column
-// state and event APIs the component and its harness rely on, and dev-time
-// validation messaging.
+// and row styling, column moving, column auto-sizing, auto-height (text wrap),
+// the grid/column state and event APIs the component and its harness rely on,
+// and dev-time validation messaging. `ColumnMoveModule` enables users to drag
+// column headers to reorder columns; it is not part of `AllCommunityModule`
+// and is only exported under an underscore-prefixed name.
 ModuleRegistry.registerModules([
   CellStyleModule,
   ClientSideRowModelApiModule,
   ClientSideRowModelModule,
   ColumnApiModule,
   ColumnAutoSizeModule,
+  ColumnMoveModule,
   EventApiModule,
   GridStateModule,
   PaginationModule,
@@ -96,6 +104,14 @@ ModuleRegistry.registerModules([
 function arraySorted(arr: string[]): string[] {
   return arr.slice().sort((a, b) => a.localeCompare(b));
 }
+
+function arraysEqual(a: readonly string[], b: readonly string[]): boolean {
+  return a.length === b.length && a.every((value, i) => value === b[i]);
+}
+
+// Columns AG Grid creates and manages itself, which are never offered to a
+// column picker and never included in the displayed column IDs.
+const RESERVED_COLUMN_IDS = ['ag-Grid-SelectionColumn'];
 
 /**
  * Displays tabular data in a grid using a declarative set of columns and inputs.
@@ -116,9 +132,10 @@ function arraySorted(arr: string[]): string[] {
   host: {
     '[class.sky-margin-stacked-lg]': 'stacked()',
   },
+  providers: [{ provide: SkyDataColumnSource, useExisting: SkyDataGrid }],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class SkyDataGrid {
+export class SkyDataGrid implements SkyDataColumnSource {
   /**
    * Whether the grid sorts the data order when a column header is clicked.
    * When `autoSort` is set to `false`, the data grid will not modify the sort
@@ -270,6 +287,17 @@ export class SkyDataGrid {
   public readonly selectedRowIds = model<string[]>([]);
 
   /**
+   * The IDs of the columns to display, in display order. Columns that are not
+   * included are hidden, except for columns marked `locked`, which always
+   * display. This is two-way bindable: it emits a new value when the user
+   * reorders columns, and you can set it to control which columns display.
+   * When empty, every column displays in declaration order except those marked
+   * `columnHidden`.
+   * @default []
+   */
+  public readonly selectedColumnIds = model<string[]>([]);
+
+  /**
    * The current sort applied to the grid. This is two-way bindable: it emits a new value
    * whenever the user sorts a column, and you can set it to sort the grid programmatically.
    * When `autoSort` is `false`, the grid emits the new value here but does not reorder the
@@ -278,6 +306,51 @@ export class SkyDataGrid {
   public readonly sort = model<SkyDataGridSort | undefined>(undefined);
 
   protected readonly columns = contentChildren(SkyDataGridColumn);
+
+  /**
+   * The columns the grid can display, in declaration order. Read by column
+   * picker integrations through `SkyDataColumnSource`.
+   * @internal
+   */
+  public readonly dataColumns = computed<readonly SkyDataColumnOption[]>(() =>
+    this.#columnCatalog().map(({ id, column }) => ({
+      alwaysDisplayed: column.locked(),
+      description: column.description(),
+      id,
+      initialHide: column.columnHidden(),
+      labelText: column.headingText(),
+    })),
+  );
+
+  /**
+   * The IDs of the columns to display, in display order, reconciled against
+   * the declared columns. Unknown IDs are dropped and `locked` columns always
+   * display. When `selectedColumnIds` is empty, the grid falls back to its
+   * declarative order and `columnHidden` values.
+   * @internal
+   */
+  public readonly displayedColumnIds = computed<string[]>(() => {
+    const catalog = this.#columnCatalog();
+    const selected = this.selectedColumnIds();
+
+    if (selected.length === 0) {
+      return catalog
+        .filter(({ column }) => column.locked() || !column.columnHidden())
+        .map(({ id }) => id);
+    }
+
+    const known = new Set(catalog.map(({ id }) => id));
+    const displayed = selected.filter((id) => known.has(id));
+    const displayedSet = new Set(displayed);
+
+    // Locked columns cannot be hidden and are documented to display first.
+    const lockedIds = catalog
+      .filter(({ column, id }) => column.locked() && !displayedSet.has(id))
+      .map(({ id }) => id);
+
+    return [...lockedIds, ...displayed];
+  });
+
   protected readonly gridApi = signal<GridApi<SkyDataGridRowData> | undefined>(
     undefined,
   );
@@ -312,6 +385,15 @@ export class SkyDataGrid {
             }
           : undefined,
         loading: untracked(() => this.loading() || !Array.isArray(this.data())),
+        onColumnMoved: (event) => {
+          // Applying a column layout moves columns too, so compare against what
+          // the grid should display; only a move the grid made on its own, such
+          // as a user dragging a column header, differs here. Intermediate
+          // moves reported mid-drag are followed by a finished one.
+          if (event.finished !== false) {
+            this.#syncColumnOrderFromGrid(event.api);
+          }
+        },
         onGridReady: (args) => {
           this.gridApi.set(args.api);
           this.gridReady.set(true);
@@ -384,10 +466,43 @@ export class SkyDataGrid {
   readonly #router = inject(Router, { optional: true });
 
   readonly #columnDefs = computed<ColDef<SkyDataGridRowData>[]>(() => {
-    const columns = this.columns();
-    return columns.map((col) => this.#createColDef(col));
+    const displayedIds = this.displayedColumnIds();
+    const displayed = new Set(displayedIds);
+    const catalog = this.#columnCatalog();
+    const byId = new Map(catalog.map((entry) => [entry.id, entry.column]));
+
+    // Displayed columns first, in display order, followed by the hidden
+    // columns. Hidden columns keep their column definitions so AG Grid retains
+    // their state and they can be shown again without being recreated.
+    const ordered = [
+      ...displayedIds.map((id) => byId.get(id)).filter((col) => !!col),
+      ...catalog
+        .filter((entry) => !displayed.has(entry.id))
+        .map((entry) => entry.column),
+    ];
+
+    return ordered.map((col) => {
+      const colDef = this.#createColDef(col);
+      colDef.hide = !displayed.has(this.#getColumnId(col) as string);
+      colDef.initialHide = colDef.hide;
+      return colDef;
+    });
   });
   readonly #hasColumnDefs = computed(() => this.#columnDefs().length > 0);
+
+  /**
+   * The declared columns that have a usable ID, in declaration order. Columns
+   * missing both `columnId` and `field` are omitted; `SkyDataGridColumn`
+   * already warns about them.
+   */
+  readonly #columnCatalog = computed(() =>
+    this.columns()
+      .map((column) => ({ column, id: this.#getColumnId(column) }))
+      .filter(
+        (entry): entry is { column: SkyDataGridColumn; id: string } =>
+          !!entry.id && !RESERVED_COLUMN_IDS.includes(entry.id),
+      ),
+  );
 
   readonly #gridDestroyed = toObservable(this.gridApi).pipe(
     filter(Boolean),
@@ -671,6 +786,17 @@ export class SkyDataGrid {
     });
   }
 
+  /**
+   * Sets the columns that display and their order. Called by column picker
+   * integrations through `SkyDataColumnSource`.
+   * @internal
+   */
+  public setDisplayedColumnIds(columnIds: string[]): void {
+    if (!arraysEqual(this.displayedColumnIds(), columnIds)) {
+      this.selectedColumnIds.set(columnIds);
+    }
+  }
+
   protected currentPageChange(page: number): void {
     if (page && page !== this.page()) {
       const pageQueryParam = this.pageQueryParam();
@@ -713,8 +839,6 @@ export class SkyDataGrid {
       field,
       headerName: col.headingText(),
       headerComponentParams: this.#getHeaderComponentParams(col),
-      hide: col.columnHidden(),
-      initialHide: col.columnHidden(),
       resizable: col.resizable(),
       sortable: col.sortable(),
       lockPosition: col.locked(),
@@ -781,6 +905,22 @@ export class SkyDataGrid {
       helpPopoverContent: col.helpPopoverContent(),
       inlineHelpComponent: SkyDataGridColumnInlineHelp,
     };
+  }
+
+  #getColumnId(col: SkyDataGridColumn): string | undefined {
+    return col.columnId() ?? col.field();
+  }
+
+  #syncColumnOrderFromGrid(api: GridApi): void {
+    const displayedColumnIds = api
+      .getColumnState()
+      .filter((state) => !state.hide)
+      .map((state) => state.colId)
+      .filter((colId) => !RESERVED_COLUMN_IDS.includes(colId));
+
+    if (!arraysEqual(this.displayedColumnIds(), displayedColumnIds)) {
+      this.selectedColumnIds.set(displayedColumnIds);
+    }
   }
 
   #getRowIds(rows: (IRowNode | undefined)[] | null | undefined): string[] {

--- a/libs/components/data-grid/src/lib/modules/data-grid/fixtures/column-selection-test.component.ts
+++ b/libs/components/data-grid/src/lib/modules/data-grid/fixtures/column-selection-test.component.ts
@@ -1,0 +1,45 @@
+import { Component, input, model } from '@angular/core';
+
+import { SkyDataGrid } from '../data-grid';
+import { SkyDataGridColumn } from '../data-grid-column';
+
+@Component({
+  selector: 'app-column-selection-test',
+  template: `<sky-data-grid
+    [data]="data()"
+    [(selectedColumnIds)]="selectedColumnIds"
+  >
+    <sky-data-grid-column
+      columnId="locked"
+      headingText="Locked"
+      locked
+      [description]="lockedDescription()"
+    />
+    <sky-data-grid-column field="name" headingText="Name" />
+    <sky-data-grid-column field="age" headingText="Age" dataType="number" />
+    @if (showExtra()) {
+      <sky-data-grid-column
+        field="extra"
+        headingText="Extra"
+        [columnHidden]="extraHidden()"
+      />
+    }
+    <!-- A column with neither columnId nor field is omitted from the catalog. -->
+    @if (showInvalid()) {
+      <sky-data-grid-column headingText="Invalid" />
+    }
+  </sky-data-grid>`,
+  imports: [SkyDataGrid, SkyDataGridColumn],
+})
+export class ColumnSelectionTestComponent {
+  public readonly data = input<{ id: string; name: string; age: number }[]>([
+    { id: '1', name: 'Amy', age: 30 },
+    { id: '2', name: 'Bob', age: 40 },
+  ]);
+
+  public readonly selectedColumnIds = model<string[]>([]);
+  public readonly extraHidden = input<boolean>(false);
+  public readonly lockedDescription = input<string | undefined>(undefined);
+  public readonly showExtra = input<boolean>(true);
+  public readonly showInvalid = input<boolean>(false);
+}

--- a/libs/components/data-manager/documentation.json
+++ b/libs/components/data-manager/documentation.json
@@ -9,6 +9,7 @@
           "SkyDataManagerService",
           "SkyDataManagerToolbarComponent",
           "SkyDataManagerToolbarSectionComponent",
+          "SkyDataManagerSortOptionComponent",
           "SkyDataManagerToolbarPrimaryItemComponent",
           "SkyDataManagerToolbarLeftItemComponent",
           "SkyDataManagerToolbarRightItemComponent",
@@ -57,6 +58,7 @@
       "codeExamples": {
         "docsIds": [
           "DataManagerBasicExampleComponent",
+          "DataManagerResourceExampleComponent",
           "PagesPageListPageListLayoutExampleComponent",
           "PagesPageDataManagerSplitViewFitLayoutExampleComponent"
         ]

--- a/libs/components/data-manager/documentation.json
+++ b/libs/components/data-manager/documentation.json
@@ -13,6 +13,7 @@
           "SkyDataManagerToolbarPrimaryItemComponent",
           "SkyDataManagerToolbarLeftItemComponent",
           "SkyDataManagerToolbarRightItemComponent",
+          "SkyDataManagerColumnControllerDirective",
           "SkyDataManagerFilterControllerDirective",
           "SkyDataViewComponent",
           "SkyDataViewConfig",

--- a/libs/components/data-manager/src/index.ts
+++ b/libs/components/data-manager/src/index.ts
@@ -22,6 +22,7 @@ export { SkyDataManagerDockType } from './lib/modules/data-manager/types/data-ma
 // Obscure names are used to indicate types are not part of public API.
 export { SkyDataManagerColumnPickerComponent as λ1 } from './lib/modules/data-manager/data-manager-column-picker/data-manager-column-picker.component';
 export { SkyDataManagerFilterControllerDirective as λ9 } from './lib/modules/data-manager/data-manager-filters/data-manager-filter-controller.directive';
+export { SkyDataManagerSortOptionComponent as λ10 } from './lib/modules/data-manager/data-manager-toolbar/data-manager-sort-option.component';
 export { SkyDataManagerToolbarLeftItemComponent as λ3 } from './lib/modules/data-manager/data-manager-toolbar/data-manager-toolbar-left-item.component';
 export { SkyDataManagerToolbarPrimaryItemComponent as λ4 } from './lib/modules/data-manager/data-manager-toolbar/data-manager-toolbar-primary-item.component';
 export { SkyDataManagerToolbarRightItemComponent as λ5 } from './lib/modules/data-manager/data-manager-toolbar/data-manager-toolbar-right-item.component';

--- a/libs/components/data-manager/src/index.ts
+++ b/libs/components/data-manager/src/index.ts
@@ -21,6 +21,7 @@ export { SkyDataManagerDockType } from './lib/modules/data-manager/types/data-ma
 // Components and directives must be exported to support Angular's "partial" Ivy compiler.
 // Obscure names are used to indicate types are not part of public API.
 export { SkyDataManagerColumnPickerComponent as λ1 } from './lib/modules/data-manager/data-manager-column-picker/data-manager-column-picker.component';
+export { SkyDataManagerColumnControllerDirective as λ11 } from './lib/modules/data-manager/data-manager-columns/data-manager-column-controller.directive';
 export { SkyDataManagerFilterControllerDirective as λ9 } from './lib/modules/data-manager/data-manager-filters/data-manager-filter-controller.directive';
 export { SkyDataManagerSortOptionComponent as λ10 } from './lib/modules/data-manager/data-manager-toolbar/data-manager-sort-option.component';
 export { SkyDataManagerToolbarLeftItemComponent as λ3 } from './lib/modules/data-manager/data-manager-toolbar/data-manager-toolbar-left-item.component';

--- a/libs/components/data-manager/src/lib/modules/data-manager/data-manager-columns/data-manager-column-controller.directive.spec.ts
+++ b/libs/components/data-manager/src/lib/modules/data-manager/data-manager-columns/data-manager-column-controller.directive.spec.ts
@@ -1,0 +1,324 @@
+import { Component, input, model, signal } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { SkyUIConfigService } from '@skyux/core';
+import { SkyDataColumnOption, SkyDataColumnSource } from '@skyux/lists';
+
+import { SkyDataManagerModule } from '../data-manager.module';
+import { SkyDataManagerService } from '../data-manager.service';
+import { SkyDataManagerState } from '../models/data-manager-state';
+
+/**
+ * A minimal `SkyDataColumnSource` so these tests exercise the directive rather
+ * than a data grid.
+ */
+@Component({
+  selector: 'app-test-columns',
+  template: '',
+  providers: [
+    { provide: SkyDataColumnSource, useExisting: TestColumnsComponent },
+  ],
+})
+class TestColumnsComponent implements SkyDataColumnSource {
+  public readonly dataColumns = input<readonly SkyDataColumnOption[]>([
+    { id: 'locked', labelText: 'Locked', alwaysDisplayed: true },
+    { id: 'name', labelText: 'Name' },
+    { id: 'age', labelText: 'Age' },
+    { id: 'notes', labelText: 'Notes', initialHide: true },
+  ]);
+
+  public readonly displayedColumnIds = signal<readonly string[]>([]);
+
+  public setDisplayedColumnIds(columnIds: string[]): void {
+    this.displayedColumnIds.set(columnIds);
+  }
+}
+
+@Component({
+  template: `<sky-data-manager>
+    <sky-data-manager-toolbar />
+    @if (useView()) {
+      <sky-data-view [viewId]="'view-1'">
+        <app-test-columns
+          skyDataManagerColumnController
+          [dataColumns]="dataColumns()"
+        />
+      </sky-data-view>
+    } @else {
+      <app-test-columns
+        skyDataManagerColumnController
+        [dataColumns]="dataColumns()"
+      />
+    }
+  </sky-data-manager>`,
+  imports: [SkyDataManagerModule, TestColumnsComponent],
+  providers: [SkyDataManagerService, SkyUIConfigService],
+})
+class TestHostComponent {
+  public readonly useView = model(false);
+  public readonly dataColumns = model<readonly SkyDataColumnOption[]>([
+    { id: 'locked', labelText: 'Locked', alwaysDisplayed: true },
+    { id: 'name', labelText: 'Name' },
+    { id: 'age', labelText: 'Age' },
+    { id: 'notes', labelText: 'Notes', initialHide: true },
+  ]);
+}
+
+describe('SkyDataManagerColumnControllerDirective', () => {
+  let fixture: ComponentFixture<TestHostComponent>;
+  let dataManagerSvc: SkyDataManagerService;
+
+  async function detect(): Promise<void> {
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+    await fixture.whenStable();
+  }
+
+  function getColumnSource(): TestColumnsComponent {
+    return fixture.debugElement.query(
+      (node) => node.componentInstance instanceof TestColumnsComponent,
+    ).componentInstance as TestColumnsComponent;
+  }
+
+  function initDataManager(state?: SkyDataManagerState): void {
+    dataManagerSvc.initDataManager({
+      activeViewId: 'view-1',
+      dataManagerConfig: {},
+      defaultDataState: state ?? new SkyDataManagerState({}),
+    });
+  }
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({ imports: [TestHostComponent] });
+    fixture = TestBed.createComponent(TestHostComponent);
+    dataManagerSvc = fixture.debugElement.injector.get(SkyDataManagerService);
+  });
+
+  describe('without a sky-data-view', () => {
+    it('should register the columns on the service', async () => {
+      initDataManager();
+      await detect();
+
+      expect(dataManagerSvc.columnOptions()?.map((col) => col.id)).toEqual([
+        'locked',
+        'name',
+        'age',
+        'notes',
+      ]);
+    });
+
+    it('should apply the declared visibility when nothing is stored', async () => {
+      initDataManager();
+      await detect();
+
+      expect(getColumnSource().displayedColumnIds()).toEqual([
+        'locked',
+        'name',
+        'age',
+      ]);
+      expect(dataManagerSvc.state().displayedColumnIds).toEqual([
+        'locked',
+        'name',
+        'age',
+      ]);
+      expect(dataManagerSvc.state().columnIds).toEqual([
+        'locked',
+        'name',
+        'age',
+        'notes',
+      ]);
+    });
+
+    it('should apply a stored column layout instead of the declared default', async () => {
+      initDataManager(
+        new SkyDataManagerState({
+          columnIds: ['locked', 'name', 'age', 'notes'],
+          displayedColumnIds: ['locked', 'age'],
+        }),
+      );
+      await detect();
+
+      expect(getColumnSource().displayedColumnIds()).toEqual(['locked', 'age']);
+    });
+
+    it('should store a column order the component changes, such as a user reordering columns', async () => {
+      initDataManager();
+      await detect();
+
+      getColumnSource().setDisplayedColumnIds(['locked', 'age', 'name']);
+      await detect();
+
+      expect(dataManagerSvc.state().displayedColumnIds).toEqual([
+        'locked',
+        'age',
+        'name',
+      ]);
+    });
+
+    it('should display a column added after the layout was stored', async () => {
+      initDataManager(
+        new SkyDataManagerState({
+          columnIds: ['locked', 'name'],
+          displayedColumnIds: ['locked', 'name'],
+        }),
+      );
+      await detect();
+
+      expect(getColumnSource().displayedColumnIds()).toEqual([
+        'locked',
+        'name',
+        'age',
+      ]);
+    });
+
+    it('should clear the registered columns when destroyed', async () => {
+      initDataManager();
+      await detect();
+
+      expect(dataManagerSvc.columnOptions()).toBeDefined();
+
+      fixture.destroy();
+
+      expect(dataManagerSvc.columnOptions()).toBeUndefined();
+    });
+
+    it('should do nothing when the component declares no columns', async () => {
+      fixture.componentInstance.dataColumns.set([]);
+      initDataManager();
+      await detect();
+
+      expect(getColumnSource().displayedColumnIds()).toEqual([]);
+      expect(dataManagerSvc.state().displayedColumnIds).toBeUndefined();
+    });
+
+    it('should handle stored column IDs without stored displayed column IDs', async () => {
+      initDataManager(
+        new SkyDataManagerState({
+          columnIds: ['locked', 'name', 'age', 'notes'],
+        }),
+      );
+      await detect();
+
+      // Every column was already known, so none is treated as new, and only
+      // the column that cannot be hidden displays.
+      expect(getColumnSource().displayedColumnIds()).toEqual(['locked']);
+      expect(dataManagerSvc.state().displayedColumnIds).toEqual(['locked']);
+    });
+  });
+
+  describe('with a sky-data-view', () => {
+    beforeEach(() => {
+      fixture.componentInstance.useView.set(true);
+    });
+
+    it('should add the columns to the view config', async () => {
+      dataManagerSvc.initDataView({
+        id: 'view-1',
+        name: 'View',
+        columnPickerEnabled: true,
+      });
+      initDataManager();
+      await detect();
+
+      expect(dataManagerSvc.getViewById('view-1')?.columnOptions).toEqual([
+        {
+          alwaysDisplayed: true,
+          description: undefined,
+          id: 'locked',
+          initialHide: undefined,
+          label: 'Locked',
+        },
+        {
+          alwaysDisplayed: undefined,
+          description: undefined,
+          id: 'name',
+          initialHide: undefined,
+          label: 'Name',
+        },
+        {
+          alwaysDisplayed: undefined,
+          description: undefined,
+          id: 'age',
+          initialHide: undefined,
+          label: 'Age',
+        },
+        {
+          alwaysDisplayed: undefined,
+          description: undefined,
+          id: 'notes',
+          initialHide: true,
+          label: 'Notes',
+        },
+      ]);
+    });
+
+    it('should keep column options the view supplied', async () => {
+      dataManagerSvc.initDataView({
+        id: 'view-1',
+        name: 'View',
+        columnPickerEnabled: true,
+        columnOptions: [{ id: 'name', label: 'Custom' }],
+      });
+      initDataManager();
+      await detect();
+
+      expect(dataManagerSvc.getViewById('view-1')?.columnOptions).toEqual([
+        { id: 'name', label: 'Custom' },
+      ]);
+    });
+
+    it('should store the column layout on the view state', async () => {
+      dataManagerSvc.initDataView({ id: 'view-1', name: 'View' });
+      initDataManager();
+      await detect();
+
+      const viewState = dataManagerSvc.state().getViewStateById('view-1');
+
+      expect(viewState?.displayedColumnIds).toEqual(['locked', 'name', 'age']);
+      expect(viewState?.columnIds).toEqual(['locked', 'name', 'age', 'notes']);
+      expect(dataManagerSvc.state().displayedColumnIds).toBeUndefined();
+    });
+
+    it('should store a column order the component changes on the view state', async () => {
+      dataManagerSvc.initDataView({ id: 'view-1', name: 'View' });
+      initDataManager();
+      await detect();
+
+      getColumnSource().setDisplayedColumnIds(['locked', 'age', 'name']);
+      await detect();
+
+      expect(
+        dataManagerSvc.state().getViewStateById('view-1')?.displayedColumnIds,
+      ).toEqual(['locked', 'age', 'name']);
+    });
+
+    it('should apply a stored view column layout', async () => {
+      dataManagerSvc.initDataView({ id: 'view-1', name: 'View' });
+      initDataManager(
+        new SkyDataManagerState({
+          views: [
+            {
+              viewId: 'view-1',
+              columnIds: ['locked', 'name', 'age', 'notes'],
+              displayedColumnIds: ['locked', 'notes'],
+            },
+          ],
+        }),
+      );
+      await detect();
+
+      expect(getColumnSource().displayedColumnIds()).toEqual([
+        'locked',
+        'notes',
+      ]);
+    });
+
+    it('should not register the columns on the service', async () => {
+      dataManagerSvc.initDataView({ id: 'view-1', name: 'View' });
+      initDataManager();
+      await detect();
+
+      expect(dataManagerSvc.columnOptions()).toBeUndefined();
+    });
+  });
+});

--- a/libs/components/data-manager/src/lib/modules/data-manager/data-manager-columns/data-manager-column-controller.directive.ts
+++ b/libs/components/data-manager/src/lib/modules/data-manager/data-manager-columns/data-manager-column-controller.directive.ts
@@ -1,0 +1,189 @@
+import {
+  DestroyRef,
+  Directive,
+  computed,
+  effect,
+  inject,
+  input,
+} from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { SkyDataColumnSource } from '@skyux/lists';
+
+import { SkyDataManagerService } from '../data-manager.service';
+import { SkyDataViewComponent } from '../data-view.component';
+import { SkyDataManagerState } from '../models/data-manager-state';
+import { SkyDataViewState } from '../models/data-view-state';
+
+import {
+  SkyDataManagerColumnState,
+  reconcileColumnState,
+} from './data-manager-column-state';
+
+const SOURCE_ID = 'skyDataManagerColumnController';
+
+function arraysEqual(a: readonly string[], b: readonly string[]): boolean {
+  return a.length === b.length && a.every((value, i) => value === b[i]);
+}
+
+/**
+ * A directive applied to a column-based component, such as a data grid, that
+ * lets a data manager's column picker control which columns display. The
+ * columns are read from the component, so the view config does not need to
+ * supply column options.
+ * @preview
+ */
+@Directive({ selector: '[skyDataManagerColumnController]' })
+export class SkyDataManagerColumnControllerDirective {
+  /**
+   * The ID of the data manager view the component belongs to. This is only
+   * needed when views are registered and the component is not inside a
+   * `sky-data-view`.
+   */
+  public readonly viewId = input<string>();
+
+  readonly #columnSource = inject(SkyDataColumnSource);
+  readonly #dataManagerSvc = inject(SkyDataManagerService);
+  readonly #dataView = inject(SkyDataViewComponent, { optional: true });
+
+  readonly #viewId = computed(() => this.viewId() ?? this.#dataView?.viewId);
+
+  readonly #dataState = toSignal(
+    this.#dataManagerSvc.getDataStateUpdates(SOURCE_ID),
+  );
+
+  /**
+   * The column state stored by the data manager, reconciled against the
+   * columns the component currently declares. This is `undefined` until the
+   * data manager emits its first state, so a stored column layout is never
+   * overwritten by the component's declarative default.
+   */
+  readonly #reconciledState = computed<SkyDataManagerColumnState | undefined>(
+    () => {
+      const dataState = this.#dataState();
+      const columns = this.#columnSource.dataColumns();
+
+      if (!dataState || columns.length === 0) {
+        return undefined;
+      }
+
+      return reconcileColumnState(this.#readStoredState(dataState), [
+        ...columns,
+      ]);
+    },
+  );
+
+  constructor() {
+    // Publish the columns so the column picker can offer them.
+    effect(() => {
+      const columns = this.#columnSource.dataColumns();
+      const viewId = this.#viewId();
+
+      if (!viewId) {
+        this.#dataManagerSvc.setColumnOptions([...columns]);
+        return;
+      }
+
+      const view = this.#dataManagerSvc.getViewById(viewId);
+
+      // A view that supplies its own column options keeps them.
+      if (view && !view.columnOptions) {
+        this.#dataManagerSvc.updateViewConfig({
+          ...view,
+          columnOptions: columns.map((column) => ({
+            alwaysDisplayed: column.alwaysDisplayed,
+            description: column.description,
+            id: column.id,
+            initialHide: column.initialHide,
+            label: column.labelText,
+          })),
+        });
+      }
+    });
+
+    // Apply the data manager's column state to the component.
+    effect(() => {
+      const reconciled = this.#reconciledState();
+
+      if (reconciled) {
+        this.#columnSource.setDisplayedColumnIds(reconciled.displayedColumnIds);
+      }
+    });
+
+    // Store what the component displays. This covers both the reconciled state
+    // applied above, which is a no-op once stored, and changes the user makes
+    // in the component itself, such as reordering columns by dragging a header.
+    effect(() => {
+      const reconciled = this.#reconciledState();
+      const displayedColumnIds = this.#columnSource.displayedColumnIds();
+
+      if (reconciled) {
+        this.#storeColumnState({
+          columnIds: reconciled.columnIds,
+          displayedColumnIds: [...displayedColumnIds],
+        });
+      }
+    });
+
+    inject(DestroyRef).onDestroy(() => {
+      if (!this.#viewId()) {
+        this.#dataManagerSvc.setColumnOptions(undefined);
+      }
+    });
+  }
+
+  #readStoredState(
+    dataState: SkyDataManagerState,
+  ): Partial<SkyDataManagerColumnState> | undefined {
+    const viewId = this.#viewId();
+
+    if (viewId) {
+      return dataState.getViewStateById(viewId);
+    }
+
+    return {
+      columnIds: dataState.columnIds,
+      displayedColumnIds: dataState.displayedColumnIds,
+    };
+  }
+
+  #storeColumnState(state: SkyDataManagerColumnState): void {
+    const dataState = this.#dataState();
+
+    /* istanbul ignore if: only reachable before the first data state */
+    if (!dataState) {
+      return;
+    }
+
+    const stored = this.#readStoredState(dataState);
+
+    if (
+      arraysEqual(stored?.columnIds ?? [], state.columnIds) &&
+      arraysEqual(stored?.displayedColumnIds ?? [], state.displayedColumnIds)
+    ) {
+      return;
+    }
+
+    const viewId = this.#viewId();
+
+    if (viewId) {
+      const viewState = new SkyDataViewState(
+        dataState.getViewStateById(viewId)?.getViewStateOptions() ?? { viewId },
+      );
+
+      viewState.columnIds = state.columnIds;
+      viewState.displayedColumnIds = state.displayedColumnIds;
+
+      this.#dataManagerSvc.updateDataState(
+        dataState.addOrUpdateView(viewId, viewState),
+        SOURCE_ID,
+      );
+    } else {
+      const newState = new SkyDataManagerState(dataState.getStateOptions());
+
+      newState.columnIds = state.columnIds;
+      newState.displayedColumnIds = state.displayedColumnIds;
+
+      this.#dataManagerSvc.updateDataState(newState, SOURCE_ID);
+    }
+  }
+}

--- a/libs/components/data-manager/src/lib/modules/data-manager/data-manager-columns/data-manager-column-state.spec.ts
+++ b/libs/components/data-manager/src/lib/modules/data-manager/data-manager-columns/data-manager-column-state.spec.ts
@@ -1,0 +1,126 @@
+import { reconcileColumnState } from './data-manager-column-state';
+
+describe('reconcileColumnState', () => {
+  const columns = [
+    { id: 'locked', alwaysDisplayed: true },
+    { id: 'name' },
+    { id: 'age' },
+    { id: 'notes', initialHide: true },
+  ];
+
+  it('should use the declared visibility when nothing is stored', () => {
+    expect(reconcileColumnState(undefined, columns)).toEqual({
+      columnIds: ['locked', 'name', 'age', 'notes'],
+      displayedColumnIds: ['locked', 'name', 'age'],
+    });
+  });
+
+  it('should use the declared visibility when the stored state is empty', () => {
+    expect(
+      reconcileColumnState({ columnIds: [], displayedColumnIds: [] }, columns),
+    ).toEqual({
+      columnIds: ['locked', 'name', 'age', 'notes'],
+      displayedColumnIds: ['locked', 'name', 'age'],
+    });
+  });
+
+  it('should keep the stored order', () => {
+    expect(
+      reconcileColumnState(
+        {
+          columnIds: ['locked', 'name', 'age', 'notes'],
+          displayedColumnIds: ['locked', 'age', 'name'],
+        },
+        columns,
+      ).displayedColumnIds,
+    ).toEqual(['locked', 'age', 'name']);
+  });
+
+  it('should keep a column the user hid hidden', () => {
+    expect(
+      reconcileColumnState(
+        {
+          columnIds: ['locked', 'name', 'age', 'notes'],
+          displayedColumnIds: ['locked', 'name'],
+        },
+        columns,
+      ).displayedColumnIds,
+    ).toEqual(['locked', 'name']);
+  });
+
+  it('should display a column added since the state was stored', () => {
+    expect(
+      reconcileColumnState(
+        {
+          columnIds: ['locked', 'name'],
+          displayedColumnIds: ['locked', 'name'],
+        },
+        columns,
+      ).displayedColumnIds,
+    ).toEqual(['locked', 'name', 'age']);
+  });
+
+  it('should not display a newly added column that starts hidden', () => {
+    expect(
+      reconcileColumnState(
+        {
+          columnIds: ['locked', 'name', 'age'],
+          displayedColumnIds: ['locked', 'name', 'age'],
+        },
+        columns,
+      ).displayedColumnIds,
+    ).not.toContain('notes');
+  });
+
+  it('should drop a column that no longer exists', () => {
+    expect(
+      reconcileColumnState(
+        {
+          columnIds: ['locked', 'name', 'age', 'notes', 'removed'],
+          displayedColumnIds: ['locked', 'name', 'removed'],
+        },
+        columns,
+      ),
+    ).toEqual({
+      columnIds: ['locked', 'name', 'age', 'notes'],
+      displayedColumnIds: ['locked', 'name'],
+    });
+  });
+
+  it('should take the stored list at face value when no column IDs were stored', () => {
+    // Without stored column IDs there is no way to tell a new column from one
+    // the user hid, so nothing is added.
+    expect(
+      reconcileColumnState({ displayedColumnIds: ['locked', 'name'] }, columns)
+        .displayedColumnIds,
+    ).toEqual(['locked', 'name']);
+  });
+
+  it('should always display a column that cannot be hidden', () => {
+    expect(
+      reconcileColumnState(
+        {
+          columnIds: ['locked', 'name', 'age', 'notes'],
+          displayedColumnIds: ['name', 'age'],
+        },
+        columns,
+      ).displayedColumnIds,
+    ).toEqual(['locked', 'name', 'age']);
+  });
+
+  it('should display multiple always-displayed columns in declaration order', () => {
+    expect(
+      reconcileColumnState(
+        {
+          columnIds: ['a', 'b', 'name'],
+          displayedColumnIds: ['name'],
+        },
+        [
+          { id: 'a', alwaysDisplayed: true },
+          { id: 'b', alwaysDisplayed: true },
+          { id: 'name' },
+        ],
+      ).displayedColumnIds,
+    ).toEqual(['a', 'b', 'name']);
+  });
+});

--- a/libs/components/data-manager/src/lib/modules/data-manager/data-manager-columns/data-manager-column-state.ts
+++ b/libs/components/data-manager/src/lib/modules/data-manager/data-manager-columns/data-manager-column-state.ts
@@ -1,0 +1,86 @@
+/**
+ * The subset of a column option needed to reconcile column state. Both
+ * `SkyDataManagerColumnPickerOption` and `SkyDataColumnOption` satisfy it.
+ * @internal
+ */
+export interface SkyDataManagerColumnStateOption {
+  alwaysDisplayed?: boolean;
+  id: string;
+  initialHide?: boolean;
+}
+
+/**
+ * The set of columns a data manager knows about and which of them display.
+ * @internal
+ */
+export interface SkyDataManagerColumnState {
+  /**
+   * The IDs of every column known about, whether displayed or not.
+   */
+  columnIds: string[];
+  /**
+   * The IDs of the columns that display, in display order.
+   */
+  displayedColumnIds: string[];
+}
+
+/**
+ * Reconciles a stored column state, such as one restored from sticky settings,
+ * against the columns that currently exist.
+ *
+ * A column the user hid and a column added since the state was stored are both
+ * absent from `displayedColumnIds`, so `columnIds` — the columns known when the
+ * state was stored — is what distinguishes them.
+ *
+ * @internal
+ */
+export function reconcileColumnState(
+  stored: Partial<SkyDataManagerColumnState> | undefined,
+  columnOptions: SkyDataManagerColumnStateOption[],
+): SkyDataManagerColumnState {
+  const columnIds = columnOptions.map((option) => option.id);
+  const previouslyKnown = new Set(stored?.columnIds ?? []);
+  const storedDisplayed = stored?.displayedColumnIds ?? [];
+
+  if (previouslyKnown.size === 0 && storedDisplayed.length === 0) {
+    // Nothing was stored, so fall back to the columns' declared visibility.
+    return {
+      columnIds,
+      displayedColumnIds: columnOptions
+        .filter((option) => option.alwaysDisplayed || !option.initialHide)
+        .map((option) => option.id),
+    };
+  }
+
+  // Drop columns that no longer exist.
+  const available = new Set(columnIds);
+  const displayedColumnIds = storedDisplayed.filter((id) => available.has(id));
+  const displayed = new Set(displayedColumnIds);
+
+  // A column that did not exist when the state was stored is new, so display it
+  // unless it is meant to start hidden. When `columnIds` was never stored there
+  // is no way to tell a new column from one the user hid, so the stored list is
+  // taken at face value.
+  if (previouslyKnown.size > 0) {
+    for (const option of columnOptions) {
+      if (
+        !previouslyKnown.has(option.id) &&
+        !displayed.has(option.id) &&
+        !option.initialHide
+      ) {
+        displayedColumnIds.push(option.id);
+        displayed.add(option.id);
+      }
+    }
+  }
+
+  // Columns that can never be hidden always display, and display first.
+  for (const option of [...columnOptions].reverse()) {
+    if (option.alwaysDisplayed && !displayed.has(option.id)) {
+      displayedColumnIds.unshift(option.id);
+      displayed.add(option.id);
+    }
+  }
+
+  return { columnIds, displayedColumnIds };
+}

--- a/libs/components/data-manager/src/lib/modules/data-manager/data-manager-toolbar/data-manager-sort-option.component.spec.ts
+++ b/libs/components/data-manager/src/lib/modules/data-manager/data-manager-toolbar/data-manager-sort-option.component.spec.ts
@@ -1,0 +1,47 @@
+import { Component } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { SkyDataManagerSortOptionComponent } from './data-manager-sort-option.component';
+
+@Component({
+  selector: 'sky-test-host',
+  template: `
+    <sky-data-manager-sort-option
+      id="az"
+      propertyName="name"
+      label="Name (A - Z)"
+    />
+  `,
+  imports: [SkyDataManagerSortOptionComponent],
+})
+class TestHostComponent {}
+
+describe('SkyDataManagerSortOptionComponent', () => {
+  let fixture: ComponentFixture<TestHostComponent>;
+  let sortOption: SkyDataManagerSortOptionComponent;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({ imports: [TestHostComponent] });
+    fixture = TestBed.createComponent(TestHostComponent);
+    fixture.detectChanges();
+    sortOption = fixture.debugElement.children[0].injector.get(
+      SkyDataManagerSortOptionComponent,
+    );
+  });
+
+  it('exposes its inputs and defaults descending to false', () => {
+    expect(sortOption.id()).toBe('az');
+    expect(sortOption.propertyName()).toBe('name');
+    expect(sortOption.label()).toBe('Name (A - Z)');
+    expect(sortOption.descending()).toBeFalse();
+  });
+
+  it('converts itself to a SkyDataManagerSortOption', () => {
+    expect(sortOption.toSortOption()).toEqual({
+      id: 'az',
+      propertyName: 'name',
+      label: 'Name (A - Z)',
+      descending: false,
+    });
+  });
+});

--- a/libs/components/data-manager/src/lib/modules/data-manager/data-manager-toolbar/data-manager-sort-option.component.ts
+++ b/libs/components/data-manager/src/lib/modules/data-manager/data-manager-toolbar/data-manager-sort-option.component.ts
@@ -1,0 +1,54 @@
+import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+
+import { SkyDataManagerSortOption } from '../models/data-manager-sort-option';
+
+/**
+ * Declares a single sort option for `SkyDataManagerToolbarComponent` to render, as
+ * an alternative to `SkyDataManagerConfig.sortOptions` for the signal-based toolbar
+ * API. Add one `sky-data-manager-sort-option` per option.
+ * @preview
+ */
+@Component({
+  selector: 'sky-data-manager-sort-option',
+  template: '',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class SkyDataManagerSortOptionComponent {
+  /**
+   * A unique ID for the sort option.
+   * @preview
+   */
+  public readonly id = input.required<string>();
+
+  /**
+   * The data property to sort by.
+   * @preview
+   */
+  public readonly propertyName = input.required<string>();
+
+  /**
+   * The label to display in the sort dropdown.
+   * @preview
+   */
+  public readonly label = input.required<string>();
+
+  /**
+   * Whether to apply the sort in descending order.
+   * @default false
+   * @preview
+   */
+  public readonly descending = input<boolean>(false);
+
+  /**
+   * Returns the `SkyDataManagerSortOption` equivalent of this component's inputs.
+   * @preview
+   */
+  public toSortOption(): SkyDataManagerSortOption {
+    return {
+      id: this.id(),
+      propertyName: this.propertyName(),
+      label: this.label(),
+      descending: this.descending(),
+    };
+  }
+}

--- a/libs/components/data-manager/src/lib/modules/data-manager/data-manager-toolbar/data-manager-toolbar.component.html
+++ b/libs/components/data-manager/src/lib/modules/data-manager/data-manager-toolbar/data-manager-toolbar.component.html
@@ -15,7 +15,7 @@
           </sky-toolbar-item>
         }
 
-        @if (activeView?.sortEnabled || sortOptions().length > 0) {
+        @if (activeView?.sortEnabled || sortOptions().length) {
           <sky-toolbar-item class="sky-data-manager-sort">
             <sky-sort [showButtonText]="activeView?.showSortButtonText">
               @for (item of dataManagerConfig?.sortOptions; track item.id) {

--- a/libs/components/data-manager/src/lib/modules/data-manager/data-manager-toolbar/data-manager-toolbar.component.html
+++ b/libs/components/data-manager/src/lib/modules/data-manager/data-manager-toolbar/data-manager-toolbar.component.html
@@ -38,7 +38,7 @@
           </sky-toolbar-item>
         }
 
-        @if (activeView?.columnPickerEnabled) {
+        @if (columnPickerEnabled) {
           <sky-toolbar-item>
             <button
               class="sky-btn sky-btn-default sky-col-picker-btn"

--- a/libs/components/data-manager/src/lib/modules/data-manager/data-manager-toolbar/data-manager-toolbar.component.html
+++ b/libs/components/data-manager/src/lib/modules/data-manager/data-manager-toolbar/data-manager-toolbar.component.html
@@ -1,6 +1,8 @@
 <div class="sky-data-manager-toolbar">
   @if (hasToolbarContent) {
-    <sky-toolbar [listDescriptor]="dataManagerConfig?.listDescriptor">
+    <sky-toolbar
+      [listDescriptor]="dataManagerConfig?.listDescriptor || labelText()"
+    >
       <sky-toolbar-section>
         <ng-content select="sky-data-manager-toolbar-primary-item" />
 
@@ -13,7 +15,7 @@
           </sky-toolbar-item>
         }
 
-        @if (activeView?.sortEnabled) {
+        @if (activeView?.sortEnabled || sortOptions().length > 0) {
           <sky-toolbar-item class="sky-data-manager-sort">
             <sky-sort [showButtonText]="activeView?.showSortButtonText">
               @for (item of dataManagerConfig?.sortOptions; track item.id) {
@@ -22,6 +24,14 @@
                   (itemSelect)="sortSelected(item)"
                 >
                   {{ item.label }}
+                </sky-sort-item>
+              }
+              @for (item of sortOptions(); track item.id()) {
+                <sky-sort-item
+                  [active]="dataState?.activeSortOption?.id === item.id()"
+                  (itemSelect)="sortSelected(item.toSortOption())"
+                >
+                  {{ item.label() }}
                 </sky-sort-item>
               }
             </sky-sort>
@@ -57,11 +67,13 @@
 
         <ng-content select="sky-data-manager-toolbar-left-item" />
 
-        @if (activeView?.searchEnabled) {
+        @if (activeView?.searchEnabled || searchEnabled()) {
           <sky-toolbar-item class="sky-data-manager-search">
             <sky-search
               [expandMode]="activeView?.searchExpandMode"
-              [placeholderText]="activeView?.searchPlaceholderText"
+              [placeholderText]="
+                activeView?.searchPlaceholderText || searchPlaceholderText()
+              "
               [searchText]="dataState?.searchText"
               (searchApply)="searchApplied($event)"
             />
@@ -96,39 +108,47 @@
   <ng-content select="sky-filter-bar" />
   <ng-content select="sky-list-summary" />
 
-  @if (activeView?.multiselectToolbarEnabled) {
+  @if (activeView?.multiselectToolbarEnabled || multiselectEnabled()) {
     <sky-toolbar class="sky-data-manager-multiselect-toolbar">
       <sky-toolbar-section>
-        <sky-toolbar-item>
-          <button
-            class="sky-btn sky-btn-link sky-data-manager-select-all-btn"
-            type="button"
-            [attr.aria-label]="
-              dataManagerConfig?.listDescriptor
-                ? ('skyux_data_manager_select_all_button_aria_label'
-                  | skyLibResources: dataManagerConfig?.listDescriptor)
-                : undefined
-            "
-            (click)="selectAll()"
-          >
-            {{ 'skyux_data_manager_select_all_button_title' | skyLibResources }}
-          </button>
-        </sky-toolbar-item>
-        <sky-toolbar-item>
-          <button
-            class="sky-btn sky-btn-link sky-data-manager-clear-all-btn"
-            type="button"
-            [attr.aria-label]="
-              dataManagerConfig?.listDescriptor
-                ? ('skyux_data_manager_clear_all_button_aria_label'
-                  | skyLibResources: dataManagerConfig?.listDescriptor)
-                : undefined
-            "
-            (click)="clearAll()"
-          >
-            {{ 'skyux_data_manager_clear_all_button_title' | skyLibResources }}
-          </button>
-        </sky-toolbar-item>
+        @if (activeView?.onSelectAllClick) {
+          <sky-toolbar-item>
+            <button
+              class="sky-btn sky-btn-link sky-data-manager-select-all-btn"
+              type="button"
+              [attr.aria-label]="
+                dataManagerConfig?.listDescriptor
+                  ? ('skyux_data_manager_select_all_button_aria_label'
+                    | skyLibResources: dataManagerConfig?.listDescriptor)
+                  : undefined
+              "
+              (click)="selectAll()"
+            >
+              {{
+                'skyux_data_manager_select_all_button_title' | skyLibResources
+              }}
+            </button>
+          </sky-toolbar-item>
+        }
+        @if (activeView?.onClearAllClick) {
+          <sky-toolbar-item>
+            <button
+              class="sky-btn sky-btn-link sky-data-manager-clear-all-btn"
+              type="button"
+              [attr.aria-label]="
+                dataManagerConfig?.listDescriptor
+                  ? ('skyux_data_manager_clear_all_button_aria_label'
+                    | skyLibResources: dataManagerConfig?.listDescriptor)
+                  : undefined
+              "
+              (click)="clearAll()"
+            >
+              {{
+                'skyux_data_manager_clear_all_button_title' | skyLibResources
+              }}
+            </button>
+          </sky-toolbar-item>
+        }
         <sky-toolbar-view-actions class="sky-data-manager-only-show-selected">
           <sky-checkbox
             [checked]="onlyShowSelected"

--- a/libs/components/data-manager/src/lib/modules/data-manager/data-manager-toolbar/data-manager-toolbar.component.spec.ts
+++ b/libs/components/data-manager/src/lib/modules/data-manager/data-manager-toolbar/data-manager-toolbar.component.spec.ts
@@ -1,3 +1,5 @@
+import { HarnessLoader } from '@angular/cdk/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { Component } from '@angular/core';
 import {
   ComponentFixture,
@@ -7,23 +9,34 @@ import {
 } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { SkyAppTestUtility, expect, expectAsync } from '@skyux-sdk/testing';
-import { SkyContentInfoProvider, SkyLogService } from '@skyux/core';
+import {
+  SkyContentInfoProvider,
+  SkyLogService,
+  SkyUIConfigService,
+} from '@skyux/core';
+import { SkyFilterState, SkyFilterStateService } from '@skyux/lists';
+import { SkySortHarness } from '@skyux/lists/testing';
+import { SkySearchHarness } from '@skyux/lookup/testing';
 import { SkyModalConfigurationInterface, SkyModalService } from '@skyux/modals';
 
-import { Subject } from 'rxjs';
+import { Subject, throwError } from 'rxjs';
 
 import { SkyDataManagerColumnPickerContext } from '../data-manager-column-picker/data-manager-column-picker-context';
 import { SKY_DATA_MANAGER_COLUMN_PICKER_PROVIDERS } from '../data-manager-column-picker/data-manager-column-picker-providers';
 import { SkyDataManagerColumnPickerComponent } from '../data-manager-column-picker/data-manager-column-picker.component';
+import { SkyDataManagerColumnPickerService } from '../data-manager-column-picker/data-manager-column-picker.service';
+import { SkyDataManagerFilterControllerDirective } from '../data-manager-filters/data-manager-filter-controller.directive';
 import { SkyDataManagerService } from '../data-manager.service';
 import { DataManagerFixtureComponent } from '../fixtures/data-manager.component.fixture';
 import { DataManagerFixtureModule } from '../fixtures/data-manager.module.fixture';
 import { SkyDataManagerColumnPickerOption } from '../models/data-manager-column-picker-option';
 import { SkyDataManagerColumnPickerSortStrategy } from '../models/data-manager-column-picker-sort-strategy';
+import { SkyDataManagerSortOption } from '../models/data-manager-sort-option';
 import { SkyDataManagerState } from '../models/data-manager-state';
 import { SkyDataViewConfig } from '../models/data-view-config';
 import { SkyDataViewState } from '../models/data-view-state';
 
+import { SkyDataManagerSortOptionComponent } from './data-manager-sort-option.component';
 import { SkyDataManagerToolbarPrimaryItemComponent } from './data-manager-toolbar-primary-item.component';
 import { SkyDataManagerToolbarComponent } from './data-manager-toolbar.component';
 
@@ -925,6 +938,8 @@ describe('SkyDataManagerToolbarComponent', () => {
         ...(dataManagerToolbarComponent.activeView as SkyDataViewConfig),
         multiselectToolbarEnabled: true,
         columnPickerEnabled: true,
+        onSelectAllClick: () => {},
+        onClearAllClick: () => {},
       });
       dataManagerToolbarFixture.detectChanges();
 
@@ -964,6 +979,8 @@ describe('SkyDataManagerToolbarComponent', () => {
         ...(dataManagerToolbarComponent.activeView as SkyDataViewConfig),
         multiselectToolbarEnabled: true,
         columnPickerEnabled: true,
+        onSelectAllClick: () => {},
+        onClearAllClick: () => {},
       });
       dataManagerToolbarFixture.detectChanges();
 
@@ -984,5 +1001,457 @@ describe('SkyDataManagerToolbarComponent', () => {
     it('should pass accessibility', async () => {
       await expectAsync(dataManagerToolbarNativeElement).toBeAccessible();
     });
+  });
+});
+
+@Component({
+  selector: 'sky-test-host',
+  template: `
+    <sky-data-manager-toolbar
+      [searchEnabled]="true"
+      [searchPlaceholderText]="'Search fruit'"
+      [(searchText)]="searchText"
+      [(sort)]="sort"
+      [(page)]="page"
+      [(selectedIds)]="selectedIds"
+      [(totalCount)]="totalCount"
+    >
+      <sky-data-manager-sort-option
+        id="az"
+        propertyName="name"
+        label="Name (A - Z)"
+      />
+    </sky-data-manager-toolbar>
+  `,
+  imports: [SkyDataManagerToolbarComponent, SkyDataManagerSortOptionComponent],
+})
+class TestHostComponent {
+  public searchText = '';
+  public sort: SkyDataManagerSortOption | undefined;
+  public page = 1;
+  public selectedIds: string[] = [];
+  public totalCount = 0;
+}
+
+describe('SkyDataManagerToolbarComponent signal API', () => {
+  let fixture: ComponentFixture<TestHostComponent>;
+  let dataManagerService: SkyDataManagerService;
+  let loader: HarnessLoader;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [TestHostComponent],
+      providers: [
+        SkyDataManagerService,
+        SkyDataManagerColumnPickerService,
+        SkyUIConfigService,
+      ],
+    });
+    dataManagerService = TestBed.inject(SkyDataManagerService);
+    fixture = TestBed.createComponent(TestHostComponent);
+    loader = TestbedHarnessEnvironment.loader(fixture);
+  });
+
+  it('seeds the data manager state from its models on init', fakeAsync(() => {
+    fixture.componentInstance.searchText = 'mango';
+    fixture.componentInstance.page = 2;
+    fixture.detectChanges();
+    tick();
+    fixture.detectChanges();
+
+    expect(dataManagerService.state().searchText).toBe('mango');
+    expect(dataManagerService.state().page).toBe(2);
+  }));
+
+  it('pushes model changes into the data manager state', () => {
+    fixture.detectChanges();
+
+    fixture.componentInstance.selectedIds = ['1', '2'];
+    fixture.detectChanges();
+
+    expect(dataManagerService.state().selectedIds).toEqual(['1', '2']);
+  });
+
+  it('resets page to 1 when searchText changes', fakeAsync(() => {
+    fixture.componentInstance.page = 4;
+    fixture.detectChanges();
+    tick();
+    fixture.detectChanges();
+    expect(dataManagerService.state().page).toBe(4);
+
+    fixture.componentInstance.searchText = 'lime';
+    fixture.detectChanges();
+
+    expect(dataManagerService.state().searchText).toBe('lime');
+    expect(dataManagerService.state().page).toBe(1);
+    expect(fixture.componentInstance.page).toBe(1);
+  }));
+
+  it('does not reset page when selectedIds changes', fakeAsync(() => {
+    fixture.componentInstance.page = 4;
+    fixture.detectChanges();
+    tick();
+    fixture.detectChanges();
+
+    fixture.componentInstance.selectedIds = ['1'];
+    fixture.detectChanges();
+
+    expect(dataManagerService.state().page).toBe(4);
+  }));
+
+  it('reflects externally-driven state changes back into its models', () => {
+    fixture.detectChanges();
+
+    dataManagerService.updateState({
+      searchText: 'banana',
+      selectedIds: ['9'],
+    });
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.searchText).toBe('banana');
+    expect(fixture.componentInstance.selectedIds).toEqual(['9']);
+  });
+
+  it('does not seed state when initDataManager() already initialized the service', () => {
+    dataManagerService.initDataManager({
+      activeViewId: 'view1',
+      dataManagerConfig: {},
+      defaultDataState: new SkyDataManagerState({ searchText: 'preexisting' }),
+    });
+
+    fixture.componentInstance.searchText = 'shouldNotSeed';
+    fixture.detectChanges();
+    // Flush the afterNextRender() callback that runs the seeding check.
+    fixture.detectChanges();
+
+    expect(dataManagerService.state().searchText).toBe('preexisting');
+  });
+
+  it('feeds totalCount into the data summary pipeline', () => {
+    let receivedTotal: number | undefined;
+    dataManagerService
+      .getDataSummaryUpdates('someOtherSource')
+      .subscribe((summary) => (receivedTotal = summary.totalItems));
+
+    fixture.detectChanges();
+    fixture.componentInstance.totalCount = 42;
+    fixture.detectChanges();
+
+    expect(receivedTotal).toBe(42);
+  });
+
+  it('does not announce a data summary on initial construction when totalCount has not been explicitly changed', () => {
+    const updateDataSummarySpy = spyOn(dataManagerService, 'updateDataSummary');
+
+    fixture.detectChanges();
+
+    expect(updateDataSummarySpy).not.toHaveBeenCalled();
+
+    fixture.componentInstance.totalCount = 7;
+    fixture.detectChanges();
+
+    expect(updateDataSummarySpy).toHaveBeenCalledWith(
+      { totalItems: 7, itemsMatching: 7 },
+      'toolbar',
+    );
+  });
+
+  it('renders the search box with no activeView, using searchPlaceholderText', async () => {
+    fixture.detectChanges();
+
+    const search = await loader.getHarness(SkySearchHarness);
+
+    expect(search).toBeTruthy();
+    expect(await search.getPlaceholderText()).toBe('Search fruit');
+  });
+
+  it('renders projected sky-data-manager-sort-option elements in the sort menu', async () => {
+    fixture.detectChanges();
+
+    const sort = await loader.getHarness(SkySortHarness);
+    await sort.click();
+    const items = await sort.getItems();
+
+    expect(items.length).toBe(1);
+    expect(await items[0].getText()).toContain('Name (A - Z)');
+  });
+
+  it('updates the sort model when a projected sort option is selected', async () => {
+    fixture.detectChanges();
+
+    const sort = await loader.getHarness(SkySortHarness);
+    await sort.click();
+    const item = await sort.getItem({ text: 'Name (A - Z)' });
+    await item.click();
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.sort).toEqual({
+      id: 'az',
+      propertyName: 'name',
+      label: 'Name (A - Z)',
+      descending: false,
+    });
+  });
+});
+
+@Component({
+  selector: 'sky-test-host-sort-page-size',
+  template: `
+    <sky-data-manager-toolbar
+      [settingsKey]="settingsKey"
+      [(sort)]="sort"
+      [(pageSize)]="pageSize"
+      [(filters)]="filters"
+    />
+  `,
+  imports: [SkyDataManagerToolbarComponent],
+})
+class TestHostSortPageSizeComponent {
+  public settingsKey: string | undefined;
+  public sort:
+    | { id: string; propertyName: string; label: string; descending: boolean }
+    | undefined;
+  public pageSize: number | undefined;
+  public filters: SkyFilterState | undefined;
+}
+
+describe('SkyDataManagerToolbarComponent signal API (sort, pageSize, settingsKey)', () => {
+  let fixture: ComponentFixture<TestHostSortPageSizeComponent>;
+  let dataManagerService: SkyDataManagerService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [TestHostSortPageSizeComponent],
+      providers: [
+        SkyDataManagerService,
+        SkyDataManagerColumnPickerService,
+        SkyUIConfigService,
+      ],
+    });
+    dataManagerService = TestBed.inject(SkyDataManagerService);
+    fixture = TestBed.createComponent(TestHostSortPageSizeComponent);
+  });
+
+  it('pushes sort model changes into the data manager state', () => {
+    fixture.detectChanges();
+
+    fixture.componentInstance.sort = {
+      id: '1',
+      propertyName: 'name',
+      label: 'Name',
+      descending: false,
+    };
+    fixture.detectChanges();
+
+    expect(dataManagerService.state().activeSortOption).toEqual({
+      id: '1',
+      propertyName: 'name',
+      label: 'Name',
+      descending: false,
+    });
+  });
+
+  it('pushes pageSize model changes into the data manager state', () => {
+    fixture.detectChanges();
+
+    fixture.componentInstance.pageSize = 50;
+    fixture.detectChanges();
+
+    expect(dataManagerService.state().pageSize).toBe(50);
+  });
+
+  it('reflects externally-driven pageSize changes back into the model', () => {
+    fixture.detectChanges();
+    // A second `detectChanges()` here flushes the `afterNextRender()` seeding
+    // check (see the "does not seed" test above) before any further state
+    // changes happen, so the seed check --- which reads this toolbar's
+    // models as they stood at the time it runs --- can't race with, and
+    // clobber, the `updateState()` call below.
+    fixture.detectChanges();
+
+    dataManagerService.updateState({ pageSize: 75 });
+    fixture.detectChanges();
+
+    expect(dataManagerService.state().pageSize).toBe(75);
+  });
+
+  it('persists and restores state through a settingsKey via SkyUIConfigService', () => {
+    fixture.componentInstance.settingsKey = 'my-settings-key';
+    fixture.detectChanges();
+
+    dataManagerService.updateState({ searchText: 'abc' });
+    fixture.detectChanges();
+
+    expect(dataManagerService.state().searchText).toBe('abc');
+  });
+
+  it('reads the initial state from SkyUIConfigService.getConfig and writes changes back via setConfig, both keyed by settingsKey', () => {
+    const uiConfigService = TestBed.inject(SkyUIConfigService);
+    const getConfigSpy = spyOn(uiConfigService, 'getConfig').and.callThrough();
+    const setConfigSpy = spyOn(uiConfigService, 'setConfig').and.callThrough();
+
+    fixture.componentInstance.settingsKey = 'my-settings-key';
+    fixture.detectChanges();
+
+    expect(getConfigSpy).toHaveBeenCalledWith(
+      'my-settings-key',
+      jasmine.objectContaining({
+        searchText: '',
+        activeSortOption: undefined,
+        selectedIds: [],
+        page: 1,
+      }),
+    );
+
+    // The initial `getConfig()` read itself round-trips back through
+    // `setConfig()` (writing back the same default state it just read), so
+    // reset the spy here to isolate the write triggered by the state change
+    // below from that initial persistence round-trip.
+    setConfigSpy.calls.reset();
+
+    dataManagerService.updateState({ searchText: 'xyz' });
+    fixture.detectChanges();
+
+    expect(setConfigSpy).toHaveBeenCalledWith(
+      'my-settings-key',
+      jasmine.objectContaining({ searchText: 'xyz' }),
+    );
+  });
+
+  it('logs an error when unable to save settings through a settingsKey', () => {
+    const uiConfigService = TestBed.inject(SkyUIConfigService);
+    spyOn(uiConfigService, 'setConfig').and.returnValue(
+      throwError(() => new Error('something went wrong')),
+    );
+    spyOn(console, 'warn');
+
+    fixture.componentInstance.settingsKey = 'my-settings-key';
+    fixture.detectChanges();
+
+    dataManagerService.updateState({ searchText: 'abc' });
+    fixture.detectChanges();
+
+    expect(console.warn).toHaveBeenCalled();
+  });
+
+  it('seeds filterData from a truthy filters model, deriving filtersApplied from appliedFilters', () => {
+    fixture.componentInstance.filters = {
+      appliedFilters: [{ filterId: 'a', filterValue: { value: 'x' } }],
+    };
+    fixture.detectChanges();
+
+    expect(dataManagerService.state().filterData).toEqual({
+      filtersApplied: true,
+      filters: {
+        appliedFilters: [{ filterId: 'a', filterValue: { value: 'x' } }],
+      },
+    });
+  });
+
+  it('seeds filtersApplied as false when the filters model has no applied filters, even though it is truthy', () => {
+    fixture.componentInstance.filters = { selectedFilterIds: ['a'] };
+    fixture.detectChanges();
+
+    expect(dataManagerService.state().filterData).toEqual({
+      filtersApplied: false,
+      filters: { selectedFilterIds: ['a'] },
+    });
+  });
+
+  it('seeds filtersApplied as false when the filters model has an empty appliedFilters array', () => {
+    fixture.componentInstance.filters = { appliedFilters: [] };
+    fixture.detectChanges();
+
+    expect(dataManagerService.state().filterData).toEqual({
+      filtersApplied: false,
+      filters: { appliedFilters: [] },
+    });
+  });
+
+  it('pushes filters model changes into state, including clearing back to undefined', () => {
+    fixture.detectChanges();
+
+    fixture.componentInstance.filters = {
+      appliedFilters: [{ filterId: 'a', filterValue: { value: 'x' } }],
+    };
+    fixture.detectChanges();
+
+    expect(dataManagerService.state().filterData).toEqual({
+      filtersApplied: true,
+      filters: {
+        appliedFilters: [{ filterId: 'a', filterValue: { value: 'x' } }],
+      },
+    });
+
+    fixture.componentInstance.filters = undefined;
+    fixture.detectChanges();
+
+    expect(dataManagerService.state().filterData).toBeUndefined();
+  });
+});
+
+@Component({
+  selector: 'sky-test-host-filter-controller',
+  template: `
+    <sky-data-manager-toolbar [(filters)]="filters" />
+    <div skyDataManagerFilterController></div>
+  `,
+  imports: [
+    SkyDataManagerToolbarComponent,
+    SkyDataManagerFilterControllerDirective,
+  ],
+})
+class TestHostFilterControllerComponent {
+  public filters: SkyFilterState | undefined;
+}
+
+describe('SkyDataManagerToolbarComponent signal API (filter-bar integration via SkyDataManagerFilterControllerDirective)', () => {
+  let fixture: ComponentFixture<TestHostFilterControllerComponent>;
+  let dataManagerService: SkyDataManagerService;
+  let filterStateService: SkyFilterStateService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [TestHostFilterControllerComponent],
+      providers: [
+        SkyDataManagerService,
+        SkyDataManagerColumnPickerService,
+        SkyUIConfigService,
+      ],
+    });
+    dataManagerService = TestBed.inject(SkyDataManagerService);
+    fixture = TestBed.createComponent(TestHostFilterControllerComponent);
+    fixture.detectChanges();
+
+    // The adapter service is provided by the directive itself (useExisting on
+    // SkyFilterStateService), so retrieve it from the directive's element
+    // injector rather than the root TestBed injector.
+    const directiveDebugEl = fixture.debugElement.query(
+      By.directive(SkyDataManagerFilterControllerDirective),
+    );
+    filterStateService = directiveDebugEl.injector.get(SkyFilterStateService);
+  });
+
+  it('derives filtersApplied as false when the filter bar reports an empty appliedFilters array', () => {
+    filterStateService.updateFilterState(
+      { appliedFilters: [] },
+      'test-filter-bar',
+    );
+    fixture.detectChanges();
+
+    expect(dataManagerService.state().filterData?.filtersApplied).toBeFalse();
+  });
+
+  it('derives filtersApplied as true once the filter bar reports a real applied filter', () => {
+    filterStateService.updateFilterState(
+      { appliedFilters: [{ filterId: 'a', filterValue: { value: 'x' } }] },
+      'test-filter-bar',
+    );
+    fixture.detectChanges();
+
+    expect(dataManagerService.state().filterData?.filtersApplied).toBeTrue();
+    expect(fixture.componentInstance.filters?.appliedFilters).toEqual([
+      { filterId: 'a', filterValue: { value: 'x' } },
+    ]);
   });
 });

--- a/libs/components/data-manager/src/lib/modules/data-manager/data-manager-toolbar/data-manager-toolbar.component.spec.ts
+++ b/libs/components/data-manager/src/lib/modules/data-manager/data-manager-toolbar/data-manager-toolbar.component.spec.ts
@@ -941,6 +941,19 @@ describe('SkyDataManagerToolbarComponent', () => {
   });
 
   describe('without a registered view', () => {
+    /**
+     * Mimics the column controller directive reconciling the registered
+     * columns into the data state, which is what makes the column picker
+     * button display when no view is registered.
+     */
+    function reconcileColumnState(displayedColumnIds: string[]): void {
+      const state =
+        dataManagerToolbarComponent.dataState as SkyDataManagerState;
+      state.displayedColumnIds = displayedColumnIds;
+      dataManagerService.updateDataState(state, 'columnController');
+      dataManagerToolbarFixture.detectChanges();
+    }
+
     beforeEach(() => {
       dataManagerToolbarComponent.activeView = undefined;
       dataManagerService.setColumnOptions([
@@ -950,7 +963,15 @@ describe('SkyDataManagerToolbarComponent', () => {
       dataManagerToolbarFixture.detectChanges();
     });
 
+    it('should not display the column picker button until the registered columns are reconciled into the data state', () => {
+      expect(
+        dataManagerToolbarNativeElement.querySelector('.sky-col-picker-btn'),
+      ).toBeNull();
+    });
+
     it('should display the column picker button when columns are registered', () => {
+      reconcileColumnState(['name', 'age']);
+
       expect(
         dataManagerToolbarNativeElement.querySelector('.sky-col-picker-btn'),
       ).toBeTruthy();
@@ -959,9 +980,7 @@ describe('SkyDataManagerToolbarComponent', () => {
     it('should open the column picker with the registered columns', () => {
       spyOn(modalServiceInstance, 'open').and.callThrough();
 
-      (
-        dataManagerToolbarComponent.dataState as SkyDataManagerState
-      ).displayedColumnIds = ['name'];
+      reconcileColumnState(['name']);
 
       const columnPickerBtn = dataManagerToolbarNativeElement.querySelector(
         '.sky-col-picker-btn',
@@ -1001,11 +1020,9 @@ describe('SkyDataManagerToolbarComponent', () => {
     });
 
     it('should save the returned columns to the data state', () => {
-      const updateSpy = spyOn(dataManagerService, 'updateDataState');
+      reconcileColumnState(['name']);
 
-      (
-        dataManagerToolbarComponent.dataState as SkyDataManagerState
-      ).displayedColumnIds = ['name'];
+      const updateSpy = spyOn(dataManagerService, 'updateDataState');
 
       const columnPickerBtn = dataManagerToolbarNativeElement.querySelector(
         '.sky-col-picker-btn',

--- a/libs/components/data-manager/src/lib/modules/data-manager/data-manager-toolbar/data-manager-toolbar.component.spec.ts
+++ b/libs/components/data-manager/src/lib/modules/data-manager/data-manager-toolbar/data-manager-toolbar.component.spec.ts
@@ -927,6 +927,104 @@ describe('SkyDataManagerToolbarComponent', () => {
     expect(dataManagerService.updateDataState).not.toHaveBeenCalled();
   });
 
+  it('should not open the column picker modal when there are no column options', () => {
+    spyOn(modalServiceInstance, 'open');
+
+    (
+      dataManagerToolbarComponent.activeView as SkyDataViewConfig
+    ).columnPickerEnabled = true;
+    dataManagerToolbarFixture.detectChanges();
+
+    dataManagerToolbarComponent.openColumnPicker();
+
+    expect(modalServiceInstance.open).not.toHaveBeenCalled();
+  });
+
+  describe('without a registered view', () => {
+    beforeEach(() => {
+      dataManagerToolbarComponent.activeView = undefined;
+      dataManagerService.setColumnOptions([
+        { id: 'name', labelText: 'Name' },
+        { id: 'age', labelText: 'Age' },
+      ]);
+      dataManagerToolbarFixture.detectChanges();
+    });
+
+    it('should display the column picker button when columns are registered', () => {
+      expect(
+        dataManagerToolbarNativeElement.querySelector('.sky-col-picker-btn'),
+      ).toBeTruthy();
+    });
+
+    it('should open the column picker with the registered columns', () => {
+      spyOn(modalServiceInstance, 'open').and.callThrough();
+
+      (
+        dataManagerToolbarComponent.dataState as SkyDataManagerState
+      ).displayedColumnIds = ['name'];
+
+      const columnPickerBtn = dataManagerToolbarNativeElement.querySelector(
+        '.sky-col-picker-btn',
+      ) as HTMLButtonElement;
+      columnPickerBtn.click();
+
+      expect(modalServiceInstance.open).toHaveBeenCalledWith(
+        SkyDataManagerColumnPickerComponent,
+        {
+          providers: [
+            SKY_DATA_MANAGER_COLUMN_PICKER_PROVIDERS,
+            {
+              provide: SkyDataManagerColumnPickerContext,
+              useValue: new SkyDataManagerColumnPickerContext(
+                [
+                  {
+                    alwaysDisplayed: undefined,
+                    description: undefined,
+                    id: 'name',
+                    initialHide: undefined,
+                    label: 'Name',
+                  },
+                  {
+                    alwaysDisplayed: undefined,
+                    description: undefined,
+                    id: 'age',
+                    initialHide: undefined,
+                    label: 'Age',
+                  },
+                ],
+                ['name'],
+              ),
+            },
+          ],
+        },
+      );
+    });
+
+    it('should save the returned columns to the data state', () => {
+      const updateSpy = spyOn(dataManagerService, 'updateDataState');
+
+      (
+        dataManagerToolbarComponent.dataState as SkyDataManagerState
+      ).displayedColumnIds = ['name'];
+
+      const columnPickerBtn = dataManagerToolbarNativeElement.querySelector(
+        '.sky-col-picker-btn',
+      ) as HTMLButtonElement;
+      columnPickerBtn.click();
+
+      modalServiceInstance.closeCallback?.({
+        reason: 'save',
+        data: [{ id: 'name' }, { id: 'age' }],
+      });
+
+      expect(updateSpy).toHaveBeenCalled();
+      expect(
+        (updateSpy.calls.mostRecent().args[0] as SkyDataManagerState)
+          .displayedColumnIds,
+      ).toEqual(['name', 'age']);
+    });
+  });
+
   describe('a11y', () => {
     it('should set accessibility labels correctly when no list descriptor is given', () => {
       const patchInfoSpy = spyOn(

--- a/libs/components/data-manager/src/lib/modules/data-manager/data-manager-toolbar/data-manager-toolbar.component.ts
+++ b/libs/components/data-manager/src/lib/modules/data-manager/data-manager-toolbar/data-manager-toolbar.component.ts
@@ -6,6 +6,7 @@ import {
   OnDestroy,
   OnInit,
   afterNextRender,
+  computed,
   contentChildren,
   effect,
   inject,
@@ -210,6 +211,36 @@ export class SkyDataManagerToolbarComponent implements OnDestroy, OnInit {
     SkyDataManagerSortOptionComponent,
   );
 
+  /**
+   * The columns a column controller directive registered when no view config
+   * supplies them.
+   */
+  readonly #registeredColumnOptions = computed<
+    SkyDataManagerColumnPickerOption[] | undefined
+  >(() => {
+    const columns = this.#dataManagerService.columnOptions();
+
+    return columns?.map((column) => ({
+      alwaysDisplayed: column.alwaysDisplayed,
+      description: column.description,
+      id: column.id,
+      initialHide: column.initialHide,
+      label: column.labelText,
+    }));
+  });
+
+  /**
+   * Whether to display the column picker button. A view config can enable it,
+   * or a column controller directive can register the columns directly, which
+   * is how consumers who do not register a view enable it.
+   */
+  protected get columnPickerEnabled(): boolean {
+    return (
+      !!this.activeView?.columnPickerEnabled ||
+      !!this.#registeredColumnOptions()
+    );
+  }
+
   protected readonly primaryItems = contentChildren(
     SkyDataManagerToolbarPrimaryItemComponent,
   );
@@ -232,7 +263,7 @@ export class SkyDataManagerToolbarComponent implements OnDestroy, OnInit {
     return (
       !!this.activeView?.filterButtonEnabled ||
       !!this.activeView?.sortEnabled ||
-      !!this.activeView?.columnPickerEnabled ||
+      this.columnPickerEnabled ||
       !!this.activeView?.searchEnabled ||
       this.searchEnabled() === true ||
       this.sortOptions().length > 0 ||
@@ -437,51 +468,70 @@ export class SkyDataManagerToolbarComponent implements OnDestroy, OnInit {
   }
 
   public openColumnPicker(): void {
-    if (this.dataState && this.activeView && this.activeView.columnOptions) {
-      const viewState = this.dataState.getViewStateById(this.activeView.id);
-      if (viewState) {
-        const context = new SkyDataManagerColumnPickerContext(
-          this.activeView.columnOptions,
-          viewState.displayedColumnIds,
-        );
+    const columnOptions =
+      this.activeView?.columnOptions ?? this.#registeredColumnOptions();
+    const viewState = this.activeView
+      ? this.dataState?.getViewStateById(this.activeView.id)
+      : undefined;
 
-        if (this.activeView.columnPickerSortStrategy) {
-          context.columnPickerSortStrategy =
-            this.activeView.columnPickerSortStrategy;
-        }
+    // With a view config, the columns that display are tracked on the view's
+    // state; without one, they are tracked on the data state itself.
+    const displayedColumnIds = this.activeView
+      ? viewState?.displayedColumnIds
+      : this.dataState?.displayedColumnIds;
 
-        const options: SkyModalConfigurationInterface = {
-          providers: [
-            SKY_DATA_MANAGER_COLUMN_PICKER_PROVIDERS,
-            {
-              provide: SkyDataManagerColumnPickerContext,
-              useValue: context,
-            },
-          ],
-        };
-
-        const modalInstance = this.#modalService.open(
-          this.#columnPickerService.getComponentType(),
-          options,
-        );
-
-        modalInstance.closed.subscribe((result: SkyModalCloseArgs) => {
-          if (result.reason === 'save') {
-            const displayedColumnIds = result.data.map(
-              (col: SkyDataManagerColumnPickerOption) => col.id,
-            );
-
-            viewState.displayedColumnIds = displayedColumnIds;
-            if (this.dataState && this.activeView) {
-              this.dataState = this.dataState.addOrUpdateView(
-                this.activeView.id,
-                viewState,
-              );
-            }
-          }
-        });
-      }
+    if (!this.dataState || !columnOptions || !displayedColumnIds) {
+      return;
     }
+
+    const context = new SkyDataManagerColumnPickerContext(
+      columnOptions,
+      displayedColumnIds,
+    );
+
+    if (this.activeView?.columnPickerSortStrategy) {
+      context.columnPickerSortStrategy =
+        this.activeView.columnPickerSortStrategy;
+    }
+
+    const options: SkyModalConfigurationInterface = {
+      providers: [
+        SKY_DATA_MANAGER_COLUMN_PICKER_PROVIDERS,
+        {
+          provide: SkyDataManagerColumnPickerContext,
+          useValue: context,
+        },
+      ],
+    };
+
+    const modalInstance = this.#modalService.open(
+      this.#columnPickerService.getComponentType(),
+      options,
+    );
+
+    modalInstance.closed.subscribe((result: SkyModalCloseArgs) => {
+      if (result.reason !== 'save' || !this.dataState) {
+        return;
+      }
+
+      const selectedIds = result.data.map(
+        (col: SkyDataManagerColumnPickerOption) => col.id,
+      );
+
+      if (this.activeView && viewState) {
+        viewState.displayedColumnIds = selectedIds;
+        this.dataState = this.dataState.addOrUpdateView(
+          this.activeView.id,
+          viewState,
+        );
+      } else {
+        const newState = new SkyDataManagerState(
+          this.dataState.getStateOptions(),
+        );
+        newState.displayedColumnIds = selectedIds;
+        this.dataState = newState;
+      }
+    });
   }
 
   public selectAll(): void {

--- a/libs/components/data-manager/src/lib/modules/data-manager/data-manager-toolbar/data-manager-toolbar.component.ts
+++ b/libs/components/data-manager/src/lib/modules/data-manager/data-manager-toolbar/data-manager-toolbar.component.ts
@@ -2,14 +2,20 @@ import {
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
+  ModelSignal,
   OnDestroy,
   OnInit,
+  afterNextRender,
   contentChildren,
+  effect,
   inject,
+  input,
   isStandalone,
+  model,
+  signal,
 } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { SkyLogService } from '@skyux/core';
+import { SkyLogService, SkyUIConfigService } from '@skyux/core';
 import {
   SkyCheckboxChange,
   SkyCheckboxModule,
@@ -17,7 +23,7 @@ import {
 } from '@skyux/forms';
 import { SkyIconModule } from '@skyux/icon';
 import { SkyToolbarModule } from '@skyux/layout';
-import { SkyFilterModule, SkySortModule } from '@skyux/lists';
+import { SkyFilterModule, SkyFilterState, SkySortModule } from '@skyux/lists';
 import { SkySearchModule } from '@skyux/lookup';
 import {
   SkyModalCloseArgs,
@@ -26,8 +32,8 @@ import {
   SkyModalService,
 } from '@skyux/modals';
 
-import { Subject } from 'rxjs';
-import { takeUntil } from 'rxjs/operators';
+import { Subject, switchMap } from 'rxjs';
+import { take, takeUntil } from 'rxjs/operators';
 
 import { SkyDataManagerResourcesModule } from '../../shared/sky-data-manager-resources.module';
 import { SkyDataManagerColumnPickerContext } from '../data-manager-column-picker/data-manager-column-picker-context';
@@ -39,8 +45,10 @@ import { SkyDataManagerColumnPickerOption } from '../models/data-manager-column-
 import { SkyDataManagerConfig } from '../models/data-manager-config';
 import { SkyDataManagerSortOption } from '../models/data-manager-sort-option';
 import { SkyDataManagerState } from '../models/data-manager-state';
+import { SkyDataManagerStateOptions } from '../models/data-manager-state-options';
 import { SkyDataViewConfig } from '../models/data-view-config';
 
+import { SkyDataManagerSortOptionComponent } from './data-manager-sort-option.component';
 import { SkyDataManagerToolbarLeftItemComponent } from './data-manager-toolbar-left-item.component';
 import { SkyDataManagerToolbarPrimaryItemComponent } from './data-manager-toolbar-primary-item.component';
 import { SkyDataManagerToolbarRightItemComponent } from './data-manager-toolbar-right-item.component';
@@ -49,7 +57,11 @@ import { SkyDataManagerToolbarSectionComponent } from './data-manager-toolbar-se
 /**
  * Renders a `sky-toolbar` with the contents specified by the active view's `SkyDataViewConfig`
  * and the `SkyDataManagerToolbarLeftItemComponent`, `SkyDataManagerToolbarRightItemComponent`,
- * and `SkyDataManagerToolbarSectionComponent` wrappers.
+ * and `SkyDataManagerToolbarSectionComponent` wrappers. Also supports a signal-based API (see
+ * the `searchText`, `sort`, `filters`, `page`, `pageSize`, `selectedIds`, and `totalCount`
+ * models, and the `settingsKey`/`searchEnabled`/`searchPlaceholderText`/`multiselectEnabled`/
+ * `labelText` inputs) as an alternative to the config-driven `SkyDataViewConfig`/
+ * `SkyDataManagerConfig` path.
  */
 @Component({
   selector: 'sky-data-manager-toolbar',
@@ -109,6 +121,95 @@ export class SkyDataManagerToolbarComponent implements OnDestroy, OnInit {
 
   public onlyShowSelected: boolean | undefined;
 
+  /**
+   * The key to use for storing and retrieving this toolbar's data state from
+   * `SkyUIConfigService`. Presence alone turns on sticky-settings persistence for
+   * the signal-based API — no `initDataManager()` call is needed.
+   * @preview
+   */
+  public readonly settingsKey = input<string>();
+
+  /**
+   * Whether to display the search box, for the signal-based API. Ignored when an
+   * active view's `SkyDataViewConfig.searchEnabled` is set.
+   * @preview
+   */
+  public readonly searchEnabled = input<boolean>();
+
+  /**
+   * Placeholder text for the search box, for the signal-based API. Ignored when an
+   * active view's `SkyDataViewConfig.searchPlaceholderText` is set.
+   * @preview
+   */
+  public readonly searchPlaceholderText = input<string>();
+
+  /**
+   * Whether to display the multiselect toolbar, for the signal-based API. Ignored
+   * when an active view's `SkyDataViewConfig.multiselectToolbarEnabled` is set.
+   * @preview
+   */
+  public readonly multiselectEnabled = input<boolean>();
+
+  /**
+   * The label to display for the toolbar's list descriptor, for the signal-based
+   * API. Falls back to `dataManagerConfig?.listDescriptor` when unset.
+   * @preview
+   */
+  public readonly labelText = input<string>();
+
+  /**
+   * The current search text. Two-way bindable.
+   * @preview
+   */
+  public readonly searchText = model<string>('');
+
+  /**
+   * The current sort option. Two-way bindable.
+   * @preview
+   */
+  public readonly sort = model<SkyDataManagerSortOption | undefined>(undefined);
+
+  /**
+   * The current filter state. Two-way bindable. Synced automatically when a
+   * `sky-filter-bar` with `skyDataManagerFilterController` is projected into this
+   * toolbar.
+   * @preview
+   */
+  public readonly filters = model<SkyFilterState | undefined>(undefined);
+
+  /**
+   * The current page number. Two-way bindable. Resets to `1` whenever `sort`,
+   * `searchText`, or `filters` changes.
+   * @default 1
+   * @preview
+   */
+  public readonly page = model<number>(1);
+
+  /**
+   * The number of items to display per page. Two-way bindable.
+   * @preview
+   */
+  public readonly pageSize = model<number | undefined>(undefined);
+
+  /**
+   * The set of IDs for the currently selected rows or objects. Two-way bindable.
+   * @preview
+   */
+  public readonly selectedIds = model<string[]>([]);
+
+  /**
+   * The total number of items matching the current search/sort/filter, set by the
+   * consumer (for example, from a `resource()`'s response). Feeds the existing
+   * data summary pipeline used for the live-announcer and `sky-list-summary`.
+   * @default 0
+   * @preview
+   */
+  public readonly totalCount = model<number>(0);
+
+  protected readonly sortOptions = contentChildren(
+    SkyDataManagerSortOptionComponent,
+  );
+
   protected readonly primaryItems = contentChildren(
     SkyDataManagerToolbarPrimaryItemComponent,
   );
@@ -133,6 +234,8 @@ export class SkyDataManagerToolbarComponent implements OnDestroy, OnInit {
       !!this.activeView?.sortEnabled ||
       !!this.activeView?.columnPickerEnabled ||
       !!this.activeView?.searchEnabled ||
+      this.searchEnabled() === true ||
+      this.sortOptions().length > 0 ||
       (!!this.activeView && this.views.length > 1) ||
       this.primaryItems().length > 0 ||
       this.leftItems().length > 0 ||
@@ -152,10 +255,75 @@ export class SkyDataManagerToolbarComponent implements OnDestroy, OnInit {
   #_dataState: SkyDataManagerState | undefined;
   #_views: SkyDataViewConfig[] = [];
 
+  // Holds the most recent externally-sourced `SkyDataManagerState`, so it can
+  // be applied to this toolbar's models from an `effect()` (see the
+  // constructor) instead of directly from the `getDataStateUpdates()`
+  // subscription below. Applying it directly from the subscription can run
+  // synchronously inside this component's own `ngOnInit()` (for example, in
+  // response to an ancestor's `initDataManager()` call made earlier in the
+  // same synchronous call stack) --- i.e. in the middle of the very change
+  // detection pass that's also checking these models' two-way template
+  // bindings --- which trips `ExpressionChangedAfterItHasBeenCheckedError`.
+  // Effects are deferred by Angular specifically to avoid that.
+  readonly #incomingState = signal<SkyDataManagerState | undefined>(undefined);
+
   readonly #changeDetector = inject(ChangeDetectorRef);
   readonly #columnPickerService = inject(SkyDataManagerColumnPickerService);
   readonly #dataManagerService = inject(SkyDataManagerService);
   readonly #modalService = inject(SkyModalService);
+  readonly #uiConfigService = inject(SkyUIConfigService);
+
+  constructor() {
+    // Each of the following effects always runs once immediately upon
+    // registration (Angular's standard `effect()` behavior), before this
+    // toolbar's own `#seedInitialStateIfNeeded()` (deferred to
+    // `afterNextRender()`, see below) has had a chance to reconcile the models
+    // with the data manager's actual current state. Without skipping that
+    // first automatic run, every model's built-in default (`''`, `[]`, `1`,
+    // etc.) would be diffed against whatever state already exists --- which,
+    // for any consumer who hasn't bound that particular model, is very likely
+    // a mismatch --- and would incorrectly push the default over real state on
+    // every render. Only genuine subsequent changes (a two-way binding update,
+    // or an internal call like `sortSelected()`/`searchApplied()`) should push.
+    this.#pushOnChange(this.searchText, (value) =>
+      this.#pushStateField('searchText', value, true),
+    );
+    this.#pushOnChange(this.sort, (value) =>
+      this.#pushStateField('activeSortOption', value, true),
+    );
+    this.#pushOnChange(this.filters, (filters) =>
+      this.#pushStateField(
+        'filterData',
+        filters
+          ? { filtersApplied: this.#deriveFiltersApplied(filters), filters }
+          : undefined,
+        true,
+      ),
+    );
+    this.#pushOnChange(this.selectedIds, (value) =>
+      this.#pushStateField('selectedIds', value, false),
+    );
+    this.#pushOnChange(this.page, (value) =>
+      this.#pushStateField('page', value, false),
+    );
+    this.#pushOnChange(this.pageSize, (value) =>
+      this.#pushStateField('pageSize', value, false),
+    );
+    this.#pushOnChange(this.totalCount, (value) =>
+      this.#dataManagerService.updateDataSummary(
+        { totalItems: value, itemsMatching: value },
+        this.#_source,
+      ),
+    );
+    effect(() => {
+      const state = this.#incomingState();
+      if (state) {
+        this.#applyStateToModels(state);
+      }
+    });
+
+    afterNextRender(() => this.#seedInitialStateIfNeeded());
+  }
 
   public ngOnInit(): void {
     this.#dataManagerService
@@ -188,6 +356,7 @@ export class SkyDataManagerToolbarComponent implements OnDestroy, OnInit {
       .subscribe((dataState) => {
         this.#_dataState = dataState;
         this.onlyShowSelected = dataState.onlyShowSelected;
+        this.#incomingState.set(dataState);
         this.#changeDetector.markForCheck();
       });
 
@@ -205,10 +374,14 @@ export class SkyDataManagerToolbarComponent implements OnDestroy, OnInit {
   }
 
   public sortSelected(sortOption: SkyDataManagerSortOption): void {
-    if (this.dataState) {
-      this.dataState.activeSortOption = sortOption;
-      this.#dataManagerService.updateDataState(this.dataState, this.#_source);
-    }
+    this.sort.set(sortOption);
+    // Pushed synchronously (in addition to the `sort` model-to-state effect,
+    // which is only guaranteed to flush on a later change-detection pass) so
+    // that this legacy, config-driven entry point keeps its original,
+    // synchronous `updateDataState()` behavior. The effect's equality guard in
+    // `#pushStateField` makes its own later, redundant push for this same
+    // value a no-op.
+    this.#pushStateField('activeSortOption', sortOption, true);
   }
 
   public onViewChange(viewId: string): void {
@@ -216,10 +389,10 @@ export class SkyDataManagerToolbarComponent implements OnDestroy, OnInit {
   }
 
   public searchApplied(text: string): void {
-    if (this.dataState) {
-      this.dataState.searchText = text;
-      this.#dataManagerService.updateDataState(this.dataState, this.#_source);
-    }
+    this.searchText.set(text);
+    // See the comment in `sortSelected()` above: pushed synchronously to
+    // preserve this legacy entry point's original synchronous behavior.
+    this.#pushStateField('searchText', text, true);
   }
 
   public filterButtonClicked(): void {
@@ -329,6 +502,217 @@ export class SkyDataManagerToolbarComponent implements OnDestroy, OnInit {
     if (this.dataState) {
       this.dataState.onlyShowSelected = !!event.checked;
       this.#dataManagerService.updateDataState(this.dataState, this.#_source);
+    }
+  }
+
+  /**
+   * Registers an `effect()` that invokes `onChange` with `model`'s value on
+   * every change *except* the first (Angular always runs a fresh `effect()`
+   * once immediately upon registration, purely to record its dependencies).
+   * Used for the model-to-state sync effects, so a model's own default value
+   * is never diffed against and pushed over already-existing data manager
+   * state before `#seedInitialStateIfNeeded()` has run.
+   */
+  #pushOnChange<T>(model: ModelSignal<T>, onChange: (value: T) => void): void {
+    let isFirstRun = true;
+
+    effect(() => {
+      const value = model();
+
+      if (isFirstRun) {
+        isFirstRun = false;
+        return;
+      }
+
+      onChange(value);
+    });
+  }
+
+  /**
+   * Pushes `value` for `key` into the data manager state, unless it already
+   * matches the current state (this equality check is what prevents the
+   * model-to-state effects above from looping against the state-to-model sync in
+   * `ngOnInit`'s `getDataStateUpdates()` subscription). When `resetPage` is true
+   * and the push actually changes something, also resets `page` to `1`.
+   */
+  #pushStateField<K extends keyof SkyDataManagerStateOptions>(
+    key: K,
+    value: SkyDataManagerStateOptions[K],
+    resetPage: boolean,
+  ): void {
+    const current = this.#dataManagerService.state().getStateOptions();
+
+    if (
+      JSON.stringify(this.#normalizeForCompare(key, current[key])) ===
+      JSON.stringify(this.#normalizeForCompare(key, value))
+    ) {
+      return;
+    }
+
+    const partial: Partial<SkyDataManagerStateOptions> = { [key]: value };
+
+    if (resetPage && (current.page ?? 1) !== 1) {
+      partial.page = 1;
+      this.page.set(1);
+    }
+
+    // Pushed via `updateDataState()` (tagged with this toolbar's own `#_source`)
+    // rather than the service's public `updateState()` (which always tags pushes
+    // with a fixed internal source). Using `#_source` here means the `ngOnInit`
+    // `getDataStateUpdates(this.#_source)` subscription below correctly filters
+    // out state changes the toolbar itself just caused, consistent with every
+    // other state push this component already makes (see `onOnlyShowSelected`,
+    // `filterButtonClicked`, `openColumnPicker`), instead of introducing a second,
+    // differently-sourced write path that those existing subscribers can't filter.
+    // Mutated in place on the existing `#_dataState` object (mirroring the
+    // existing `onOnlyShowSelected()` / `filterButtonClicked()` /
+    // `openColumnPicker()` pattern of mutating `this.dataState` before
+    // pushing), rather than replacing `#_dataState` with a new object,
+    // because the `getDataStateUpdates()` subscription in `ngOnInit()`
+    // filters out updates sourced from `this.#_source` --- i.e. this
+    // toolbar's own pushes --- so it never reflects this change back into
+    // `#_dataState` on its own. Any existing reference to `this.dataState`
+    // a consumer is holding needs to observe this change the same way it
+    // always could for those other methods.
+    const dataState = this.#_dataState ?? new SkyDataManagerState(current);
+    Object.assign(dataState, partial);
+    this.#_dataState = dataState;
+    this.#dataManagerService.updateDataState(dataState, this.#_source);
+  }
+
+  /**
+   * Reflects an incoming `SkyDataManagerState` (from any source) into this
+   * toolbar's models, skipping fields that already match to avoid re-triggering
+   * the model-to-state effects above.
+   */
+  #applyStateToModels(state: SkyDataManagerState): void {
+    this.#setIfChanged(this.searchText, state.searchText ?? '');
+    this.#setIfChanged(this.sort, state.activeSortOption);
+    this.#setIfChanged(
+      this.filters,
+      state.filterData?.filters as SkyFilterState | undefined,
+    );
+    this.#setIfChanged(this.selectedIds, state.selectedIds ?? []);
+    this.#setIfChanged(this.page, state.page ?? 1);
+    if (state.pageSize !== undefined) {
+      this.#setIfChanged(this.pageSize, state.pageSize);
+    }
+  }
+
+  /**
+   * Derives whether filters are considered "applied" from a `SkyFilterState`,
+   * matching `SkyDataManagerFilterControllerDirective#updateDataManagerFromAdapter()`'s
+   * derivation (a non-empty `appliedFilters` array), rather than treating any
+   * truthy `filters` object --- including one with an empty `appliedFilters`
+   * array, or none at all --- as "applied".
+   */
+  #deriveFiltersApplied(filters: SkyFilterState | undefined): boolean {
+    return !!(filters?.appliedFilters && filters.appliedFilters.length > 0);
+  }
+
+  #setIfChanged<T>(model: ModelSignal<T>, value: T): void {
+    if (JSON.stringify(model()) !== JSON.stringify(value)) {
+      model.set(value);
+    }
+  }
+
+  /**
+   * Normalizes `value` for `key` so that an unset `SkyDataManagerStateOptions`
+   * field (`undefined`) compares equal to the corresponding model's own
+   * built-in default (`''`, `[]`, or `1`). Without this, a model that was
+   * never explicitly touched would still be diffed, as its concrete default,
+   * against `undefined` in state that has genuinely never been set --- always
+   * finding a "difference" and pushing that default over real state on every
+   * render, for every consumer regardless of whether they use these models.
+   */
+  #normalizeForCompare<K extends keyof SkyDataManagerStateOptions>(
+    key: K,
+    value: SkyDataManagerStateOptions[K],
+  ): unknown {
+    switch (key) {
+      case 'searchText':
+        return value ?? '';
+      case 'selectedIds':
+        return value ?? [];
+      case 'page':
+        return value ?? 1;
+      default:
+        return value;
+    }
+  }
+
+  /**
+   * Seeds the data manager state from this toolbar's own inputs/models (or from
+   * persisted `settingsKey` state), but only if `initDataManager()` was never
+   * called for this service instance. Deferred to `afterNextRender()` so it runs
+   * after any ancestor component's `ngOnInit` (where `initDataManager()` is
+   * typically called) has already executed.
+   */
+  #seedInitialStateIfNeeded(): void {
+    if (this.#dataManagerService.isInitialized) {
+      return;
+    }
+
+    const settingsKey = this.settingsKey();
+    const defaultOptions: SkyDataManagerStateOptions = {
+      searchText: this.searchText(),
+      activeSortOption: this.sort(),
+      filterData: this.filters()
+        ? {
+            filtersApplied: this.#deriveFiltersApplied(this.filters()),
+            filters: this.filters(),
+          }
+        : undefined,
+      selectedIds: this.selectedIds(),
+      page: this.page(),
+      pageSize: this.pageSize(),
+    };
+
+    if (settingsKey) {
+      this.#uiConfigService
+        .getConfig(settingsKey, defaultOptions)
+        .pipe(take(1))
+        .subscribe((config) => {
+          this.#dataManagerService.updateState(config);
+        });
+
+      this.#dataManagerService
+        .getDataStateUpdates(this.#_source)
+        .pipe(
+          takeUntil(this.#ngUnsubscribe),
+          switchMap((state) =>
+            this.#uiConfigService.setConfig(
+              settingsKey,
+              state.getStateOptions(),
+            ),
+          ),
+        )
+        .subscribe({
+          error: (err) => {
+            console.warn('Could not save data manager toolbar settings.');
+            console.warn(err);
+          },
+        });
+    } else {
+      // Pushed field-by-field (through the same `#pushStateField()` used by
+      // the model-to-state effects, including its normalized equality guard)
+      // rather than as one `updateState(defaultOptions)` call. A consumer who
+      // never touches any of these models still has this seed check run
+      // (since `isInitialized` is false whenever `initDataManager()` was never
+      // called), and every model's built-in default would otherwise always be
+      // pushed over whatever state already exists --- including a
+      // `SkyDataManagerState` that a consumer/test set up some other way
+      // without going through `initDataManager()`.
+      this.#pushStateField('searchText', defaultOptions.searchText, false);
+      this.#pushStateField(
+        'activeSortOption',
+        defaultOptions.activeSortOption,
+        false,
+      );
+      this.#pushStateField('filterData', defaultOptions.filterData, false);
+      this.#pushStateField('selectedIds', defaultOptions.selectedIds, false);
+      this.#pushStateField('page', defaultOptions.page, false);
+      this.#pushStateField('pageSize', defaultOptions.pageSize, false);
     }
   }
 }

--- a/libs/components/data-manager/src/lib/modules/data-manager/data-manager-toolbar/data-manager-toolbar.component.ts
+++ b/libs/components/data-manager/src/lib/modules/data-manager/data-manager-toolbar/data-manager-toolbar.component.ts
@@ -126,7 +126,10 @@ export class SkyDataManagerToolbarComponent implements OnDestroy, OnInit {
   /**
    * The key to use for storing and retrieving this toolbar's data state from
    * `SkyUIConfigService`. Presence alone turns on sticky-settings persistence for
-   * the signal-based API — no `initDataManager()` call is needed.
+   * the signal-based API — no `initDataManager()` call is needed. Ignored when
+   * `initDataManager()` has already initialized the data manager: consumers who
+   * call `initDataManager()` must configure persistence through its
+   * `SkyDataManagerConfig` instead of setting this input.
    * @preview
    */
   public readonly settingsKey = input<string>();
@@ -237,12 +240,18 @@ export class SkyDataManagerToolbarComponent implements OnDestroy, OnInit {
   /**
    * Whether to display the column picker button. A view config can enable it,
    * or a column controller directive can register the columns directly, which
-   * is how consumers who do not register a view enable it.
+   * is how consumers who do not register a view enable it. Without a view, the
+   * button waits for the column controller to reconcile the registered columns
+   * into the data state, since the picker has nothing to display until then.
    */
   protected get columnPickerEnabled(): boolean {
+    if (this.activeView?.columnPickerEnabled) {
+      return true;
+    }
+
     return (
-      !!this.activeView?.columnPickerEnabled ||
-      !!this.#registeredColumnOptions()
+      !!this.#registeredColumnOptions()?.length &&
+      !!this.dataState?.displayedColumnIds
     );
   }
 

--- a/libs/components/data-manager/src/lib/modules/data-manager/data-manager-toolbar/data-manager-toolbar.component.ts
+++ b/libs/components/data-manager/src/lib/modules/data-manager/data-manager-toolbar/data-manager-toolbar.component.ts
@@ -6,6 +6,7 @@ import {
   OnDestroy,
   OnInit,
   afterNextRender,
+  booleanAttribute,
   computed,
   contentChildren,
   effect,
@@ -135,7 +136,9 @@ export class SkyDataManagerToolbarComponent implements OnDestroy, OnInit {
    * active view's `SkyDataViewConfig.searchEnabled` is set.
    * @preview
    */
-  public readonly searchEnabled = input<boolean>();
+  public readonly searchEnabled = input<boolean, unknown>(false, {
+    transform: booleanAttribute,
+  });
 
   /**
    * Placeholder text for the search box, for the signal-based API. Ignored when an
@@ -149,7 +152,9 @@ export class SkyDataManagerToolbarComponent implements OnDestroy, OnInit {
    * when an active view's `SkyDataViewConfig.multiselectToolbarEnabled` is set.
    * @preview
    */
-  public readonly multiselectEnabled = input<boolean>();
+  public readonly multiselectEnabled = input<boolean, unknown>(false, {
+    transform: booleanAttribute,
+  });
 
   /**
    * The label to display for the toolbar's list descriptor, for the signal-based

--- a/libs/components/data-manager/src/lib/modules/data-manager/data-manager.component.spec.ts
+++ b/libs/components/data-manager/src/lib/modules/data-manager/data-manager.component.spec.ts
@@ -1,10 +1,13 @@
+import { Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
 import { expect, expectAsync } from '@skyux-sdk/testing';
 import { SkyLiveAnnouncerService } from '@skyux/core';
 import { provideSkyMediaQueryTesting } from '@skyux/core/testing';
 import { SkyTextHighlightDirective } from '@skyux/indicators';
 import { SkyBackToTopMessageType } from '@skyux/layout';
 
+import { SkyDataManagerComponent } from './data-manager.component';
 import { SkyDataManagerService } from './data-manager.service';
 import { SkyDataViewComponent } from './data-view.component';
 import { DataViewCardFixtureComponent } from './fixtures/data-manager-card-view.component.fixture';
@@ -258,5 +261,46 @@ describe('SkyDataManagerComponent', () => {
     await validateDockCssClass('none', 'sky-data-manager-dock-none');
     await validateDockCssClass('fill', 'sky-data-manager-dock-fill');
     await validateDockCssClass(undefined, 'sky-data-manager-dock-none');
+  });
+
+  describe('self-providing SkyDataManagerService', () => {
+    it('reuses an ancestor-provided SkyDataManagerService instance instead of creating its own', () => {
+      // The existing fixture module provides `SkyDataManagerService` itself, so the
+      // component must reuse that exact instance, not create a second one.
+      const ancestorInstance = TestBed.inject(SkyDataManagerService);
+      const fixture = TestBed.createComponent(DataManagerFixtureComponent);
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.dataManagerComponent).toBeTruthy();
+      const componentInjectedInstance = fixture.debugElement
+        .query(By.directive(SkyDataManagerComponent))
+        .injector.get(SkyDataManagerService);
+
+      expect(componentInjectedInstance).toBe(ancestorInstance);
+    });
+
+    it('self-provides SkyDataManagerService when no ancestor provides it', async () => {
+      @Component({
+        selector: 'sky-data-manager-no-provider-fixture',
+        template: `<sky-data-manager />`,
+        imports: [SkyDataManagerComponent],
+      })
+      class NoProviderFixtureComponent {}
+
+      TestBed.resetTestingModule();
+      await TestBed.configureTestingModule({
+        imports: [NoProviderFixtureComponent],
+      }).compileComponents();
+
+      const fixture = TestBed.createComponent(NoProviderFixtureComponent);
+      fixture.detectChanges();
+
+      const injectedInstance = fixture.debugElement
+        .query(By.directive(SkyDataManagerComponent))
+        .injector.get(SkyDataManagerService);
+
+      expect(injectedInstance).toBeInstanceOf(SkyDataManagerService);
+      expect(TestBed.inject(SkyDataManagerService, null)).toBeNull();
+    });
   });
 });

--- a/libs/components/data-manager/src/lib/modules/data-manager/data-manager.component.ts
+++ b/libs/components/data-manager/src/lib/modules/data-manager/data-manager.component.ts
@@ -8,7 +8,11 @@ import {
   inject,
   input,
 } from '@angular/core';
-import { SkyLiveAnnouncerService, SkyViewkeeperModule } from '@skyux/core';
+import {
+  SkyLiveAnnouncerService,
+  SkyUIConfigService,
+  SkyViewkeeperModule,
+} from '@skyux/core';
 import { SkyLibResourcesService } from '@skyux/i18n';
 import {
   SkyBackToTopMessage,
@@ -28,7 +32,8 @@ const VIEWKEEPER_CLASSES_DEFAULT = ['.sky-data-manager-toolbar'];
 const DEFAULT_DOCK_TYPE: SkyDataManagerDockType = 'none';
 
 /**
- * The top-level data manager component. Provide `SkyDataManagerService` at this level.
+ * The top-level data manager component. Providing `SkyDataManagerService` at this level is
+ * optional --- this component self-provides an instance if no ancestor already provides one.
  */
 @Component({
   selector: 'sky-data-manager',
@@ -36,6 +41,14 @@ const DEFAULT_DOCK_TYPE: SkyDataManagerDockType = 'none';
   styleUrl: './data-manager.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [SkyBackToTopModule, SkyViewkeeperModule],
+  providers: [
+    {
+      provide: SkyDataManagerService,
+      useFactory: (): SkyDataManagerService =>
+        inject(SkyDataManagerService, { skipSelf: true, optional: true }) ??
+        new SkyDataManagerService(inject(SkyUIConfigService)),
+    },
+  ],
 })
 export class SkyDataManagerComponent implements OnDestroy, OnInit {
   public get currentViewkeeperClasses(): string[] {

--- a/libs/components/data-manager/src/lib/modules/data-manager/data-manager.module.ts
+++ b/libs/components/data-manager/src/lib/modules/data-manager/data-manager.module.ts
@@ -2,6 +2,7 @@ import { NgModule } from '@angular/core';
 
 import { SKY_DATA_MANAGER_COLUMN_PICKER_PROVIDERS } from './data-manager-column-picker/data-manager-column-picker-providers';
 import { SkyDataManagerFilterControllerDirective } from './data-manager-filters/data-manager-filter-controller.directive';
+import { SkyDataManagerSortOptionComponent } from './data-manager-toolbar/data-manager-sort-option.component';
 import { SkyDataManagerToolbarLeftItemComponent } from './data-manager-toolbar/data-manager-toolbar-left-item.component';
 import { SkyDataManagerToolbarPrimaryItemComponent } from './data-manager-toolbar/data-manager-toolbar-primary-item.component';
 import { SkyDataManagerToolbarRightItemComponent } from './data-manager-toolbar/data-manager-toolbar-right-item.component';
@@ -14,6 +15,7 @@ import { SkyDataViewComponent } from './data-view.component';
   imports: [
     SkyDataManagerComponent,
     SkyDataManagerFilterControllerDirective,
+    SkyDataManagerSortOptionComponent,
     SkyDataManagerToolbarComponent,
     SkyDataManagerToolbarLeftItemComponent,
     SkyDataManagerToolbarPrimaryItemComponent,
@@ -24,6 +26,7 @@ import { SkyDataViewComponent } from './data-view.component';
   exports: [
     SkyDataManagerComponent,
     SkyDataManagerFilterControllerDirective,
+    SkyDataManagerSortOptionComponent,
     SkyDataManagerToolbarComponent,
     SkyDataManagerToolbarLeftItemComponent,
     SkyDataManagerToolbarPrimaryItemComponent,

--- a/libs/components/data-manager/src/lib/modules/data-manager/data-manager.module.ts
+++ b/libs/components/data-manager/src/lib/modules/data-manager/data-manager.module.ts
@@ -1,6 +1,7 @@
 import { NgModule } from '@angular/core';
 
 import { SKY_DATA_MANAGER_COLUMN_PICKER_PROVIDERS } from './data-manager-column-picker/data-manager-column-picker-providers';
+import { SkyDataManagerColumnControllerDirective } from './data-manager-columns/data-manager-column-controller.directive';
 import { SkyDataManagerFilterControllerDirective } from './data-manager-filters/data-manager-filter-controller.directive';
 import { SkyDataManagerSortOptionComponent } from './data-manager-toolbar/data-manager-sort-option.component';
 import { SkyDataManagerToolbarLeftItemComponent } from './data-manager-toolbar/data-manager-toolbar-left-item.component';
@@ -13,6 +14,7 @@ import { SkyDataViewComponent } from './data-view.component';
 
 @NgModule({
   imports: [
+    SkyDataManagerColumnControllerDirective,
     SkyDataManagerComponent,
     SkyDataManagerFilterControllerDirective,
     SkyDataManagerSortOptionComponent,
@@ -24,6 +26,7 @@ import { SkyDataViewComponent } from './data-view.component';
     SkyDataViewComponent,
   ],
   exports: [
+    SkyDataManagerColumnControllerDirective,
     SkyDataManagerComponent,
     SkyDataManagerFilterControllerDirective,
     SkyDataManagerSortOptionComponent,

--- a/libs/components/data-manager/src/lib/modules/data-manager/data-manager.service.spec.ts
+++ b/libs/components/data-manager/src/lib/modules/data-manager/data-manager.service.spec.ts
@@ -1087,4 +1087,49 @@ describe('SkyDataManagerService', () => {
     expect(viewkeeperClasses?.[viewId]).toBeDefined();
     expect(viewkeeperClasses?.[viewId].includes(newClass)).toBeTrue();
   });
+
+  describe('state signal and updateState()', () => {
+    it('reflects the current data state as a signal', () => {
+      expect(dataManagerService.state().searchText).toBeUndefined();
+
+      dataManagerService.updateState({ searchText: 'mango' });
+
+      expect(dataManagerService.state().searchText).toBe('mango');
+    });
+
+    it('merges partial updates onto the current state without a sourceId', () => {
+      dataManagerService.updateState({ searchText: 'mango', page: 2 });
+      dataManagerService.updateState({ page: 3 });
+
+      expect(dataManagerService.state().searchText).toBe('mango');
+      expect(dataManagerService.state().page).toBe(3);
+    });
+
+    it('emits updateState() changes to existing getDataStateUpdates() subscribers', () => {
+      let received: string | undefined;
+      dataManagerService
+        .getDataStateUpdates('someOtherSource')
+        .subscribe((state) => (received = state.searchText));
+
+      dataManagerService.updateState({ searchText: 'lime' });
+
+      expect(received).toBe('lime');
+    });
+
+    it('reports isInitialized as false until initDataManager() is called', () => {
+      const freshService = new SkyDataManagerService(
+        TestBed.inject(SkyUIConfigService),
+      );
+
+      expect(freshService.isInitialized).toBeFalse();
+
+      freshService.initDataManager({
+        activeViewId: 'view1',
+        dataManagerConfig: {},
+        defaultDataState: new SkyDataManagerState({}),
+      });
+
+      expect(freshService.isInitialized).toBeTrue();
+    });
+  });
 });

--- a/libs/components/data-manager/src/lib/modules/data-manager/data-manager.service.ts
+++ b/libs/components/data-manager/src/lib/modules/data-manager/data-manager.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, OnDestroy, Signal, signal } from '@angular/core';
 import { SkyUIConfigService } from '@skyux/core';
+import { SkyDataColumnOption } from '@skyux/lists';
 
 import {
   BehaviorSubject,
@@ -57,6 +58,9 @@ export class SkyDataManagerService implements OnDestroy {
   #stateUpdateSource = 'dataManagerServiceUpdateState';
   #uiConfigService: SkyUIConfigService;
   #state = signal<SkyDataManagerState>(new SkyDataManagerState({}));
+  readonly #columnOptions = signal<SkyDataColumnOption[] | undefined>(
+    undefined,
+  );
 
   // eslint-disable-next-line @angular-eslint/prefer-inject -- constructor injection is required to maintain the public API for consumers who may instantiate this service directly (e.g. `new SkyDataManagerService(...)`).
   constructor(uiConfigService: SkyUIConfigService) {
@@ -417,6 +421,23 @@ export class SkyDataManagerService implements OnDestroy {
       currentViews[existingViewIndex] = view;
       this.#views.next(currentViews);
     }
+  }
+
+  /**
+   * The columns registered by a column controller directive for consumers who
+   * display columns without a `SkyDataViewConfig`-registered view. The catalog
+   * is intentionally kept out of `SkyDataManagerState`, which is persisted.
+   * @internal
+   */
+  public readonly columnOptions = this.#columnOptions.asReadonly();
+
+  /**
+   * Registers the columns available to a column picker when no view config
+   * supplies them.
+   * @internal
+   */
+  public setColumnOptions(options: SkyDataColumnOption[] | undefined): void {
+    this.#columnOptions.set(options);
   }
 
   /**

--- a/libs/components/data-manager/src/lib/modules/data-manager/data-manager.service.ts
+++ b/libs/components/data-manager/src/lib/modules/data-manager/data-manager.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, OnDestroy } from '@angular/core';
+import { Injectable, OnDestroy, Signal, signal } from '@angular/core';
 import { SkyUIConfigService } from '@skyux/core';
 
 import {
@@ -34,7 +34,9 @@ import { SkyDataViewState } from './models/data-view-state';
  *
  * Provide this service at the component level for each instance of a data manager. Do not
  * provide it at the module level or in `app-extras`. This allows multiple data
- * managers to be used and self-contained.
+ * managers to be used and self-contained. `SkyDataManagerComponent` self-provides an
+ * instance if none is provided by an ancestor, so providing it explicitly is optional
+ * when a single `SkyDataManagerComponent` is the closest ancestor.
  */
 @Injectable()
 export class SkyDataManagerService implements OnDestroy {
@@ -52,11 +54,20 @@ export class SkyDataManagerService implements OnDestroy {
   #isInitialized: boolean | undefined;
   #ngUnsubscribe = new Subject<void>();
   #initSource = 'dataManagerServiceInit';
+  #stateUpdateSource = 'dataManagerServiceUpdateState';
   #uiConfigService: SkyUIConfigService;
+  #state = signal<SkyDataManagerState>(new SkyDataManagerState({}));
 
   // eslint-disable-next-line @angular-eslint/prefer-inject -- constructor injection is required to maintain the public API for consumers who may instantiate this service directly (e.g. `new SkyDataManagerService(...)`).
   constructor(uiConfigService: SkyUIConfigService) {
     this.#uiConfigService = uiConfigService;
+
+    // Manual subscription (not `toSignal()`) because this service supports being
+    // constructed manually outside of Angular DI (see the constructor above),
+    // where `toSignal()`'s injection-context requirement would throw.
+    this.#dataStateChange
+      .pipe(takeUntil(this.#ngUnsubscribe))
+      .subscribe((change) => this.#state.set(change.dataState));
   }
 
   public ngOnDestroy(): void {
@@ -66,6 +77,38 @@ export class SkyDataManagerService implements OnDestroy {
     this.#dataStateChange.complete();
     this.#ngUnsubscribe.next();
     this.#ngUnsubscribe.complete();
+  }
+
+  /**
+   * A signal projection of the current data state, suitable for driving an Angular
+   * `resource()`'s `params()` callback. Reflects changes from any source, including
+   * `initDataManager()`, `updateDataState()`, and `updateState()`.
+   * @preview
+   */
+  public readonly state: Signal<SkyDataManagerState> = this.#state.asReadonly();
+
+  /**
+   * Whether `initDataManager()` has already been called on this service instance.
+   * @preview
+   */
+  public get isInitialized(): boolean {
+    return !!this.#isInitialized;
+  }
+
+  /**
+   * Merges `partial` into the current data state and emits the result to entities
+   * subscribed to data state changes (`getDataStateUpdates()`, `state`). Unlike
+   * `updateDataState()`, callers do not need to invent or track a `sourceId`.
+   * @param partial The properties to merge into the current `SkyDataManagerState`.
+   * @preview
+   */
+  public updateState(partial: Partial<SkyDataManagerStateOptions>): void {
+    const merged = new SkyDataManagerState({
+      ...this.state().getStateOptions(),
+      ...partial,
+    });
+
+    this.updateDataState(merged, this.#stateUpdateSource);
   }
 
   /**
@@ -377,7 +420,12 @@ export class SkyDataManagerService implements OnDestroy {
   }
 
   /**
-   * @internal
+   * Registers CSS selectors for a view's elements that should stick to the top of
+   * the page alongside the data manager toolbar (for example, a grid's header row).
+   * `SkyDataManagerComponent` combines these with its own toolbar selector when
+   * setting up `SkyViewkeeperModule`.
+   * @param viewId The ID of the view contributing the selectors.
+   * @param classes The CSS selectors for the view's elements to stick.
    */
   public setViewkeeperClasses(viewId: string, classes: string[]): void {
     const viewkeeperClasses = this.viewkeeperClasses.value;

--- a/libs/components/data-manager/src/lib/modules/data-manager/models/data-manager-state-options.ts
+++ b/libs/components/data-manager/src/lib/modules/data-manager/models/data-manager-state-options.ts
@@ -23,6 +23,20 @@ export interface SkyDataManagerStateOptions {
    */
   onlyShowSelected?: boolean;
   /**
+   * The current page number to display. Used by the signal-based
+   * `SkyDataManagerToolbarComponent` API for consumers paging data without a
+   * `SkyDataViewConfig`-registered view.
+   * @preview
+   */
+  page?: number;
+  /**
+   * The number of items to display per page. Used by the signal-based
+   * `SkyDataManagerToolbarComponent` API for consumers paging data without a
+   * `SkyDataViewConfig`-registered view.
+   * @preview
+   */
+  pageSize?: number;
+  /**
    * The search text to apply.
    */
   searchText?: string;

--- a/libs/components/data-manager/src/lib/modules/data-manager/models/data-manager-state-options.ts
+++ b/libs/components/data-manager/src/lib/modules/data-manager/models/data-manager-state-options.ts
@@ -14,6 +14,22 @@ export interface SkyDataManagerStateOptions {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   additionalData?: any;
   /**
+   * The IDs of the columns available to display. Used by the signal-based
+   * `SkyDataManagerToolbarComponent` API for consumers displaying columns
+   * without a `SkyDataViewConfig`-registered view. This is tracked separately
+   * from `displayedColumnIds` so that a column the user hid can be
+   * distinguished from a column that has been newly added.
+   * @preview
+   */
+  columnIds?: string[];
+  /**
+   * The IDs of the columns to display, in display order. Used by the
+   * signal-based `SkyDataManagerToolbarComponent` API for consumers displaying
+   * columns without a `SkyDataViewConfig`-registered view.
+   * @preview
+   */
+  displayedColumnIds?: string[];
+  /**
    * The state of the filters.
    */
   filterData?: SkyDataManagerFilterData;

--- a/libs/components/data-manager/src/lib/modules/data-manager/models/data-manager-state.spec.ts
+++ b/libs/components/data-manager/src/lib/modules/data-manager/models/data-manager-state.spec.ts
@@ -1,0 +1,19 @@
+import { SkyDataManagerState } from './data-manager-state';
+
+describe('SkyDataManagerState', () => {
+  it('round-trips page and pageSize through getStateOptions', () => {
+    const state = new SkyDataManagerState({ page: 3, pageSize: 25 });
+
+    expect(state.page).toBe(3);
+    expect(state.pageSize).toBe(25);
+    expect(state.getStateOptions().page).toBe(3);
+    expect(state.getStateOptions().pageSize).toBe(25);
+  });
+
+  it('defaults page and pageSize to undefined when not provided', () => {
+    const state = new SkyDataManagerState({});
+
+    expect(state.page).toBeUndefined();
+    expect(state.pageSize).toBeUndefined();
+  });
+});

--- a/libs/components/data-manager/src/lib/modules/data-manager/models/data-manager-state.ts
+++ b/libs/components/data-manager/src/lib/modules/data-manager/models/data-manager-state.ts
@@ -20,6 +20,22 @@ export class SkyDataManagerState {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   public additionalData: any;
   /**
+   * The IDs of the columns available to display. Used by the signal-based
+   * `SkyDataManagerToolbarComponent` API for consumers displaying columns
+   * without a `SkyDataViewConfig`-registered view. This is tracked separately
+   * from `displayedColumnIds` so that a column the user hid can be
+   * distinguished from a column that has been newly added.
+   * @preview
+   */
+  public columnIds: string[] | undefined;
+  /**
+   * The IDs of the columns to display, in display order. Used by the
+   * signal-based `SkyDataManagerToolbarComponent` API for consumers displaying
+   * columns without a `SkyDataViewConfig`-registered view.
+   * @preview
+   */
+  public displayedColumnIds: string[] | undefined;
+  /**
    * The state of the filters.
    */
   public filterData: SkyDataManagerFilterData | undefined;
@@ -57,6 +73,8 @@ export class SkyDataManagerState {
 
     this.activeSortOption = data.activeSortOption;
     this.additionalData = data.additionalData;
+    this.columnIds = data.columnIds;
+    this.displayedColumnIds = data.displayedColumnIds;
     this.filterData = data.filterData;
     this.onlyShowSelected = data.onlyShowSelected;
     this.page = data.page;
@@ -83,6 +101,10 @@ export class SkyDataManagerState {
         this.additionalData !== undefined
           ? safeStructuredClone(this.additionalData)
           : undefined,
+      columnIds: this.columnIds ? [...this.columnIds] : undefined,
+      displayedColumnIds: this.displayedColumnIds
+        ? [...this.displayedColumnIds]
+        : undefined,
       filterData: this.filterData
         ? {
             filtersApplied: this.filterData.filtersApplied,

--- a/libs/components/data-manager/src/lib/modules/data-manager/models/data-manager-state.ts
+++ b/libs/components/data-manager/src/lib/modules/data-manager/models/data-manager-state.ts
@@ -29,6 +29,16 @@ export class SkyDataManagerState {
    */
   public onlyShowSelected: boolean | undefined;
   /**
+   * The current page number to display.
+   * @preview
+   */
+  public page: number | undefined;
+  /**
+   * The number of items to display per page.
+   * @preview
+   */
+  public pageSize: number | undefined;
+  /**
    * The search text to apply.
    */
   public searchText: string | undefined;
@@ -49,6 +59,8 @@ export class SkyDataManagerState {
     this.additionalData = data.additionalData;
     this.filterData = data.filterData;
     this.onlyShowSelected = data.onlyShowSelected;
+    this.page = data.page;
+    this.pageSize = data.pageSize;
     this.selectedIds = data.selectedIds;
     this.searchText = data.searchText;
     this.views = views || [];
@@ -81,6 +93,8 @@ export class SkyDataManagerState {
           }
         : undefined,
       onlyShowSelected: this.onlyShowSelected,
+      page: this.page,
+      pageSize: this.pageSize,
       searchText: this.searchText,
       selectedIds: this.selectedIds ? [...this.selectedIds] : undefined,
       views: viewStates,

--- a/libs/components/data-manager/testing/src/modules/data-manager/fixtures/data-manager-harness-test.component.ts
+++ b/libs/components/data-manager/testing/src/modules/data-manager/fixtures/data-manager-harness-test.component.ts
@@ -78,6 +78,8 @@ export class DataManagerHarnessTestComponent implements OnInit {
       columnPickerEnabled: true,
       sortEnabled: true,
       filterButtonEnabled: true,
+      onSelectAllClick: () => {},
+      onClearAllClick: () => {},
       columnOptions: [
         {
           id: 'selected',

--- a/libs/components/lists/documentation.json
+++ b/libs/components/lists/documentation.json
@@ -140,6 +140,18 @@
       "codeExamples": {
         "docsIds": ["ListsSortBasicExampleComponent"]
       }
+    },
+    "data-column-source": {
+      "development": {
+        "docsIds": ["SkyDataColumnSource", "SkyDataColumnOption"],
+        "primaryDocsId": "SkyDataColumnSource"
+      },
+      "testing": {
+        "docsIds": []
+      },
+      "codeExamples": {
+        "docsIds": []
+      }
     }
   }
 }

--- a/libs/components/lists/src/index.ts
+++ b/libs/components/lists/src/index.ts
@@ -10,6 +10,9 @@ export { SkyPagingContentChangeArgs } from './lib/modules/paging/types/paging-co
 export { SkyRepeaterExpandModeType } from './lib/modules/repeater/repeater-expand-mode-type';
 export { SkyRepeaterModule } from './lib/modules/repeater/repeater.module';
 
+export { SkyDataColumnOption } from './lib/modules/shared/data-column-source/data-column-option';
+export { SkyDataColumnSource } from './lib/modules/shared/data-column-source/data-column-source';
+
 export { SkyFilterState } from './lib/modules/shared/filter-state-service/filter-state';
 export { SkyFilterStateFilterItem } from './lib/modules/shared/filter-state-service/filter-state-filter-item';
 export { SkyFilterStateFilterValue } from './lib/modules/shared/filter-state-service/filter-state-filter-value';

--- a/libs/components/lists/src/lib/modules/shared/data-column-source/data-column-option.ts
+++ b/libs/components/lists/src/lib/modules/shared/data-column-source/data-column-option.ts
@@ -1,0 +1,30 @@
+/**
+ * Describes a column that a column-based component can display.
+ * @preview
+ */
+export interface SkyDataColumnOption {
+  /**
+   * Whether the column is always visible and is not offered as an option in a
+   * column picker. For example, a context menu column may always be visible.
+   */
+  alwaysDisplayed?: boolean;
+  /**
+   * The description text rendered beneath the column label in a column picker.
+   */
+  description?: string;
+  /**
+   * The unique ID of the column.
+   * @required
+   */
+  id: string;
+  /**
+   * Whether the column starts hidden. A column that is added after a column
+   * state has been stored displays automatically unless this is `true`.
+   */
+  initialHide?: boolean;
+  /**
+   * The label to display for the column in a column picker.
+   * @required
+   */
+  labelText: string;
+}

--- a/libs/components/lists/src/lib/modules/shared/data-column-source/data-column-source.ts
+++ b/libs/components/lists/src/lib/modules/shared/data-column-source/data-column-source.ts
@@ -1,0 +1,28 @@
+import { Signal } from '@angular/core';
+
+import { SkyDataColumnOption } from './data-column-option';
+
+/**
+ * Implemented by column-based components, such as a data grid, so that column
+ * picker UIs can discover the available columns and control which columns
+ * display without depending on the component itself.
+ * @preview
+ */
+export abstract class SkyDataColumnSource {
+  /**
+   * The columns the component can display, in declaration order.
+   */
+  public abstract readonly dataColumns: Signal<readonly SkyDataColumnOption[]>;
+
+  /**
+   * The IDs of the columns that currently display, in display order. This
+   * always reflects what the component displays, including its own default
+   * before any columns have been set.
+   */
+  public abstract readonly displayedColumnIds: Signal<readonly string[]>;
+
+  /**
+   * Sets the columns that display and their order.
+   */
+  public abstract setDisplayedColumnIds(columnIds: string[]): void;
+}

--- a/libs/components/packages/src/schematics/rules/convert-grid-to-data-grid/convert-grid-to-data-grid.spec.ts
+++ b/libs/components/packages/src/schematics/rules/convert-grid-to-data-grid/convert-grid-to-data-grid.spec.ts
@@ -96,7 +96,7 @@ describe('Convert Grid to Data Grid', () => {
     tree.create(
       'src/app/test.component.html',
       stripIndents`
-        <sky-grid [data]="data" hasToolbar="true" [height]="300" highlightText="x" [messageStream]="ms" multiselectRowId="key" [rowHighlightedId]="rid" [selectedColumnIds]="cols" (selectedColumnIdsChange)="onCols($event)" settingsKey="grid1" [width]="500" (columnWidthChange)="onW($event)" (rowDeleteCancel)="onCancel($event)" (rowDeleteConfirm)="onConfirm($event)"></sky-grid>
+        <sky-grid [data]="data" hasToolbar="true" [height]="300" highlightText="x" [messageStream]="ms" multiselectRowId="key" [rowHighlightedId]="rid" settingsKey="grid1" [width]="500" (columnWidthChange)="onW($event)" (rowDeleteCancel)="onCancel($event)" (rowDeleteConfirm)="onConfirm($event)"></sky-grid>
       `,
     );
     const result = await convert(tree);
@@ -107,9 +107,24 @@ describe('Convert Grid to Data Grid', () => {
     expect(hasLog('"hasToolbar" binding')).toBe(true);
     expect(hasLog('"settingsKey" binding')).toBe(true);
     expect(hasLog('"columnWidthChange" binding')).toBe(true);
-    expect(hasLog('"selectedColumnIdsChange" binding')).toBe(true);
     expect(hasLog('"rowDeleteCancel" binding')).toBe(true);
     expect(hasLog('"rowDeleteConfirm" binding')).toBe(true);
+  });
+
+  it('should keep the selected column ID bindings', async () => {
+    const tree = await createTestApp(runner, { projectName: 'test-app' });
+    tree.create(
+      'src/app/test.component.html',
+      stripIndents`
+        <sky-grid [data]="data" [selectedColumnIds]="cols" (selectedColumnIdsChange)="onCols($event)"></sky-grid>
+      `,
+    );
+    const result = await convert(tree);
+    expect(stripIndents`${result.readText('src/app/test.component.html')}`)
+      .toBe(stripIndents`
+      <sky-data-grid [data]="data" [selectedColumnIds]="cols" (selectedColumnIdsChange)="onCols($event)"></sky-data-grid>
+    `);
+    expect(hasLog('"selectedColumnIds" binding')).toBe(false);
   });
 
   it('should map description to helpPopoverContent and drop other column inputs', async () => {

--- a/libs/components/packages/src/schematics/rules/convert-grid-to-data-grid/convert-grid-to-data-grid.ts
+++ b/libs/components/packages/src/schematics/rules/convert-grid-to-data-grid/convert-grid-to-data-grid.ts
@@ -63,7 +63,8 @@ const LIST_VIEW_GRID_TAG = 'sky-list-view-grid';
  * because parse5 treats them as distinct attribute names. `fit`'s unbound
  * `width`/`scroll` literal values are additionally translated to `columnFit`'s
  * `container`/`content` values by `gridAttributeSwapCallback`. Anything not
- * listed (`data`, `selectedRowIds`) is copied through unchanged.
+ * listed (`data`, `selectedRowIds`, `selectedColumnIds`) is copied through
+ * unchanged.
  */
 const GRID_ATTRIBUTE_SWAPS: Record<string, string> = {
   enableMultiselect: 'multiselect',
@@ -85,9 +86,6 @@ const GRID_ATTRIBUTE_SWAPS: Record<string, string> = {
   '(rowDeleteConfirm)': '',
   rowHighlightedId: '',
   '[rowHighlightedId]': '',
-  selectedColumnIds: '',
-  '[selectedColumnIds]': '',
-  '(selectedColumnIdsChange)': '',
   settingsKey: '',
   '[settingsKey]': '',
   sortField: 'sort',
@@ -108,14 +106,12 @@ const GRID_REMOVED_INPUTS = [
   'messageStream',
   'multiselectRowId',
   'rowHighlightedId',
-  'selectedColumnIds',
   'settingsKey',
   'width',
 ];
 
 /** Outputs removed from `<sky-grid>` with no `<sky-data-grid>` equivalent. */
 const GRID_REMOVED_OUTPUTS = [
-  'selectedColumnIdsChange',
   'columnWidthChange',
   'rowDeleteCancel',
   'rowDeleteConfirm',

--- a/libs/components/packages/src/schematics/rules/convert-grid-to-data-grid/convert-grid-to-data-grid.ts
+++ b/libs/components/packages/src/schematics/rules/convert-grid-to-data-grid/convert-grid-to-data-grid.ts
@@ -243,6 +243,18 @@ function gridTagSwap(context: SchematicContext): SwapTagCallback<'sky-grid'> {
         'The "data" binding on <sky-grid> was copied to <sky-data-grid>, whose "data" input is typed as SkyDataGridRowData[]: each row object must have a unique string "id" property. Update the bound array if template type checking reports an assignment error.',
       );
     }
+    if (
+      hasAttribute(node, [
+        ...inputForms('selectedColumnIds'),
+        outputForm('selectedColumnIdsChange'),
+      ])
+    ) {
+      logOnce(
+        context,
+        'warn',
+        'The "selectedColumnIds"/"(selectedColumnIdsChange)" bindings on <sky-grid> were copied to <sky-data-grid>, where an empty array means every column displays instead of no columns. Review the bound value and handler.',
+      );
+    }
     for (const label of GRID_REMOVED_INPUTS) {
       if (hasAttribute(node, inputForms(label))) {
         logOnce(context, 'warn', gridRemovedMessage(label));


### PR DESCRIPTION
- **feat(components/data-manager): provide configuration inputs and make SkyDataManagerService optional**
- **feat(components/data-grid): data manager integration**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable data-grid columns with visibility, descriptions, ordering, locked columns, and persistent settings.
  * Added data-manager support for search, sorting, pagination, multiselect, column pickers, and state synchronization.
  * Added reusable sort options and column controls.
  * Preserved selected-column bindings when converting legacy grids.
  * Added searchable, sortable fruit data-grid and resource-backed list examples.

* **Documentation**
  * Added documentation for data-manager resources, column selection, and shared column configuration.

* **Tests**
  * Expanded coverage for column selection, toolbar behavior, state management, conversions, and examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->