### PR TITLE
fix(sdk/testing)!: visibility checks no longer ignore earlier failed rules

### DIFF
--- a/libs/sdk/testing/private/src/utility/check-visibility-options.ts
+++ b/libs/sdk/testing/private/src/utility/check-visibility-options.ts
@@ -25,6 +25,7 @@ export interface _SkyTestingCheckVisibilityOptions {
   /**
    * Indicates if the element's existence on the document should be considered when checking an
    * element's visibility. If the element exists, it is considered visible.
+   * @deprecated Existence is always checked, so this option has no effect.
    */
   checkExists?: boolean;
 }

--- a/libs/sdk/testing/private/src/utility/check-visibility.spec.ts
+++ b/libs/sdk/testing/private/src/utility/check-visibility.spec.ts
@@ -62,6 +62,11 @@ describe('checkVisibility', () => {
     el.style.display = 'none';
     el.style.visibility = 'visible';
 
+    vi.spyOn(el, 'getBoundingClientRect').mockReturnValue({
+      width: 100,
+      height: 50,
+    } as DOMRect);
+
     expect(
       _skyTestingCheckVisibility(el, {
         checkCssDisplay: true,

--- a/libs/sdk/testing/private/src/utility/check-visibility.spec.ts
+++ b/libs/sdk/testing/private/src/utility/check-visibility.spec.ts
@@ -58,20 +58,29 @@ describe('checkVisibility', () => {
     ).toBe(true);
   });
 
-  it('should return pass: true when checkExists is true and element exists', () => {
+  it('should return pass: false when an earlier check fails and a later check passes', () => {
+    el.style.display = 'none';
+    el.style.visibility = 'visible';
+
     expect(
       _skyTestingCheckVisibility(el, {
-        checkCssDisplay: false,
-        checkExists: true,
+        checkCssDisplay: true,
+        checkCssVisibility: true,
+        checkDimensions: true,
       }).pass,
-    ).toBe(true);
+    ).toBe(false);
   });
 
-  it('should return pass: false when checkExists is true and element is falsy', () => {
+  it('should return pass: false for a null element', () => {
+    expect(_skyTestingCheckVisibility(null).pass).toBe(false);
+  });
+
+  it('should return pass: false for an undefined element', () => {
     expect(
-      _skyTestingCheckVisibility(undefined as unknown as Element, {
+      _skyTestingCheckVisibility(undefined, {
         checkCssDisplay: false,
-        checkExists: true,
+        checkCssVisibility: true,
+        checkDimensions: true,
       }).pass,
     ).toBe(false);
   });

--- a/libs/sdk/testing/private/src/utility/check-visibility.ts
+++ b/libs/sdk/testing/private/src/utility/check-visibility.ts
@@ -5,38 +5,33 @@ const DEFAULTS: _SkyTestingCheckVisibilityOptions = {
   checkCssDisplay: true,
   checkCssVisibility: false,
   checkDimensions: false,
-  checkExists: false,
 };
 
 /**
  * @internal
  */
 export function _skyTestingCheckVisibility(
-  el: Element,
+  el: Element | null | undefined,
   options?: _SkyTestingCheckVisibilityOptions,
 ): MatcherResult {
   const settings = { ...DEFAULTS, ...options };
 
-  let pass = true;
+  let pass = !!el;
 
-  if (settings.checkExists) {
-    pass = !!el;
-  }
-
-  if (pass) {
+  if (el) {
     const computedStyle = window.getComputedStyle(el);
 
     if (settings.checkCssDisplay) {
-      pass = computedStyle.display !== 'none';
+      pass = pass && computedStyle.display !== 'none';
     }
 
     if (settings.checkCssVisibility) {
-      pass = computedStyle.visibility !== 'hidden';
+      pass = pass && computedStyle.visibility !== 'hidden';
     }
 
     if (settings.checkDimensions) {
       const box = el.getBoundingClientRect();
-      pass = box.width > 0 && box.height > 0;
+      pass = pass && box.width > 0 && box.height > 0;
     }
   }
 


### PR DESCRIPTION
[AB#3959363](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3959363)

BREAKING CHANGE

`toBeVisible` now requires every enabled check to pass. Previously each rule
overwrote the previous result, so the last enabled rule decided the outcome.
Assertions such as `toBeVisible({ checkCssVisibility: true })` against a
`display: none` element reported the element as visible and now correctly
report it as hidden, which may surface previously-masked test failures.
A `null` or `undefined` element now returns `false` instead of throwing, and
`checkExists` is deprecated because existence is always checked.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Visibility checks now correctly fail when an element is missing or undefined.
  - Earlier visibility failures are preserved instead of being overwritten by later passing checks.
  - Style, dimension, and visibility conditions now combine more reliably.

- **Documentation**
  - Clarified that element existence is always checked; the `checkExists` option no longer affects results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->