### PR TITLE
feat(components/i18n): support non-region-specific locales for library resources (#4648)

### DIFF
--- a/libs/components/i18n/src/lib/modules/i18n/get-lib-string-for-locale.spec.ts
+++ b/libs/components/i18n/src/lib/modules/i18n/get-lib-string-for-locale.spec.ts
@@ -11,6 +11,26 @@ describe('Get library string', () => {
           message: 'bar',
         },
       },
+      ES: {
+        foo: {
+          message: 'ejemplo',
+        },
+      },
+      FIL: {
+        foo: {
+          message: 'halimbawa',
+        },
+      },
+      SR: {
+        foo: {
+          message: 'primer',
+        },
+      },
+      'SR-LATN-RS': {
+        foo: {
+          message: 'primer (latinica)',
+        },
+      },
     };
   });
 
@@ -32,5 +52,25 @@ describe('Get library string', () => {
   it('should handle mixed-case locales', () => {
     const result = getLibStringForLocale(resources, 'en-us', 'foo');
     expect(result).toEqual('bar');
+  });
+
+  it('should handle non-region locales', () => {
+    const result = getLibStringForLocale(resources, 'es-mx', 'foo');
+    expect(result).toEqual('ejemplo');
+  });
+
+  it('should handle 3-letter language tags (e.g. fil-PH)', () => {
+    const result = getLibStringForLocale(resources, 'fil-PH', 'foo');
+    expect(result).toEqual('halimbawa');
+  });
+
+  it('should handle locales with multiple underscores (e.g. sr_Latn_RS)', () => {
+    const result = getLibStringForLocale(resources, 'sr_Latn_RS', 'foo');
+    expect(result).toEqual('primer (latinica)');
+  });
+
+  it('should fall back to the language tag when the full locale is not supported', () => {
+    const result = getLibStringForLocale(resources, 'sr_Cyrl_RS', 'foo');
+    expect(result).toEqual('primer');
   });
 });

--- a/libs/components/i18n/src/lib/modules/i18n/get-lib-string-for-locale.ts
+++ b/libs/components/i18n/src/lib/modules/i18n/get-lib-string-for-locale.ts
@@ -10,22 +10,25 @@ export function getLibStringForLocale(
 ): string | undefined {
   const defaultLocale = 'en-US';
 
-  function getResourcesForLocale(locale: string): SkyLibResources {
-    const parsedLocale = locale.toLocaleUpperCase().replace('_', '-');
-    return resources[parsedLocale];
-  }
+  const normalizeLocale = (locale: string): string =>
+    locale.toUpperCase().replace(/_/g, '-');
 
-  let values: SkyLibResources = getResourcesForLocale(preferredLocale);
+  const normalizedPreferred = normalizeLocale(preferredLocale);
+  const languageTag = normalizedPreferred.split('-')[0];
 
-  if (values && values[name]) {
-    return values[name].message;
-  }
+  const localeFallback = [
+    ...new Set([
+      normalizedPreferred,
+      languageTag,
+      normalizeLocale(defaultLocale),
+    ]),
+  ];
 
-  // Attempt to locate default resources.
-  values = getResourcesForLocale(defaultLocale);
-
-  if (values && values[name]) {
-    return values[name].message;
+  for (const locale of localeFallback) {
+    const values = resources[locale];
+    if (values && values[name]) {
+      return values[name].message;
+    }
   }
   return undefined;
 }


### PR DESCRIPTION
:cherries: Cherry picked from #4648 [feat(components/i18n): support non-region-specific locales for library resources](https://github.com/blackbaud/skyux/pull/4648)

[AB#4092222](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/4092222) 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved language and regional locale matching for internationalized content.
  - Locale casing and separators are now handled consistently.
  - Added fallback support from unsupported regional Serbian locales to the corresponding language entry.
  - Improved fallback behavior for non-region and three-letter language codes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->