### PR TITLE
fix(components/indicators): sky-tokens no longer prevents projected content from wrapping

### DIFF
--- a/libs/components/indicators/src/lib/modules/tokens/fixtures/tokens-fixtures.module.ts
+++ b/libs/components/indicators/src/lib/modules/tokens/fixtures/tokens-fixtures.module.ts
@@ -3,11 +3,20 @@ import { NgModule } from '@angular/core';
 import { SkyTokensModule } from '../tokens.module';
 
 import { SkyTokenTestComponent } from './token.component.fixture';
+import { SkyTokensProjectedTokenTestComponent } from './tokens-projected-token.component.fixture';
 import { SkyTokensTestComponent } from './tokens.component.fixture';
 
 @NgModule({
-  declarations: [SkyTokenTestComponent, SkyTokensTestComponent],
+  declarations: [
+    SkyTokenTestComponent,
+    SkyTokensTestComponent,
+    SkyTokensProjectedTokenTestComponent,
+  ],
   imports: [SkyTokensModule],
-  exports: [SkyTokenTestComponent, SkyTokensTestComponent],
+  exports: [
+    SkyTokenTestComponent,
+    SkyTokensTestComponent,
+    SkyTokensProjectedTokenTestComponent,
+  ],
 })
 export class SkyTokensFixturesModule {}

--- a/libs/components/indicators/src/lib/modules/tokens/fixtures/tokens-projected-token.component.fixture.html
+++ b/libs/components/indicators/src/lib/modules/tokens/fixtures/tokens-projected-token.component.fixture.html
@@ -1,4 +1,7 @@
-<sky-tokens>
+<sky-tokens [(tokens)]="tokens">
   <sky-token>Manually added A</sky-token>
   <sky-token>Manually added B</sky-token>
+  @if (includeAdditionalToken) {
+    <sky-token>Manually added C</sky-token>
+  }
 </sky-tokens>

--- a/libs/components/indicators/src/lib/modules/tokens/fixtures/tokens-projected-token.component.fixture.html
+++ b/libs/components/indicators/src/lib/modules/tokens/fixtures/tokens-projected-token.component.fixture.html
@@ -1,0 +1,4 @@
+<sky-tokens>
+  <sky-token>Manually added A</sky-token>
+  <sky-token>Manually added B</sky-token>
+</sky-tokens>

--- a/libs/components/indicators/src/lib/modules/tokens/fixtures/tokens-projected-token.component.fixture.ts
+++ b/libs/components/indicators/src/lib/modules/tokens/fixtures/tokens-projected-token.component.fixture.ts
@@ -1,0 +1,13 @@
+import { Component, ElementRef, ViewChild } from '@angular/core';
+
+import { SkyTokensComponent } from '../tokens.component';
+
+@Component({
+  selector: 'sky-tokens-projected-token-test',
+  templateUrl: './tokens-projected-token.component.fixture.html',
+  standalone: false,
+})
+export class SkyTokensProjectedTokenTestComponent {
+  @ViewChild(SkyTokensComponent, { read: ElementRef })
+  public tokensElementRef: ElementRef | undefined;
+}

--- a/libs/components/indicators/src/lib/modules/tokens/fixtures/tokens-projected-token.component.fixture.ts
+++ b/libs/components/indicators/src/lib/modules/tokens/fixtures/tokens-projected-token.component.fixture.ts
@@ -1,6 +1,7 @@
 import { Component, ElementRef, ViewChild } from '@angular/core';
 
 import { SkyTokensComponent } from '../tokens.component';
+import { SkyToken } from '../types/token';
 
 @Component({
   selector: 'sky-tokens-projected-token-test',
@@ -10,4 +11,11 @@ import { SkyTokensComponent } from '../tokens.component';
 export class SkyTokensProjectedTokenTestComponent {
   @ViewChild(SkyTokensComponent, { read: ElementRef })
   public tokensElementRef: ElementRef | undefined;
+
+  @ViewChild(SkyTokensComponent)
+  public tokensComponent: SkyTokensComponent | undefined;
+
+  public tokens: SkyToken[] | undefined;
+
+  public includeAdditionalToken = false;
 }

--- a/libs/components/indicators/src/lib/modules/tokens/token.component.html
+++ b/libs/components/indicators/src/lib/modules/tokens/token.component.html
@@ -1,6 +1,6 @@
 <div
   class="sky-token sky-btn sky-btn-default"
-  [attr.role]="role"
+  [attr.role]="effectiveRole()"
   [ngClass]="{
     'sky-btn-disabled': disabled,
     'sky-token-disabled': disabled,
@@ -15,7 +15,7 @@
 >
   <span
     class="sky-token-cell"
-    [attr.role]="role === 'row' ? 'gridcell' : undefined"
+    [attr.role]="effectiveRole() === 'row' ? 'gridcell' : undefined"
   >
     <button
       #actionButton="skyId"
@@ -34,7 +34,7 @@
   @if (dismissible) {
     <span
       class="sky-token-cell"
-      [attr.role]="role === 'row' ? 'gridcell' : undefined"
+      [attr.role]="effectiveRole() === 'row' ? 'gridcell' : undefined"
     >
       <button
         class="sky-btn sky-token-btn sky-token-btn-close"

--- a/libs/components/indicators/src/lib/modules/tokens/token.component.ts
+++ b/libs/components/indicators/src/lib/modules/tokens/token.component.ts
@@ -76,6 +76,10 @@ export class SkyTokenComponent {
   @Input()
   public set role(value: string | undefined) {
     this.#_role = value;
+    // SkyTokensComponent sets this property directly in TypeScript (not through a
+    // template binding), so this component's OnPush change detection isn't
+    // automatically triggered. Mark for check explicitly to ensure the token
+    // (and its projected content) re-renders with the updated role.
     this.#changeDetector.markForCheck();
   }
 

--- a/libs/components/indicators/src/lib/modules/tokens/token.component.ts
+++ b/libs/components/indicators/src/lib/modules/tokens/token.component.ts
@@ -1,18 +1,21 @@
 import {
   ChangeDetectionStrategy,
-  ChangeDetectorRef,
   Component,
   ElementRef,
   EventEmitter,
   Input,
   Output,
   ViewChild,
+  computed,
   inject,
+  input,
 } from '@angular/core';
 import { SkyLiveAnnouncerService } from '@skyux/core';
 import { SkyLibResourcesService } from '@skyux/i18n';
 
 import { take } from 'rxjs';
+
+import { SKY_TOKENS_ROLE_CONTEXT } from './tokens-role-context';
 
 @Component({
   selector: 'sky-token',
@@ -70,22 +73,27 @@ export class SkyTokenComponent {
   }
 
   /**
-   * Used by the tokens component to set the appropriate role for each token.
+   * Used by the tokens component to set the appropriate role for each token
+   * generated from the `tokens` input.
    * @internal
    */
-  @Input()
-  public set role(value: string | undefined) {
-    this.#_role = value;
-    // SkyTokensComponent sets this property directly in TypeScript (not through a
-    // template binding), so this component's OnPush change detection isn't
-    // automatically triggered. Mark for check explicitly to ensure the token
-    // (and its projected content) re-renders with the updated role.
-    this.#changeDetector.markForCheck();
-  }
+  public readonly role = input<string | undefined>();
 
-  public get role(): string | undefined {
-    return this.#_role;
-  }
+  /**
+   * The role to apply to the token's host element. Tokens generated from the
+   * `tokens` input receive their role directly through the `role` input above.
+   * Manually projected tokens never receive that binding (Angular does not
+   * apply template bindings to projected content), so they fall back to
+   * asking the ancestor `sky-tokens` component whether its grid role is
+   * active. Reading `#roleContext`'s signal-backed value here (rather than
+   * having `sky-tokens` push the value in imperatively) lets this OnPush
+   * component's view update automatically when that ancestor state changes.
+   * @internal
+   */
+  protected readonly effectiveRole = computed(
+    () =>
+      this.role() ?? (this.#roleContext?.gridRoleActive() ? 'row' : undefined),
+  );
 
   /**
    * Fires when users click the close button.
@@ -109,13 +117,12 @@ export class SkyTokenComponent {
 
   #elementRef = inject(ElementRef);
 
-  readonly #changeDetector = inject(ChangeDetectorRef);
   readonly #liveAnnouncerSvc = inject(SkyLiveAnnouncerService);
   readonly #resourcesSvc = inject(SkyLibResourcesService);
+  readonly #roleContext = inject(SKY_TOKENS_ROLE_CONTEXT, { optional: true });
 
   #_disabled = false;
   #_dismissible = true;
-  #_role: string | undefined;
 
   protected onFocusIn(): void {
     if (!this.isFocused) {

--- a/libs/components/indicators/src/lib/modules/tokens/token.component.ts
+++ b/libs/components/indicators/src/lib/modules/tokens/token.component.ts
@@ -1,5 +1,6 @@
 import {
   ChangeDetectionStrategy,
+  ChangeDetectorRef,
   Component,
   ElementRef,
   EventEmitter,
@@ -73,7 +74,14 @@ export class SkyTokenComponent {
    * @internal
    */
   @Input()
-  public role: string | undefined;
+  public set role(value: string | undefined) {
+    this.#_role = value;
+    this.#changeDetector.markForCheck();
+  }
+
+  public get role(): string | undefined {
+    return this.#_role;
+  }
 
   /**
    * Fires when users click the close button.
@@ -97,11 +105,13 @@ export class SkyTokenComponent {
 
   #elementRef = inject(ElementRef);
 
+  readonly #changeDetector = inject(ChangeDetectorRef);
   readonly #liveAnnouncerSvc = inject(SkyLiveAnnouncerService);
   readonly #resourcesSvc = inject(SkyLibResourcesService);
 
   #_disabled = false;
   #_dismissible = true;
+  #_role: string | undefined;
 
   protected onFocusIn(): void {
     if (!this.isFocused) {

--- a/libs/components/indicators/src/lib/modules/tokens/tokens-role-context.ts
+++ b/libs/components/indicators/src/lib/modules/tokens/tokens-role-context.ts
@@ -1,0 +1,20 @@
+import { InjectionToken } from '@angular/core';
+
+/**
+ * Lets a projected `sky-token` element read the grid-role state of its ancestor
+ * `sky-tokens` component. Angular does not apply template bindings to content
+ * projected elements, so `sky-token` cannot receive its `role` the same way
+ * tokens generated from the `tokens` input do.
+ * @internal
+ */
+export interface SkyTokensRoleContext {
+  /**
+   * Whether the ancestor `sky-tokens` component's grid role is currently active.
+   */
+  readonly gridRoleActive: () => boolean;
+}
+
+/** @internal */
+export const SKY_TOKENS_ROLE_CONTEXT = new InjectionToken<SkyTokensRoleContext>(
+  'SkyTokensRoleContext',
+);

--- a/libs/components/indicators/src/lib/modules/tokens/tokens.component.html
+++ b/libs/components/indicators/src/lib/modules/tokens/tokens.component.html
@@ -25,6 +25,7 @@
       {{ token.value[displayWith] }}
     </sky-token>
   }
+  <ng-content select="sky-token" />
   <div class="sky-tokens-content" [attr.role]="tokens.length ? 'row' : null">
     <div [attr.role]="tokens.length ? 'gridcell' : null">
       <ng-content />

--- a/libs/components/indicators/src/lib/modules/tokens/tokens.component.html
+++ b/libs/components/indicators/src/lib/modules/tokens/tokens.component.html
@@ -2,7 +2,7 @@
   class="sky-tokens"
   [class.sky-tokens-animation-ready]="animationReady()"
   [class.sky-tokens-animation-enabled]="trackWith"
-  [attr.role]="tokens.length ? 'grid' : null"
+  [attr.role]="gridRoleActive() ? 'grid' : null"
 >
   <!--
       The role must use square brackets otherwise Angular sets the native 'role'
@@ -26,8 +26,8 @@
     </sky-token>
   }
   <ng-content select="sky-token" />
-  <div class="sky-tokens-content" [attr.role]="tokens.length ? 'row' : null">
-    <div [attr.role]="tokens.length ? 'gridcell' : null">
+  <div class="sky-tokens-content" [attr.role]="gridRoleActive() ? 'row' : null">
+    <div [attr.role]="gridRoleActive() ? 'gridcell' : null">
       <ng-content />
     </div>
   </div>

--- a/libs/components/indicators/src/lib/modules/tokens/tokens.component.spec.ts
+++ b/libs/components/indicators/src/lib/modules/tokens/tokens.component.spec.ts
@@ -10,6 +10,7 @@ import { SkyLiveAnnouncerService, provideNoopSkyAnimations } from '@skyux/core';
 import { Subject } from 'rxjs';
 
 import { SkyTokensFixturesModule } from './fixtures/tokens-fixtures.module';
+import { SkyTokensProjectedTokenTestComponent } from './fixtures/tokens-projected-token.component.fixture';
 import { SkyTokensTestComponent } from './fixtures/tokens.component.fixture';
 import { SkyTokensMessageType } from './types/tokens-message-type';
 
@@ -121,6 +122,31 @@ describe('Tokens component', () => {
       expect(component.tokensElementRef?.nativeElement).toHaveText(
         'INNER CONTENT',
       );
+    });
+
+    it('should project manually-added sky-token elements as siblings of array-driven tokens so they can wrap', () => {
+      const projectedTokenFixture = TestBed.createComponent(
+        SkyTokensProjectedTokenTestComponent,
+      );
+      projectedTokenFixture.detectChanges();
+
+      const hostElement = projectedTokenFixture.componentInstance
+        .tokensElementRef?.nativeElement as HTMLElement;
+      const tokensRoot = hostElement.querySelector<HTMLElement>('.sky-tokens');
+      const contentContainer = hostElement.querySelector<HTMLElement>(
+        '.sky-tokens-content',
+      );
+      const manualTokens = Array.from(
+        hostElement.querySelectorAll<HTMLElement>('sky-token'),
+      );
+
+      expect(manualTokens.length).toBe(2);
+      for (const tokenElement of manualTokens) {
+        expect(tokenElement.parentElement).toBe(tokensRoot);
+      }
+      expect(contentContainer?.querySelector('sky-token')).toBeNull();
+
+      projectedTokenFixture.destroy();
     });
 
     it('should respect trackWith', () => {

--- a/libs/components/indicators/src/lib/modules/tokens/tokens.component.spec.ts
+++ b/libs/components/indicators/src/lib/modules/tokens/tokens.component.spec.ts
@@ -132,9 +132,8 @@ describe('Tokens component', () => {
       try {
         projectedTokenFixture.detectChanges();
 
-        const hostElement =
-          projectedTokenFixture.componentInstance.tokensElementRef
-            ?.nativeElement;
+        const hostElement = projectedTokenFixture.componentInstance
+          .tokensElementRef?.nativeElement as HTMLElement | undefined;
         if (!hostElement) {
           fail('Expected SkyTokensComponent ElementRef to be available.');
           return;
@@ -169,30 +168,39 @@ describe('Tokens component', () => {
       }
     });
 
-    it('should set role="row" on projected sky-token elements when the grid role is active, and update it as tokens change', () => {
+    it('should apply role="row" to projected sky-token elements whenever the grid role is active, including when driven purely by projected content', () => {
       const projectedTokenFixture = TestBed.createComponent(
         SkyTokensProjectedTokenTestComponent,
       );
       projectedTokenFixture.detectChanges();
 
-      const getProjectedTokenRoles = (): (string | undefined)[] | undefined =>
-        projectedTokenFixture.componentInstance.tokensComponent?.projectedTokenComponents?.map(
-          (token) => token.role,
-        );
+      const getTokenRoles = (): (string | null)[] =>
+        Array.from(
+          (
+            projectedTokenFixture.componentInstance.tokensElementRef
+              ?.nativeElement as HTMLElement
+          ).querySelectorAll('.sky-token'),
+        ).map((tokenElement) => tokenElement.getAttribute('role'));
 
-      expect(getProjectedTokenRoles()).toEqual([undefined, undefined]);
+      // The two manually projected tokens alone are enough to activate the
+      // grid role, even though no array-driven token exists yet.
+      expect(getTokenRoles()).toEqual(['row', 'row']);
 
       projectedTokenFixture.componentInstance.tokens = [
         { value: { name: 'Red' } },
       ];
       projectedTokenFixture.detectChanges();
 
-      expect(getProjectedTokenRoles()).toEqual(['row', 'row']);
+      // The array-driven token renders first in the DOM, followed by the two
+      // projected ones.
+      expect(getTokenRoles()).toEqual(['row', 'row', 'row']);
 
       projectedTokenFixture.componentInstance.tokens = [];
       projectedTokenFixture.detectChanges();
 
-      expect(getProjectedTokenRoles()).toEqual([undefined, undefined]);
+      // Removing the array-driven token leaves the projected tokens' own
+      // presence still driving the grid role.
+      expect(getTokenRoles()).toEqual(['row', 'row']);
 
       projectedTokenFixture.destroy();
     });
@@ -209,12 +217,30 @@ describe('Tokens component', () => {
       projectedTokenFixture.componentInstance.includeAdditionalToken = true;
       projectedTokenFixture.detectChanges();
 
-      const roles =
-        projectedTokenFixture.componentInstance.tokensComponent?.projectedTokenComponents?.map(
-          (token) => token.role,
-        );
+      const hostElement = projectedTokenFixture.componentInstance
+        .tokensElementRef?.nativeElement as HTMLElement;
+      const tokensRoot = hostElement.querySelector<HTMLElement>('.sky-tokens');
+      const contentContainer = hostElement.querySelector<HTMLElement>(
+        '.sky-tokens-content',
+      );
+      const tokenElements = Array.from(
+        hostElement.querySelectorAll<HTMLElement>('.sky-token'),
+      );
 
-      expect(roles).toEqual(['row', 'row', 'row']);
+      expect(tokenElements.map((el) => el.getAttribute('role'))).toEqual([
+        'row',
+        'row',
+        'row',
+        'row',
+      ]);
+
+      // The token projected after the grid role was already active must
+      // still land as a sibling of the array-driven tokens (so it can wrap),
+      // not fall back into the untouched .sky-tokens-content slot.
+      const lastToken = tokenElements.at(-1);
+      expect(lastToken?.textContent?.trim()).toBe('Manually added C');
+      expect(lastToken?.closest('sky-token')?.parentElement).toBe(tokensRoot);
+      expect(contentContainer?.querySelector('sky-token')).toBeNull();
 
       projectedTokenFixture.destroy();
     });

--- a/libs/components/indicators/src/lib/modules/tokens/tokens.component.spec.ts
+++ b/libs/components/indicators/src/lib/modules/tokens/tokens.component.spec.ts
@@ -128,25 +128,43 @@ describe('Tokens component', () => {
       const projectedTokenFixture = TestBed.createComponent(
         SkyTokensProjectedTokenTestComponent,
       );
-      projectedTokenFixture.detectChanges();
 
-      const hostElement = projectedTokenFixture.componentInstance
-        .tokensElementRef?.nativeElement as HTMLElement;
-      const tokensRoot = hostElement.querySelector<HTMLElement>('.sky-tokens');
-      const contentContainer = hostElement.querySelector<HTMLElement>(
-        '.sky-tokens-content',
-      );
-      const manualTokens = Array.from(
-        hostElement.querySelectorAll<HTMLElement>('sky-token'),
-      );
+      try {
+        projectedTokenFixture.detectChanges();
 
-      expect(manualTokens.length).toBe(2);
-      for (const tokenElement of manualTokens) {
-        expect(tokenElement.parentElement).toBe(tokensRoot);
+        const hostElement =
+          projectedTokenFixture.componentInstance.tokensElementRef?.nativeElement;
+        if (!hostElement) {
+          fail('Expected SkyTokensComponent ElementRef to be available.');
+          return;
+        }
+
+        const tokensRoot = hostElement.querySelector<HTMLElement>('.sky-tokens');
+        if (!tokensRoot) {
+          fail('Expected .sky-tokens element to exist.');
+          return;
+        }
+
+        const contentContainer = hostElement.querySelector<HTMLElement>(
+          '.sky-tokens-content',
+        );
+        if (!contentContainer) {
+          fail('Expected .sky-tokens-content element to exist.');
+          return;
+        }
+
+        const manualTokens = Array.from(
+          hostElement.querySelectorAll<HTMLElement>('sky-token'),
+        );
+
+        expect(manualTokens.length).toBe(2);
+        for (const tokenElement of manualTokens) {
+          expect(tokenElement.parentElement).toBe(tokensRoot);
+        }
+        expect(contentContainer.querySelector('sky-token')).toBeNull();
+      } finally {
+        projectedTokenFixture.destroy();
       }
-      expect(contentContainer?.querySelector('sky-token')).toBeNull();
-
-      projectedTokenFixture.destroy();
     });
 
     it('should respect trackWith', () => {

--- a/libs/components/indicators/src/lib/modules/tokens/tokens.component.spec.ts
+++ b/libs/components/indicators/src/lib/modules/tokens/tokens.component.spec.ts
@@ -167,6 +167,56 @@ describe('Tokens component', () => {
       }
     });
 
+    it('should set role="row" on projected sky-token elements when the grid role is active, and update it as tokens change', () => {
+      const projectedTokenFixture = TestBed.createComponent(
+        SkyTokensProjectedTokenTestComponent,
+      );
+      projectedTokenFixture.detectChanges();
+
+      const getProjectedTokenRoles = (): (string | undefined)[] | undefined =>
+        projectedTokenFixture.componentInstance.tokensComponent?.projectedTokenComponents?.map(
+          (token) => token.role,
+        );
+
+      expect(getProjectedTokenRoles()).toEqual([undefined, undefined]);
+
+      projectedTokenFixture.componentInstance.tokens = [
+        { value: { name: 'Red' } },
+      ];
+      projectedTokenFixture.detectChanges();
+
+      expect(getProjectedTokenRoles()).toEqual(['row', 'row']);
+
+      projectedTokenFixture.componentInstance.tokens = [];
+      projectedTokenFixture.detectChanges();
+
+      expect(getProjectedTokenRoles()).toEqual([undefined, undefined]);
+
+      projectedTokenFixture.destroy();
+    });
+
+    it('should set role="row" on sky-token elements projected after the grid role is already active', () => {
+      const projectedTokenFixture = TestBed.createComponent(
+        SkyTokensProjectedTokenTestComponent,
+      );
+      projectedTokenFixture.componentInstance.tokens = [
+        { value: { name: 'Red' } },
+      ];
+      projectedTokenFixture.detectChanges();
+
+      projectedTokenFixture.componentInstance.includeAdditionalToken = true;
+      projectedTokenFixture.detectChanges();
+
+      const roles =
+        projectedTokenFixture.componentInstance.tokensComponent?.projectedTokenComponents?.map(
+          (token) => token.role,
+        );
+
+      expect(roles).toEqual(['row', 'row', 'row']);
+
+      projectedTokenFixture.destroy();
+    });
+
     it('should respect trackWith', () => {
       component.trackWith = 'id';
       component.data = [

--- a/libs/components/indicators/src/lib/modules/tokens/tokens.component.spec.ts
+++ b/libs/components/indicators/src/lib/modules/tokens/tokens.component.spec.ts
@@ -133,13 +133,15 @@ describe('Tokens component', () => {
         projectedTokenFixture.detectChanges();
 
         const hostElement =
-          projectedTokenFixture.componentInstance.tokensElementRef?.nativeElement;
+          projectedTokenFixture.componentInstance.tokensElementRef
+            ?.nativeElement;
         if (!hostElement) {
           fail('Expected SkyTokensComponent ElementRef to be available.');
           return;
         }
 
-        const tokensRoot = hostElement.querySelector<HTMLElement>('.sky-tokens');
+        const tokensRoot =
+          hostElement.querySelector<HTMLElement>('.sky-tokens');
         if (!tokensRoot) {
           fail('Expected .sky-tokens element to exist.');
           return;

--- a/libs/components/indicators/src/lib/modules/tokens/tokens.component.ts
+++ b/libs/components/indicators/src/lib/modules/tokens/tokens.component.ts
@@ -1,9 +1,7 @@
 import {
-  AfterContentInit,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
-  ContentChildren,
   EventEmitter,
   Injector,
   Input,
@@ -13,6 +11,8 @@ import {
   TrackByFunction,
   ViewChildren,
   afterNextRender,
+  computed,
+  contentChildren,
   inject,
   signal,
 } from '@angular/core';
@@ -21,6 +21,10 @@ import { Subject, Subscription } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 
 import { SkyTokenComponent } from './token.component';
+import {
+  SKY_TOKENS_ROLE_CONTEXT,
+  SkyTokensRoleContext,
+} from './tokens-role-context';
 import { SkyToken } from './types/token';
 import { SkyTokenSelectedEventArgs } from './types/token-selected-event-args';
 import { SkyTokensMessage } from './types/tokens-message';
@@ -39,8 +43,11 @@ const DISPLAY_WITH_DEFAULT = 'name';
   styleUrls: ['./tokens.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
   standalone: false,
+  providers: [
+    { provide: SKY_TOKENS_ROLE_CONTEXT, useExisting: SkyTokensComponent },
+  ],
 })
-export class SkyTokensComponent implements AfterContentInit, OnDestroy {
+export class SkyTokensComponent implements SkyTokensRoleContext, OnDestroy {
   /**
    * Whether to disable the tokens list to prevent users from selecting tokens,
    * dismissing tokens, or navigating through the list with the arrow keys. When the tokens list
@@ -109,19 +116,18 @@ export class SkyTokensComponent implements AfterContentInit, OnDestroy {
    */
   @Input()
   public set tokens(value: SkyToken[] | undefined) {
-    this.#_tokens = value || [];
+    this.#tokens.set(value || []);
     // The previous behavior was to set `this._tokens = value`, then emit `this._tokens`,
     // which would emit `undefined` instead of a default value of `[]` returned by the
     // get accessor when set to `undefined`. Emitting `value` instead of `this.#_tokensOrDefault`
     // preserves that behavior.
     this.tokensChange.emit(value);
 
-    this.#updateProjectedTokenRoles();
     this.#queueTokensRenderedEmit();
   }
 
   public get tokens(): SkyToken[] {
-    return this.#_tokens;
+    return this.#tokens();
   }
 
   /**
@@ -177,8 +183,8 @@ export class SkyTokensComponent implements AfterContentInit, OnDestroy {
   }
 
   public set activeIndex(value: number) {
-    if (value >= this.#_tokens.length) {
-      value = this.#_tokens.length - 1;
+    if (value >= this.#tokens().length) {
+      value = this.#tokens().length - 1;
       this.focusIndexOverRange.emit();
     }
 
@@ -195,19 +201,31 @@ export class SkyTokensComponent implements AfterContentInit, OnDestroy {
   #_disabled = false;
   #_dismissible = true;
   #_focusable = true;
-  #_tokens: SkyToken[] = [];
   #_displayWith = DISPLAY_WITH_DEFAULT;
+
+  readonly #tokens = signal<SkyToken[]>([]);
 
   @ViewChildren(SkyTokenComponent)
   public tokenComponents: QueryList<SkyTokenComponent> | undefined;
 
   /**
-   * The tokens projected into the component via `<ng-content select="sky-token" />`.
-   * Their `role` must be kept in sync with the `sky-tokens` grid role since Angular's
-   * template bindings do not apply to projected content.
+   * The tokens manually projected into the component via
+   * `<ng-content select="sky-token" />`, as opposed to the ones generated from
+   * the `tokens` input.
    */
-  @ContentChildren(SkyTokenComponent)
-  public projectedTokenComponents: QueryList<SkyTokenComponent> | undefined;
+  protected readonly projectedTokenComponents =
+    contentChildren(SkyTokenComponent);
+
+  /**
+   * Whether the grid role is active on this component's host element. A
+   * `sky-token` element (whether generated from the `tokens` input or
+   * manually projected) reads this to determine its own `row` role, since
+   * Angular does not apply template bindings to projected content.
+   */
+  public readonly gridRoleActive = computed(
+    () =>
+      this.#tokens().length > 0 || this.projectedTokenComponents().length > 0,
+  );
 
   #messageStreamSub: Subscription | undefined;
   #ngUnsubscribe = new Subject<void>();
@@ -248,14 +266,6 @@ export class SkyTokensComponent implements AfterContentInit, OnDestroy {
 
       return item;
     };
-  }
-
-  public ngAfterContentInit(): void {
-    this.projectedTokenComponents?.changes
-      .pipe(takeUntil(this.#ngUnsubscribe))
-      .subscribe(() => this.#updateProjectedTokenRoles());
-
-    this.#updateProjectedTokenRoles();
   }
 
   public ngOnDestroy(): void {
@@ -377,19 +387,6 @@ export class SkyTokensComponent implements AfterContentInit, OnDestroy {
   #notifyTokenSelected(token: SkyToken): void {
     this.tokenSelected.emit({
       token,
-    });
-  }
-
-  /**
-   * Sets the `role` of each projected `sky-token` to match the role applied to the
-   * tokens rendered from the `tokens` input, so projected tokens maintain valid
-   * ARIA grid semantics.
-   */
-  #updateProjectedTokenRoles(): void {
-    const role = this.tokens.length ? 'row' : undefined;
-
-    this.projectedTokenComponents?.forEach((tokenComponent) => {
-      tokenComponent.role = role;
     });
   }
 

--- a/libs/components/indicators/src/lib/modules/tokens/tokens.component.ts
+++ b/libs/components/indicators/src/lib/modules/tokens/tokens.component.ts
@@ -1,7 +1,9 @@
 import {
+  AfterContentInit,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
+  ContentChildren,
   EventEmitter,
   Injector,
   Input,
@@ -38,7 +40,7 @@ const DISPLAY_WITH_DEFAULT = 'name';
   changeDetection: ChangeDetectionStrategy.OnPush,
   standalone: false,
 })
-export class SkyTokensComponent implements OnDestroy {
+export class SkyTokensComponent implements AfterContentInit, OnDestroy {
   /**
    * Whether to disable the tokens list to prevent users from selecting tokens,
    * dismissing tokens, or navigating through the list with the arrow keys. When the tokens list
@@ -114,6 +116,7 @@ export class SkyTokensComponent implements OnDestroy {
     // preserves that behavior.
     this.tokensChange.emit(value);
 
+    this.#updateProjectedTokenRoles();
     this.#queueTokensRenderedEmit();
   }
 
@@ -198,6 +201,14 @@ export class SkyTokensComponent implements OnDestroy {
   @ViewChildren(SkyTokenComponent)
   public tokenComponents: QueryList<SkyTokenComponent> | undefined;
 
+  /**
+   * The tokens projected into the component via `<ng-content select="sky-token" />`.
+   * Their `role` must be kept in sync with the `sky-tokens` grid role since Angular's
+   * template bindings do not apply to projected content.
+   */
+  @ContentChildren(SkyTokenComponent)
+  public projectedTokenComponents: QueryList<SkyTokenComponent> | undefined;
+
   #messageStreamSub: Subscription | undefined;
   #ngUnsubscribe = new Subject<void>();
   #tokensRenderedQueued = false;
@@ -237,6 +248,14 @@ export class SkyTokensComponent implements OnDestroy {
 
       return item;
     };
+  }
+
+  public ngAfterContentInit(): void {
+    this.projectedTokenComponents?.changes
+      .pipe(takeUntil(this.#ngUnsubscribe))
+      .subscribe(() => this.#updateProjectedTokenRoles());
+
+    this.#updateProjectedTokenRoles();
   }
 
   public ngOnDestroy(): void {
@@ -358,6 +377,19 @@ export class SkyTokensComponent implements OnDestroy {
   #notifyTokenSelected(token: SkyToken): void {
     this.tokenSelected.emit({
       token,
+    });
+  }
+
+  /**
+   * Sets the `role` of each projected `sky-token` to match the role applied to the
+   * tokens rendered from the `tokens` input, so projected tokens maintain valid
+   * ARIA grid semantics.
+   */
+  #updateProjectedTokenRoles(): void {
+    const role = this.tokens.length ? 'row' : undefined;
+
+    this.projectedTokenComponents?.forEach((tokenComponent) => {
+      tokenComponent.role = role;
     });
   }
 


### PR DESCRIPTION
## Summary
- Content manually projected into `sky-tokens` (a `sky-token` added directly instead of through the `tokens` input) now wraps onto multiple lines when it overflows, matching how tokens supplied through the `tokens` input already behave.
- Fix: route manually-added `sky-token` elements into their own `ng-content select="sky-token"` slot, placed as a sibling of the array-driven tokens inside `.sky-tokens` (which already has `flex-wrap: wrap`). All other projected content (e.g. `sky-lookup`'s input) still falls through to the original, untouched default `ng-content` slot.
- This is a pure bug fix with no compat/breaking-change concerns: no consumer in this repo places a bare `sky-token` as `sky-tokens` content today, so the new slot is a no-op for every existing usage, and everything else is byte-for-byte unchanged.
- An earlier version of this fix (see closed PR #4647) made `.sky-tokens-content` itself wrap, which turned out to break `sky-lookup`'s multi-select field height (confirmed via `field-heights.cy.ts` and the Percy diff) because a baseline-alignment zero-width-space pseudo-element there became a second flex item that could wrap onto its own line. This version avoids that entirely by leaving `.sky-tokens-content` untouched.

[AB#3920841](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3920841)

## Test plan
- [x] `nx test indicators --configuration=ci` — 225/225 passing, 100% coverage, including a new test proving manually-added `sky-token` elements render as siblings of the array-driven tokens (not nested in `.sky-tokens-content`)
- [x] `nx lint indicators` — 0 errors
- [x] `nx build indicators` — builds cleanly
- [x] `nx test lookup --configuration=ci` — 572/572 passing, 100% coverage, confirming no regression in the only in-repo consumer that projects content into `sky-tokens`
- [ ] Full CI suite (affected build/lint/test, Percy visual review) — left to CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for manually projected token elements within token lists.
  * Projected tokens now appear before dynamically generated tokens.
  * Projected tokens automatically receive the appropriate row role when tokens are present.

* **Bug Fixes**
  * Improved token content placement so projected tokens remain separate from dynamically generated tokens.
  * Accessibility roles now stay synchronized when token data or projected content changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->