### PR TITLE
fix(sdk/testing): move `SkyAppTestUtility` to private entrypoint to avoid leaking jasmine types

### DIFF
--- a/libs/components/avatar/testing/src/legacy/avatar-fixture.ts
+++ b/libs/components/avatar/testing/src/legacy/avatar-fixture.ts
@@ -1,7 +1,7 @@
 import { DebugElement } from '@angular/core';
 import { ComponentFixture } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { SkyAppTestUtility } from '@skyux-sdk/testing';
+import { _SkyAppTestUtility as SkyAppTestUtility } from '@skyux-sdk/testing/private';
 
 /**
  * Allows interaction with a SKY UX avatar component.

--- a/libs/components/code-examples/src/lib/modules/layout/back-to-top/infinite-scroll/example.component.spec.ts
+++ b/libs/components/code-examples/src/lib/modules/layout/back-to-top/infinite-scroll/example.component.spec.ts
@@ -1,6 +1,5 @@
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { TestBed } from '@angular/core/testing';
-import { SkyAppTestUtility } from '@skyux-sdk/testing';
 import { SkyBackToTopHarness } from '@skyux/layout/testing';
 import { SkyInfiniteScrollHarness } from '@skyux/lists/testing';
 
@@ -43,7 +42,7 @@ describe('Back to top repeater with infinite scroll example', () => {
     await fixture.whenStable();
 
     window.scrollTo(0, document.body.scrollHeight);
-    SkyAppTestUtility.fireDomEvent(window, 'scroll');
+    window.dispatchEvent(new Event('scroll'));
     fixture.detectChanges();
     await fixture.whenStable();
 

--- a/libs/components/code-examples/src/lib/modules/layout/back-to-top/repeater/example.component.spec.ts
+++ b/libs/components/code-examples/src/lib/modules/layout/back-to-top/repeater/example.component.spec.ts
@@ -1,6 +1,5 @@
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { TestBed } from '@angular/core/testing';
-import { SkyAppTestUtility } from '@skyux-sdk/testing';
 import { SkyBackToTopHarness } from '@skyux/layout/testing';
 
 import { LayoutBackToTopRepeaterExampleComponent } from './example.component';
@@ -33,7 +32,7 @@ describe('Back to top repeater example', () => {
     await expectAsync(loader.getHarness(SkyBackToTopHarness)).toBeRejected();
 
     window.scrollTo(0, document.body.scrollHeight);
-    SkyAppTestUtility.fireDomEvent(window, 'scroll');
+    window.dispatchEvent(new Event('scroll'));
     fixture.detectChanges();
     await fixture.whenStable();
 

--- a/libs/components/colorpicker/testing/src/legacy/colorpicker-fixture.ts
+++ b/libs/components/colorpicker/testing/src/legacy/colorpicker-fixture.ts
@@ -1,7 +1,7 @@
 import { DebugElement } from '@angular/core';
 import { ComponentFixture } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { SkyAppTestUtility } from '@skyux-sdk/testing';
+import { _SkyAppTestUtility as SkyAppTestUtility } from '@skyux-sdk/testing/private';
 
 /**
  * Allows interaction with a SKY UX colorpicker component.

--- a/libs/components/errors/testing/src/legacy/error-fixture.ts
+++ b/libs/components/errors/testing/src/legacy/error-fixture.ts
@@ -1,7 +1,7 @@
 import { DebugElement } from '@angular/core';
 import { ComponentFixture } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { SkyAppTestUtility } from '@skyux-sdk/testing';
+import { _SkyAppTestUtility as SkyAppTestUtility } from '@skyux-sdk/testing/private';
 
 const SKY_ERROR_IMAGE_CLS_REGEX = /^sky-error-(\w*)-image$/;
 

--- a/libs/components/forms/testing/src/legacy/checkbox-fixture.ts
+++ b/libs/components/forms/testing/src/legacy/checkbox-fixture.ts
@@ -1,7 +1,7 @@
 import { DebugElement } from '@angular/core';
 import { ComponentFixture } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { SkyAppTestUtility } from '@skyux-sdk/testing';
+import { _SkyAppTestUtility as SkyAppTestUtility } from '@skyux-sdk/testing/private';
 
 /**
  * Allows interaction with a SKY UX checkbox component.

--- a/libs/components/forms/testing/src/legacy/radio-fixture.ts
+++ b/libs/components/forms/testing/src/legacy/radio-fixture.ts
@@ -1,7 +1,7 @@
 import { DebugElement } from '@angular/core';
 import { ComponentFixture } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { SkyAppTestUtility } from '@skyux-sdk/testing';
+import { _SkyAppTestUtility as SkyAppTestUtility } from '@skyux-sdk/testing/private';
 
 /**
  * Allows interaction with a SKY UX radio buttons within a radio group.

--- a/libs/components/indicators/testing/src/legacy/alert-fixture.ts
+++ b/libs/components/indicators/testing/src/legacy/alert-fixture.ts
@@ -1,7 +1,7 @@
 import { DebugElement } from '@angular/core';
 import { ComponentFixture } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { SkyAppTestUtility } from '@skyux-sdk/testing';
+import { _SkyAppTestUtility as SkyAppTestUtility } from '@skyux-sdk/testing/private';
 
 /**
  * Allows interaction with a SKY UX alert component.

--- a/libs/components/indicators/testing/src/legacy/label-fixture.ts
+++ b/libs/components/indicators/testing/src/legacy/label-fixture.ts
@@ -1,7 +1,7 @@
 import { DebugElement } from '@angular/core';
 import { ComponentFixture } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { SkyAppTestUtility } from '@skyux-sdk/testing';
+import { _SkyAppTestUtility as SkyAppTestUtility } from '@skyux-sdk/testing/private';
 
 /**
  * Allows interaction with a SKY UX label component.

--- a/libs/components/indicators/testing/src/legacy/wait-fixture.ts
+++ b/libs/components/indicators/testing/src/legacy/wait-fixture.ts
@@ -1,6 +1,6 @@
 import { DebugElement } from '@angular/core';
 import { ComponentFixture } from '@angular/core/testing';
-import { SkyAppTestUtility } from '@skyux-sdk/testing';
+import { _SkyAppTestUtility as SkyAppTestUtility } from '@skyux-sdk/testing/private';
 
 /**
  * @deprecated Use `SkyWaitHarness` instead.

--- a/libs/components/layout/testing/src/legacy/action-button-fixture.ts
+++ b/libs/components/layout/testing/src/legacy/action-button-fixture.ts
@@ -1,7 +1,7 @@
 import { DebugElement } from '@angular/core';
 import { ComponentFixture } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { SkyAppTestUtility } from '@skyux-sdk/testing';
+import { _SkyAppTestUtility as SkyAppTestUtility } from '@skyux-sdk/testing/private';
 
 /**
  * Allows interaction with a SKY UX action button component.

--- a/libs/components/layout/testing/src/legacy/card-fixture.ts
+++ b/libs/components/layout/testing/src/legacy/card-fixture.ts
@@ -1,7 +1,7 @@
 import { DebugElement } from '@angular/core';
 import { ComponentFixture } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { SkyAppTestUtility } from '@skyux-sdk/testing';
+import { _SkyAppTestUtility as SkyAppTestUtility } from '@skyux-sdk/testing/private';
 
 /**
  * Allows interaction with a SKY UX avatar component.

--- a/libs/components/layout/testing/src/legacy/page-summary-fixture.ts
+++ b/libs/components/layout/testing/src/legacy/page-summary-fixture.ts
@@ -1,7 +1,7 @@
 import { DebugElement } from '@angular/core';
 import { ComponentFixture } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { SkyAppTestUtility } from '@skyux-sdk/testing';
+import { _SkyAppTestUtility as SkyAppTestUtility } from '@skyux-sdk/testing/private';
 
 /**
  * Allows interaction with a SKY UX page summary component.

--- a/libs/components/list-builder-view-checklist/testing/src/legacy/list-view-checklist-fixture.ts
+++ b/libs/components/list-builder-view-checklist/testing/src/legacy/list-view-checklist-fixture.ts
@@ -1,7 +1,7 @@
 import { DebugElement } from '@angular/core';
 import { ComponentFixture } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { SkyAppTestUtility } from '@skyux-sdk/testing';
+import { _SkyAppTestUtility as SkyAppTestUtility } from '@skyux-sdk/testing/private';
 
 import { SkyListViewChecklistItem } from './list-view-checklist-item';
 

--- a/libs/components/list-builder-view-grids/testing/src/legacy/list-view-grid-fixture.ts
+++ b/libs/components/list-builder-view-grids/testing/src/legacy/list-view-grid-fixture.ts
@@ -1,7 +1,7 @@
 import { DebugElement } from '@angular/core';
 import { ComponentFixture } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { SkyAppTestUtility } from '@skyux-sdk/testing';
+import { _SkyAppTestUtility as SkyAppTestUtility } from '@skyux-sdk/testing/private';
 
 import { SkyListViewGridFixtureCell } from './list-view-grid-fixture-cell';
 import { SkyListViewGridFixtureHeader } from './list-view-grid-fixture-header';

--- a/libs/components/lists/testing/src/legacy/infinite-scroll/infinite-scroll-fixture.ts
+++ b/libs/components/lists/testing/src/legacy/infinite-scroll/infinite-scroll-fixture.ts
@@ -1,6 +1,6 @@
 import { DebugElement } from '@angular/core';
 import { ComponentFixture } from '@angular/core/testing';
-import { SkyAppTestUtility } from '@skyux-sdk/testing';
+import { _SkyAppTestUtility as SkyAppTestUtility } from '@skyux-sdk/testing/private';
 
 /**
  * Provides information for and interaction with a SKY UX infinite scroll component.

--- a/libs/components/lists/testing/src/legacy/paging/paging-fixture.ts
+++ b/libs/components/lists/testing/src/legacy/paging/paging-fixture.ts
@@ -1,7 +1,7 @@
 import { DebugElement } from '@angular/core';
 import { ComponentFixture } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { SkyAppTestUtility } from '@skyux-sdk/testing';
+import { _SkyAppTestUtility as SkyAppTestUtility } from '@skyux-sdk/testing/private';
 
 import { SkyPagingFixtureButton } from './paging-fixture-button';
 

--- a/libs/components/lists/testing/src/legacy/sort/sort-fixture.ts
+++ b/libs/components/lists/testing/src/legacy/sort/sort-fixture.ts
@@ -1,7 +1,7 @@
 import { DebugElement } from '@angular/core';
 import { ComponentFixture } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { SkyAppTestUtility } from '@skyux-sdk/testing';
+import { _SkyAppTestUtility as SkyAppTestUtility } from '@skyux-sdk/testing/private';
 
 import { SkySortFixtureMenu } from './sort-fixture-menu';
 import { SkySortFixtureMenuItem } from './sort-fixture-menu-item';

--- a/libs/components/lookup/testing/src/legacy/search/search-fixture.ts
+++ b/libs/components/lookup/testing/src/legacy/search/search-fixture.ts
@@ -1,7 +1,7 @@
 import { DebugElement } from '@angular/core';
 import { ComponentFixture } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { SkyAppTestUtility } from '@skyux-sdk/testing';
+import { _SkyAppTestUtility as SkyAppTestUtility } from '@skyux-sdk/testing/private';
 
 /**
  * Allows interaction with a SKY UX search component.

--- a/libs/components/phone-field/testing/src/modules/phone-field/fixtures/phone-field-harness-test.component.ts
+++ b/libs/components/phone-field/testing/src/modules/phone-field/fixtures/phone-field-harness-test.component.ts
@@ -61,7 +61,7 @@ export class PhoneFieldHarnessTestComponent {
   public phoneControl: UntypedFormControl | undefined;
   public phoneForm: FormGroup;
 
-  public selectedCountryChange = jasmine.createSpy();
+  public selectedCountryChange = (_country: SkyPhoneFieldCountry): void => {};
 
   #formBuilder = inject(FormBuilder);
 

--- a/libs/components/phone-field/testing/src/modules/phone-field/phone-field-harness.spec.ts
+++ b/libs/components/phone-field/testing/src/modules/phone-field/phone-field-harness.spec.ts
@@ -25,12 +25,17 @@ describe('Phone field harness', () => {
     phoneFieldHarness: SkyPhoneFieldHarness;
     fixture: ComponentFixture<PhoneFieldHarnessTestComponent>;
     loader: HarnessLoader;
+    selectedCountryChangeSpy: jasmine.Spy;
   }> {
     await TestBed.configureTestingModule({
       imports: [PhoneFieldHarnessTestComponent],
     }).compileComponents();
 
     const fixture = TestBed.createComponent(PhoneFieldHarnessTestComponent);
+    const selectedCountryChangeSpy = spyOn(
+      fixture.componentInstance,
+      'selectedCountryChange',
+    );
     const loader = TestbedHarnessEnvironment.loader(fixture);
 
     const phoneFieldHarness: SkyPhoneFieldHarness = options.dataSkyId
@@ -39,7 +44,7 @@ describe('Phone field harness', () => {
         )
       : await loader.getHarness(SkyPhoneFieldHarness);
 
-    return { phoneFieldHarness, fixture, loader };
+    return { phoneFieldHarness, fixture, loader, selectedCountryChangeSpy };
   }
 
   it('should use selected country', async () => {
@@ -61,10 +66,11 @@ describe('Phone field harness', () => {
   });
 
   it('should use newly selected country', async () => {
-    const { phoneFieldHarness, fixture } = await setupTest({
-      dataSkyId: DATA_SKY_ID,
-    });
-    fixture.componentInstance.selectedCountryChange.calls.reset();
+    const { phoneFieldHarness, fixture, selectedCountryChangeSpy } =
+      await setupTest({
+        dataSkyId: DATA_SKY_ID,
+      });
+    selectedCountryChangeSpy.calls.reset();
 
     if (COUNTRY_AU.name) {
       // change the country
@@ -86,9 +92,9 @@ describe('Phone field harness', () => {
     if (COUNTRY_AU?.iso2 && countryIos2) {
       expect(countryIos2).toBe(COUNTRY_AU.iso2);
     }
-    expect(
-      fixture.componentInstance.selectedCountryChange,
-    ).toHaveBeenCalledWith(jasmine.objectContaining(COUNTRY_AU));
+    expect(selectedCountryChangeSpy).toHaveBeenCalledWith(
+      jasmine.objectContaining(COUNTRY_AU),
+    );
 
     // enter a valid phone number for the new country
     await (await phoneFieldHarness.getControl()).setValue(VALID_AU_NUMBER);
@@ -103,12 +109,13 @@ describe('Phone field harness', () => {
   });
 
   it('should return expected country search results', async () => {
-    const { phoneFieldHarness, fixture } = await setupTest({
-      dataSkyId: DATA_SKY_ID,
-    });
+    const { phoneFieldHarness, fixture, selectedCountryChangeSpy } =
+      await setupTest({
+        dataSkyId: DATA_SKY_ID,
+      });
     fixture.detectChanges();
     await fixture.whenStable();
-    fixture.componentInstance.selectedCountryChange.calls.reset();
+    selectedCountryChangeSpy.calls.reset();
 
     if (COUNTRY_AU.name) {
       // search for a country by name
@@ -118,9 +125,7 @@ describe('Phone field harness', () => {
       await fixture.whenStable();
 
       // ensure no country selection has taken place yet
-      expect(
-        fixture.componentInstance.selectedCountryChange,
-      ).toHaveBeenCalledTimes(0);
+      expect(selectedCountryChangeSpy).toHaveBeenCalledTimes(0);
 
       // verify the country search results match the country
       // the dial code that exists as part of the result label is missing the leading '+'

--- a/libs/components/popovers/testing/src/legacy/dropdown/dropdown-fixture.ts
+++ b/libs/components/popovers/testing/src/legacy/dropdown/dropdown-fixture.ts
@@ -1,7 +1,7 @@
 import { DebugElement } from '@angular/core';
 import { ComponentFixture } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { SkyAppTestUtility } from '@skyux-sdk/testing';
+import { _SkyAppTestUtility as SkyAppTestUtility } from '@skyux-sdk/testing/private';
 
 import { SkyPopoversFixtureDropdown } from './popovers-fixture-dropdown';
 import { SkyPopoversFixtureDropdownItem } from './popovers-fixture-dropdown-item';

--- a/libs/components/popovers/testing/src/legacy/popover/popover-fixture.ts
+++ b/libs/components/popovers/testing/src/legacy/popover/popover-fixture.ts
@@ -1,5 +1,5 @@
 import { ComponentFixture } from '@angular/core/testing';
-import { SkyAppTestUtility } from '@skyux-sdk/testing';
+import { _SkyAppTestUtility as SkyAppTestUtility } from '@skyux-sdk/testing/private';
 
 /**
  * Provides information for and interaction with a SKY UX popover component.

--- a/libs/components/tabs/testing/src/legacy/tabs/tabset-fixture.ts
+++ b/libs/components/tabs/testing/src/legacy/tabs/tabset-fixture.ts
@@ -1,7 +1,7 @@
 import { DebugElement } from '@angular/core';
 import { ComponentFixture } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { SkyAppTestUtility } from '@skyux-sdk/testing';
+import { _SkyAppTestUtility as SkyAppTestUtility } from '@skyux-sdk/testing/private';
 
 import { SkyTabsetFixtureTab } from './tab-fixture-tab';
 

--- a/libs/sdk/testing/private/src/index.ts
+++ b/libs/sdk/testing/private/src/index.ts
@@ -1,5 +1,7 @@
 export { _SkyA11yAnalyzer } from './a11y/a11y-analyzer';
 export type { _SkyA11yAnalyzerConfig } from './a11y/a11y-analyzer-config';
+export { _SkyAppTestUtility } from './test-utility/test-utility';
+export type { _SkyAppTestUtilityDomEventOptions } from './test-utility/test-utility-dom-event-options';
 export { _skyTestingCheckAccessibility } from './utility/check-accessibility';
 export { _skyTestingCheckExistence } from './utility/check-existence';
 export { _skyTestingCheckLibResourceTemplate } from './utility/check-lib-resource-template';

--- a/libs/sdk/testing/private/src/test-utility/test-utility-dom-event-options.ts
+++ b/libs/sdk/testing/private/src/test-utility/test-utility-dom-event-options.ts
@@ -1,4 +1,4 @@
-export interface SkyAppTestUtilityDomEventOptions {
+export interface _SkyAppTestUtilityDomEventOptions {
   bubbles?: boolean;
   cancelable?: boolean;
   keyboardEventInit?: KeyboardEventInit;

--- a/libs/sdk/testing/private/src/test-utility/test-utility.spec.ts
+++ b/libs/sdk/testing/private/src/test-utility/test-utility.spec.ts
@@ -1,15 +1,22 @@
+import 'zone.js';
+import 'zone.js/testing';
+
 //#region imports
 import { Component, DebugElement } from '@angular/core';
+import { ComponentFixture, TestBed, getTestBed } from '@angular/core/testing';
 import {
-  ComponentFixture,
-  TestBed,
-  fakeAsync,
-  tick,
-} from '@angular/core/testing';
+  BrowserTestingModule,
+  platformBrowserTesting,
+} from '@angular/platform-browser/testing';
 
 import { _SkyAppTestUtility as SkyAppTestUtility } from './test-utility';
 
 //#endregion
+
+getTestBed().initTestEnvironment(
+  BrowserTestingModule,
+  platformBrowserTesting(),
+);
 
 //#region test components
 
@@ -55,7 +62,7 @@ describe('Test utility', () => {
     document.body.removeChild(inputEl);
   });
 
-  it('should use keyboard event values', fakeAsync(() => {
+  it('should use keyboard event values', () => {
     const elem = document.createElement('div');
     document.body.appendChild(elem);
 
@@ -79,11 +86,10 @@ describe('Test utility', () => {
       },
     });
 
-    tick();
     expect(listenerCalled).toBeTruthy();
-  }));
+  });
 
-  it('should use custom event values', fakeAsync(() => {
+  it('should use custom event values', () => {
     const elem = document.createElement('div');
     document.body.appendChild(elem);
 
@@ -99,9 +105,8 @@ describe('Test utility', () => {
       },
     });
 
-    tick();
     expect(listenerCalled).toBeTruthy();
-  }));
+  });
 
   it('should determine if an element is visible', () => {
     expect(SkyAppTestUtility.isVisible(textEl)).toBe(true);
@@ -114,6 +119,9 @@ describe('Test utility', () => {
   });
 
   it("should retrieve an element's inner text", () => {
+    // jsdom does not compute `innerText` from rendered content like a real browser does.
+    textEl.innerText = '';
+
     expect(SkyAppTestUtility.getText(textEl)).toBe('');
 
     textEl.innerText = '    test   ';
@@ -139,6 +147,12 @@ describe('Test utility', () => {
     imageUrl = SkyAppTestUtility.getBackgroundImageUrl(new DebugElement(bgEl));
 
     expect(imageUrl).toBe('https://example.com/bg/');
+
+    bgEl.style.backgroundImage = 'linear-gradient(red, blue)';
+
+    imageUrl = SkyAppTestUtility.getBackgroundImageUrl(bgEl);
+
+    expect(imageUrl).toBeUndefined();
 
     imageUrl = SkyAppTestUtility.getBackgroundImageUrl(undefined);
 

--- a/libs/sdk/testing/private/src/test-utility/test-utility.spec.ts
+++ b/libs/sdk/testing/private/src/test-utility/test-utility.spec.ts
@@ -7,7 +7,7 @@ import {
   tick,
 } from '@angular/core/testing';
 
-import { SkyAppTestUtility } from './test-utility';
+import { _SkyAppTestUtility as SkyAppTestUtility } from './test-utility';
 
 //#endregion
 

--- a/libs/sdk/testing/private/src/test-utility/test-utility.ts
+++ b/libs/sdk/testing/private/src/test-utility/test-utility.ts
@@ -2,7 +2,7 @@ import { DebugElement } from '@angular/core';
 import { ComponentFixture } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
-import { SkyAppTestUtilityDomEventOptions } from './test-utility-dom-event-options';
+import { _SkyAppTestUtilityDomEventOptions as SkyAppTestUtilityDomEventOptions } from './test-utility-dom-event-options';
 
 function getNativeEl(el: any): any {
   if (!el) {
@@ -16,7 +16,7 @@ function getNativeEl(el: any): any {
   return el;
 }
 
-export class SkyAppTestUtility {
+export class _SkyAppTestUtility {
   public static fireDomEvent(
     element: EventTarget | null | undefined,
     eventName: string,

--- a/libs/sdk/testing/private/src/test-utility/test-utility.ts
+++ b/libs/sdk/testing/private/src/test-utility/test-utility.ts
@@ -97,9 +97,6 @@ export class _SkyAppTestUtility {
     if (nativeEl) {
       const backgroundImageUrl = getComputedStyle(nativeEl).backgroundImage;
 
-      /* istanbul ignore else */
-      // Browser will likely not return an empty value for the computed style,
-      // but leave the if statement here anyway as a sanity check.
       if (backgroundImageUrl) {
         const matches = /url\(('|")([^'"]+)('|")\)/gi.exec(backgroundImageUrl);
 

--- a/libs/sdk/testing/src/index.ts
+++ b/libs/sdk/testing/src/index.ts
@@ -1,6 +1,10 @@
 // Export the a11y analyzer to avoid a breaking change. Remove in a future major version.
 // eslint-disable-next-line @nx/enforce-module-boundaries
-export { _SkyA11yAnalyzer as SkyA11yAnalyzer } from '@skyux-sdk/testing/private';
+export {
+  _SkyA11yAnalyzer as SkyA11yAnalyzer,
+  _SkyAppTestUtility as SkyAppTestUtility,
+  type _SkyAppTestUtilityDomEventOptions as SkyAppTestUtilityDomEventOptions,
+} from '@skyux-sdk/testing/private';
 export type { SkyA11yAnalyzerConfig } from './lib/matchers/a11y-analyzer-config';
 export {
   SkyAsyncMatchers,
@@ -10,5 +14,3 @@ export {
 } from './lib/matchers/matchers';
 export { SkyToBeVisibleOptions } from './lib/matchers/to-be-visible-options';
 export { SkyBy } from './lib/query-predicates/sky-by';
-export { SkyAppTestUtility } from './lib/test-utility/test-utility';
-export { SkyAppTestUtilityDomEventOptions } from './lib/test-utility/test-utility-dom-event-options';


### PR DESCRIPTION
[AB#3987231](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3987231)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized access to shared testing utilities across component fixtures.
  * Preserved existing testing utility behavior and compatibility.

* **Tests**
  * Updated event-handling tests to use more reliable browser event behavior.
  * Improved phone-field test setup with typed callbacks and direct event-spy assertions.
  * Strengthened test coverage for keyboard, custom events, text, and background-image handling.
  * No changes to end-user runtime behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->