### PR TITLE
fix: display toasts above all layers except the full-page wait

### DIFF
--- a/libs/components/theme/src/lib/styles/_public-api/_compat/_variables.scss
+++ b/libs/components/theme/src/lib/styles/_public-api/_compat/_variables.scss
@@ -27,7 +27,9 @@ $sky-font-size-base: 15px !default;
 $sky-line-height-base: 1.428571429 !default;
 
 // Z-INDEXES
-$sky-page-wait-z-index: 2000 !default;
+// The full-page wait blocks the entire page, so it sits above every other layer, including
+// toasts (100000) and overlays (which start at 5001 and increment as overlays are created).
+$sky-page-wait-z-index: 200000 !default;
 $sky-component-wait-z-index: 1000 !default;
 
 // COMPONENTS

--- a/libs/components/toast/src/lib/modules/toast/toaster.component.ts
+++ b/libs/components/toast/src/lib/modules/toast/toaster.component.ts
@@ -30,6 +30,15 @@ import { SkyToastContainerOptions } from './types/toast-container-options';
 import { SkyToastDisplayDirection } from './types/toast-display-direction';
 
 /**
+ * Toasts appear above every other layer except the full-page wait, which uses
+ * `$sky-page-wait-z-index`. The value must stay well above the z-indexes that grow as
+ * layers are created — overlays start at 5001 and increment for every overlay created
+ * over the life of the page — so it leaves generous headroom rather than sitting just
+ * above the highest static layer (the skip link, at 10000).
+ */
+const TOASTER_Z_INDEX = 100000;
+
+/**
  * @internal
  */
 @Component({
@@ -56,7 +65,7 @@ export class SkyToasterComponent implements OnInit, OnDestroy {
   public toastComponents: QueryList<SkyToastComponent> | undefined;
 
   protected toastInjectors = new Map<number, EnvironmentInjector>();
-  protected zIndex$ = new BehaviorSubject(1051);
+  protected zIndex$ = new BehaviorSubject(TOASTER_Z_INDEX);
 
   #ngUnsubscribe = new Subject<void>();
 


### PR DESCRIPTION
## What changed

Toasts now sit above every other layer except the full-page wait, per the story.

| File | Before | After |
| --- | --- | --- |
| `toaster.component.ts` | `1051` | `100000` (`TOASTER_Z_INDEX`) |
| `_variables.scss` — `$sky-page-wait-z-index` | `2000` | `200000` |

Resulting order: full-page wait (200000) > toasts (100000) > skip link (10000) > overlays (5001+) > modals (1051 + 10n) > flyout host (1001) / omnibar (1000) / component wait (1000).

## Why both values changed

The story says toasts should be higher than everything *except* the full-page wait — but the full-page wait was not the top layer to begin with. At `2000` it sat below overlays (`SkyOverlayComponent` starts at 5001) and below the skip link (10000). So there was no value that put toasts above overlays and still left the page wait above toasts; raising `$sky-page-wait-z-index` is what makes the story's ordering expressible at all.

`$sky-page-wait-z-index` is a public `!default` compat variable, so consumers who already override it keep their own value.

## Why 100000 rather than a value just above the existing maximum

`SkyOverlayComponent` increments a module-level counter for every overlay created over the life of the page, so its z-index grows without bound. A toast value just above the skip link would eventually be overtaken by a long-lived session; the toaster reads its value once at creation and never re-races. 100000 leaves roughly 95k overlay creations of headroom, and the page wait keeps a wide margin above that.

## Notes

- Dropdowns, popovers, and pickers opened *inside* a toast body read `SKY_STACKING_CONTEXT` and adopt the toaster's z-index, so they moved up with it.
- Nothing referenced the old literals: the `1051` assertions in `modal.component.spec.ts` are the modal base z-index and are unrelated, and `$sky-page-wait-z-index` has one consumer (`wait-page.component.scss`).
- Targets `14.x.x`, the branch this work was cut from. A port to `main` (15.x) is likely wanted as a follow-up.

## Testing

- `nx test toast` — 30/30 passing, 100% coverage. (Karma's "Some of your tests did a full page reload!" line also appears on an unmodified tree, so it is pre-existing.)
- Visual/e2e suites were not run locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated visual layering so page-wait indicators appear above toasts and other overlays.
  - Ensured toast notifications consistently display at the correct stacking level.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->