### PR TITLE
fix: dark mode flyouts, summary action bars, and back to top bars have an edge border

### DIFF
--- a/libs/components/action-bars/src/lib/modules/summary-action-bar/summary-action-bar.component.scss
+++ b/libs/components/action-bars/src/lib/modules/summary-action-bar/summary-action-bar.component.scss
@@ -6,6 +6,7 @@
   --sky-override-summary-action-bar-actions-padding: #{$sky-padding
     $sky-padding-double $sky-padding $sky-padding};
   --sky-override-summary-action-bar-background-color: #{$sky-color-white};
+  --sky-override-summary-action-border-top: none;
   --sky-override-summary-action-bar-box-shadow: 0 -3px 3px 0
     #{$sky-color-gray-20};
   --sky-override-summary-action-bar-details-expand-margin-right: #{$sky-margin};
@@ -26,14 +27,6 @@
   --sky-override-summary-action-bar-summary-margin: #{$sky-margin} 0;
 }
 
-:host-context(.sky-theme-mode-light) {
-  --sky-comp-sab-border-top-style: none;
-}
-
-:host-context(.sky-theme-mode-dark) {
-  --sky-comp-sab-border-top-style: solid;
-}
-
 .sky-summary-action-bar {
   --sky-summary-action-bar-left: var(--sky-viewport-left);
 
@@ -43,9 +36,12 @@
   margin-top: var(--sky-override-summary-action-bar-margin-top, 0);
   position: fixed;
   bottom: var(--sky-dock-height, 0);
-  border-top: var(--sky-border-width-container-base)
-    var(--sky-comp-sab-border-top-style, solid)
-    var(--sky-color-border-container-base);
+  border-top: var(
+    --sky-override-summary-action-border-top,
+    var(--sky-border-width-container-base)
+      var(--sky-border-style-container-overlay)
+      var(--sky-color-border-container-base)
+  );
   transition-property: bottom;
   transition-duration: 60ms;
   transition-timing-function: ease-out;

--- a/libs/components/action-bars/src/lib/modules/summary-action-bar/summary-action-bar.component.scss
+++ b/libs/components/action-bars/src/lib/modules/summary-action-bar/summary-action-bar.component.scss
@@ -26,6 +26,14 @@
   --sky-override-summary-action-bar-summary-margin: #{$sky-margin} 0;
 }
 
+:host-context(.sky-theme-mode-light) {
+  --sky-comp-sab-border-top-style: none;
+}
+
+:host-context(.sky-theme-mode-dark) {
+  --sky-comp-sab-border-top-style: solid;
+}
+
 .sky-summary-action-bar {
   --sky-summary-action-bar-left: var(--sky-viewport-left);
 
@@ -35,6 +43,9 @@
   margin-top: var(--sky-override-summary-action-bar-margin-top, 0);
   position: fixed;
   bottom: var(--sky-dock-height, 0);
+  border-top: var(--sky-border-width-container-base)
+    var(--sky-comp-sab-border-top-style, solid)
+    var(--sky-color-border-container-base);
   transition-property: bottom;
   transition-duration: 60ms;
   transition-timing-function: ease-out;

--- a/libs/components/flyout/src/lib/modules/flyout/flyout.component.scss
+++ b/libs/components/flyout/src/lib/modules/flyout/flyout.component.scss
@@ -16,6 +16,14 @@
   --sky-flyout-resize-handle-width: 14px;
 }
 
+:host-context(.sky-theme-mode-light) {
+  --sky-comp-flyout-border-left-style: none;
+}
+
+:host-context(.sky-theme-mode-dark) {
+  --sky-comp-flyout-border-left-style: solid;
+}
+
 .sky-flyout {
   position: fixed;
   right: 0;
@@ -32,7 +40,12 @@
   );
   --sky-comp-override-list-header-background-color: initial;
 
-  border-left: var(--sky-override-flyout-border-left);
+  border-left: var(
+    --sky-override-flyout-border-left,
+    var(--sky-border-width-container-base)
+      var(--sky-comp-flyout-border-left-style)
+      var(--sky-color-border-container-base)
+  );
 
   transform: translateX(100%);
   transition-duration: var(--sky-global-duration-medium);

--- a/libs/components/flyout/src/lib/modules/flyout/flyout.component.scss
+++ b/libs/components/flyout/src/lib/modules/flyout/flyout.component.scss
@@ -16,14 +16,6 @@
   --sky-flyout-resize-handle-width: 14px;
 }
 
-:host-context(.sky-theme-mode-light) {
-  --sky-comp-flyout-border-left-style: none;
-}
-
-:host-context(.sky-theme-mode-dark) {
-  --sky-comp-flyout-border-left-style: solid;
-}
-
 .sky-flyout {
   position: fixed;
   right: 0;
@@ -43,7 +35,7 @@
   border-left: var(
     --sky-override-flyout-border-left,
     var(--sky-border-width-container-base)
-      var(--sky-comp-flyout-border-left-style)
+      var(--sky-border-style-container-overlay)
       var(--sky-color-border-container-base)
   );
 

--- a/libs/components/layout/src/lib/modules/back-to-top/back-to-top.component.scss
+++ b/libs/components/layout/src/lib/modules/back-to-top/back-to-top.component.scss
@@ -3,17 +3,10 @@
 @use 'libs/components/theme/src/lib/styles/compat-tokens-mixins' as compatMixins;
 
 @include compatMixins.sky-default-overrides('.sky-back-to-top') {
+  --sky-override-back-to-top-border-top: none;
   --sky-override-back-to-top-padding: var(--sky-margin-stacked-sm)
     var(--sky-margin-inline-lg);
   --sky-override-back-to-top-background-color: #{$sky-color-white};
-}
-
-:host-context(.sky-theme-mode-light) {
-  --sky-comp-back_to_top-border-top-style: none;
-}
-
-:host-context(.sky-theme-mode-dark) {
-  --sky-comp-back_to_top-border-top-style: solid;
 }
 
 .sky-back-to-top {
@@ -24,9 +17,12 @@
     --sky-override-back-to-top-background-color,
     var(--sky-color-background-container-base)
   );
-  border-top: var(--sky-border-width-container-base)
-    var(--sky-comp-back_to_top-border-top-style)
-    var(--sky-color-border-container-base);
+  border-top: var(
+    --sky-override-back-to-top-border-top,
+    var(--sky-border-width-container-base)
+      var(--sky-border-style-container-overlay)
+      var(--sky-color-border-container-base)
+  );
   padding: var(
     --sky-override-back-to-top-padding,
     var(--sky-comp-back_to_top-space-inset-top)

--- a/libs/components/layout/src/lib/modules/back-to-top/back-to-top.component.scss
+++ b/libs/components/layout/src/lib/modules/back-to-top/back-to-top.component.scss
@@ -8,6 +8,14 @@
   --sky-override-back-to-top-background-color: #{$sky-color-white};
 }
 
+:host-context(.sky-theme-mode-light) {
+  --sky-comp-back_to_top-border-top-style: none;
+}
+
+:host-context(.sky-theme-mode-dark) {
+  --sky-comp-back_to_top-border-top-style: solid;
+}
+
 .sky-back-to-top {
   display: flex;
   align-items: center;
@@ -16,6 +24,9 @@
     --sky-override-back-to-top-background-color,
     var(--sky-color-background-container-base)
   );
+  border-top: var(--sky-border-width-container-base)
+    var(--sky-comp-back_to_top-border-top-style)
+    var(--sky-color-border-container-base);
   padding: var(
     --sky-override-back-to-top-padding,
     var(--sky-comp-back_to_top-space-inset-top)

--- a/libs/components/modals/src/lib/modules/modal/modal.component.html
+++ b/libs/components/modals/src/lib/modules/modal/modal.component.html
@@ -21,6 +21,9 @@
     <div
       class="sky-modal-header"
       [hidden]="headingHidden()"
+      [ngClass]="{
+        'sky-modal-header-shadow-enabled': scrollShadow?.topShadow !== 'none'
+      }"
       [ngStyle]="{
         'box-shadow': scrollShadow?.topShadow
       }"
@@ -85,6 +88,9 @@
     </div>
     <div
       class="sky-modal-footer"
+      [ngClass]="{
+        'sky-modal-footer-shadow-enabled': scrollShadow?.bottomShadow !== 'none'
+      }"
       [ngStyle]="{
         'box-shadow': scrollShadow?.bottomShadow
       }"

--- a/libs/components/modals/src/lib/modules/modal/modal.component.scss
+++ b/libs/components/modals/src/lib/modules/modal/modal.component.scss
@@ -266,8 +266,8 @@
   z-index: 2;
 
   &.sky-modal-footer-shadow-enabled {
-    border-bottom: var(
-      --sky-override-modal-footer-tops-border,
+    border-top: var(
+      --sky-override-modal-footer-top-border,
       var(--sky-border-width-container-base)
         var(--sky-border-style-container-overlay)
         var(--sky-color-border-container-base)

--- a/libs/components/modals/src/lib/modules/modal/modal.component.scss
+++ b/libs/components/modals/src/lib/modules/modal/modal.component.scss
@@ -9,6 +9,7 @@
   --sky-override-modal-dock-margin-left-right-bottom: #{-$sky-margin-plus-half};
   --sky-override-modal-dock-padding-top: #{$sky-padding-plus-half};
   --sky-override-modal-dock-width: calc(100% + 30px);
+  --sky-override-modal-footer-top-border: none;
   --sky-override-modal-full-page-margin-xs: 0;
   --sky-override-modal-full-page-margin: 0;
   --sky-override-modal-full-page-width: 100%;
@@ -226,6 +227,15 @@
 
   display: flex;
   align-items: var(--sky-override-modal-header-align-items, center);
+
+  &.sky-modal-header-shadow-enabled {
+    border-bottom: var(
+      --sky-override-modal-header-bottom-border,
+      var(--sky-border-width-container-base)
+        var(--sky-border-style-container-overlay)
+        var(--sky-color-border-container-base)
+    );
+  }
 }
 
 .sky-modal-header-buttons {
@@ -254,6 +264,15 @@
 .sky-modal-footer {
   flex-shrink: 0;
   z-index: 2;
+
+  &.sky-modal-footer-shadow-enabled {
+    border-bottom: var(
+      --sky-override-modal-footer-tops-border,
+      var(--sky-border-width-container-base)
+        var(--sky-border-style-container-overlay)
+        var(--sky-color-border-container-base)
+    );
+  }
 }
 
 .sky-modal-full-page .sky-modal-content {

--- a/libs/components/packages/package.json
+++ b/libs/components/packages/package.json
@@ -107,7 +107,7 @@
     "@angular/core": "^21.2.0"
   },
   "dependencies": {
-    "@blackbaud/skyux-design-tokens": "6.2.1",
+    "@blackbaud/skyux-design-tokens": "6.3.1",
     "fs-extra": "11.3.4",
     "jsonc-parser": "3.3.1",
     "parse5": "7.3.0",

--- a/libs/components/theme/package.json
+++ b/libs/components/theme/package.json
@@ -20,7 +20,7 @@
     "@angular/core": "^21.2.0"
   },
   "dependencies": {
-    "@blackbaud/skyux-design-tokens": "6.2.1",
+    "@blackbaud/skyux-design-tokens": "6.3.1",
     "fontfaceobserver": "2.3.0",
     "tslib": "^2.8.1"
   },

--- a/libs/sdk/skyux-eslint/package.json
+++ b/libs/sdk/skyux-eslint/package.json
@@ -33,7 +33,7 @@
     "@typescript-eslint/utils": "^8.56.1"
   },
   "dependencies": {
-    "@blackbaud/skyux-design-tokens": "6.2.1",
+    "@blackbaud/skyux-design-tokens": "6.3.1",
     "@skyux-sdk/eslint-schematics": "0.0.0-PLACEHOLDER",
     "@skyux/manifest": "0.0.0-PLACEHOLDER",
     "tslib": "^2.8.1"

--- a/libs/sdk/skyux-stylelint/package.json
+++ b/libs/sdk/skyux-stylelint/package.json
@@ -23,7 +23,7 @@
     "stylelint": "^17.14.1"
   },
   "dependencies": {
-    "@blackbaud/skyux-design-tokens": "6.2.1",
+    "@blackbaud/skyux-design-tokens": "6.3.1",
     "tslib": "^2.8.1"
   },
   "type": "module",

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@angular/platform-browser-dynamic": "21.2.0",
         "@angular/router": "21.2.0",
         "@blackbaud/angular-tree-component": "1.0.0",
-        "@blackbaud/skyux-design-tokens": "6.2.1",
+        "@blackbaud/skyux-design-tokens": "6.3.1",
         "@eslint/js": "9.39.3",
         "@nx/angular": "22.5.3",
         "@skyux/icons": "10.4.0",
@@ -3287,9 +3287,9 @@
       }
     },
     "node_modules/@blackbaud/skyux-design-tokens": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@blackbaud/skyux-design-tokens/-/skyux-design-tokens-6.2.1.tgz",
-      "integrity": "sha512-SrL2x3HfBGfdlpAZGhs5GSp+TrEWSFWfVbr6k9Vfyr8I8PiJ7xY8lMgXNJ9NMS7X5EmEOUpLhNriLu3/59fpuA==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@blackbaud/skyux-design-tokens/-/skyux-design-tokens-6.3.1.tgz",
+      "integrity": "sha512-u73GxyvJIYAQ81h00RxM7vDCHCwzAEFql2gYNyljrErYDyALCI0BAOaBcgL3S3CltTAFlrWAlVlhLz9Cq+W+Vw==",
       "license": "MIT",
       "engines": {
         "node": ">= 4.2.1",

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "@angular/platform-browser-dynamic": "21.2.0",
     "@angular/router": "21.2.0",
     "@blackbaud/angular-tree-component": "1.0.0",
-    "@blackbaud/skyux-design-tokens": "6.2.1",
+    "@blackbaud/skyux-design-tokens": "6.3.1",
     "@eslint/js": "9.39.3",
     "@nx/angular": "22.5.3",
     "@skyux/icons": "10.4.0",


### PR DESCRIPTION
[AB#4061509](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/4061509)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved border styling across summary action bars, flyouts, and back-to-top controls for more consistent theme behavior.
  * Added configurable border handling for modal footers.
  * Enhanced modal header and footer scroll-shadow styling using the appropriate border settings.
  * Improved support for customized container border styles across these components.
  * Updated visual styling to provide more consistent borders and shadows across supported themes and layouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->