### PR TITLE
fix(components/forms): make file attachment file link keyboard accessible (#4638)

### DIFF
--- a/libs/components/forms/src/lib/modules/file-attachment/file-attachment/file-attachment.component.html
+++ b/libs/components/forms/src/lib/modules/file-attachment/file-attachment/file-attachment.component.html
@@ -112,8 +112,11 @@
         @if (value) {
           <a
             class="sky-btn sky-btn-link-inline"
+            role="link"
+            tabindex="0"
             [attr.title]="fileName"
             (click)="emitClick()"
+            (keydown.enter)="emitClick()"
           >
             {{ truncatedFileName }}
           </a>

--- a/libs/components/forms/src/lib/modules/file-attachment/file-attachment/file-attachment.component.spec.ts
+++ b/libs/components/forms/src/lib/modules/file-attachment/file-attachment/file-attachment.component.spec.ts
@@ -830,6 +830,56 @@ describe('File attachment', () => {
     });
   });
 
+  it('should place the uploaded file link in the tab order without a bound href', () => {
+    const testFile = {
+      file: {
+        name: 'test.png',
+        size: 1000,
+        type: 'image/png',
+      },
+      url: '$/myFile',
+    } as SkyFileItem;
+
+    fileAttachmentInstance.writeValue(testFile);
+    fixture.detectChanges();
+
+    const fileNameDebugEl = fixture.debugElement.query(
+      By.css('.sky-file-attachment-file-link a'),
+    );
+
+    expect(fileNameDebugEl.attributes['tabindex']).toBe('0');
+    expect(fileNameDebugEl.attributes['role']).toBe('link');
+    expect(fileNameDebugEl.attributes['href']).toBeUndefined();
+  });
+
+  it('should emit fileClick when the uploaded file link is activated via the keyboard', () => {
+    const testFile = {
+      file: {
+        name: 'test.png',
+        size: 1000,
+        type: 'image/png',
+      },
+      url: '$/myFile',
+    } as SkyFileItem;
+
+    spyOn(fileAttachmentInstance.fileClick, 'emit');
+
+    fileAttachmentInstance.writeValue(testFile);
+    fixture.detectChanges();
+
+    const fileNameDebugEl = fixture.debugElement.query(
+      By.css('.sky-file-attachment-file-link a'),
+    );
+
+    fileNameDebugEl.nativeElement.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }),
+    );
+
+    expect(fileAttachmentInstance.fileClick.emit).toHaveBeenCalledWith({
+      file: testFile,
+    });
+  });
+
   it('should load files and set classes on drag and drop', async () => {
     let fileChangeActual: SkyFileAttachmentChange | undefined;
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Made selected file links keyboard-focusable.
  * Added Enter-key activation support for opening selected files.

* **Bug Fixes**
  * Improved keyboard interaction for uploaded file attachments without direct links.

* **Tests**
  * Added coverage for focusability, link semantics, and Enter-key activation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->