### PR TITLE
feat(components/icon): allow icon URL to be provided with injection token

### DIFF
--- a/libs/components/core/src/index.ts
+++ b/libs/components/core/src/index.ts
@@ -52,6 +52,8 @@ export { SkyHelpOpenArgs } from './lib/modules/help/help-open-args';
 export { SkyHelpUpdateArgs } from './lib/modules/help/help-update-args';
 export { SkyHelpService } from './lib/modules/help/help.service';
 
+export { SKY_ICON_SVG_URL } from './lib/modules/icons/icon-svg-url';
+
 export { SkyIdModule } from './lib/modules/id/id.module';
 export { SkyIdService } from './lib/modules/id/id.service';
 

--- a/libs/components/core/src/lib/modules/icons/icon-svg-url.ts
+++ b/libs/components/core/src/lib/modules/icons/icon-svg-url.ts
@@ -1,0 +1,6 @@
+import { InjectionToken } from '@angular/core';
+
+// This exists in @skyux/core instead of @skyux/icons in the case where a consuming shared library
+// does not have an existing peer dependency on @skyux/icons. Consider moving this to @skyux/icons
+// in a breaking change.
+export const SKY_ICON_SVG_URL = new InjectionToken<string>('SKY_ICON_SVG_URL');

--- a/libs/components/icon/src/lib/modules/icon/icon-svg-resolver.service.spec.ts
+++ b/libs/components/icon/src/lib/modules/icon/icon-svg-resolver.service.spec.ts
@@ -1,7 +1,12 @@
 import { TestBed } from '@angular/core/testing';
 
+import { SKY_ICON_SVG_URL } from '@skyux/core';
+
 import { SkyIconSvgResolverService } from './icon-svg-resolver.service';
 import { SkyIconVariantType } from './types/icon-variant-type';
+
+const DEFAULT_SVG_URL =
+  'https://sky.blackbaudcdn.net/static/skyux-icons/10/assets/svg/skyux-icons.svg';
 
 describe('Icon SVG resolver service', () => {
   let fetchMock: jasmine.Spy<typeof fetch>;
@@ -23,6 +28,7 @@ describe('Icon SVG resolver service', () => {
     size?: number,
     variant?: SkyIconVariantType,
     expectedError?: string,
+    expectedUrl = DEFAULT_SVG_URL,
   ): Promise<void> {
     const hrefPromise = resolverSvc.resolveHref(name, size, variant);
 
@@ -34,9 +40,7 @@ describe('Icon SVG resolver service', () => {
 
     // Fetch should only be called once per instance of the resolver service
     // and the result shared across subsequent calls to resolveHref().
-    expect(fetchMock).toHaveBeenCalledOnceWith(
-      'https://sky.blackbaudcdn.net/static/skyux-icons/10/assets/svg/skyux-icons.svg',
-    );
+    expect(fetchMock).toHaveBeenCalledOnceWith(expectedUrl);
   }
 
   beforeAll(() => {
@@ -146,6 +150,33 @@ describe('Icon SVG resolver service', () => {
 
     it('should resolve to the icon size closest to the default size when size is not specified', async () => {
       await validate('multi-size', '#sky-i-multi-size-12-line');
+    });
+  });
+
+  describe('with SKY_ICON_SVG_URL provided', () => {
+    const customUrl = 'https://example.com/custom-icons.svg';
+
+    beforeEach(() => {
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({
+        providers: [
+          SkyIconSvgResolverService,
+          { provide: SKY_ICON_SVG_URL, useValue: customUrl },
+        ],
+      });
+
+      resolverSvc = TestBed.inject(SkyIconSvgResolverService);
+    });
+
+    it('should fetch the icon sprite from the provided URL instead of the default', async () => {
+      await validate(
+        'single-size',
+        '#sky-i-single-size-12-line',
+        12,
+        'line',
+        undefined,
+        customUrl,
+      );
     });
   });
 });

--- a/libs/components/icon/src/lib/modules/icon/icon-svg-resolver.service.spec.ts
+++ b/libs/components/icon/src/lib/modules/icon/icon-svg-resolver.service.spec.ts
@@ -69,9 +69,7 @@ describe('Icon SVG resolver service', () => {
       ),
     );
 
-    logSvcSpy = jasmine.createSpyObj<SkyLogService>('SkyLogService', [
-      'warn',
-    ]);
+    logSvcSpy = jasmine.createSpyObj<SkyLogService>('SkyLogService', ['warn']);
 
     TestBed.configureTestingModule({
       providers: [

--- a/libs/components/icon/src/lib/modules/icon/icon-svg-resolver.service.spec.ts
+++ b/libs/components/icon/src/lib/modules/icon/icon-svg-resolver.service.spec.ts
@@ -1,7 +1,7 @@
 import { Injector } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 
-import { SKY_ICON_SVG_URL } from '@skyux/core';
+import { SKY_ICON_SVG_URL, SkyLogService } from '@skyux/core';
 
 import { SkyIconSvgResolverService } from './icon-svg-resolver.service';
 import { SkyIconVariantType } from './types/icon-variant-type';
@@ -12,6 +12,7 @@ const DEFAULT_SVG_URL =
 describe('Icon SVG resolver service', () => {
   let fetchMock: jasmine.Spy<typeof fetch>;
   let resolverSvc: SkyIconSvgResolverService;
+  let logSvcSpy: jasmine.SpyObj<SkyLogService>;
 
   function buildSymbolHtml(
     name: string,
@@ -68,8 +69,15 @@ describe('Icon SVG resolver service', () => {
       ),
     );
 
+    logSvcSpy = jasmine.createSpyObj<SkyLogService>('SkyLogService', [
+      'warn',
+    ]);
+
     TestBed.configureTestingModule({
-      providers: [SkyIconSvgResolverService],
+      providers: [
+        SkyIconSvgResolverService,
+        { provide: SkyLogService, useValue: logSvcSpy },
+      ],
     });
 
     resolverSvc = TestBed.inject(SkyIconSvgResolverService);
@@ -167,6 +175,7 @@ describe('Icon SVG resolver service', () => {
         providers: [
           SkyIconSvgResolverService,
           { provide: SKY_ICON_SVG_URL, useValue: customUrl },
+          { provide: SkyLogService, useValue: logSvcSpy },
         ],
       });
 
@@ -187,13 +196,15 @@ describe('Icon SVG resolver service', () => {
 
   it('should warn (but not throw) when a second instance is configured with a different SVG URL', async () => {
     const customUrl = 'https://example.com/different-icons.svg';
-    const consoleWarnSpy = spyOn(console, 'warn');
 
     // Establish the icon map via the default-configured instance.
     await expectAsync(
       resolverSvc.resolveHref('single-size', 12, 'line'),
     ).toBeResolvedTo('#sky-i-single-size-12-line');
 
+    // The custom instance resolves SkyLogService from the same TestBed
+    // injector (via its parent), so it shares `logSvcSpy`.
+    // The warning should fire once, at construction time...
     const customResolverSvc = Injector.create({
       providers: [
         SkyIconSvgResolverService,
@@ -202,15 +213,20 @@ describe('Icon SVG resolver service', () => {
       parent: TestBed.inject(Injector),
     }).get(SkyIconSvgResolverService);
 
-    // A differently-configured instance should warn rather than throw, and
-    // still resolve using whichever sprite was already loaded.
+    expect(logSvcSpy.warn).toHaveBeenCalledOnceWith(
+      `SkyIconSvgResolverService only supports one SKY_ICON_SVG_URL value per application. An icon sprite has already been loaded from '${DEFAULT_SVG_URL}', so a sprite will not also be loaded from '${customUrl}'.`,
+    );
+
+    // ...not repeatedly on every call to resolveHref(), which should still
+    // resolve using whichever sprite was already loaded.
+    await expectAsync(
+      customResolverSvc.resolveHref('single-size', 12, 'line'),
+    ).toBeResolvedTo('#sky-i-single-size-12-line');
     await expectAsync(
       customResolverSvc.resolveHref('single-size', 12, 'line'),
     ).toBeResolvedTo('#sky-i-single-size-12-line');
 
-    expect(consoleWarnSpy).toHaveBeenCalledOnceWith(
-      `SkyIconSvgResolverService only supports one SKY_ICON_SVG_URL value per application. An icon sprite has already been loaded from '${DEFAULT_SVG_URL}', so a sprite will not also be loaded from '${customUrl}'.`,
-    );
+    expect(logSvcSpy.warn).toHaveBeenCalledTimes(1);
 
     // The second instance's URL should never have been fetched.
     expect(fetchMock).toHaveBeenCalledOnceWith(DEFAULT_SVG_URL);

--- a/libs/components/icon/src/lib/modules/icon/icon-svg-resolver.service.spec.ts
+++ b/libs/components/icon/src/lib/modules/icon/icon-svg-resolver.service.spec.ts
@@ -1,3 +1,4 @@
+import { Injector } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 
 import { SKY_ICON_SVG_URL } from '@skyux/core';
@@ -76,7 +77,11 @@ describe('Icon SVG resolver service', () => {
 
   afterEach(() => {
     resolverSvc.resetIconMap();
-    document.getElementById('sky-icon-svg-sprite')?.remove();
+    // Some tests insert more than one sprite (each sharing the same id), so
+    // remove them all rather than only the first match.
+    document
+      .querySelectorAll('#sky-icon-svg-sprite')
+      .forEach((el) => el.remove());
   });
 
   it('should resolve the expected variant', async () => {
@@ -178,5 +183,36 @@ describe('Icon SVG resolver service', () => {
         customUrl,
       );
     });
+  });
+
+  it('should warn (but not throw) when a second instance is configured with a different SVG URL', async () => {
+    const customUrl = 'https://example.com/different-icons.svg';
+    const consoleWarnSpy = spyOn(console, 'warn');
+
+    // Establish the icon map via the default-configured instance.
+    await expectAsync(
+      resolverSvc.resolveHref('single-size', 12, 'line'),
+    ).toBeResolvedTo('#sky-i-single-size-12-line');
+
+    const customResolverSvc = Injector.create({
+      providers: [
+        SkyIconSvgResolverService,
+        { provide: SKY_ICON_SVG_URL, useValue: customUrl },
+      ],
+      parent: TestBed.inject(Injector),
+    }).get(SkyIconSvgResolverService);
+
+    // A differently-configured instance should warn rather than throw, and
+    // still resolve using whichever sprite was already loaded.
+    await expectAsync(
+      customResolverSvc.resolveHref('single-size', 12, 'line'),
+    ).toBeResolvedTo('#sky-i-single-size-12-line');
+
+    expect(consoleWarnSpy).toHaveBeenCalledOnceWith(
+      `SkyIconSvgResolverService only supports one SKY_ICON_SVG_URL value per application. An icon sprite has already been loaded from '${DEFAULT_SVG_URL}', so a sprite will not also be loaded from '${customUrl}'.`,
+    );
+
+    // The second instance's URL should never have been fetched.
+    expect(fetchMock).toHaveBeenCalledOnceWith(DEFAULT_SVG_URL);
   });
 });

--- a/libs/components/icon/src/lib/modules/icon/icon-svg-resolver.service.ts
+++ b/libs/components/icon/src/lib/modules/icon/icon-svg-resolver.service.ts
@@ -1,11 +1,15 @@
-import { Injectable } from '@angular/core';
+import { inject, Injectable } from '@angular/core';
+
+import { SKY_ICON_SVG_URL } from '@skyux/core';
 
 import { SkyIconVariantType } from './types/icon-variant-type';
 
-async function getIconMap(): Promise<Map<string, number[]>> {
-  const response = await fetch(
-    `https://sky.blackbaudcdn.net/static/skyux-icons/10/assets/svg/skyux-icons.svg`,
-  );
+async function getIconMap(
+  svgUrl: string | null,
+): Promise<Map<string, number[]>> {
+  svgUrl ||= `https://sky.blackbaudcdn.net/static/skyux-icons/10/assets/svg/skyux-icons.svg`;
+
+  const response = await fetch(svgUrl);
 
   /* istanbul ignore next */
   if (!response.ok) {
@@ -93,13 +97,15 @@ let iconMapPromise: Promise<Map<string, number[]>> | undefined;
   providedIn: 'root',
 })
 export class SkyIconSvgResolverService {
+  #svgUrl = inject(SKY_ICON_SVG_URL, { optional: true });
+
   public async resolveHref(
     name: string,
     pixelSize = 16,
     variant: SkyIconVariantType = 'line',
   ): Promise<string> {
     if (!iconMapPromise) {
-      iconMapPromise = getIconMap();
+      iconMapPromise = getIconMap(this.#svgUrl);
     }
 
     const iconMap = await iconMapPromise;

--- a/libs/components/icon/src/lib/modules/icon/icon-svg-resolver.service.ts
+++ b/libs/components/icon/src/lib/modules/icon/icon-svg-resolver.service.ts
@@ -6,6 +6,20 @@ import { SkyIconVariantType } from './types/icon-variant-type';
 
 const DEFAULT_SVG_URL = `https://sky.blackbaudcdn.net/static/skyux-icons/10/assets/svg/skyux-icons.svg`;
 
+// The icon sprite is loaded into (and queried from) the document as a single
+// global element, so only one SKY_ICON_SVG_URL can be active per application
+// at a time. These track which URL "owns" the current icon map.
+let iconMapPromise: Promise<Map<string, number[]>> | undefined;
+let loadedSvgUrl: string | undefined;
+
+function warnIfUrlMismatch(svgUrl: string): void {
+  if (loadedSvgUrl && loadedSvgUrl !== svgUrl) {
+    console.warn(
+      `SkyIconSvgResolverService only supports one SKY_ICON_SVG_URL value per application. An icon sprite has already been loaded from '${loadedSvgUrl}', so a sprite will not also be loaded from '${svgUrl}'.`,
+    );
+  }
+}
+
 async function getIconMap(svgUrl: string): Promise<Map<string, number[]>> {
   const response = await fetch(svgUrl);
 
@@ -84,20 +98,6 @@ function getNearestSize(
   }
 
   return undefined;
-}
-
-// The icon sprite is loaded into (and queried from) the document as a single
-// global element, so only one SKY_ICON_SVG_URL can be active per application
-// at a time. These track which URL "owns" the current icon map.
-let iconMapPromise: Promise<Map<string, number[]>> | undefined;
-let loadedSvgUrl: string | undefined;
-
-function warnIfUrlMismatch(svgUrl: string): void {
-  if (loadedSvgUrl && loadedSvgUrl !== svgUrl) {
-    console.warn(
-      `SkyIconSvgResolverService only supports one SKY_ICON_SVG_URL value per application. An icon sprite has already been loaded from '${loadedSvgUrl}', so a sprite will not also be loaded from '${svgUrl}'.`,
-    );
-  }
 }
 
 /**

--- a/libs/components/icon/src/lib/modules/icon/icon-svg-resolver.service.ts
+++ b/libs/components/icon/src/lib/modules/icon/icon-svg-resolver.service.ts
@@ -1,6 +1,6 @@
 import { inject, Injectable } from '@angular/core';
 
-import { SKY_ICON_SVG_URL } from '@skyux/core';
+import { SKY_ICON_SVG_URL, SkyLogService } from '@skyux/core';
 
 import { SkyIconVariantType } from './types/icon-variant-type';
 
@@ -11,14 +11,6 @@ const DEFAULT_SVG_URL = `https://sky.blackbaudcdn.net/static/skyux-icons/10/asse
 // at a time. These track which URL "owns" the current icon map.
 let iconMapPromise: Promise<Map<string, number[]>> | undefined;
 let loadedSvgUrl: string | undefined;
-
-function warnIfUrlMismatch(svgUrl: string): void {
-  if (loadedSvgUrl && loadedSvgUrl !== svgUrl) {
-    console.warn(
-      `SkyIconSvgResolverService only supports one SKY_ICON_SVG_URL value per application. An icon sprite has already been loaded from '${loadedSvgUrl}', so a sprite will not also be loaded from '${svgUrl}'.`,
-    );
-  }
-}
 
 async function getIconMap(svgUrl: string): Promise<Map<string, number[]>> {
   const response = await fetch(svgUrl);
@@ -108,14 +100,17 @@ function getNearestSize(
 })
 export class SkyIconSvgResolverService {
   #svgUrl = inject(SKY_ICON_SVG_URL, { optional: true }) ?? DEFAULT_SVG_URL;
+  #logSvc = inject(SkyLogService);
+
+  constructor() {
+    this.#warnIfUrlMismatch();
+  }
 
   public async resolveHref(
     name: string,
     pixelSize = 16,
     variant: SkyIconVariantType = 'line',
   ): Promise<string> {
-    warnIfUrlMismatch(this.#svgUrl);
-
     if (!iconMapPromise) {
       loadedSvgUrl = this.#svgUrl;
       iconMapPromise = getIconMap(this.#svgUrl);
@@ -144,5 +139,13 @@ export class SkyIconSvgResolverService {
   public resetIconMap(): void {
     iconMapPromise = undefined;
     loadedSvgUrl = undefined;
+  }
+
+  #warnIfUrlMismatch(): void {
+    if (loadedSvgUrl && loadedSvgUrl !== this.#svgUrl) {
+      this.#logSvc.warn(
+        `SkyIconSvgResolverService only supports one SKY_ICON_SVG_URL value per application. An icon sprite has already been loaded from '${loadedSvgUrl}', so a sprite will not also be loaded from '${this.#svgUrl}'.`,
+      );
+    }
   }
 }

--- a/libs/components/icon/src/lib/modules/icon/icon-svg-resolver.service.ts
+++ b/libs/components/icon/src/lib/modules/icon/icon-svg-resolver.service.ts
@@ -4,11 +4,9 @@ import { SKY_ICON_SVG_URL } from '@skyux/core';
 
 import { SkyIconVariantType } from './types/icon-variant-type';
 
-async function getIconMap(
-  svgUrl: string | null,
-): Promise<Map<string, number[]>> {
-  svgUrl ||= `https://sky.blackbaudcdn.net/static/skyux-icons/10/assets/svg/skyux-icons.svg`;
+const DEFAULT_SVG_URL = `https://sky.blackbaudcdn.net/static/skyux-icons/10/assets/svg/skyux-icons.svg`;
 
+async function getIconMap(svgUrl: string): Promise<Map<string, number[]>> {
   const response = await fetch(svgUrl);
 
   /* istanbul ignore next */
@@ -88,7 +86,19 @@ function getNearestSize(
   return undefined;
 }
 
+// The icon sprite is loaded into (and queried from) the document as a single
+// global element, so only one SKY_ICON_SVG_URL can be active per application
+// at a time. These track which URL "owns" the current icon map.
 let iconMapPromise: Promise<Map<string, number[]>> | undefined;
+let loadedSvgUrl: string | undefined;
+
+function warnIfUrlMismatch(svgUrl: string): void {
+  if (loadedSvgUrl && loadedSvgUrl !== svgUrl) {
+    console.warn(
+      `SkyIconSvgResolverService only supports one SKY_ICON_SVG_URL value per application. An icon sprite has already been loaded from '${loadedSvgUrl}', so a sprite will not also be loaded from '${svgUrl}'.`,
+    );
+  }
+}
 
 /**
  * @internal
@@ -97,14 +107,17 @@ let iconMapPromise: Promise<Map<string, number[]>> | undefined;
   providedIn: 'root',
 })
 export class SkyIconSvgResolverService {
-  #svgUrl = inject(SKY_ICON_SVG_URL, { optional: true });
+  #svgUrl = inject(SKY_ICON_SVG_URL, { optional: true }) ?? DEFAULT_SVG_URL;
 
   public async resolveHref(
     name: string,
     pixelSize = 16,
     variant: SkyIconVariantType = 'line',
   ): Promise<string> {
+    warnIfUrlMismatch(this.#svgUrl);
+
     if (!iconMapPromise) {
+      loadedSvgUrl = this.#svgUrl;
       iconMapPromise = getIconMap(this.#svgUrl);
     }
 
@@ -130,5 +143,6 @@ export class SkyIconSvgResolverService {
 
   public resetIconMap(): void {
     iconMapPromise = undefined;
+    loadedSvgUrl = undefined;
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configuration support for customizing the SVG sprite URL used by icons.
  * The icon resolver uses the configured URL when provided, with the default CDN URL as a fallback.
  * Prevented repeated icon sprite loading when multiple configurations are used, with a warning for conflicting URLs.
* **Tests**
  * Added coverage for custom URLs, sprite reuse, fallback behavior, and preventing alternate URL requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->