### PR TITLE
feat(components/i18n): support non-region-specific locales for library resources

### DIFF
--- a/libs/components/i18n/src/lib/modules/i18n/get-lib-string-for-locale.spec.ts
+++ b/libs/components/i18n/src/lib/modules/i18n/get-lib-string-for-locale.spec.ts
@@ -11,6 +11,11 @@ describe('Get library string', () => {
           message: 'bar',
         },
       },
+      ES: {
+        foo: {
+          message: 'ejemplo',
+        },
+      },
     };
   });
 
@@ -32,5 +37,10 @@ describe('Get library string', () => {
   it('should handle mixed-case locales', () => {
     const result = getLibStringForLocale(resources, 'en-us', 'foo');
     expect(result).toEqual('bar');
+  });
+
+  it('should handle non-region locales', () => {
+    const result = getLibStringForLocale(resources, 'es-mx', 'foo');
+    expect(result).toEqual('ejemplo');
   });
 });

--- a/libs/components/i18n/src/lib/modules/i18n/get-lib-string-for-locale.spec.ts
+++ b/libs/components/i18n/src/lib/modules/i18n/get-lib-string-for-locale.spec.ts
@@ -26,6 +26,11 @@ describe('Get library string', () => {
           message: 'primer',
         },
       },
+      'SR-LATN-RS': {
+        foo: {
+          message: 'primer (latinica)',
+        },
+      },
     };
   });
 
@@ -61,6 +66,11 @@ describe('Get library string', () => {
 
   it('should handle locales with multiple underscores (e.g. sr_Latn_RS)', () => {
     const result = getLibStringForLocale(resources, 'sr_Latn_RS', 'foo');
+    expect(result).toEqual('primer (latinica)');
+  });
+
+  it('should fall back to the language tag when the full locale is not supported', () => {
+    const result = getLibStringForLocale(resources, 'sr_Cyrl_RS', 'foo');
     expect(result).toEqual('primer');
   });
 });

--- a/libs/components/i18n/src/lib/modules/i18n/get-lib-string-for-locale.spec.ts
+++ b/libs/components/i18n/src/lib/modules/i18n/get-lib-string-for-locale.spec.ts
@@ -16,6 +16,16 @@ describe('Get library string', () => {
           message: 'ejemplo',
         },
       },
+      FIL: {
+        foo: {
+          message: 'halimbawa',
+        },
+      },
+      SR: {
+        foo: {
+          message: 'primer',
+        },
+      },
     };
   });
 
@@ -42,5 +52,15 @@ describe('Get library string', () => {
   it('should handle non-region locales', () => {
     const result = getLibStringForLocale(resources, 'es-mx', 'foo');
     expect(result).toEqual('ejemplo');
+  });
+
+  it('should handle 3-letter language tags (e.g. fil-PH)', () => {
+    const result = getLibStringForLocale(resources, 'fil-PH', 'foo');
+    expect(result).toEqual('halimbawa');
+  });
+
+  it('should handle locales with multiple underscores (e.g. sr_Latn_RS)', () => {
+    const result = getLibStringForLocale(resources, 'sr_Latn_RS', 'foo');
+    expect(result).toEqual('primer');
   });
 });

--- a/libs/components/i18n/src/lib/modules/i18n/get-lib-string-for-locale.ts
+++ b/libs/components/i18n/src/lib/modules/i18n/get-lib-string-for-locale.ts
@@ -11,12 +11,15 @@ export function getLibStringForLocale(
   const defaultLocale = 'en-US';
 
   const normalizeLocale = (locale: string): string =>
-    locale.toLocaleUpperCase().replace('_', '-');
+    locale.toUpperCase().replace(/_/g, '-');
+
+  const normalizedPreferred = normalizeLocale(preferredLocale);
+  const languageTag = normalizedPreferred.split('-')[0];
 
   const localeFallback = [
     ...new Set([
-      normalizeLocale(preferredLocale),
-      normalizeLocale(preferredLocale.substring(0, 2)),
+      normalizedPreferred,
+      languageTag,
       normalizeLocale(defaultLocale),
     ]),
   ];

--- a/libs/components/i18n/src/lib/modules/i18n/get-lib-string-for-locale.ts
+++ b/libs/components/i18n/src/lib/modules/i18n/get-lib-string-for-locale.ts
@@ -10,22 +10,22 @@ export function getLibStringForLocale(
 ): string | undefined {
   const defaultLocale = 'en-US';
 
-  function getResourcesForLocale(locale: string): SkyLibResources {
-    const parsedLocale = locale.toLocaleUpperCase().replace('_', '-');
-    return resources[parsedLocale];
-  }
+  const normalizeLocale = (locale: string): string =>
+    locale.toLocaleUpperCase().replace('_', '-');
 
-  let values: SkyLibResources = getResourcesForLocale(preferredLocale);
+  const localeFallback = [
+    ...new Set([
+      normalizeLocale(preferredLocale),
+      normalizeLocale(preferredLocale.substring(0, 2)),
+      normalizeLocale(defaultLocale),
+    ]),
+  ];
 
-  if (values && values[name]) {
-    return values[name].message;
-  }
-
-  // Attempt to locate default resources.
-  values = getResourcesForLocale(defaultLocale);
-
-  if (values && values[name]) {
-    return values[name].message;
+  for (const locale of localeFallback) {
+    const values = resources[locale];
+    if (values && values[name]) {
+      return values[name].message;
+    }
   }
   return undefined;
 }


### PR DESCRIPTION
[AB#4092222](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/4092222)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved localized message selection across locale formats, including underscores, hyphens, regional variants, and three-letter language tags.
  * Added fallback from unsupported locale variants to language-only and default messages, while avoiding duplicate lookups.
  * Returns no message when no supported locale matches.

* **Tests**
  * Added coverage for Spanish, Filipino, Serbian, Serbian Latin, non-region locales, and multi-component locale tags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->