### PR TITLE
feat: add borders to elevated overlay containers for dark mode

### DIFF
--- a/libs/components/colorpicker/src/lib/modules/colorpicker/colorpicker.component.scss
+++ b/libs/components/colorpicker/src/lib/modules/colorpicker/colorpicker.component.scss
@@ -35,6 +35,7 @@
 @include compatMixins.sky-default-overrides('.sky-colorpicker-container') {
   --sky-override-colorpicker-alpha-margin-top: 16px;
   --sky-override-colorpicker-background-color: #fff;
+  --sky-override-colorpicker-border: none;
   --sky-override-colorpicker-box-padding: 4px 8px;
   --sky-override-colorpicker-current-color-padding: 16px 8px;
   --sky-override-colorpicker-current-controls-padding: 12px 8px;
@@ -82,6 +83,11 @@ sky-colorpicker.sky-form-field-stacked {
   background-color: var(
     --sky-override-colorpicker-background-color,
     var(--sky-color-background-container-menu)
+  );
+  border: var(
+    --sky-override-colorpicker-border,
+    var(--sky-border-style-elevation) var(--sky-border-width-container-base)
+      var(--sky-color-border-container-base)
   );
   border-radius: 0 0 var(--sky-border-radius-s) var(--sky-border-radius-s);
 }

--- a/libs/components/datetime/src/lib/modules/datepicker/datepicker.component.scss
+++ b/libs/components/datetime/src/lib/modules/datepicker/datepicker.component.scss
@@ -3,11 +3,17 @@
 @include compatMixins.sky-default-overrides(
   '.sky-datepicker-calendar-container'
 ) {
+  --sky-override-datepicker-border: none;
   --sky-override-datepicker-border-radius: 5px;
 }
 
 .sky-datepicker-calendar-container {
   position: fixed;
+  border: var(
+    --sky-override-datepicker-border,
+    var(--sky-border-style-elevation) var(--sky-border-width-container-base)
+      var(--sky-color-border-container-base)
+  );
   border-radius: var(
     --sky-override-datepicker-border-radius,
     var(--sky-border-radius-s)

--- a/libs/components/datetime/src/lib/modules/timepicker/timepicker.component.scss
+++ b/libs/components/datetime/src/lib/modules/timepicker/timepicker.component.scss
@@ -4,6 +4,7 @@
 
 @include compatMixins.sky-default-overrides('.sky-timepicker-container') {
   --sky-override-timepicker-background-color: #{$sky-color-gray-05};
+  --sky-override-timepicker-border: none;
   --sky-override-timepicker-border-radius: 5px;
   --sky-override-timepicker-button-active-background-color: #{$sky-color-gray-10};
   --sky-override-timepicker-button-background-color: #{$sky-color-white};
@@ -41,6 +42,11 @@
   background-color: var(
     --sky-override-timepicker-background-color,
     var(--sky-color-background-container-menu)
+  );
+  border: var(
+    --sky-override-timepicker-border,
+    var(--sky-border-style-elevation) var(--sky-border-width-container-base)
+      var(--sky-color-border-container-base)
   );
   border-radius: var(
     --sky-override-timepicker-border-radius,

--- a/libs/components/lookup/src/lib/modules/autocomplete/autocomplete.component.scss
+++ b/libs/components/lookup/src/lib/modules/autocomplete/autocomplete.component.scss
@@ -22,6 +22,7 @@
   --sky-override-autocomplete-result-margin-bottom: 4px;
   --sky-override-autocomplete-result-padding: 3px #{$sky-padding-double};
   --sky-override-autocomplete-results-container-background-color: #{$sky-color-white};
+  --sky-override-autocomplete-results-container-border: none;
   --sky-override-autocomplete-results-container-border-radius: 0;
   --sky-override-autocomplete-results-no-results-padding: 4px;
   --sky-override-autocomplete-results-padding: 4px;
@@ -38,6 +39,11 @@
   background-color: var(
     --sky-override-autocomplete-results-container-background-color,
     var(--sky-color-background-container-menu)
+  );
+  border: var(
+    --sky-override-autocomplete-results-container-border,
+    var(--sky-border-style-elevation) var(--sky-border-width-container-base)
+      var(--sky-color-border-container-base)
   );
   border-radius: var(
     --sky-override-autocomplete-results-container-border-radius,

--- a/libs/components/popovers/src/lib/modules/dropdown/dropdown-menu.component.scss
+++ b/libs/components/popovers/src/lib/modules/dropdown/dropdown-menu.component.scss
@@ -2,6 +2,7 @@
 @use 'libs/components/theme/src/lib/styles/compat-tokens-mixins' as compatMixins;
 
 @include compatMixins.sky-default-overrides('.sky-dropdown-menu') {
+  --sky-override-dropdown-menu-border: none;
   --sky-override-dropdown-menu-border-radius: 0px;
   --sky-override-dropdown-menu-color-background: #fff;
   --sky-override-dropdown-menu-padding: 0;
@@ -15,6 +16,11 @@
   background-color: var(
     --sky-override-dropdown-menu-color-background,
     var(--sky-color-background-container-menu)
+  );
+  border: var(
+    --sky-override-dropdown-menu-border,
+    var(--sky-border-style-elevation) var(--sky-border-width-container-base)
+      var(--sky-color-border-container-base)
   );
   border-radius: var(
     --sky-override-dropdown-menu-border-radius,

--- a/libs/components/popovers/src/lib/modules/popover/popover-content.component.scss
+++ b/libs/components/popovers/src/lib/modules/popover/popover-content.component.scss
@@ -199,6 +199,21 @@ $popover-max-width: 276px;
 
 @include mixins.sky-theme-modern {
   .sky-popover {
+    // The container edges are drawn as inset shadows rather than borders. A border on these
+    // sides would have to blend into the thicker accent border at the two corners they
+    // share, which distorts the corner radius. Shadows have no width to blend, so each
+    // placement below composes only the three edges that the accent does not cover.
+    --sky-popover-edge-top: inset 0 var(--sky-border-width-container-base) 0 0
+      var(--sky-color-border-container-base);
+    --sky-popover-edge-right: inset
+      calc(-1 * var(--sky-border-width-container-base)) 0 0 0
+      var(--sky-color-border-container-base);
+    --sky-popover-edge-bottom: inset 0
+      calc(-1 * var(--sky-border-width-container-base)) 0 0
+      var(--sky-color-border-container-base);
+    --sky-popover-edge-left: inset var(--sky-border-width-container-base) 0 0 0
+      var(--sky-color-border-container-base);
+
     border-radius: var(--sky-border-radius-s);
   }
 
@@ -225,6 +240,9 @@ $popover-max-width: 276px;
     .sky-popover {
       border-bottom: var(--sky-border-width-accent)
         var(--sky-border-style-accent) var(--sky-color-border-info);
+      box-shadow:
+        var(--sky-popover-edge-top), var(--sky-popover-edge-right),
+        var(--sky-popover-edge-left), var(--sky-elevation-overlay-100);
     }
 
     .sky-popover-arrow {
@@ -244,6 +262,9 @@ $popover-max-width: 276px;
     .sky-popover {
       border-top: var(--sky-border-width-accent) var(--sky-border-style-accent)
         var(--sky-color-border-info);
+      box-shadow:
+        var(--sky-popover-edge-right), var(--sky-popover-edge-bottom),
+        var(--sky-popover-edge-left), var(--sky-elevation-overlay-100);
     }
 
     .sky-popover-arrow {
@@ -263,6 +284,9 @@ $popover-max-width: 276px;
     .sky-popover {
       border-left: var(--sky-border-width-accent) var(--sky-border-style-accent)
         var(--sky-color-border-info);
+      box-shadow:
+        var(--sky-popover-edge-top), var(--sky-popover-edge-right),
+        var(--sky-popover-edge-bottom), var(--sky-elevation-overlay-100);
     }
 
     .sky-popover-arrow {
@@ -282,6 +306,9 @@ $popover-max-width: 276px;
     .sky-popover {
       border-right: var(--sky-border-width-accent)
         var(--sky-border-style-accent) var(--sky-color-border-info);
+      box-shadow:
+        var(--sky-popover-edge-top), var(--sky-popover-edge-bottom),
+        var(--sky-popover-edge-left), var(--sky-elevation-overlay-100);
     }
 
     .sky-popover-arrow {


### PR DESCRIPTION
## Summary

In light mode, several overlay containers are distinguished from the content behind them only by an elevation box shadow. Shadows read poorly in dark mode, so these containers now also draw a border.

Six containers were audited and found to be elevation/shadow-only, all on `sky-elevation-4`. Each now draws a 1px `container-base` border:

| Component | Selector |
| --- | --- |
| Dropdown menu | `.sky-dropdown-menu` |
| Popover | `.sky-popover` |
| Colorpicker menu | `.sky-colorpicker-container` |
| Datepicker menu | `.sky-datepicker-calendar-container` |
| Timepicker menu | `.sky-timepicker-container` |
| Autocomplete dropdown | `.sky-autocomplete-results-container` |

The autocomplete change covers the lookup, country field, and phone field dropdowns, since all three render `<sky-autocomplete>`.

**Box, tile, and modal were also audited and needed no change** — box and tile already use `sky-elevation-1-bordered`, and modal draws its own `container-base` border despite being on shadow-only `sky-elevation-16`.

## Implementation notes

**The border is per-component, not on the elevation class.** Per design's request, `_elevation.scss` is untouched. Each component follows the `--sky-override-*` convention already used in these files: the base rule carries the modern token value, and the default theme opts out via the `sky-default-overrides` block. This preserves the existing scoping (modern only, default theme unchanged) and gives consuming apps an override hook.

**The popover needed a different approach.** It sets a 6px accent border on whichever side faces its trigger. A 1px border on the remaining sides has to blend into that thicker border at the two shared corners, and `border-radius` renders that mismatch as a distorted corner. Squaring those corners was rejected — the popover must stay rounded on all four sides.

Instead, the popover's three non-accent edges are drawn as **inset box shadows**. A shadow has no width to blend, so the corner radius stays intact and the accent border is untouched. Four reusable edge custom properties are defined on `.sky-popover`, and each placement composes the three the accent does not cover.

Two consequences:

- `sky-elevation-4` sets `box-shadow` on the same element, so its drop shadow is re-declared as the last layer via `var(--sky-elevation-overlay-100)`. Referencing elevation tokens directly in a component follows existing precedent in modal, split-view footer, and summary action bar. This does couple the popover to that token.
- The `danger` variant needed no changes — the accent is still a border, so the existing `border-*-color` overrides apply, and the edge shadows only use `container-base`.

## Scope

Elevation levels 3, 8, and 16 were deliberately left alone. Their consumers are not uniformly floating overlays: the split-view workspace footer is flush-mounted and re-declares its own `box-shadow`, and modal already has its own border and would end up with a doubled line. Flyout and back-to-top are being handled separately.

`sky-elevation-24` has no consumers outside the e2e theming fixture.

## Testing

Visually verified in dark mode: timepicker, datepicker, colorpicker, and popover.

Not yet run: `npm run test:affected`. Some Karma suites load SKY UX styles and can assert computed styles, so that needs a pass before this leaves draft. The popover is the most likely to surface something, since its non-accent `border-*` declarations were replaced by shadows.

Not yet reviewed: e2e/Percy screenshot baselines will need approving, including the elevation swatches in `apps/e2e/theme-storybook`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Added configurable border overrides for color pickers, datepickers, timepickers, autocomplete results, and dropdown menus.
  * Components retain their standard themed borders when no override is supplied.
  * Improved modern popover styling with consistent inset shadows around the container edges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->