### PR TITLE
fix(components/lookup): autocomplete does not clear value on blur when all values are allowed

### DIFF
--- a/libs/components/lookup/src/lib/modules/autocomplete/autocomplete.component.spec.ts
+++ b/libs/components/lookup/src/lib/modules/autocomplete/autocomplete.component.spec.ts
@@ -1644,6 +1644,31 @@ describe('Autocomplete component', () => {
         });
       }));
 
+      it('should not select the provisional placeholder as a canonical match when blurring before the delayed async result resolves', fakeAsync(() => {
+        component.allowAnyValue = true;
+        fixture.detectChanges();
+        tick();
+
+        const inputElement = getInputElement(true);
+        const notifySpy = spyOn(
+          asyncAutocomplete.selectionChange,
+          'emit',
+        ).and.callThrough();
+
+        enterSearch('Red', fixture, true);
+
+        // Blur immediately, before the 150ms delayed async result (which
+        // would resolve to the canonical { name: 'Red', objectid: 'abc' })
+        // has a chance to arrive.
+        blurInput(inputElement, fixture);
+
+        expect(notifySpy).toHaveBeenCalledWith({
+          selectedItem: { name: 'Red' },
+        });
+
+        tick(200);
+      }));
+
       it('should not show the search text item when an exact match is loaded', fakeAsync(() => {
         component.allowAnyValue = true;
         fixture.detectChanges();

--- a/libs/components/lookup/src/lib/modules/autocomplete/autocomplete.component.spec.ts
+++ b/libs/components/lookup/src/lib/modules/autocomplete/autocomplete.component.spec.ts
@@ -1596,6 +1596,54 @@ describe('Autocomplete component', () => {
         });
       }));
 
+      it('should keep the typed value on blur when it does not match any list item', fakeAsync(() => {
+        component.allowAnyValue = true;
+        fixture.detectChanges();
+        tick();
+
+        const inputElement = getInputElement(true);
+        const notifySpy = spyOn(
+          asyncAutocomplete.selectionChange,
+          'emit',
+        ).and.callThrough();
+
+        enterSearch('not_in_datasource', fixture, true);
+
+        tick(200);
+        fixture.detectChanges();
+
+        blurInput(inputElement, fixture);
+
+        expect(inputElement.value).toEqual('not_in_datasource');
+        expect(notifySpy).toHaveBeenCalledWith({
+          selectedItem: { name: 'not_in_datasource' },
+        });
+      }));
+
+      it('should select the existing list item as the value on blur when the typed text matches it exactly', fakeAsync(() => {
+        component.allowAnyValue = true;
+        fixture.detectChanges();
+        tick();
+
+        const inputElement = getInputElement(true);
+        const notifySpy = spyOn(
+          asyncAutocomplete.selectionChange,
+          'emit',
+        ).and.callThrough();
+
+        enterSearch('Red', fixture, true);
+
+        tick(200);
+        fixture.detectChanges();
+
+        blurInput(inputElement, fixture);
+
+        expect(inputElement.value).toEqual('Red');
+        expect(notifySpy).toHaveBeenCalledWith({
+          selectedItem: { name: 'Red', objectid: 'abc' },
+        });
+      }));
+
       it('should not show the search text item when an exact match is loaded', fakeAsync(() => {
         component.allowAnyValue = true;
         fixture.detectChanges();

--- a/libs/components/lookup/src/lib/modules/autocomplete/autocomplete.component.ts
+++ b/libs/components/lookup/src/lib/modules/autocomplete/autocomplete.component.ts
@@ -310,7 +310,10 @@ export class SkyAutocompleteComponent implements OnDestroy, AfterViewInit {
   /**
    * When using `searchAsync`, allows the user to specify arbitrary
    * values not in the search results. This only works in combination
-   * with `searchAsync`.
+   * with `searchAsync`. On blur, the typed text is kept as the value
+   * rather than reverted, using a matching search result if one is
+   * available. Consumers should guard against values set before a
+   * `searchAsync` call resolves.
    * @default false
    */
   public allowAnyValue = input(false, { transform: booleanAttribute });

--- a/libs/components/lookup/src/lib/modules/autocomplete/autocomplete.component.ts
+++ b/libs/components/lookup/src/lib/modules/autocomplete/autocomplete.component.ts
@@ -800,8 +800,21 @@ export class SkyAutocompleteComponent implements OnDestroy, AfterViewInit {
     if (!hasInputText && inputDirective?.value?.[this.descriptorProperty]) {
       inputDirective.value = undefined;
       this.selectionChange.emit({ selectedItem: undefined });
-    } else if (hasInputText) {
-      inputDirective?.restoreInputTextValueToPreviousState();
+    } else if (hasInputText && inputDirective) {
+      if (this.allowAnyValue()) {
+        const matchedResult = this.searchResults.find(
+          (result) =>
+            result.data[this.descriptorProperty] ===
+            inputDirective.inputTextValue,
+        );
+        const selectedItem = matchedResult
+          ? matchedResult.data
+          : { [this.descriptorProperty]: inputDirective.inputTextValue };
+        inputDirective.value = selectedItem;
+        this.selectionChange.emit({ selectedItem });
+      } else {
+        inputDirective.restoreInputTextValueToPreviousState();
+      }
     }
   }
 

--- a/libs/components/lookup/src/lib/modules/autocomplete/autocomplete.component.ts
+++ b/libs/components/lookup/src/lib/modules/autocomplete/autocomplete.component.ts
@@ -802,11 +802,16 @@ export class SkyAutocompleteComponent implements OnDestroy, AfterViewInit {
       this.selectionChange.emit({ selectedItem: undefined });
     } else if (hasInputText && inputDirective) {
       if (this.allowAnyValue()) {
-        const matchedResult = this.searchResults.find(
-          (result) =>
-            result.data[this.descriptorProperty] ===
-            inputDirective.inputTextValue,
-        );
+        // While a search is still in flight, `searchResults` may only
+        // contain the provisional placeholder for the current search text
+        // (see `#combineSearchTextWithResult`), not a confirmed match.
+        const matchedResult = this.isSearchingAsync
+          ? undefined
+          : this.searchResults.find(
+              (result) =>
+                result.data[this.descriptorProperty] ===
+                inputDirective.inputTextValue,
+            );
         const selectedItem = matchedResult
           ? matchedResult.data
           : { [this.descriptorProperty]: inputDirective.inputTextValue };


### PR DESCRIPTION
[AB#3971721](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3971721)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Autocomplete fields configured to allow arbitrary values now retain and emit unmatched text when focus leaves the field.
  * Exact matches are automatically selected and emitted when available.
  * Unmatched entries are emitted as new selectable values.
  * If focus leaves before search results load, the entered text is emitted provisionally.

* **Bug Fixes**
  * Improved autocomplete behavior when exiting the field with typed input, including restoring previous text when the feature is disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->