### PR TITLE
feat(components/tabs): add `tabWidth` input to vertical tabset with `auto` sizing and harness/example support (#4410)

### DIFF
--- a/libs/components/code-examples/src/lib/modules/tabs/vertical-tabs/basic/example.component.html
+++ b/libs/components/code-examples/src/lib/modules/tabs/vertical-tabs/basic/example.component.html
@@ -1,9 +1,12 @@
-<sky-vertical-tabset data-sky-id="vertical-tabs-basic">
-  <sky-vertical-tab tabHeading="Tab 1"> Tab 1 content </sky-vertical-tab>
+<sky-vertical-tabset data-sky-id="vertical-tabs-basic" tabWidth="auto">
+  <sky-vertical-tab tabHeading="A short tab"> Tab 1 content </sky-vertical-tab>
   <sky-vertical-tab tabHeading="Tab 2" [active]="true">
     Tab 2 content
   </sky-vertical-tab>
-  <sky-vertical-tab tabHeading="Tab 3" [disabled]="true">
+  <sky-vertical-tab
+    tabHeading="A very long tab heading that wraps when the width is constrained"
+    [disabled]="true"
+  >
     Tab 3 content
   </sky-vertical-tab>
 </sky-vertical-tabset>

--- a/libs/components/code-examples/src/lib/modules/tabs/vertical-tabs/basic/example.component.spec.ts
+++ b/libs/components/code-examples/src/lib/modules/tabs/vertical-tabs/basic/example.component.spec.ts
@@ -1,6 +1,10 @@
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideNoopSkyAnimations } from '@skyux/core';
+import {
+  SkyMediaQueryTestingController,
+  provideSkyMediaQueryTesting,
+} from '@skyux/core/testing';
 import { SkyVerticalTabsetHarness } from '@skyux/tabs/testing';
 
 import { TabsVerticalTabsBasicExampleComponent } from './example.component';
@@ -13,6 +17,11 @@ describe('Basic vertical tabs example', () => {
     const fixture = TestBed.createComponent(
       TabsVerticalTabsBasicExampleComponent,
     );
+
+    // Pin a wide breakpoint so the tabset renders its side-by-side layout
+    // (and applies `tabWidth`) regardless of the test runner's window size.
+    TestBed.inject(SkyMediaQueryTestingController).setBreakpoint('lg');
+
     const loader = TestbedHarnessEnvironment.loader(fixture);
 
     const harness = await loader.getHarness(
@@ -25,12 +34,14 @@ describe('Basic vertical tabs example', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [TabsVerticalTabsBasicExampleComponent],
-      providers: [provideNoopSkyAnimations()],
+      providers: [provideNoopSkyAnimations(), provideSkyMediaQueryTesting()],
     });
   });
 
   it('should set up vertical tabs', async () => {
     const { harness } = await setupTest({ dataSkyId: 'vertical-tabs-basic' });
+
+    await expectAsync(harness.getTabWidth()).toBeResolvedTo('auto');
 
     const allTabs = await harness.getTabs();
     expect(allTabs.length).toBe(3);
@@ -40,7 +51,10 @@ describe('Basic vertical tabs example', () => {
     const activeTabContent = await activeTab?.getTabContent();
     expect(await activeTabContent?.isVisible()).toBeTrue();
 
-    const disabledTab = await harness.getTab({ tabHeading: 'Tab 3' });
+    const disabledTab = await harness.getTab({
+      tabHeading:
+        'A very long tab heading that wraps when the width is constrained',
+    });
     expect(await disabledTab?.isDisabled()).toBeTrue();
   });
 });

--- a/libs/components/tabs/src/lib/modules/vertical-tabset/fixtures/vertical-tabset.component.fixture.html
+++ b/libs/components/tabs/src/lib/modules/vertical-tabset/fixtures/vertical-tabset.component.fixture.html
@@ -3,6 +3,7 @@
     showTabsText="Tab list"
     [ariaRole]="tabsetAriaRole()"
     [maintainTabContent]="maintainTabContent"
+    [tabWidth]="tabWidth"
   >
     <sky-vertical-tabset-group
       groupHeading="Group 1"

--- a/libs/components/tabs/src/lib/modules/vertical-tabset/fixtures/vertical-tabset.component.fixture.ts
+++ b/libs/components/tabs/src/lib/modules/vertical-tabset/fixtures/vertical-tabset.component.fixture.ts
@@ -35,6 +35,7 @@ export class VerticalTabsetTestComponent {
   public tab1AriaRole = input<string | undefined>('tab');
   public tab1Id = input<string | undefined>('some-tab');
   public tab1Required = false;
+  public tabWidth: string | undefined;
   public tabsetAriaRole = input<string | undefined>('tablist');
 
   @ViewChild(SkyVerticalTabsetComponent)

--- a/libs/components/tabs/src/lib/modules/vertical-tabset/vertical-tabset.component.html
+++ b/libs/components/tabs/src/lib/modules/vertical-tabset/vertical-tabset.component.html
@@ -18,17 +18,19 @@
     class="sky-vertical-tabset-tablist"
     [attr.aria-label]="ariaLabel"
     [attr.aria-labelledby]="ariaLabelledBy"
-    [attr.aria-orientation]="isMobile ? undefined : 'vertical'"
+    [attr.aria-orientation]="isMobile() ? undefined : 'vertical'"
     [attr.aria-owns]="
-      isMobile ? undefined : (tabIdSvc.ids | async)?.join(' ') || undefined
+      isMobile() ? undefined : (tabIdSvc.ids | async)?.join(' ') || undefined
     "
-    [attr.role]="isMobile ? undefined : ariaRole"
+    [attr.role]="isMobile() ? undefined : ariaRole"
   ></span>
   <div
     #groupContainerWrapper
     class="sky-vertical-tabset-group-container"
     skyTransitionEndHandler
     transitionPropertyToTrack="transform"
+    [style.flex-basis]="tabGroupContainerFlexBasis()"
+    [style.max-width]="tabGroupContainerMaxWidth()"
     [class.sky-animation-slide-enter-left]="tabService.isMobile()"
     [ngClass]="{ 'sky-vertical-tabset-hidden': !tabService.tabsVisible() }"
     [tabIndex]="tablistHasFocus ? -1 : 0"

--- a/libs/components/tabs/src/lib/modules/vertical-tabset/vertical-tabset.component.scss
+++ b/libs/components/tabs/src/lib/modules/vertical-tabset/vertical-tabset.component.scss
@@ -39,6 +39,8 @@
       var(--sky-border-width-divider) var(--sky-border-style-divider)
         var(--sky-color-border-divider)
     );
+    flex-grow: 0;
+    flex-shrink: 0;
   }
 }
 
@@ -54,7 +56,6 @@
       var(--sky-comp-tab-vertical-content-space-inset-xs-bottom)
       var(--sky-comp-tab-vertical-content-space-inset-xs-left)
   );
-  flex-basis: 75%;
   overflow-y: auto;
 }
 
@@ -68,7 +69,6 @@
 
 .sky-vertical-tabset-group-container {
   background-color: var(--sky-color-background-container-dimmed);
-  flex-basis: 25%;
   overflow-y: auto;
   padding: var(
     --sky-override-vertical-tabset-group-container-padding,
@@ -104,6 +104,7 @@
 
 @include mixins.sky-host-responsive-container-sm-min() {
   .sky-vertical-tabset-content {
+    flex: 1 1 auto;
     margin: var(
       --sky-override-vertical-tabset-content-margin-sm-lg,
       var(--sky-comp-tab-vertical-content-space-inset-sm-top)

--- a/libs/components/tabs/src/lib/modules/vertical-tabset/vertical-tabset.component.spec.ts
+++ b/libs/components/tabs/src/lib/modules/vertical-tabset/vertical-tabset.component.spec.ts
@@ -651,6 +651,91 @@ describe('Vertical tabset component', () => {
     expect(showTabsButton.length).toBe(0);
   });
 
+  it('should default tab width to 25%', () => {
+    mediaQueryController.setBreakpoint('lg');
+    const fixture = createTestComponent();
+    fixture.detectChanges();
+
+    const tabsContainer = getTabsContainer(fixture);
+
+    expect(tabsContainer.style.flexBasis).toBe('25%');
+    expect(tabsContainer.style.maxWidth).toBe('25%');
+  });
+
+  it('should size tabs automatically when tabWidth is set to auto', () => {
+    mediaQueryController.setBreakpoint('lg');
+    const fixture = createTestComponent();
+    fixture.componentInstance.tabWidth = 'auto';
+    fixture.detectChanges();
+
+    const tabsContainer = getTabsContainer(fixture);
+
+    expect(tabsContainer.style.flexBasis).toBe('auto');
+    expect(tabsContainer.style.maxWidth).toBe('25%');
+  });
+
+  it('should set custom tab width', () => {
+    mediaQueryController.setBreakpoint('lg');
+    const fixture = createTestComponent();
+    fixture.componentInstance.tabWidth = '18rem';
+    fixture.detectChanges();
+
+    const tabsContainer = getTabsContainer(fixture);
+
+    expect(tabsContainer.style.flexBasis).toBe('18rem');
+    expect(tabsContainer.style.maxWidth).toBe('25%');
+  });
+
+  it('should not constrain the tab width on mobile', () => {
+    mediaQueryController.setBreakpoint('xs');
+    const fixture = createTestComponent();
+    fixture.componentInstance.tabWidth = 'auto';
+    fixture.detectChanges();
+
+    // The tabs container is hidden by default on mobile, so query it directly.
+    const tabsContainer: HTMLElement = fixture.nativeElement.querySelector(
+      '.sky-vertical-tabset-group-container',
+    );
+
+    // Inline width styles must not be applied on mobile, where the tabset
+    // switches to a full-width block layout. Otherwise `max-width: 25%` would
+    // clamp the nav column on small screens.
+    expect(tabsContainer.style.flexBasis).toBe('');
+    const mobileStyle = getComputedStyle(tabsContainer);
+    expect(mobileStyle.maxWidth).toBe('none');
+    expect(mobileStyle.minWidth).toBe('0px');
+  });
+
+  it('should constrain the nav width only in the side-by-side layout', () => {
+    mediaQueryController.setBreakpoint('lg');
+    const fixture = createTestComponent();
+    fixture.componentInstance.tabWidth = 'auto';
+    fixture.detectChanges();
+
+    const tabsContainer = getTabsContainer(fixture);
+    // The `auto` 25% cap is applied only in the side-by-side (desktop) layout;
+    // the mobile layout leaves it unset (see the mobile test).
+    const desktopStyle = getComputedStyle(tabsContainer);
+    expect(desktopStyle.maxWidth).not.toBe('none');
+  });
+
+  it('should update tab width styles when switching between mobile and desktop', () => {
+    mediaQueryController.setBreakpoint('lg');
+    const fixture = createTestComponent();
+    fixture.detectChanges();
+
+    const tabsContainer = getTabsContainer(fixture);
+    expect(tabsContainer.style.flexBasis).toBe('25%');
+
+    mediaQueryController.setBreakpoint('xs');
+    fixture.detectChanges();
+    expect(tabsContainer.style.flexBasis).toBe('');
+
+    mediaQueryController.setBreakpoint('lg');
+    fixture.detectChanges();
+    expect(tabsContainer.style.flexBasis).toBe('25%');
+  });
+
   it('mobile button should be visible on small screen', () => {
     mediaQueryController.setBreakpoint('xs');
     const fixture = createTestComponent();

--- a/libs/components/tabs/src/lib/modules/vertical-tabset/vertical-tabset.component.ts
+++ b/libs/components/tabs/src/lib/modules/vertical-tabset/vertical-tabset.component.ts
@@ -10,7 +10,10 @@ import {
   OnInit,
   Output,
   ViewChild,
+  computed,
   inject,
+  input,
+  signal,
 } from '@angular/core';
 import { SkyLibResourcesService } from '@skyux/i18n';
 
@@ -21,6 +24,12 @@ import { SkyTabIdService } from '../shared/tab-id.service';
 
 import { SkyVerticalTabsetAdapterService } from './vertical-tabset-adapter.service';
 import { SkyVerticalTabsetService } from './vertical-tabset.service';
+
+/**
+ * The default width of the tabs pane. Also serves as the maximum width of the
+ * pane for any `tabWidth` value.
+ */
+const DEFAULT_TAB_WIDTH = '25%';
 
 @Component({
   selector: 'sky-vertical-tabset',
@@ -86,6 +95,17 @@ export class SkyVerticalTabsetComponent
   public maintainTabContent: boolean | undefined = false;
 
   /**
+   * The width of the tabs pane as a CSS width value (such as `200px`, `15rem`,
+   * or `20%`). Set to `"auto"` to size based on tab label content. Maximum
+   * width is 25%.
+   * @default "25%"
+   */
+  public readonly tabWidth = input(DEFAULT_TAB_WIDTH, {
+    transform: (value: string | undefined): string =>
+      value?.trim() || DEFAULT_TAB_WIDTH,
+  });
+
+  /**
    * Fires when the active tab changes. Emits the index of the active tab. The
    * index is based on the tab's position when it loads.
    */
@@ -103,7 +123,7 @@ export class SkyVerticalTabsetComponent
 
   public ariaOwns: string | undefined;
 
-  public isMobile = false;
+  public readonly isMobile = signal(false);
 
   protected tablistHasFocus = false;
 
@@ -133,13 +153,11 @@ export class SkyVerticalTabsetComponent
     this.tabService.switchingMobile
       .pipe(takeUntil(this.#ngUnsubscribe))
       .subscribe((mobile: boolean) => {
-        this.isMobile = mobile;
-        this.#changeRef.markForCheck();
+        this.isMobile.set(mobile);
       });
 
     if (this.tabService.isMobile()) {
-      this.isMobile = true;
-      this.#changeRef.markForCheck();
+      this.isMobile.set(true);
     }
     if (!this.showTabsText) {
       this.#resources
@@ -188,4 +206,12 @@ export class SkyVerticalTabsetComponent
   protected tabGroupsArrowUp(): void {
     this.adapterService.focusPreviousButton(this.tabGroups);
   }
+
+  protected readonly tabGroupContainerFlexBasis = computed<string | undefined>(
+    () => (this.isMobile() ? undefined : this.tabWidth()),
+  );
+
+  protected readonly tabGroupContainerMaxWidth = computed<string | undefined>(
+    () => (this.isMobile() ? undefined : DEFAULT_TAB_WIDTH),
+  );
 }

--- a/libs/components/tabs/testing/src/modules/vertical-tabset/vertical-tabset-harness.spec.ts
+++ b/libs/components/tabs/testing/src/modules/vertical-tabset/vertical-tabset-harness.spec.ts
@@ -17,6 +17,7 @@ import { SkyVerticalTabsetHarness } from './vertical-tabset-harness';
       ariaLabel="Vertical tabset"
       ariaLabelledBy="Tabset label"
       [showTabsText]="showTabsText()"
+      [tabWidth]="tabWidth()"
     >
       <sky-vertical-tab
         tabHeading="Tab 1"
@@ -62,6 +63,7 @@ import { SkyVerticalTabsetHarness } from './vertical-tabset-harness';
 class TestComponent {
   public readonly active = input(true);
   public readonly showTabsText = input<string | undefined>(undefined);
+  public readonly tabWidth = input<string | undefined>(undefined);
   public groups: TabGroup[] = [
     {
       heading: 'Group 1',
@@ -248,6 +250,37 @@ describe('Vertical Tabset harness', () => {
     const activeTab = await tabsetHarness.getActiveTab();
 
     await expectAsync(activeTab?.getTabHeaderCount()).toBeResolvedTo(15);
+  });
+
+  it('should get the default tab width', async () => {
+    const { tabsetHarness, fixture } = await setupTest();
+    // Pin a wide breakpoint so the tabset renders its side-by-side layout
+    // (and applies inline width styles) regardless of the test runner's
+    // window size.
+    TestBed.inject(SkyMediaQueryTestingController).setBreakpoint('lg');
+    fixture.detectChanges();
+
+    await expectAsync(tabsetHarness.getTabWidth()).toBeResolvedTo('25%');
+  });
+
+  it('should get the auto tab width', async () => {
+    const { tabsetHarness, fixture } = await setupTest();
+    TestBed.inject(SkyMediaQueryTestingController).setBreakpoint('lg');
+    fixture.componentRef.setInput('tabWidth', 'auto');
+    fixture.detectChanges();
+
+    await expectAsync(tabsetHarness.getTabWidth()).toBeResolvedTo('auto');
+  });
+
+  it('should return null for the tab width on mobile', async () => {
+    const { tabsetHarness, fixture } = await setupTest();
+    const mediaQueryController = TestBed.inject(SkyMediaQueryTestingController);
+    mediaQueryController.setBreakpoint('xs');
+    fixture.detectChanges();
+
+    // On mobile the tabset uses a full-width block layout, so no inline width
+    // styles are applied to the nav container.
+    await expectAsync(tabsetHarness.getTabWidth()).toBeResolvedTo(null);
   });
 
   describe('vertical tabset group', () => {

--- a/libs/components/tabs/testing/src/modules/vertical-tabset/vertical-tabset-harness.ts
+++ b/libs/components/tabs/testing/src/modules/vertical-tabset/vertical-tabset-harness.ts
@@ -20,6 +20,7 @@ export class SkyVerticalTabsetHarness extends SkyComponentHarness {
   #showTabsButton = this.locatorForOptional(
     '.sky-vertical-tabset-content > button.sky-vertical-tabset-show-tabs-btn',
   );
+  #tabsContainer = this.locatorFor('.sky-vertical-tabset-group-container');
 
   /**
    * Gets a `HarnessPredicate` that can be used to search for a
@@ -139,6 +140,20 @@ export class SkyVerticalTabsetHarness extends SkyComponentHarness {
     }
 
     return undefined;
+  }
+
+  /**
+   * Gets the tab width as a CSS `flex-basis` value (for example, `200px`),
+   * or `null` when no width is set. The width is only applied in the desktop
+   * layout, so this returns `null` in the mobile layout.
+   */
+  public async getTabWidth(): Promise<string | null> {
+    const styleAttribute = await (
+      await this.#tabsContainer()
+    ).getAttribute('style');
+    const styleMatch = styleAttribute?.match(/flex-basis:\s*([^;]+)/i);
+
+    return styleMatch?.[1]?.trim() ?? null;
   }
 
   /**


### PR DESCRIPTION
This change adds a `tabWidth` input to `sky-vertical-tabset` (default
`25%`) and introduces an `auto` mode where the tab-nav column sizes to
label content while remaining capped at 25%. Existing long-label
wrapping behavior is preserved by keeping tab button text flow
unchanged.

- **Component API and layout behavior**
- Added `@Input() tabWidth: string | undefined` to
`SkyVerticalTabsetComponent` with default normalization to `"25%"`.
  - Added dynamic width bindings in the template:
    - Tab pane uses `flex-basis` from `tabWidth`.
- `tabWidth="auto"` sets tab pane `flex-basis: auto` and `max-width:
25%`.
- Content pane flex-basis is derived from tab width (`calc(100% -
tabWidth)`) or `0%` in auto mode.

- **Vertical tabset test coverage**
  - Added focused spec assertions for:
    - default width behavior (`25%` / derived content width),
    - `auto` mode (`auto` + `max-width: 25%`),
    - custom width values (e.g., `18rem`).

- **Harness API**
- Added `SkyVerticalTabsetHarness#getTabWidth()` to expose tab pane
width for integration/example tests.
  - Added harness spec coverage for default and `auto` width scenarios.

- **Code example updates**
- Updated the basic vertical tabs example to demonstrate
`tabWidth="auto"` and include a long heading to show constrained
auto-width behavior.

```html
<sky-vertical-tabset tabWidth="auto">
  <sky-vertical-tab tabHeading="A short tab">...</sky-vertical-tab>
  <sky-vertical-tab
    tabHeading="A very long tab heading that wraps when the width is constrained"
  >
    ...
  </sky-vertical-tab>
</sky-vertical-tabset>
```


[AB#3934239](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3934239) 🍒 #4410

