### PR TITLE
fix: use menu background color for timepicker and popover

### DIFF
--- a/libs/components/datetime/src/lib/modules/timepicker/timepicker.component.html
+++ b/libs/components/datetime/src/lib/modules/timepicker/timepicker.component.html
@@ -44,7 +44,7 @@
 <ng-template #timepickerTemplateRef>
   <div
     #timepickerRef
-    class="sky-timepicker-container sky-shadow sky-box sky-elevation-4"
+    class="sky-timepicker-container sky-shadow sky-elevation-4"
     role="dialog"
     [attr.aria-labelledby]="triggerButtonId"
     [attr.id]="timepickerId"

--- a/libs/components/popovers/src/lib/modules/popover/popover-content.component.scss
+++ b/libs/components/popovers/src/lib/modules/popover/popover-content.component.scss
@@ -67,7 +67,7 @@ $popover-max-width: 276px;
 .sky-popover {
   background-color: var(
     --sky-override-popover-background-color,
-    var(--sky-color-background-container-base)
+    var(--sky-color-background-container-menu)
   );
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timepicker styling by removing an unnecessary container style.
  * Updated popover fallback background coloring for better visual consistency with menus.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->