### PR TITLE
feat: tokenize the icon used by HTML select fields (#4619)

### DIFF
--- a/libs/components/forms/src/lib/modules/input-box/input-box.component.scss
+++ b/libs/components/forms/src/lib/modules/input-box/input-box.component.scss
@@ -116,8 +116,7 @@ sky-input-box {
       );
       background: var(
         --sky-override-input-box-select-background,
-        var(--sky-color-background-input-base)
-          url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjAiIGhlaWdodD0iMjAiIHZpZXdCb3g9IjAgMCAyMCAyMCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4NCjxwYXRoIGQ9Ik0xMC41MzAzIDIuNzE5NjdDMTAuMjM3NCAyLjQyNjc4IDkuNzYyNTYgMi40MjY3OCA5LjQ2OTY3IDIuNzE5NjdMNS4yMTk2NyA2Ljk2OTY3QzQuOTI2NzggNy4yNjI1NiA0LjkyNjc4IDcuNzM3NDQgNS4yMTk2NyA4LjAzMDMzQzUuNTEyNTYgOC4zMjMyMiA1Ljk4NzQ0IDguMzIzMjIgNi4yODAzMyA4LjAzMDMzTDEwIDQuMzEwNjZMMTMuNzE5NyA4LjAzMDMzQzE0LjAxMjYgOC4zMjMyMiAxNC40ODc0IDguMzIzMjIgMTQuNzgwMyA4LjAzMDMzQzE1LjA3MzIgNy43Mzc0NCAxNS4wNzMyIDcuMjYyNTYgMTQuNzgwMyA2Ljk2OTY3TDEwLjUzMDMgMi43MTk2N1pNMTQuNzgwMyAxMy4wMzAzTDEwLjUzMDMgMTcuMjgwM0MxMC4yMzc0IDE3LjU3MzIgOS43NjI1NiAxNy41NzMyIDkuNDY5NjcgMTcuMjgwM0w1LjIxOTY3IDEzLjAzMDNDNC45MjY3OCAxMi43Mzc0IDQuOTI2NzggMTIuMjYyNiA1LjIxOTY3IDExLjk2OTdDNS41MTI1NiAxMS42NzY4IDUuOTg3NDQgMTEuNjc2OCA2LjI4MDMzIDExLjk2OTdMMTAgMTUuNjg5M0wxMy43MTk3IDExLjk2OTdDMTQuMDEyNiAxMS42NzY4IDE0LjQ4NzQgMTEuNjc2OCAxNC43ODAzIDExLjk2OTdDMTUuMDczMiAxMi4yNjI2IDE1LjA3MzIgMTIuNzM3NCAxNC43ODAzIDEzLjAzMDNaIiBmaWxsPSIjMmI2YmQ1Ii8+DQo8L3N2Zz4NCg==)
+        var(--sky-color-background-input-base) var(--sky-image-select_icon-base)
           no-repeat right/var(--sky-size-icon-m) var(--sky-size-icon-m)
       );
       // This rule is not specific enough for modern theme. The modern theme version is specified in the modern section below.
@@ -126,8 +125,8 @@ sky-input-box {
         background: var(
           --sky-override-input-box-select-background-disabled,
           var(--sky-color-background-input-base)
-            url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjAiIGhlaWdodD0iMjAiIHZpZXdCb3g9IjAgMCAyMCAyMCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTEwLjUzMDMgMi43MTk2N0MxMC4yMzc0IDIuNDI2NzggOS43NjI1NiAyLjQyNjc4IDkuNDY5NjcgMi43MTk2N0w1LjIxOTY3IDYuOTY5NjdDNC45MjY3OCA3LjI2MjU2IDQuOTI2NzggNy43Mzc0NCA1LjIxOTY3IDguMDMwMzNDNS41MTI1NiA4LjMyMzIyIDUuOTg3NDQgOC4zMjMyMiA2LjI4MDMzIDguMDMwMzNMMTAgNC4zMTA2NkwxMy43MTk3IDguMDMwMzNDMTQuMDEyNiA4LjMyMzIyIDE0LjQ4NzQgOC4zMjMyMiAxNC43ODAzIDguMDMwMzNDMTUuMDczMiA3LjczNzQ0IDE1LjA3MzIgNy4yNjI1NiAxNC43ODAzIDYuOTY5NjdMMTAuNTMwMyAyLjcxOTY3Wk0xNC43ODAzIDEzLjAzMDNMMTAuNTMwMyAxNy4yODAzQzEwLjIzNzQgMTcuNTczMiA5Ljc2MjU2IDE3LjU3MzIgOS40Njk2NyAxNy4yODAzTDUuMjE5NjcgMTMuMDMwM0M0LjkyNjc4IDEyLjczNzQgNC45MjY3OCAxMi4yNjI2IDUuMjE5NjcgMTEuOTY5N0M1LjUxMjU2IDExLjY3NjggNS45ODc0NCAxMS42NzY4IDYuMjgwMzMgMTEuOTY5N0wxMCAxNS42ODkzTDEzLjcxOTcgMTEuOTY5N0MxNC4wMTI2IDExLjY3NjggMTQuNDg3NCAxMS42NzY4IDE0Ljc4MDMgMTEuOTY5N0MxNS4wNzMyIDEyLjI2MjYgMTUuMDczMiAxMi43Mzc0IDE0Ljc4MDMgMTMuMDMwM1oiIGZpbGw9IiM2NjZiNzAiLz4KPC9zdmc+)
-            no-repeat right/var(--sky-size-icon-m) var(--sky-size-icon-m)
+            var(--sky-image-select_icon-disabled) no-repeat
+            right/var(--sky-size-icon-m) var(--sky-size-icon-m)
         );
       }
 

--- a/libs/components/theme/src/lib/styles/_forms.scss
+++ b/libs/components/theme/src/lib/styles/_forms.scss
@@ -21,6 +21,10 @@
   --sky-override-form-control-color: var(--sky-text-color-default);
 }
 
+@include compatMixins.sky-default-overrides('select') {
+  --sky-override-select-icon-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA1IDEwIiB3aWR0aD0iNSIgaGVpZ2h0PSIxMCI+Cgk8c3R5bGU+CgkJdHNwYW4geyB3aGl0ZS1zcGFjZTpwcmUgfQoJCS5zaHAwIHsgZmlsbDogIzQ0NDQ0NCB9IAoJPC9zdHlsZT4KCTxwYXRoIGlkPSJMYXllciIgY2xhc3M9InNocDAiIGQ9Ik0xLjQxIDQuNjdMMi40OCAzLjE4TDMuNTQgNC42N0wxLjQxIDQuNjdMMS40MSA0LjY3WiIgLz4KCTxwYXRoIGlkPSJMYXllciIgY2xhc3M9InNocDAiIGQ9Ik0zLjU0IDUuMzNMMi40OCA2LjgyTDEuNDEgNS4zM0wzLjU0IDUuMzNMMy41NCA1LjMzWiIgLz4KPC9zdmc+);
+}
+
 .sky-form-control {
   width: 100%;
   padding: 6px 12px;
@@ -108,7 +112,7 @@ fieldset {
 select {
   appearance: none;
   background: #fff
-    url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA1IDEwIiB3aWR0aD0iNSIgaGVpZ2h0PSIxMCI+Cgk8c3R5bGU+CgkJdHNwYW4geyB3aGl0ZS1zcGFjZTpwcmUgfQoJCS5zaHAwIHsgZmlsbDogIzQ0NDQ0NCB9IAoJPC9zdHlsZT4KCTxwYXRoIGlkPSJMYXllciIgY2xhc3M9InNocDAiIGQ9Ik0xLjQxIDQuNjdMMi40OCAzLjE4TDMuNTQgNC42N0wxLjQxIDQuNjdMMS40MSA0LjY3WiIgLz4KCTxwYXRoIGlkPSJMYXllciIgY2xhc3M9InNocDAiIGQ9Ik0zLjU0IDUuMzNMMi40OCA2LjgyTDEuNDEgNS4zM0wzLjU0IDUuMzNMMy41NCA1LjMzWiIgLz4KPC9zdmc+)
+    var(--sky-override-select-icon-image, var(--sky-image-select_icon-base))
     no-repeat right / 15px 30px;
   @include mixins.sky-border(light, top, bottom, left, right);
   border-radius: $sky-border-radius;


### PR DESCRIPTION
:cherries: Cherry picked from #4619 [feat: tokenize the icon used by HTML select fields](https://github.com/blackbaud/skyux/pull/4619)

[AB#3444164](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3444164) 