### PR TITLE
feat(components/ag-grid): add `defineSkyAgGridColDef` to validate cell editor and renderer params against cell types (#4582)

### DIFF
--- a/libs/components/ag-grid/documentation.json
+++ b/libs/components/ag-grid/documentation.json
@@ -29,7 +29,12 @@
           "SkyCellEditorLookupParams",
           "SkyAgGridNumberProperties",
           "SkyAgGridTextProperties",
-          "SkyAgGridValidatorProperties"
+          "SkyAgGridValidatorProperties",
+          "defineSkyAgGridColDef",
+          "SkyAgGridColDef",
+          "SkyCellEditorParamsByType",
+          "SkyCellRendererParamsByType",
+          "SkyCellRendererTemplateContext"
         ],
         "primaryDocsId": "SkyAgGridModule"
       },
@@ -81,7 +86,12 @@
           "SkyCellEditorLookupParams",
           "SkyAgGridNumberProperties",
           "SkyAgGridTextProperties",
-          "SkyAgGridValidatorProperties"
+          "SkyAgGridValidatorProperties",
+          "defineSkyAgGridColDef",
+          "SkyAgGridColDef",
+          "SkyCellEditorParamsByType",
+          "SkyCellRendererParamsByType",
+          "SkyCellRendererTemplateContext"
         ],
         "primaryDocsId": "SkyAgGridModule"
       },

--- a/libs/components/ag-grid/src/index.ts
+++ b/libs/components/ag-grid/src/index.ts
@@ -1,6 +1,10 @@
 // Export any types that should be included in the root.
 export { SkyAgGridModule } from './lib/modules/ag-grid/ag-grid.module';
 export { SkyAgGridService } from './lib/modules/ag-grid/ag-grid.service';
+export {
+  defineSkyAgGridColDef,
+  type SkyAgGridColDef,
+} from './lib/modules/ag-grid/types/ag-grid-col-def';
 export { SkyAgGridRowDeleteCancelArgs } from './lib/modules/ag-grid/types/ag-grid-row-delete-cancel-args';
 export { SkyAgGridRowDeleteConfirmArgs } from './lib/modules/ag-grid/types/ag-grid-row-delete-confirm-args';
 export {
@@ -12,7 +16,10 @@ export { SkyCellEditorAutocompleteParams } from './lib/modules/ag-grid/types/cel
 export { SkyCellEditorDatepickerParams } from './lib/modules/ag-grid/types/cell-editor-datepicker-params';
 export { SkyAgGridCellEditorInitialAction } from './lib/modules/ag-grid/types/cell-editor-initial-action';
 export { SkyCellEditorLookupParams } from './lib/modules/ag-grid/types/cell-editor-lookup-params';
+export type { SkyCellEditorParamsByType } from './lib/modules/ag-grid/types/cell-editor-params-by-type';
 export { SkyAgGridCellEditorUtils } from './lib/modules/ag-grid/types/cell-editor-utils';
+export type { SkyCellRendererParamsByType } from './lib/modules/ag-grid/types/cell-renderer-params-by-type';
+export type { SkyCellRendererTemplateContext } from './lib/modules/ag-grid/types/cell-renderer-template-context';
 export { SkyCellType } from './lib/modules/ag-grid/types/cell-type';
 export { SkyAgGridCurrencyProperties } from './lib/modules/ag-grid/types/currency-properties';
 export {

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/cell-renderers/cell-renderer-template/cell-renderer-template-context.type.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/cell-renderers/cell-renderer-template/cell-renderer-template-context.type.ts
@@ -1,4 +1,0 @@
-export interface CellRendererTemplateContext {
-  value: unknown;
-  row: object;
-}

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/cell-renderers/cell-renderer-template/cell-renderer-template.component.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/cell-renderers/cell-renderer-template/cell-renderer-template.component.ts
@@ -10,18 +10,18 @@ import {
 import { ICellRendererAngularComp } from 'ag-grid-angular';
 import { ICellRendererParams } from 'ag-grid-community';
 
-import { CellRendererTemplateContext } from './cell-renderer-template-context.type';
+import { SkyCellRendererTemplateContext } from '../../types/cell-renderer-template-context';
 
 type CellState =
   | {
       hasTemplate: true;
-      template: TemplateRef<CellRendererTemplateContext>;
-      context: CellRendererTemplateContext;
+      template: TemplateRef<SkyCellRendererTemplateContext>;
+      context: SkyCellRendererTemplateContext;
     }
   | {
       hasTemplate: 'signal';
-      template: Signal<TemplateRef<CellRendererTemplateContext>>;
-      context: CellRendererTemplateContext;
+      template: Signal<TemplateRef<SkyCellRendererTemplateContext>>;
+      context: SkyCellRendererTemplateContext;
     }
   | {
       hasTemplate: false;
@@ -57,12 +57,12 @@ export class SkyAgGridCellRendererTemplateComponent implements ICellRendererAngu
       params.colDef.cellRendererParams.template
     );
     const template:
-      | TemplateRef<CellRendererTemplateContext>
-      | Signal<TemplateRef<CellRendererTemplateContext>>
+      | TemplateRef<SkyCellRendererTemplateContext>
+      | Signal<TemplateRef<SkyCellRendererTemplateContext>>
       | undefined = hasTemplate
       ? (params.colDef?.cellRendererParams.template as
-          | TemplateRef<CellRendererTemplateContext>
-          | Signal<TemplateRef<CellRendererTemplateContext>>)
+          | TemplateRef<SkyCellRendererTemplateContext>
+          | Signal<TemplateRef<SkyCellRendererTemplateContext>>)
       : undefined;
     this.state = {
       hasTemplate: isSignal(template) ? 'signal' : hasTemplate,

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/types/ag-grid-col-def.spec.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/types/ag-grid-col-def.spec.ts
@@ -1,0 +1,101 @@
+import { SkyCellType } from './cell-type';
+
+import { defineSkyAgGridColDef } from './ag-grid-col-def';
+
+describe('defineSkyAgGridColDef', () => {
+  it('should return the column definition unchanged', () => {
+    const colDef = {
+      field: 'name',
+      type: SkyCellType.Text,
+    };
+
+    expect(defineSkyAgGridColDef(colDef)).toBe(colDef);
+  });
+
+  it('should validate params against the cell type', () => {
+    const validatorColDef = defineSkyAgGridColDef({
+      field: 'endDate',
+      type: [SkyCellType.Date, SkyCellType.Validator],
+      cellRendererParams: {
+        skyComponentProperties: {
+          validator: (value: Date): boolean => !!value,
+          validatorMessage: 'Enter a valid date',
+        },
+      },
+    });
+
+    const autocompleteColDef = defineSkyAgGridColDef({
+      field: 'department',
+      type: SkyCellType.Autocomplete,
+      cellEditorParams: {
+        skyComponentProperties: { data: [] },
+      },
+    });
+
+    expect(validatorColDef.type).toEqual([
+      SkyCellType.Date,
+      SkyCellType.Validator,
+    ]);
+    expect(autocompleteColDef.type).toBe(SkyCellType.Autocomplete);
+
+    defineSkyAgGridColDef({
+      field: 'name',
+      type: SkyCellType.Text,
+      // @ts-expect-error - misspelled properties are rejected
+      cellRenderrerParams: {},
+    });
+
+    defineSkyAgGridColDef({
+      field: 'endDate',
+      type: [SkyCellType.Date, SkyCellType.Validator],
+      cellRendererParams: {
+        skyComponentProperties: {
+          // @ts-expect-error - validatorMessage must be a string
+          validatorMessage: 123,
+        },
+      },
+    });
+
+    defineSkyAgGridColDef({
+      field: 'template',
+      type: SkyCellType.Template,
+      // @ts-expect-error - Template cells require a template param
+      cellRendererParams: {},
+    });
+
+    defineSkyAgGridColDef({
+      field: 'template',
+      type: SkyCellType.Template,
+      // @ts-expect-error - Template cells accept no editor params
+      cellEditorParams: {},
+    });
+
+    defineSkyAgGridColDef({
+      field: 'department',
+      type: SkyCellType.Autocomplete,
+      // @ts-expect-error - Autocomplete cells accept no renderer params
+      cellRendererParams: {},
+    });
+
+    defineSkyAgGridColDef({
+      field: 'name',
+      type: SkyCellType.RightAligned,
+      // @ts-expect-error - RightAligned cells accept no editor params
+      cellEditorParams: {},
+    });
+
+    defineSkyAgGridColDef({
+      field: 'name',
+      type: SkyCellType.RightAligned,
+      // @ts-expect-error - RightAligned cells accept no renderer params
+      cellRendererParams: {},
+    });
+
+    defineSkyAgGridColDef({
+      field: 'selected',
+      type: SkyCellType.RowSelector,
+      // @ts-expect-error - RowSelector cells accept no editor params
+      cellEditorParams: {},
+    });
+  });
+});

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/types/ag-grid-col-def.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/types/ag-grid-col-def.ts
@@ -1,0 +1,75 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import {
+  ColDef,
+  ICellEditorParams,
+  ICellRendererParams,
+} from 'ag-grid-community';
+
+import { SkyCellEditorParamsByType } from './cell-editor-params-by-type';
+import { SkyCellRendererParamsByType } from './cell-renderer-params-by-type';
+import { SkyCellType } from './cell-type';
+
+// Merges the params of all cell types in a union into a single type. Cell
+// types that accept no params map to `never`, so the intersection stays `never`
+// (rejecting any params) instead of collapsing to `unknown`.
+type UnionToIntersection<U> = [U] extends [never]
+  ? never
+  : (U extends unknown ? (u: U) => void : never) extends (i: infer I) => void
+    ? I
+    : never;
+
+/**
+ * A column definition that validates `cellEditorParams` and
+ * `cellRendererParams` against the SKY UX cell types in the column's `type`
+ * property. Combine cell types by passing a union of `SkyCellType` values,
+ * like `SkyAgGridColDef<SkyCellType.Number | SkyCellType.Validator>`.
+ */
+export type SkyAgGridColDef<
+  T extends SkyCellType,
+  TData = any,
+  TValue = any,
+> = Omit<
+  ColDef<TData, TValue>,
+  'type' | 'cellEditorParams' | 'cellRendererParams'
+> & {
+  type: T | T[];
+  cellEditorParams?:
+    | UnionToIntersection<SkyCellEditorParamsByType[T]>
+    | ((
+        params: ICellEditorParams<TData, TValue>,
+      ) => UnionToIntersection<SkyCellEditorParamsByType[T]>);
+  cellRendererParams?:
+    | UnionToIntersection<SkyCellRendererParamsByType<TData, TValue>[T]>
+    | ((
+        params: ICellRendererParams<TData, TValue>,
+      ) => UnionToIntersection<SkyCellRendererParamsByType<TData, TValue>[T]>);
+};
+
+/**
+ * Builds a column definition whose `cellEditorParams` and `cellRendererParams`
+ * are validated against the SKY UX cell types in the `type` property. The cell
+ * type is inferred, so no type arguments are needed:
+ * ```
+ * defineSkyAgGridColDef({
+ *   field: 'endDate',
+ *   type: [SkyCellType.Date, SkyCellType.Validator],
+ *   cellRendererParams: { skyComponentProperties: { validator: ... } },
+ * })
+ * ```
+ */
+// `C` preserves the exact shape of the passed literal (like `satisfies`), `F`
+// keeps `field` narrowed to its literal type for row-typed grid options, and
+// the `Record` intersection rejects misspelled or unknown properties.
+export function defineSkyAgGridColDef<
+  T extends SkyCellType,
+  F extends string = never,
+  C extends SkyAgGridColDef<T> = SkyAgGridColDef<T>,
+>(
+  colDef: C &
+    SkyAgGridColDef<T> & { field?: F } & Record<
+      Exclude<keyof C, keyof SkyAgGridColDef<T>>,
+      never
+    >,
+): C & { field?: F } {
+  return colDef;
+}

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/types/cell-editor-params-by-type.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/types/cell-editor-params-by-type.ts
@@ -1,0 +1,79 @@
+import {
+  SkyAgGridAutocompleteProperties,
+  SkyAutocompleteProperties,
+} from './autocomplete-properties';
+import { SkyCellType } from './cell-type';
+import { SkyAgGridCurrencyProperties } from './currency-properties';
+import {
+  SkyAgGridDatepickerProperties,
+  SkyDatepickerProperties,
+} from './datepicker-properties';
+import { SkyAgGridLookupProperties } from './lookup-properties';
+import { SkyAgGridNumberProperties } from './number-properties';
+import { SkyAgGridTextProperties } from './text-properties';
+
+/**
+ * The parameters that each SKY UX cell type accepts in the
+ * [column definition's `cellEditorParams` property](https://www.ag-grid.com/angular-data-grid/column-properties/#reference-editing-cellEditorParams).
+ * Cell types that map to `never` do not accept editor parameters.
+ * Use `defineSkyAgGridColDef()` to validate `cellEditorParams` against the column's
+ * cell type.
+ */
+export interface SkyCellEditorParamsByType {
+  [SkyCellType.Autocomplete]: {
+    /**
+     * The parameters provided to the autocomplete component.
+     */
+    skyComponentProperties?:
+      | SkyAutocompleteProperties
+      | SkyAgGridAutocompleteProperties;
+  };
+  [SkyCellType.Currency]: {
+    /**
+     * The parameters provided to the currency cell editor.
+     */
+    skyComponentProperties?: SkyAgGridCurrencyProperties;
+  };
+  [SkyCellType.CurrencyValidator]: {
+    /**
+     * The parameters provided to the currency cell editor.
+     */
+    skyComponentProperties?: SkyAgGridCurrencyProperties;
+  };
+  [SkyCellType.Date]: {
+    /**
+     * The parameters provided to the datepicker component.
+     */
+    skyComponentProperties?:
+      | SkyDatepickerProperties
+      | SkyAgGridDatepickerProperties;
+  };
+  [SkyCellType.Lookup]: {
+    /**
+     * The parameters provided to the lookup component.
+     */
+    skyComponentProperties?: SkyAgGridLookupProperties;
+  };
+  [SkyCellType.Number]: {
+    /**
+     * The parameters provided to the number cell editor.
+     */
+    skyComponentProperties?: SkyAgGridNumberProperties;
+  };
+  [SkyCellType.NumberValidator]: {
+    /**
+     * The parameters provided to the number cell editor.
+     */
+    skyComponentProperties?: SkyAgGridNumberProperties;
+  };
+  [SkyCellType.RightAligned]: never;
+  [SkyCellType.RowSelector]: never;
+  [SkyCellType.Template]: never;
+  [SkyCellType.Text]: {
+    /**
+     * The parameters provided to the text cell editor.
+     */
+    skyComponentProperties?: SkyAgGridTextProperties;
+  };
+  [SkyCellType.Validator]: never;
+}

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/types/cell-editor-params-by-type.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/types/cell-editor-params-by-type.ts
@@ -25,8 +25,7 @@ export interface SkyCellEditorParamsByType {
      * The parameters provided to the autocomplete component.
      */
     skyComponentProperties?:
-      | SkyAutocompleteProperties
-      | SkyAgGridAutocompleteProperties;
+      SkyAutocompleteProperties | SkyAgGridAutocompleteProperties;
   };
   [SkyCellType.Currency]: {
     /**
@@ -45,8 +44,7 @@ export interface SkyCellEditorParamsByType {
      * The parameters provided to the datepicker component.
      */
     skyComponentProperties?:
-      | SkyDatepickerProperties
-      | SkyAgGridDatepickerProperties;
+      SkyDatepickerProperties | SkyAgGridDatepickerProperties;
   };
   [SkyCellType.Lookup]: {
     /**

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/types/cell-renderer-params-by-type.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/types/cell-renderer-params-by-type.ts
@@ -1,0 +1,93 @@
+import { Signal, TemplateRef } from '@angular/core';
+import { SkyNumericOptions } from '@skyux/core';
+
+import type { Observable } from 'rxjs';
+
+import { SkyCellType } from './cell-type';
+import { SkyAgGridLookupProperties } from './lookup-properties';
+import { SkyAgGridValidatorProperties } from './validator-properties';
+
+/**
+ * The parameters that each SKY UX cell type accepts in the
+ * [column definition's `cellRendererParams` property](https://www.ag-grid.com/angular-data-grid/column-properties/#reference-styling-cellRendererParams).
+ * Cell types that map to `never` do not accept renderer parameters.
+ * Use `defineSkyAgGridColDef()` to validate `cellRendererParams` against the column's
+ * cell type.
+ */
+export interface SkyCellRendererParamsByType<
+  TData = unknown,
+  TValue = unknown,
+> {
+  [SkyCellType.Autocomplete]: never;
+  [SkyCellType.Currency]: {
+    /**
+     * Options to pass to the `SkyNumericPipe` for formatting the cell value,
+     * and validator properties to flag erroneous entries. `format` is always
+     * set to `'currency'`. If not specified, `minDigits` defaults to `2` and
+     * `truncate` defaults to `false`.
+     */
+    skyComponentProperties?: SkyNumericOptions &
+      SkyAgGridValidatorProperties<TValue, TData>;
+  };
+  [SkyCellType.CurrencyValidator]: {
+    /**
+     * Options to pass to the `SkyNumericPipe` for formatting the cell value,
+     * and validator properties to flag erroneous entries. `format` is always
+     * set to `'currency'`. If not specified, `minDigits` defaults to `2` and
+     * `truncate` defaults to `false`.
+     */
+    skyComponentProperties?: SkyNumericOptions &
+      SkyAgGridValidatorProperties<TValue, TData>;
+  };
+  [SkyCellType.Date]: never;
+  [SkyCellType.Lookup]: {
+    /**
+     * The parameters provided to the lookup component.
+     */
+    skyComponentProperties?: SkyAgGridLookupProperties;
+  };
+  [SkyCellType.Number]: {
+    /**
+     * The validator properties used to validate the cell value and display a
+     * validation message.
+     */
+    skyComponentProperties?: SkyAgGridValidatorProperties<TValue, TData>;
+  };
+  [SkyCellType.NumberValidator]: {
+    /**
+     * The validator properties used to validate the cell value and display a
+     * validation message.
+     */
+    skyComponentProperties?: SkyAgGridValidatorProperties<TValue, TData>;
+  };
+  [SkyCellType.RightAligned]: never;
+  [SkyCellType.RowSelector]: {
+    /**
+     * The `aria-label` for the row selector checkbox, or a function that
+     * returns it from the row's data. If not specified, the label defaults to
+     * a localized string that includes the row number.
+     */
+    label?: string | ((data: TData) => string | Observable<string>);
+  };
+  [SkyCellType.Template]: {
+    /**
+     * The template to render in the cell. The template's context is a
+     * `SkyCellRendererTemplateContext` with `value` and `row` properties.
+     */
+    template: TemplateRef<unknown> | Signal<TemplateRef<unknown> | undefined>;
+  };
+  [SkyCellType.Text]: {
+    /**
+     * The validator properties used to validate the cell value and display a
+     * validation message.
+     */
+    skyComponentProperties?: SkyAgGridValidatorProperties<TValue, TData>;
+  };
+  [SkyCellType.Validator]: {
+    /**
+     * The validator properties used to validate the cell value and display a
+     * validation message.
+     */
+    skyComponentProperties?: SkyAgGridValidatorProperties<TValue, TData>;
+  };
+}

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/types/cell-renderer-template-context.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/types/cell-renderer-template-context.ts
@@ -1,0 +1,13 @@
+/**
+ * The context provided to the template of a template cell renderer.
+ */
+export interface SkyCellRendererTemplateContext {
+  /**
+   * The cell's value.
+   */
+  value: unknown;
+  /**
+   * The row's data.
+   */
+  row: object | undefined;
+}

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/types/cell-type.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/types/cell-type.ts
@@ -1,6 +1,7 @@
 /**
  * These column types can be used by setting the AG Grid [column definition `type`](https://www.ag-grid.com/angular-data-grid/column-properties/#reference-editing) to one of the following values.
  * Any [SKY UX component](https://developer.blackbaud.com/skyux/components) can be made into a [cell editor](https://www.ag-grid.com/angular-data-grid/cell-editors/) or [cell renderer](https://www.ag-grid.com/angular-data-grid/component-cell-renderer/) component. If you would like to use a component that does not have a column definition yet, please consider [contributing it](https://github.com/blackbaud/skyux/blob/main/CONTRIBUTING.md) to the SKY UX data entry grid module.
+ * Use `defineSkyAgGridColDef()` to validate a column definition's `cellEditorParams` and `cellRendererParams` against its cell type.
  */
 export enum SkyCellType {
   /**
@@ -46,7 +47,7 @@ export enum SkyCellType {
    *
    * **Read-only mode**
    *
-   * Cells the column will display, by default, either: the name(s) of the selected value(s) if there are less than 6, or a summary count of the values if there are more than 5. If the lookup needs to show a different property or needs to be formatted in any way, you can [define a `valueFormatter`](https://www.ag-grid.com/angular-data-grid/value-formatters/) on the column definition.
+   * Cells in the column will display, by default, either: the name(s) of the selected value(s) if there are less than 6, or a summary count of the values if there are more than 5. If the lookup needs to show a different property or needs to be formatted in any way, you can [define a `valueFormatter`](https://www.ag-grid.com/angular-data-grid/value-formatters/) on the column definition.
    */
   Lookup = 'skyCellLookup',
   /**

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/types/validator-properties.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/types/validator-properties.ts
@@ -2,14 +2,17 @@ import { Signal } from '@angular/core';
 
 import type { Observable } from 'rxjs';
 
-export interface SkyAgGridValidatorProperties {
+export interface SkyAgGridValidatorProperties<
+  TValue = unknown,
+  TData = unknown,
+> {
   /**
    * An optional function that returns an observable that emits a string. Can be used with resources to localize the
    * value displayed in the cell.
    */
   valueResourceObservable?: (
-    value: unknown,
-    data?: unknown,
+    value: TValue,
+    data?: TData,
     rowIndex?: number | null,
   ) => Observable<string>;
   /**
@@ -17,8 +20,8 @@ export interface SkyAgGridValidatorProperties {
    * will be highlighted and display a validation message.
    */
   validator?: (
-    value: unknown,
-    data?: unknown,
+    value: TValue,
+    data?: TData,
     rowIndex?: number | null,
   ) => boolean;
   /**
@@ -28,5 +31,5 @@ export interface SkyAgGridValidatorProperties {
   validatorMessage?:
     | Signal<string>
     | string
-    | ((value: unknown, data?: unknown, rowIndex?: number | null) => string);
+    | ((value: TValue, data?: TData, rowIndex?: number | null) => string);
 }

--- a/libs/components/code-examples/src/lib/modules/ag-grid/data-entry-grid/basic/data.ts
+++ b/libs/components/code-examples/src/lib/modules/ag-grid/data-entry-grid/basic/data.ts
@@ -93,6 +93,8 @@ export interface AgGridDemoRow {
   endDate?: Date;
   department: AutocompleteOption;
   jobTitle?: AutocompleteOption;
+  validationCurrency?: number;
+  validationDate?: Date;
 }
 
 export const AG_GRID_DEMO_DATA: AgGridDemoRow[] = [

--- a/libs/components/code-examples/src/lib/modules/ag-grid/data-entry-grid/basic/edit-modal.component.ts
+++ b/libs/components/code-examples/src/lib/modules/ag-grid/data-entry-grid/basic/edit-modal.component.ts
@@ -12,6 +12,7 @@ import {
   SkyAgGridModule,
   SkyAgGridService,
   SkyCellType,
+  defineSkyAgGridColDef,
 } from '@skyux/ag-grid';
 import { SkyAutocompleteSelectionChange } from '@skyux/lookup';
 import { SkyModalInstance, SkyModalModule } from '@skyux/modals';
@@ -48,10 +49,12 @@ export class EditModalComponent {
     viewChild<TemplateRef<unknown>>('markInactiveAction');
 
   protected gridData = inject(EditModalContext).gridData;
-  protected gridOptions = inject(SkyAgGridService).getEditableGridOptions({
+  protected gridOptions = inject(
+    SkyAgGridService,
+  ).getEditableGridOptions<AgGridDemoRow>({
     gridOptions: {
       columnDefs: [
-        {
+        defineSkyAgGridColDef({
           colId: 'markInactiveAction',
           headerName: 'Mark inactive',
           type: SkyCellType.Template,
@@ -59,8 +62,8 @@ export class EditModalComponent {
           cellRendererParams: {
             template: this.markInactiveAction,
           },
-        },
-        {
+        }),
+        defineSkyAgGridColDef({
           field: 'name',
           headerName: 'Name',
           type: SkyCellType.Text,
@@ -76,8 +79,8 @@ export class EditModalComponent {
             },
           },
           editable: true,
-        },
-        {
+        }),
+        defineSkyAgGridColDef({
           field: 'age',
           headerName: 'Age',
           type: SkyCellType.Number,
@@ -94,14 +97,14 @@ export class EditModalComponent {
             },
           },
           editable: true,
-        },
+        }),
         {
           field: 'startDate',
           headerName: 'Start date',
           type: SkyCellType.Date,
           sort: 'asc',
         },
-        {
+        defineSkyAgGridColDef({
           field: 'endDate',
           headerName: 'End date',
           type: SkyCellType.Date,
@@ -113,8 +116,8 @@ export class EditModalComponent {
               skyComponentProperties: { minDate: params.data.startDate },
             };
           },
-        },
-        {
+        }),
+        defineSkyAgGridColDef({
           field: 'department',
           headerName: 'Department',
           type: SkyCellType.Autocomplete,
@@ -138,8 +141,8 @@ export class EditModalComponent {
               this.#clearJobTitle(event.node);
             }
           },
-        },
-        {
+        }),
+        defineSkyAgGridColDef({
           field: 'jobTitle',
           headerName: 'Title',
           type: SkyCellType.Autocomplete,
@@ -160,7 +163,7 @@ export class EditModalComponent {
 
             return editParams;
           },
-        },
+        }),
         {
           colId: 'validationCurrency',
           field: 'validationCurrency',
@@ -168,7 +171,7 @@ export class EditModalComponent {
           type: [SkyCellType.CurrencyValidator],
           editable: true,
         },
-        {
+        defineSkyAgGridColDef({
           colId: 'validationDate',
           field: 'validationDate',
           headerName: 'Validation date',
@@ -181,7 +184,7 @@ export class EditModalComponent {
             },
           },
           editable: true,
-        },
+        }),
       ],
       onGridReady: (gridReadyEvent): void => {
         this.#gridApi.set(gridReadyEvent.api);

--- a/libs/components/code-examples/src/lib/modules/ag-grid/data-entry-grid/basic/example.component.ts
+++ b/libs/components/code-examples/src/lib/modules/ag-grid/data-entry-grid/basic/example.component.ts
@@ -5,7 +5,12 @@ import {
   inject,
   signal,
 } from '@angular/core';
-import { SkyAgGridModule, SkyAgGridService, SkyCellType } from '@skyux/ag-grid';
+import {
+  SkyAgGridModule,
+  SkyAgGridService,
+  SkyCellType,
+  defineSkyAgGridColDef,
+} from '@skyux/ag-grid';
 import { SkyToolbarModule } from '@skyux/layout';
 import { SkySearchModule } from '@skyux/lookup';
 import { SkyModalConfigurationInterface, SkyModalService } from '@skyux/modals';
@@ -40,14 +45,14 @@ export class AgGridDataEntryGridBasicExampleComponent {
   protected readonly gridData = signal<AgGridDemoRow[]>(AG_GRID_DEMO_DATA);
 
   readonly #columnDefs: ColDef[] = [
-    {
+    defineSkyAgGridColDef({
       field: 'selected',
       type: SkyCellType.RowSelector,
       cellRendererParams: {
         // Could be a SkyAppResourcesService.getString call that returns an observable.
         label: (data: AgGridDemoRow) => of(`Select ${data.name}`),
       },
-    },
+    }),
     {
       colId: 'context',
       maxWidth: 50,
@@ -58,7 +63,7 @@ export class AgGridDataEntryGridBasicExampleComponent {
         headerHidden: true,
       },
     },
-    {
+    defineSkyAgGridColDef({
       field: 'name',
       headerName: 'Name',
       type: SkyCellType.Text,
@@ -68,8 +73,8 @@ export class AgGridDataEntryGridBasicExampleComponent {
           validatorMessage: `Value exceeds maximum length`,
         },
       },
-    },
-    {
+    }),
+    defineSkyAgGridColDef({
       field: 'age',
       headerName: 'Age',
       type: SkyCellType.Number,
@@ -80,7 +85,7 @@ export class AgGridDataEntryGridBasicExampleComponent {
         },
       },
       maxWidth: 60,
-    },
+    }),
     {
       field: 'startDate',
       headerName: 'Start date',
@@ -110,7 +115,7 @@ export class AgGridDataEntryGridBasicExampleComponent {
       headerName: 'Validation currency',
       type: [SkyCellType.CurrencyValidator],
     },
-    {
+    defineSkyAgGridColDef({
       colId: 'validationDate',
       field: 'validationDate',
       headerName: 'Validation date',
@@ -122,7 +127,7 @@ export class AgGridDataEntryGridBasicExampleComponent {
           validatorMessage: 'Enter a future date',
         },
       },
-    },
+    }),
   ];
 
   readonly #modalSvc = inject(SkyModalService);

--- a/libs/components/code-examples/src/lib/modules/ag-grid/data-entry-grid/data-manager-added/data.ts
+++ b/libs/components/code-examples/src/lib/modules/ag-grid/data-entry-grid/data-manager-added/data.ts
@@ -94,8 +94,8 @@ export interface AgGridDemoRow {
   endDate?: Date;
   department: AutocompleteOption;
   jobTitle?: AutocompleteOption;
-  validationCurrency?: string;
-  validationDate?: string;
+  validationCurrency?: number;
+  validationDate?: Date;
 }
 
 export const AG_GRID_DEMO_DATA: AgGridDemoRow[] = [

--- a/libs/components/code-examples/src/lib/modules/ag-grid/data-entry-grid/data-manager-added/edit-modal.component.ts
+++ b/libs/components/code-examples/src/lib/modules/ag-grid/data-entry-grid/data-manager-added/edit-modal.component.ts
@@ -10,6 +10,7 @@ import {
   SkyAgGridModule,
   SkyAgGridService,
   SkyCellType,
+  defineSkyAgGridColDef,
 } from '@skyux/ag-grid';
 import { SkyAutocompleteSelectionChange } from '@skyux/lookup';
 import { SkyModalInstance, SkyModalModule } from '@skyux/modals';
@@ -40,7 +41,7 @@ export class EditModalComponent {
   protected readonly gridData = inject(EditModalContext).gridData;
   protected readonly gridOptions = inject(
     SkyAgGridService,
-  ).getEditableGridOptions({
+  ).getEditableGridOptions<AgGridDemoRow>({
     gridOptions: {
       columnDefs: [
         {
@@ -60,7 +61,7 @@ export class EditModalComponent {
           type: SkyCellType.Date,
           sort: 'asc',
         },
-        {
+        defineSkyAgGridColDef({
           field: 'endDate',
           headerName: 'End date',
           type: SkyCellType.Date,
@@ -74,8 +75,8 @@ export class EditModalComponent {
               },
             };
           },
-        },
-        {
+        }),
+        defineSkyAgGridColDef({
           field: 'department',
           headerName: 'Department',
           type: SkyCellType.Autocomplete,
@@ -97,8 +98,8 @@ export class EditModalComponent {
               this.#clearJobTitle(event.node);
             }
           },
-        },
-        {
+        }),
+        defineSkyAgGridColDef({
           field: 'jobTitle',
           headerName: 'Title',
           type: SkyCellType.Autocomplete,
@@ -119,7 +120,7 @@ export class EditModalComponent {
 
             return editParams;
           },
-        },
+        }),
         {
           colId: 'validationCurrency',
           field: 'validationCurrency',
@@ -127,7 +128,7 @@ export class EditModalComponent {
           type: [SkyCellType.CurrencyValidator],
           editable: true,
         },
-        {
+        defineSkyAgGridColDef({
           colId: 'validationDate',
           field: 'validationDate',
           headerName: 'Validation date',
@@ -140,7 +141,7 @@ export class EditModalComponent {
             },
           },
           editable: true,
-        },
+        }),
       ],
       onGridReady: (gridReadyEvent): void => {
         this.#gridApi.set(gridReadyEvent.api);

--- a/libs/components/code-examples/src/lib/modules/ag-grid/data-entry-grid/data-manager-added/view-grid.component.ts
+++ b/libs/components/code-examples/src/lib/modules/ag-grid/data-entry-grid/data-manager-added/view-grid.component.ts
@@ -8,7 +8,12 @@ import {
   signal,
 } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
-import { SkyAgGridModule, SkyAgGridService, SkyCellType } from '@skyux/ag-grid';
+import {
+  SkyAgGridModule,
+  SkyAgGridService,
+  SkyCellType,
+  defineSkyAgGridColDef,
+} from '@skyux/ag-grid';
 import {
   SkyDataManagerModule,
   SkyDataManagerService,
@@ -43,14 +48,14 @@ export class ViewGridComponent {
   protected readonly viewId = 'dataEntryGridWithDataManagerView';
 
   readonly #columnDefs: ColDef[] = [
-    {
+    defineSkyAgGridColDef({
       field: 'selected',
       type: SkyCellType.RowSelector,
       cellRendererParams: {
         // Could be a SkyAppResourcesService.getString call that returns an observable.
         label: (data: AgGridDemoRow) => of(`Select ${data.name}`),
       },
-    },
+    }),
     {
       colId: 'context',
       maxWidth: 50,
@@ -99,7 +104,7 @@ export class ViewGridComponent {
       headerName: 'Validation currency',
       type: [SkyCellType.CurrencyValidator],
     },
-    {
+    defineSkyAgGridColDef({
       field: 'validationDate',
       headerName: 'Validation date',
       type: [SkyCellType.Date, SkyCellType.Validator],
@@ -110,7 +115,7 @@ export class ViewGridComponent {
           validatorMessage: 'Please enter a future date',
         },
       },
-    },
+    }),
   ];
 
   protected noRowsTemplate = `<div class="sky-theme-font-body-deemphasized-m">No results found.</div>`;

--- a/libs/components/code-examples/src/lib/modules/ag-grid/data-entry-grid/focus/data.ts
+++ b/libs/components/code-examples/src/lib/modules/ag-grid/data-entry-grid/focus/data.ts
@@ -93,8 +93,8 @@ export interface AgGridDemoRow {
   endDate?: Date;
   department: AutocompleteOption;
   jobTitle?: AutocompleteOption;
-  validationCurrency?: AutocompleteOption;
-  validationDate?: AutocompleteOption;
+  validationCurrency?: number;
+  validationDate?: Date;
 }
 
 export const AG_GRID_DEMO_DATA: AgGridDemoRow[] = [

--- a/libs/components/code-examples/src/lib/modules/ag-grid/data-entry-grid/focus/example.component.ts
+++ b/libs/components/code-examples/src/lib/modules/ag-grid/data-entry-grid/focus/example.component.ts
@@ -1,5 +1,10 @@
 import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
-import { SkyAgGridModule, SkyAgGridService, SkyCellType } from '@skyux/ag-grid';
+import {
+  SkyAgGridModule,
+  SkyAgGridService,
+  SkyCellType,
+  defineSkyAgGridColDef,
+} from '@skyux/ag-grid';
 import { SkyInputBoxModule } from '@skyux/forms';
 
 import { AgGridAngular } from 'ag-grid-angular';
@@ -23,10 +28,12 @@ ModuleRegistry.registerModules([AllCommunityModule]);
   imports: [AgGridAngular, SkyAgGridModule, SkyInputBoxModule],
 })
 export class AgGridDataEntryGridFocusExampleComponent {
-  protected gridOptions = inject(SkyAgGridService).getEditableGridOptions({
+  protected gridOptions = inject(
+    SkyAgGridService,
+  ).getEditableGridOptions<AgGridDemoRow>({
     gridOptions: {
       columnDefs: [
-        {
+        defineSkyAgGridColDef({
           field: 'name',
           headerName: 'Name',
           type: SkyCellType.Text,
@@ -37,8 +44,8 @@ export class AgGridDataEntryGridFocusExampleComponent {
               validatorMessage: `Value exceeds maximum length`,
             },
           },
-        },
-        {
+        }),
+        defineSkyAgGridColDef({
           field: 'age',
           headerName: 'Age',
           type: SkyCellType.Number,
@@ -50,7 +57,7 @@ export class AgGridDataEntryGridFocusExampleComponent {
             },
           },
           maxWidth: 60,
-        },
+        }),
         {
           field: 'startDate',
           headerName: 'Start date',
@@ -86,7 +93,7 @@ export class AgGridDataEntryGridFocusExampleComponent {
           type: [SkyCellType.CurrencyValidator],
           editable: true,
         },
-        {
+        defineSkyAgGridColDef({
           colId: 'validationDate',
           field: 'validationDate',
           headerName: 'Validation date',
@@ -99,7 +106,7 @@ export class AgGridDataEntryGridFocusExampleComponent {
               validatorMessage: 'Enter a future date',
             },
           },
-        },
+        }),
       ],
       focusGridInnerElement: (params) => {
         params.api.startEditingCell({

--- a/libs/components/code-examples/src/lib/modules/ag-grid/data-entry-grid/inline-help/data.ts
+++ b/libs/components/code-examples/src/lib/modules/ag-grid/data-entry-grid/inline-help/data.ts
@@ -93,8 +93,8 @@ export interface AgGridDemoRow {
   endDate?: Date;
   department: AutocompleteOption;
   jobTitle?: AutocompleteOption;
-  validationCurrency?: string;
-  validationDate?: string;
+  validationCurrency?: number;
+  validationDate?: Date;
 }
 
 export const AG_GRID_DEMO_DATA: AgGridDemoRow[] = [

--- a/libs/components/code-examples/src/lib/modules/ag-grid/data-entry-grid/inline-help/edit-modal.component.ts
+++ b/libs/components/code-examples/src/lib/modules/ag-grid/data-entry-grid/inline-help/edit-modal.component.ts
@@ -10,6 +10,7 @@ import {
   SkyAgGridModule,
   SkyAgGridService,
   SkyCellType,
+  defineSkyAgGridColDef,
 } from '@skyux/ag-grid';
 import { SkyAutocompleteSelectionChange } from '@skyux/lookup';
 import { SkyModalInstance, SkyModalModule } from '@skyux/modals';
@@ -40,7 +41,7 @@ export class EditModalComponent {
   protected gridOptions = inject(SkyAgGridService).getEditableGridOptions({
     gridOptions: {
       columnDefs: [
-        {
+        defineSkyAgGridColDef({
           field: 'name',
           headerName: 'Name',
           type: SkyCellType.Text,
@@ -56,8 +57,8 @@ export class EditModalComponent {
             },
           },
           editable: true,
-        },
-        {
+        }),
+        defineSkyAgGridColDef({
           field: 'age',
           headerName: 'Age',
           type: SkyCellType.Number,
@@ -74,14 +75,14 @@ export class EditModalComponent {
             },
           },
           editable: true,
-        },
+        }),
         {
           field: 'startDate',
           headerName: 'Start date',
           type: SkyCellType.Date,
           sort: 'asc',
         },
-        {
+        defineSkyAgGridColDef({
           field: 'endDate',
           headerName: 'End date',
           type: SkyCellType.Date,
@@ -93,8 +94,8 @@ export class EditModalComponent {
               skyComponentProperties: { minDate: params.data.startDate },
             };
           },
-        },
-        {
+        }),
+        defineSkyAgGridColDef({
           field: 'department',
           headerName: 'Department',
           type: SkyCellType.Autocomplete,
@@ -116,8 +117,8 @@ export class EditModalComponent {
               this.#clearJobTitle(event.node);
             }
           },
-        },
-        {
+        }),
+        defineSkyAgGridColDef({
           field: 'jobTitle',
           headerName: 'Title',
           type: SkyCellType.Autocomplete,
@@ -137,7 +138,7 @@ export class EditModalComponent {
 
             return editParams;
           },
-        },
+        }),
         {
           colId: 'validationCurrency',
           field: 'validationCurrency',
@@ -145,7 +146,7 @@ export class EditModalComponent {
           type: [SkyCellType.CurrencyValidator],
           editable: true,
         },
-        {
+        defineSkyAgGridColDef({
           colId: 'validationDate',
           field: 'validationDate',
           headerName: 'Validation date',
@@ -158,7 +159,7 @@ export class EditModalComponent {
             },
           },
           editable: true,
-        },
+        }),
       ] as ColDef<AgGridDemoRow>[],
       onGridReady: (gridReadyEvent): void => {
         this.#gridApi.set(gridReadyEvent.api);

--- a/libs/components/code-examples/src/lib/modules/ag-grid/data-entry-grid/inline-help/example.component.ts
+++ b/libs/components/code-examples/src/lib/modules/ag-grid/data-entry-grid/inline-help/example.component.ts
@@ -5,7 +5,12 @@ import {
   inject,
   signal,
 } from '@angular/core';
-import { SkyAgGridModule, SkyAgGridService, SkyCellType } from '@skyux/ag-grid';
+import {
+  SkyAgGridModule,
+  SkyAgGridService,
+  SkyCellType,
+  defineSkyAgGridColDef,
+} from '@skyux/ag-grid';
 import { SkyToolbarModule } from '@skyux/layout';
 import { SkySearchModule } from '@skyux/lookup';
 import { SkyModalConfigurationInterface, SkyModalService } from '@skyux/modals';
@@ -44,14 +49,14 @@ export class AgGridDataEntryGridInlineHelpExampleComponent {
   ).getGridOptions({
     gridOptions: {
       columnDefs: [
-        {
+        defineSkyAgGridColDef({
           field: 'selected',
           type: SkyCellType.RowSelector,
           cellRendererParams: {
             // Could be a SkyAppResourcesService.getString call that returns an observable.
             label: (data: AgGridDemoRow) => of(`Select ${data.name}`),
           },
-        },
+        }),
         {
           colId: 'context',
           maxWidth: 50,
@@ -62,7 +67,7 @@ export class AgGridDataEntryGridInlineHelpExampleComponent {
             headerHidden: true,
           },
         },
-        {
+        defineSkyAgGridColDef({
           field: 'name',
           headerName: 'Name',
           type: SkyCellType.Text,
@@ -75,8 +80,8 @@ export class AgGridDataEntryGridInlineHelpExampleComponent {
           headerComponentParams: {
             inlineHelpComponent: InlineHelpComponent,
           },
-        },
-        {
+        }),
+        defineSkyAgGridColDef({
           field: 'age',
           headerName: 'Age',
           type: SkyCellType.Number,
@@ -90,7 +95,7 @@ export class AgGridDataEntryGridInlineHelpExampleComponent {
           headerComponentParams: {
             inlineHelpComponent: InlineHelpComponent,
           },
-        },
+        }),
         {
           field: 'startDate',
           headerName: 'Start date',
@@ -135,7 +140,7 @@ export class AgGridDataEntryGridInlineHelpExampleComponent {
             inlineHelpComponent: InlineHelpComponent,
           },
         },
-        {
+        defineSkyAgGridColDef({
           colId: 'validationDate',
           field: 'validationDate',
           headerName: 'Validation date',
@@ -150,7 +155,7 @@ export class AgGridDataEntryGridInlineHelpExampleComponent {
           headerComponentParams: {
             inlineHelpComponent: InlineHelpComponent,
           },
-        },
+        }),
       ],
       onGridReady: (gridReadyEvent): void => {
         this.#gridApi.set(gridReadyEvent.api);

--- a/libs/components/code-examples/src/lib/modules/ag-grid/data-grid/basic-multiselect/example.component.ts
+++ b/libs/components/code-examples/src/lib/modules/ag-grid/data-grid/basic-multiselect/example.component.ts
@@ -1,5 +1,10 @@
 import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
-import { SkyAgGridModule, SkyAgGridService, SkyCellType } from '@skyux/ag-grid';
+import {
+  SkyAgGridModule,
+  SkyAgGridService,
+  SkyCellType,
+  defineSkyAgGridColDef,
+} from '@skyux/ag-grid';
 
 import { AgGridAngular } from 'ag-grid-angular';
 import {
@@ -30,14 +35,14 @@ export class AgGridDataGridBasicMultiselectExampleComponent {
   protected gridOptions: GridOptions;
 
   #columnDefs: ColDef[] = [
-    {
+    defineSkyAgGridColDef({
       field: 'selected',
       type: SkyCellType.RowSelector,
       cellRendererParams: {
         // Could be a SkyAppResourcesService.getString call that returns an observable.
         label: (data: AgGridDemoRow) => of(`Select ${data.name}`),
       },
-    },
+    }),
     {
       colId: 'context',
       maxWidth: 50,

--- a/libs/components/code-examples/src/lib/modules/ag-grid/data-grid/data-manager-multiselect/view-grid.component.ts
+++ b/libs/components/code-examples/src/lib/modules/ag-grid/data-grid/data-manager-multiselect/view-grid.component.ts
@@ -8,7 +8,12 @@ import {
   signal,
 } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
-import { SkyAgGridModule, SkyAgGridService, SkyCellType } from '@skyux/ag-grid';
+import {
+  SkyAgGridModule,
+  SkyAgGridService,
+  SkyCellType,
+  defineSkyAgGridColDef,
+} from '@skyux/ag-grid';
 import {
   SkyDataManagerModule,
   SkyDataManagerService,
@@ -45,7 +50,7 @@ export class ViewGridComponent {
   protected noRowsTemplate = `<div class="sky-deemphasized">No results found.</div>`;
 
   readonly #columnDefs: ColDef[] = [
-    {
+    defineSkyAgGridColDef({
       field: 'selected',
       type: SkyCellType.RowSelector,
       suppressMovable: true,
@@ -55,7 +60,7 @@ export class ViewGridComponent {
         // Could be a SkyAppResourcesService.getString call that returns an observable.
         label: (data: AgGridDemoRow) => of(`Select ${data.name}`),
       },
-    },
+    }),
     {
       colId: 'context',
       maxWidth: 50,

--- a/libs/components/code-examples/src/lib/modules/ag-grid/data-grid/inline-help/example.component.ts
+++ b/libs/components/code-examples/src/lib/modules/ag-grid/data-grid/inline-help/example.component.ts
@@ -4,7 +4,12 @@ import {
   Component,
   inject,
 } from '@angular/core';
-import { SkyAgGridModule, SkyAgGridService, SkyCellType } from '@skyux/ag-grid';
+import {
+  SkyAgGridModule,
+  SkyAgGridService,
+  SkyCellType,
+  defineSkyAgGridColDef,
+} from '@skyux/ag-grid';
 import { SkyToolbarModule } from '@skyux/layout';
 import { SkySearchModule } from '@skyux/lookup';
 
@@ -42,14 +47,14 @@ export class AgGridDataGridInlineHelpExampleComponent {
   protected noRowsTemplate: string;
 
   #columnDefs: ColDef[] = [
-    {
+    defineSkyAgGridColDef({
       field: 'selected',
       type: SkyCellType.RowSelector,
       cellRendererParams: {
         // Could be a SkyAppResourcesService.getString call that returns an observable.
         label: (data: AgGridDemoRow) => of(`Select ${data.name}`),
       },
-    },
+    }),
     {
       colId: 'context',
       maxWidth: 50,

--- a/libs/components/code-examples/src/lib/modules/ag-grid/data-grid/template-ref-column/example.component.ts
+++ b/libs/components/code-examples/src/lib/modules/ag-grid/data-grid/template-ref-column/example.component.ts
@@ -5,12 +5,17 @@ import {
   inject,
   viewChild,
 } from '@angular/core';
-import { SkyAgGridModule, SkyAgGridService, SkyCellType } from '@skyux/ag-grid';
+import {
+  SkyAgGridModule,
+  SkyAgGridService,
+  SkyCellType,
+  defineSkyAgGridColDef,
+} from '@skyux/ag-grid';
 
 import { AgGridAngular } from 'ag-grid-angular';
 import { AllCommunityModule, ModuleRegistry } from 'ag-grid-community';
 
-import { AG_GRID_DEMO_DATA } from './data';
+import { AG_GRID_DEMO_DATA, AgGridDemoRow } from './data';
 
 ModuleRegistry.registerModules([AllCommunityModule]);
 
@@ -27,7 +32,9 @@ export class AgGridDataGridTemplateRefColumnExampleComponent {
   protected readonly boldColumn = viewChild<TemplateRef<unknown>>('boldColumn');
   protected readonly emphasizedColumn =
     viewChild<TemplateRef<unknown>>('emphasizedColumn');
-  protected gridOptions = inject(SkyAgGridService).getGridOptions({
+  protected gridOptions = inject(
+    SkyAgGridService,
+  ).getGridOptions<AgGridDemoRow>({
     gridOptions: {
       columnDefs: [
         {
@@ -42,7 +49,7 @@ export class AgGridDataGridTemplateRefColumnExampleComponent {
           maxWidth: 80,
           resizable: false,
         },
-        {
+        defineSkyAgGridColDef({
           field: 'department',
           headerName: 'Department',
           type: SkyCellType.Template,
@@ -50,8 +57,8 @@ export class AgGridDataGridTemplateRefColumnExampleComponent {
             template: this.boldColumn,
           },
           initialWidth: 220,
-        },
-        {
+        }),
+        defineSkyAgGridColDef({
           field: 'jobTitle',
           headerName: 'Title',
           type: SkyCellType.Template,
@@ -59,7 +66,7 @@ export class AgGridDataGridTemplateRefColumnExampleComponent {
             template: this.emphasizedColumn,
           },
           initialWidth: 220,
-        },
+        }),
       ],
       rowData: AG_GRID_DEMO_DATA,
     },

--- a/libs/components/code-examples/src/lib/modules/ag-grid/data-grid/top-scroll/example.component.ts
+++ b/libs/components/code-examples/src/lib/modules/ag-grid/data-grid/top-scroll/example.component.ts
@@ -1,5 +1,10 @@
 import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
-import { SkyAgGridModule, SkyAgGridService, SkyCellType } from '@skyux/ag-grid';
+import {
+  SkyAgGridModule,
+  SkyAgGridService,
+  SkyCellType,
+  defineSkyAgGridColDef,
+} from '@skyux/ag-grid';
 import { SkyToolbarModule } from '@skyux/layout';
 import { SkySearchModule } from '@skyux/lookup';
 
@@ -42,14 +47,14 @@ export class AgGridDataGridTopScrollExampleComponent {
       sortable: false,
       cellRenderer: ContextMenuComponent,
     },
-    {
+    defineSkyAgGridColDef({
       field: 'selected',
       type: SkyCellType.RowSelector,
       cellRendererParams: {
         // Could be a SkyAppResourcesService.getString call that returns an observable.
         label: (data: AgGridDemoRow) => of(`Select ${data.name}`),
       },
-    },
+    }),
     {
       field: 'name',
       headerName: 'Name',


### PR DESCRIPTION
[AB#3928427](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3928427) 🍒 #4582

<!-- This is an auto-generated comment: release notes by coderabbit.ai
-->

- **New Features**
- Added strongly typed AG Grid column definitions with
cell-type-specific editor and renderer parameters.
- Added public types for renderer contexts, editor parameters, renderer
parameters, and generic validator properties.
  - Improved validation for unsupported or misspelled column properties.

- **Documentation**
  - Added the new AG Grid APIs and types to development documentation.
  - Clarified cell-type guidance and descriptions.

- **Tests**
- Added coverage for column definition validation and required template
parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a helper for creating strongly typed AG Grid column definitions.
  * Added public types for cell editor parameters, renderer parameters, and template contexts.
  * Improved type safety for cell-specific editors, renderers, validators, and fields.

* **Documentation**
  * Expanded AG Grid development documentation with the new column-definition APIs and types.
  * Corrected Lookup cell documentation wording.

* **Tests**
  * Added coverage for valid configurations and invalid editor, renderer, and property combinations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->