### PR TITLE
fix(components/indicators): tokens use tertiary action tokens for focus-visible styles

### DIFF
--- a/libs/components/indicators/src/lib/modules/tokens/token.component.scss
+++ b/libs/components/indicators/src/lib/modules/tokens/token.component.scss
@@ -80,7 +80,8 @@
   align-items: var(--sky-override-token-align-items, center);
   display: var(--sky-override-token-display, inline-flex);
 
-  &.sky-token-focused:not(:active) {
+  &.sky-token-focused:not(:active),
+  &:focus-visible:not(:active) {
     background-color: var(
       --sky-override-token-focused-background-color,
       var(--sky-color-background-selected-soft)


### PR DESCRIPTION
The token element carries `sky-btn-default`, so the modern theme's
`.sky-theme-modern .sky-btn-default:focus-visible:not(:active)` rule applied the
secondary action background color and border to a focused token instead of the
token's own selected/tertiary styling.

This applies the token's existing focused styles — `--sky-color-background-selected-soft`
plus the `--sky-border-width-action-focus` / `--sky-color-border-action-tertiary-focus`
inset border — to `:focus-visible` as well, alongside the existing `:hover` and
`:active` states. The `--sky-override-token-focused-*` hooks are reused, so the
default theme is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved token focus styling to provide a visible focus indicator for keyboard navigation.
  * Preserved active-token styling when focus is applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->