### PR TITLE
fix(components/indicators)!: `sky-tokens` no longer prevents projected content from wrapping

### DIFF
--- a/libs/components/indicators/src/lib/modules/tokens/tokens.component.scss
+++ b/libs/components/indicators/src/lib/modules/tokens/tokens.component.scss
@@ -52,6 +52,7 @@ $sky-tokens-gutter-size: 2px;
   .sky-tokens-content {
     flex: 0 0 auto;
     display: inline-flex;
+    flex-wrap: var(--sky-compat-tokens-content-flex-wrap, wrap);
     padding: $sky-tokens-gutter-size;
     flex-grow: 1;
     flex-basis: 0px;

--- a/libs/components/indicators/src/lib/modules/tokens/tokens.component.spec.ts
+++ b/libs/components/indicators/src/lib/modules/tokens/tokens.component.spec.ts
@@ -123,6 +123,34 @@ describe('Tokens component', () => {
       );
     });
 
+    it('should allow content projected into the tokens component to wrap by default', () => {
+      fixture.detectChanges();
+
+      const contentElement = (
+        component.tokensElementRef?.nativeElement as HTMLElement
+      ).querySelector('.sky-tokens-content');
+
+      expect(contentElement).not.toBeNull();
+      expect(getComputedStyle(contentElement as Element).flexWrap).toBe('wrap');
+    });
+
+    it('should allow consumers to restore the previous non-wrapping behavior with --sky-compat-tokens-content-flex-wrap', () => {
+      const hostStyle = (fixture.nativeElement as HTMLElement).style;
+      hostStyle.setProperty('--sky-compat-tokens-content-flex-wrap', 'nowrap');
+
+      fixture.detectChanges();
+
+      const contentElement = (
+        component.tokensElementRef?.nativeElement as HTMLElement
+      ).querySelector('.sky-tokens-content');
+
+      expect(getComputedStyle(contentElement as Element).flexWrap).toBe(
+        'nowrap',
+      );
+
+      hostStyle.removeProperty('--sky-compat-tokens-content-flex-wrap');
+    });
+
     it('should respect trackWith', () => {
       fixture.componentRef.setInput('trackWith', 'id');
       fixture.componentRef.setInput('data', [

--- a/libs/components/packages/src/schematics/migrations/update-15/add-compat-stylesheets/add-compat-stylesheet.schematic.spec.ts
+++ b/libs/components/packages/src/schematics/migrations/update-15/add-compat-stylesheets/add-compat-stylesheet.schematic.spec.ts
@@ -137,6 +137,27 @@ describe('Migrations > Add compat stylesheets', () => {
     );
   });
 
+  it('should add a compat stylesheet for the indicators tokens component', async () => {
+    const { runSchematic, tree } = await setupTest();
+
+    tree.overwrite(
+      '/package.json',
+      JSON.stringify({
+        dependencies: {
+          '@skyux/indicators': 'CURRENT_VERSION.0.0',
+        },
+      }),
+    );
+
+    const updatedTree = await runSchematic();
+    const compatStylesheetContents = updatedTree.readText(compatStylesheetPath);
+
+    expect(compatStylesheetContents).toContain(
+      '--sky-compat-tokens-content-flex-wrap: nowrap;',
+    );
+    expect(compatStylesheetContents).toContain('COMPONENT: TOKENS');
+  });
+
   it('should add a compat stylesheet for libraries in devDependencies', async () => {
     await validateCompatStylesheet(
       JSON.stringify({

--- a/libs/components/packages/src/schematics/migrations/update-15/add-compat-stylesheets/add-compat-stylesheet.schematic.ts
+++ b/libs/components/packages/src/schematics/migrations/update-15/add-compat-stylesheets/add-compat-stylesheet.schematic.ts
@@ -42,6 +42,25 @@ Pointer events are no longer disabled on elements with the "sky-btn-disabled" cl
         },
       ],
     },
+    {
+      name: '@skyux/indicators',
+      components: [
+        {
+          name: 'tokens',
+          styles: [
+            {
+              css: `
+:root {
+  --sky-compat-tokens-content-flex-wrap: nowrap;
+}
+`,
+              instructions: `
+Content projected into the "sky-tokens" component (including "sky-token" elements added directly instead of through the "tokens" input) now wraps onto multiple lines when it doesn't fit within the available width, matching how tokens supplied through the "tokens" input already behave. To address this change, remove this block of code, then verify your layout still looks correct when projected content wraps onto multiple lines.`,
+            },
+          ],
+        },
+      ],
+    },
   ],
 };
 


### PR DESCRIPTION
## Summary
- Content manually projected into `sky-tokens` (e.g. a `sky-token` added directly instead of through the `tokens` input) now wraps onto multiple lines when it overflows, matching how tokens supplied through the `tokens` input already behave. Root cause: `.sky-tokens-content` (the flex item hosting `ng-content`) had no `flex-wrap` declaration, unlike its sibling `.sky-tokens`.
- Ships as an intentional breaking change on this v15-alpha branch, with a `--sky-compat-tokens-content-flex-wrap` CSS custom property (fallback `wrap`) and a matching entry in the `add-compat-stylesheets` migration schematic, so any consumer depending on `@skyux/indicators` automatically gets an `ng update`-generated opt-out restoring the old `nowrap` behavior until they've verified their layout.
- `@skyux/lookup`'s multi-select is the only in-repo consumer that projects content into `sky-tokens`, and it only ever projects a single `textarea` — with one flex item, `wrap` vs `nowrap` is a layout no-op, so its behavior is unaffected (verified: 572/572 tests passing).

BREAKING CHANGE: Content manually projected into `sky-tokens` (via `ng-content`) may now wrap onto a new line instead of running past the container's edge on a single line. To restore the previous behavior temporarily, set `--sky-compat-tokens-content-flex-wrap: nowrap`, or run `ng update` to add this override automatically via the generated compat stylesheet.

[AB#3920841](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3920841)

## Test plan
- [x] `nx test indicators --configuration=ci` — 226/226 passing, including new tests proving the default `wrap` behavior and the compat-variable override
- [x] `nx test packages --configuration=ci` — 184/184 individual test assertions passing (new schematic test included); the Nx task-level failure is a pre-existing, unrelated global coverage-threshold gap confirmed to also exist on the unmodified base commit
- [x] `nx test lookup --configuration=ci` — 572/572 passing, 100% coverage, confirming no regression in the only in-repo consumer that projects content into `sky-tokens`
- [x] `nx run-many --target=build,lint --projects=indicators,packages` — both build and lint clean (0 errors)
- [ ] Full affected-graph sweep across `@skyux/indicators`'s ~100 transitive dependents — deferred to CI (impractical to run serially in an interactive session for a low-level shared package)
- [ ] Manual visual verification in a browser — reviewer/requester plans to do this once the PR is up

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Token content now wraps by default, improving layout behavior when multiple tokens are displayed.
  * Existing layouts can retain non-wrapping behavior through the compatibility styling option.

* **Chores**
  * Added migration support to automatically provide compatibility styling for the indicators token component.
  * Added coverage to verify default wrapping and compatibility behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->