### PR TITLE
fix(components/charts): fix horizontal bar spacing; add visual tests (#4552)

### DIFF
--- a/.github/skills/add-component-visual-tests/SKILL.md
+++ b/.github/skills/add-component-visual-tests/SKILL.md
@@ -71,7 +71,43 @@ patterns.
    (default, key inputs, selected/disabled/error/empty/loading) the snapshot
    should capture. Do not add assertions or interaction logic.
 
-4. **Verify.** Build the storybook app to confirm it compiles, then lint and
+4. **Capture snapshots with `skyVisualTest`.** The `story` generator also
+   creates a Cypress spec at
+   `apps/e2e/<library>-storybook-e2e/src/e2e/<name>/<name>.component.cy.ts`.
+   Capture each snapshot with `skyVisualTest` (not `cy.screenshot` +
+   `cy.percySnapshot`), iterating themes with `E2eVariations.forEachTheme`,
+   waiting for the component with `cy.skyReady`, and passing
+   `disableTimersAndAnimations: true` for components that animate on render
+   (e.g. charts). Scope the capture based on where the content renders:
+   - **Inline components** — scope to the wrapper element:
+     `cy.get('app-<name>').skyVisualTest(...)`.
+   - **Portaled overlays** — a component that renders into an overlay outside
+     the wrapper (such as a modal `sky-modal`, flyout, or dropdown) is missed
+     by a wrapper-scoped capture. Assert the overlay is visible, then capture
+     the viewport instead: `cy.skyVisualTest(name, { capture: 'viewport' })`.
+
+   ```typescript
+   import { E2eVariations } from '@skyux-sdk/e2e-schematics';
+
+   describe('<Name>', () => {
+     E2eVariations.forEachTheme((theme) => {
+       describe(`in ${theme} theme`, () => {
+         it('should render', () => {
+           cy.visit(
+             `/iframe.html?globals=theme:${theme}&id=<storyId>--<story>`,
+           );
+           cy.skyReady('app-<name>').end();
+           cy.get('app-<name>').skyVisualTest(`<name>-${theme}`, {
+             overwrite: true,
+             disableTimersAndAnimations: true,
+           });
+         });
+       });
+     });
+   });
+   ```
+
+5. **Verify.** Build the storybook app to confirm it compiles, then lint and
    format:
 
    ```bash
@@ -80,7 +116,7 @@ patterns.
    nx format --files=<changed-file-paths>
    ```
 
-5. **Commit.** Use a Conventional Commit with the `components/<library>` scope
+6. **Commit.** Use a Conventional Commit with the `components/<library>` scope
    per
    [commit-message.instructions.md](../../instructions/commit-message.instructions.md).
 
@@ -91,5 +127,9 @@ patterns.
 - The story's `Meta` has a stable `id`, a `Components/<DisplayName>` title, and
   a `moduleMetadata` decorator; each meaningful visual state is captured as a
   named story or args permutation, with no assertion/interaction logic.
+- The generated Cypress spec captures each snapshot with `skyVisualTest`
+  (iterated over `forEachTheme`), not `cy.screenshot` + `cy.percySnapshot`:
+  inline content is scoped to the wrapper element, while portaled overlays
+  such as a modal (`sky-modal`) use `capture: 'viewport'`.
 - `npx nx build <library>-storybook` compiles, lint is clean, and changed
   files are formatted.

--- a/apps/e2e/charts-storybook-e2e/cypress.config.ts
+++ b/apps/e2e/charts-storybook-e2e/cypress.config.ts
@@ -1,0 +1,14 @@
+import { sendCypressScreenshotsToPercy } from '@skyux-sdk/e2e-schematics';
+import { skyE2ePreset } from '@skyux-sdk/e2e-schematics/cypress-preset';
+
+import { defineConfig } from 'cypress';
+
+export default defineConfig({
+  e2e: {
+    ...skyE2ePreset(__dirname, {
+      setupNodeEvents: (on, config) => {
+        sendCypressScreenshotsToPercy(on, config);
+      },
+    }),
+  },
+});

--- a/apps/e2e/charts-storybook-e2e/eslint.config.js
+++ b/apps/e2e/charts-storybook-e2e/eslint.config.js
@@ -1,0 +1,3 @@
+const config = require('../../../eslint-e2e.config');
+
+module.exports = config;

--- a/apps/e2e/charts-storybook-e2e/project.json
+++ b/apps/e2e/charts-storybook-e2e/project.json
@@ -1,0 +1,37 @@
+{
+  "name": "charts-storybook-e2e",
+  "$schema": "../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "apps/e2e/charts-storybook-e2e/src",
+  "projectType": "application",
+  "targets": {
+    "e2e": {
+      "executor": "@nx/cypress:cypress",
+      "options": {
+        "cypressConfig": "apps/e2e/charts-storybook-e2e/cypress.config.ts",
+        "devServerTarget": "charts-storybook:storybook",
+        "testingType": "e2e",
+        "browser": "chrome",
+        "baseUrl": "http://localhost:4400"
+      },
+      "configurations": {
+        "ci": {
+          "devServerTarget": "charts-storybook:static-storybook:ci",
+          "browser": "chrome",
+          "baseUrl": "http://localhost:4200"
+        },
+        "prebuilt": {
+          "devServerTarget": "charts-storybook:static-storybook:prebuilt",
+          "baseUrl": ""
+        }
+      }
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint",
+      "options": {
+        "lintFilePatterns": ["{projectRoot}/**/*.{js,ts}"]
+      }
+    }
+  },
+  "tags": [],
+  "implicitDependencies": ["charts-storybook"]
+}

--- a/apps/e2e/charts-storybook-e2e/src/e2e/chart-bar/chart-bar.component.cy.ts
+++ b/apps/e2e/charts-storybook-e2e/src/e2e/chart-bar/chart-bar.component.cy.ts
@@ -1,0 +1,45 @@
+import { E2eVariations } from '@skyux-sdk/e2e-schematics';
+
+describe('ChartBar', () => {
+  E2eVariations.forEachTheme((theme) => {
+    describe(`in ${theme} theme`, () => {
+      for (const orientation of ['vertical', 'horizontal']) {
+        it(`should render ${orientation} bars`, () => {
+          cy.visit(
+            `/iframe.html?globals=theme:${theme}&id=chart-barcomponent--${orientation}`,
+          );
+
+          cy.skyReady('app-chart-bar').end();
+
+          cy.get('app-chart-bar').skyVisualTest(
+            `chart-bar-${orientation}-${theme}`,
+            {
+              overwrite: true,
+              disableTimersAndAnimations: true,
+              widths: E2eVariations.DISPLAY_WIDTHS,
+            },
+          );
+        });
+      }
+
+      it('should render the data table modal', () => {
+        cy.visit(
+          `/iframe.html?globals=theme:${theme}&id=chart-barcomponent--vertical`,
+        );
+        cy.skyReady('app-chart-bar').end();
+
+        cy.get('#floating-chart .sky-dropdown-button')
+          .should('be.visible')
+          .click();
+        cy.get('.sky-dropdown-item button').should('be.visible').click();
+        cy.get('sky-modal').should('be.visible');
+
+        cy.skyVisualTest(`chart-bar-data-table-${theme}`, {
+          capture: 'viewport',
+          overwrite: true,
+          disableTimersAndAnimations: true,
+        });
+      });
+    });
+  });
+});

--- a/apps/e2e/charts-storybook-e2e/src/support/e2e.ts
+++ b/apps/e2e/charts-storybook-e2e/src/support/e2e.ts
@@ -1,0 +1,19 @@
+// ***********************************************************
+// This example support/index.js is processed and
+// loaded automatically before your test files.
+//
+// This is a great place to put global configuration and
+// behavior that modifies Cypress.
+//
+// You can change the location of this file or turn off
+// automatically serving support files with the
+// 'supportFile' configuration option.
+//
+// You can read more here:
+// https://on.cypress.io/configuration
+// ***********************************************************
+// Import commands.js using ES2015 syntax:
+import '@percy/cypress';
+import '@skyux-sdk/cypress-commands';
+
+import './commands';

--- a/apps/e2e/charts-storybook-e2e/tsconfig.json
+++ b/apps/e2e/charts-storybook-e2e/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "sourceMap": false,
+    "outDir": "../../../dist/out-tsc",
+    "allowJs": true,
+    "types": ["cypress", "node"]
+  },
+  "include": ["src/**/*.ts", "src/**/*.js", "cypress.config.ts"]
+}

--- a/apps/e2e/charts-storybook/.storybook/main.ts
+++ b/apps/e2e/charts-storybook/.storybook/main.ts
@@ -1,0 +1,10 @@
+import type { StorybookConfig } from 'storybook/internal/types';
+
+// eslint-disable-next-line @nx/enforce-module-boundaries
+import { rootMain } from '../../../../.storybook/main';
+
+const config: StorybookConfig = {
+  ...rootMain,
+  stories: ['../src/app/**/*.stories.@(js|ts)'],
+};
+export default config;

--- a/apps/e2e/charts-storybook/.storybook/manager.ts
+++ b/apps/e2e/charts-storybook/.storybook/manager.ts
@@ -1,0 +1,2 @@
+// eslint-disable-next-line @nx/enforce-module-boundaries
+export * from '../../../../.storybook/manager';

--- a/apps/e2e/charts-storybook/.storybook/preview.ts
+++ b/apps/e2e/charts-storybook/.storybook/preview.ts
@@ -1,0 +1,21 @@
+import {
+  previewWrapperDecorators,
+  previewWrapperGlobalTypes,
+  previewWrapperParameters,
+} from '@skyux/storybook';
+import { moduleMetadata } from '@storybook/angular';
+
+export const parameters = {
+  ...previewWrapperParameters,
+};
+
+export const globalTypes = {
+  ...previewWrapperGlobalTypes,
+};
+
+export const decorators = [
+  ...previewWrapperDecorators,
+  moduleMetadata({
+    imports: [],
+  }),
+];

--- a/apps/e2e/charts-storybook/.storybook/tsconfig.json
+++ b/apps/e2e/charts-storybook/.storybook/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "emitDecoratorMetadata": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true
+  },
+  "exclude": ["../**/*.spec.ts", "jest.config.ts"],
+  "include": [
+    "../src/**/*.stories.ts",
+    "../src/**/*.stories.js",
+    "../src/**/*.stories.jsx",
+    "../src/**/*.stories.tsx",
+
+    "*.ts",
+    "*.js",
+    "./*"
+  ]
+}

--- a/apps/e2e/charts-storybook/eslint.config.js
+++ b/apps/e2e/charts-storybook/eslint.config.js
@@ -1,0 +1,3 @@
+const config = require('../../../eslint-storybook.config');
+
+module.exports = config;

--- a/apps/e2e/charts-storybook/project.json
+++ b/apps/e2e/charts-storybook/project.json
@@ -1,0 +1,138 @@
+{
+  "name": "charts-storybook",
+  "$schema": "../../../node_modules/nx/schemas/project-schema.json",
+  "projectType": "application",
+  "sourceRoot": "apps/e2e/charts-storybook/src",
+  "prefix": "app",
+  "tags": ["component-e2e"],
+  "targets": {
+    "build": {
+      "executor": "@angular/build:application",
+      "outputs": ["{options.outputPath.base}"],
+      "options": {
+        "outputPath": {
+          "base": "dist/apps/e2e/charts-storybook"
+        },
+        "index": "apps/e2e/charts-storybook/src/index.html",
+        "polyfills": ["zone.js"],
+        "tsConfig": "apps/e2e/charts-storybook/tsconfig.app.json",
+        "inlineStyleLanguage": "scss",
+        "stylePreprocessorOptions": {
+          "includePaths": ["{workspaceRoot}"]
+        },
+        "styles": [
+          "apps/e2e/charts-storybook/src/styles.scss",
+          "libs/components/theme/src/lib/styles/sky.scss",
+          "libs/components/theme/src/lib/styles/themes/modern/styles.scss"
+        ],
+        "scripts": [],
+        "browser": "apps/e2e/charts-storybook/src/main.ts"
+      },
+      "configurations": {
+        "production": {
+          "budgets": [
+            {
+              "type": "initial",
+              "maximumWarning": "500kb",
+              "maximumError": "1mb"
+            },
+            {
+              "type": "anyComponentStyle",
+              "maximumWarning": "2kb",
+              "maximumError": "4kb"
+            }
+          ],
+          "outputHashing": "all"
+        },
+        "development": {
+          "optimization": false,
+          "extractLicenses": false,
+          "sourceMap": true,
+          "namedChunks": true
+        }
+      },
+      "defaultConfiguration": "production"
+    },
+    "serve": {
+      "executor": "@angular-devkit/build-angular:dev-server",
+      "configurations": {
+        "production": {
+          "buildTarget": "charts-storybook:build:production"
+        },
+        "development": {
+          "buildTarget": "charts-storybook:build:development"
+        }
+      },
+      "defaultConfiguration": "development",
+      "continuous": true
+    },
+    "extract-i18n": {
+      "executor": "@angular-devkit/build-angular:extract-i18n",
+      "options": {
+        "buildTarget": "charts-storybook:build"
+      }
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint",
+      "options": {
+        "lintFilePatterns": ["{projectRoot}/**/*.ts", "{projectRoot}/**/*.html"]
+      }
+    },
+    "storybook": {
+      "executor": "@storybook/angular:start-storybook",
+      "options": {
+        "port": 4400,
+        "configDir": "apps/e2e/charts-storybook/.storybook",
+        "browserTarget": "charts-storybook:build",
+        "compodoc": false,
+        "styles": [
+          "libs/components/theme/src/lib/styles/sky.scss",
+          "libs/components/theme/src/lib/styles/themes/modern/styles.scss"
+        ]
+      },
+      "configurations": {
+        "ci": {
+          "quiet": true,
+          "ci": true
+        }
+      }
+    },
+    "build-storybook": {
+      "executor": "@storybook/angular:build-storybook",
+      "outputs": ["{options.outputDir}"],
+      "options": {
+        "outputDir": "dist/storybook/charts-storybook",
+        "configDir": "apps/e2e/charts-storybook/.storybook",
+        "browserTarget": "charts-storybook:build",
+        "compodoc": false,
+        "styles": [
+          "libs/components/theme/src/lib/styles/sky.scss",
+          "libs/components/theme/src/lib/styles/themes/modern/styles.scss"
+        ]
+      },
+      "configurations": {
+        "ci": {
+          "quiet": true
+        }
+      }
+    },
+    "static-storybook": {
+      "executor": "@nx/web:file-server",
+      "options": {
+        "buildTarget": "charts-storybook:build-storybook",
+        "staticFilePath": "dist/storybook/charts-storybook"
+      },
+      "configurations": {
+        "ci": {
+          "buildTarget": "charts-storybook:build-storybook:ci"
+        },
+        "prebuilt": {
+          "buildTarget": "charts-storybook:noop"
+        }
+      }
+    },
+    "noop": {
+      "executor": "nx:noop"
+    }
+  }
+}

--- a/apps/e2e/charts-storybook/src/app/app.component.ts
+++ b/apps/e2e/charts-storybook/src/app/app.component.ts
@@ -1,0 +1,9 @@
+import { Component } from '@angular/core';
+import { RouterOutlet } from '@angular/router';
+
+@Component({
+  selector: 'app-root',
+  template: `<router-outlet />`,
+  imports: [RouterOutlet],
+})
+export class AppComponent {}

--- a/apps/e2e/charts-storybook/src/app/app.routes.ts
+++ b/apps/e2e/charts-storybook/src/app/app.routes.ts
@@ -1,0 +1,3 @@
+import { Route } from '@angular/router';
+
+export const routes: Route[] = [];

--- a/apps/e2e/charts-storybook/src/app/chart-bar/chart-bar.component.html
+++ b/apps/e2e/charts-storybook/src/app/chart-bar/chart-bar.component.html
@@ -1,0 +1,44 @@
+<sky-chart headingText="Acquisitions by year">
+  <sky-chart-bar [orientation]="orientation">
+    <sky-chart-axis-category labelText="Year" [categories]="years" />
+    <sky-chart-axis-value labelText="Acquisitions" format="currency" />
+    <sky-chart-bar-series
+      labelText="Acquisitions by year"
+      [values]="acquisitions"
+    />
+  </sky-chart-bar>
+</sky-chart>
+
+<sky-chart headingText="Actual vs. target">
+  <sky-chart-bar [orientation]="orientation">
+    <sky-chart-axis-category labelText="Year" [categories]="years" />
+    <sky-chart-axis-value labelText="Acquisitions" />
+    <sky-chart-bar-series labelText="Actual" [values]="acquisitions" />
+    <sky-chart-bar-series labelText="Target" [values]="target" />
+  </sky-chart-bar>
+</sky-chart>
+
+<sky-chart headingText="Monthly sales">
+  <sky-chart-bar seriesLayout="stacked" [orientation]="orientation">
+    <sky-chart-axis-category labelText="Month" [categories]="months" />
+    <sky-chart-axis-value labelText="Value" />
+    <sky-chart-bar-series labelText="In store" [values]="inStore" />
+    <sky-chart-bar-series labelText="Online" [values]="online" />
+    <sky-chart-bar-series labelText="Phone" [values]="phone" />
+  </sky-chart-bar>
+</sky-chart>
+
+<sky-chart
+  id="floating-chart"
+  headingText="Temperature range by month"
+  subheadingText="Degrees Celsius"
+>
+  <sky-chart-bar [orientation]="orientation">
+    <sky-chart-axis-category labelText="Month" [categories]="months" />
+    <sky-chart-axis-value labelText="Temperature (°C)" />
+    <sky-chart-bar-series
+      labelText="Temperature range"
+      [values]="temperatureRanges"
+    />
+  </sky-chart-bar>
+</sky-chart>

--- a/apps/e2e/charts-storybook/src/app/chart-bar/chart-bar.component.scss
+++ b/apps/e2e/charts-storybook/src/app/chart-bar/chart-bar.component.scss
@@ -1,0 +1,3 @@
+:host {
+  display: block;
+}

--- a/apps/e2e/charts-storybook/src/app/chart-bar/chart-bar.component.stories.ts
+++ b/apps/e2e/charts-storybook/src/app/chart-bar/chart-bar.component.stories.ts
@@ -1,0 +1,20 @@
+import type { Meta, StoryObj } from '@storybook/angular';
+
+import { ChartBarComponent } from './chart-bar.component';
+
+export default {
+  id: 'chart-barcomponent',
+  title: 'Components/Chart Bar',
+  component: ChartBarComponent,
+} as Meta<ChartBarComponent>;
+type Story = StoryObj<ChartBarComponent>;
+
+export const Vertical: Story = {};
+Vertical.args = {
+  orientation: 'vertical',
+};
+
+export const Horizontal: Story = {};
+Horizontal.args = {
+  orientation: 'horizontal',
+};

--- a/apps/e2e/charts-storybook/src/app/chart-bar/chart-bar.component.ts
+++ b/apps/e2e/charts-storybook/src/app/chart-bar/chart-bar.component.ts
@@ -1,0 +1,56 @@
+import { CommonModule } from '@angular/common';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import {
+  SkyChart,
+  SkyChartAxisCategory,
+  SkyChartAxisValue,
+  SkyChartBar,
+  type SkyChartBarOrientation,
+  SkyChartBarSeries,
+  type SkyChartBarSeriesValue,
+} from '@skyux/charts';
+
+@Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [
+    CommonModule,
+    SkyChart,
+    SkyChartAxisCategory,
+    SkyChartAxisValue,
+    SkyChartBar,
+    SkyChartBarSeries,
+  ],
+  selector: 'app-chart-bar',
+  templateUrl: './chart-bar.component.html',
+  styleUrls: ['./chart-bar.component.scss'],
+})
+export class ChartBarComponent {
+  public orientation: SkyChartBarOrientation = 'vertical';
+
+  protected readonly years = [2010, 2011, 2012, 2013, 2014, 2015, 2016];
+  protected readonly acquisitions = [10, 20, 15, 25, 22, 30, 28];
+  protected readonly target = [12, 18, 20, 22, 26, 28, 32];
+
+  protected readonly months = [
+    'January',
+    'February',
+    'March',
+    'April',
+    'May',
+    'June',
+    'July',
+  ];
+  protected readonly online = [38, 6, 54, 69, 88, 13, 87];
+  protected readonly inStore = [37, 84, 28, 84, 97, 22, 63];
+  protected readonly phone = [86, 4, 7, 85, 8, 51, 30];
+
+  protected readonly temperatureRanges: SkyChartBarSeriesValue[] = [
+    [-2, 5],
+    [0, 8],
+    [4, 14],
+    [9, 19],
+    [14, 24],
+    [18, 28],
+    [20, 30],
+  ];
+}

--- a/apps/e2e/charts-storybook/src/index.html
+++ b/apps/e2e/charts-storybook/src/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>ChartsStorybook</title>
+    <base href="/" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+  </head>
+  <body>
+    <app-root></app-root>
+  </body>
+</html>

--- a/apps/e2e/charts-storybook/src/main.ts
+++ b/apps/e2e/charts-storybook/src/main.ts
@@ -1,0 +1,16 @@
+import { provideZoneChangeDetection } from '@angular/core';
+import { bootstrapApplication } from '@angular/platform-browser';
+import {
+  provideRouter,
+  withEnabledBlockingInitialNavigation,
+} from '@angular/router';
+
+import { AppComponent } from './app/app.component';
+import { routes } from './app/app.routes';
+
+bootstrapApplication(AppComponent, {
+  providers: [
+    provideZoneChangeDetection(),
+    provideRouter(routes, withEnabledBlockingInitialNavigation()),
+  ],
+}).catch((err) => console.error(err));

--- a/apps/e2e/charts-storybook/src/styles.scss
+++ b/apps/e2e/charts-storybook/src/styles.scss
@@ -1,0 +1,1 @@
+/* You can add global styles to this file, and also import other style files */

--- a/apps/e2e/charts-storybook/tsconfig.app.json
+++ b/apps/e2e/charts-storybook/tsconfig.app.json
@@ -1,0 +1,18 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/out-tsc",
+    "types": [],
+    "esModuleInterop": true,
+    "resolveJsonModule": true
+  },
+  "files": ["src/main.ts"],
+  "include": ["src/**/*.d.ts"],
+  "exclude": [
+    "jest.config.ts",
+    "**/*.test.ts",
+    "**/*.spec.ts",
+    "**/*.stories.ts",
+    "**/*.stories.js"
+  ]
+}

--- a/apps/e2e/charts-storybook/tsconfig.editor.json
+++ b/apps/e2e/charts-storybook/tsconfig.editor.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["**/*.ts"],
+  "compilerOptions": {
+    "types": ["jest", "node"]
+  }
+}

--- a/apps/e2e/charts-storybook/tsconfig.json
+++ b/apps/e2e/charts-storybook/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.app.json"
+    },
+    {
+      "path": "./tsconfig.editor.json"
+    },
+    {
+      "path": "./.storybook/tsconfig.json"
+    }
+  ]
+}

--- a/libs/components/charts/documentation.json
+++ b/libs/components/charts/documentation.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../manifest-generator/documentation-schema.json",
   "groups": {
-    "charts": {
+    "chart-bar": {
       "development": {
         "docsIds": [
           "SkyChart",

--- a/libs/components/charts/src/lib/chart-bar/chart-bar.spec.ts
+++ b/libs/components/charts/src/lib/chart-bar/chart-bar.spec.ts
@@ -543,16 +543,69 @@ describe('Chart bar component', () => {
     );
   });
 
-  it('should set an explicit bar thickness on a horizontal chart', () => {
+  it('should cap horizontal bars at the target thickness', () => {
     fixture.componentRef.setInput('orientation', 'horizontal');
     fixture.detectChanges();
 
-    // Few bars render at the full (max) thickness, and the explicit thickness
-    // replaces the cap so Chart.js does not auto-size the bars thinner.
-    expect(requireChart().data.datasets[0].barThickness).toBe(
+    // Few bars target the full (max) thickness. The cap — not an explicit
+    // `barThickness` — must carry it: a numeric `barThickness` makes Chart.js
+    // ignore the fill percentages and render fixed-size bars that overlap
+    // adjacent categories when the band is smaller than budgeted.
+    expect(requireChart().data.datasets[0].maxBarThickness).toBe(
       1 * rootFontSize(),
     );
-    expect(requireChart().data.datasets[0].maxBarThickness).toBeUndefined();
+    expect(requireChart().data.datasets[0].barThickness).toBeUndefined();
+  });
+
+  it('should budget the category band for horizontal bars and their gaps', () => {
+    fixture.componentRef.setInput('orientation', 'horizontal');
+    fixture.componentRef.setInput('renderSecondSeries', true);
+    fixture.componentRef.setInput('categories', [
+      '2021',
+      '2022',
+      '2023',
+      '2024',
+    ]);
+    fixture.componentRef.setInput('values', [10, 20, 30, 40]);
+    fixture.detectChanges();
+
+    // Chart.js sizes each bar as `min(maxBarThickness,
+    // band * categoryPercentage * barPercentage / barsPerCategory)`, so the
+    // datasets must declare the fractions of each category band the bars
+    // occupy — the container height budgets the band as one slot (bar + gap)
+    // per bar plus the category gap. Chart.js's defaults (categoryPercentage
+    // 0.8, barPercentage 0.9) are unrelated to that budget and squeeze the
+    // bars once a category holds more than one.
+    const barThickness = 1 * rootFontSize();
+    const categoryGap = 0.375 * barThickness;
+    const barSlot = barThickness + 0.25 * barThickness;
+    const barsPerCategory = 2;
+    const rowHeight = barSlot * barsPerCategory + categoryGap;
+
+    const dataset = requireChart().data.datasets[0];
+    expect(dataset.categoryPercentage).toBeCloseTo(
+      (barSlot * barsPerCategory) / rowHeight,
+      6,
+    );
+    expect(dataset.barPercentage).toBeCloseTo(barThickness / barSlot, 6);
+    expect(dataset.maxBarThickness).toBe(barThickness);
+  });
+
+  it('should not reserve an intra-category bar gap for a single bar per category', () => {
+    fixture.componentRef.setInput('orientation', 'horizontal');
+    fixture.detectChanges();
+
+    // With one bar per category there is no neighboring bar to separate, so
+    // the bar fills its slot and only the category gap surrounds it.
+    const barThickness = 1 * rootFontSize();
+    const categoryGap = 0.375 * barThickness;
+
+    const dataset = requireChart().data.datasets[0];
+    expect(dataset.categoryPercentage).toBeCloseTo(
+      barThickness / (barThickness + categoryGap),
+      6,
+    );
+    expect(dataset.barPercentage).toBe(1);
   });
 
   it('should taper the bar thickness for a dense horizontal chart', () => {
@@ -567,8 +620,8 @@ describe('Chart bar component', () => {
     );
     fixture.detectChanges();
 
-    // Past the taper range every bar renders at the minimum thickness.
-    expect(requireChart().data.datasets[0].barThickness).toBe(
+    // Past the taper range every bar targets the minimum thickness.
+    expect(requireChart().data.datasets[0].maxBarThickness).toBe(
       0.75 * rootFontSize(),
     );
   });

--- a/libs/components/charts/src/lib/chart-bar/chart-bar.ts
+++ b/libs/components/charts/src/lib/chart-bar/chart-bar.ts
@@ -176,11 +176,11 @@ export class SkyChartBar extends SkyChartPlot {
     const valueDirection = isHorizontal ? 'x' : 'y';
     const formatValue = valueAxis.formatValue();
 
-    // Horizontal bars are rendered at an explicit thickness (see below), which
-    // the container height is also derived from; resolve it once so the two
-    // always agree.
-    const horizontalBarThickness = isHorizontal
-      ? this.#getHorizontalBarSpacing(themeStyles).barThickness
+    // Horizontal bars target an explicit thickness (see below), which the
+    // container height is also derived from; resolve the spacing once so the
+    // two always agree.
+    const horizontalSpacing = isHorizontal
+      ? this.#getHorizontalBarSpacing(themeStyles)
       : undefined;
 
     // Vertical bars fill their responsive width; the fill percentages are
@@ -201,10 +201,14 @@ export class SkyChartBar extends SkyChartPlot {
       };
 
       if (isHorizontal) {
-        // Render bars at the exact thickness the container height was computed
-        // for. Without this, Chart.js shrinks each bar to a fraction of its
-        // category slot, ignoring the minimum thickness.
-        dataset.barThickness = horizontalBarThickness;
+        // Size horizontal bars through the band fill fractions, capped at the
+        // target thickness (see #getHorizontalBarSpacing). An explicit numeric
+        // `barThickness` would not work here: Chart.js then ignores the fill
+        // fractions and renders bars that sit flush against each other and
+        // overlap adjacent categories when the band is smaller than budgeted.
+        dataset.categoryPercentage = horizontalSpacing?.categoryPercentage;
+        dataset.barPercentage = horizontalSpacing?.barPercentage;
+        dataset.maxBarThickness = horizontalSpacing?.barThickness;
       } else {
         // Shape the whitespace around vertical bars and cap their width so
         // sparse charts do not render unusably wide bars.
@@ -293,9 +297,8 @@ export class SkyChartBar extends SkyChartPlot {
       return themeStyles.height.default;
     }
 
-    const { barThickness, categoryGap, categoryCount, barsPerCategory } =
+    const { rowHeight, categoryCount } =
       this.#getHorizontalBarSpacing(themeStyles);
-    const rowHeight = barThickness * barsPerCategory + categoryGap;
     const totalRowsHeight = categoryCount * rowHeight;
 
     const computedHeight =
@@ -309,15 +312,17 @@ export class SkyChartBar extends SkyChartPlot {
   }
 
   /**
-   * Resolves the horizontal bar layout — the per-bar thickness, the gap between
-   * categories, and the counts they derive from — shared by the container
-   * height and the datasets so the two always agree.
+   * Resolves the horizontal bar layout — the target per-bar thickness, the
+   * fractions of each category band the bars fill, and the per-category row
+   * height — shared by the container height and the datasets so the two always
+   * agree.
    */
   #getHorizontalBarSpacing(themeStyles: SkyChartThemeStyles): {
     barThickness: number;
-    categoryGap: number;
+    categoryPercentage: number;
+    barPercentage: number;
+    rowHeight: number;
     categoryCount: number;
-    barsPerCategory: number;
   } {
     const seriesCount = this.series().length;
     // Chart.js renders one row per category-axis label, so the row count must
@@ -338,10 +343,32 @@ export class SkyChartBar extends SkyChartPlot {
         : seriesCount;
     const totalBars = categoryCount * barsPerCategory;
 
+    const { barThickness, categoryGap } =
+      this.#computeHorizontalBarElementSpacing(totalBars, themeStyles);
+
+    // Bars that share a category are separated by a small gap so grouped bars
+    // read as distinct; a category with a single bar needs none.
+    const barGapPercentage = 0.25;
+    const barGap = barsPerCategory > 1 ? barThickness * barGapPercentage : 0;
+
+    // Each bar's slot is the bar plus its gap, and each category's row is its
+    // slots plus the gap that separates it from the next category — the same
+    // budget the container height is derived from.
+    const barSlot = barThickness + barGap;
+    const rowHeight = barSlot * barsPerCategory + categoryGap;
+
+    // Chart.js divides the plotted area evenly into category bands, so at the
+    // derived container height each band matches `rowHeight`; these fractions
+    // size each bar at the target thickness with the budgeted gaps.
+    const categoryPercentage = (barSlot * barsPerCategory) / rowHeight;
+    const barPercentage = barThickness / barSlot;
+
     return {
-      ...this.#computeHorizontalBarElementSpacing(totalBars, themeStyles),
+      barThickness,
+      categoryPercentage,
+      barPercentage,
+      rowHeight,
       categoryCount,
-      barsPerCategory,
     };
   }
 


### PR DESCRIPTION
🍒 #4552

<!-- This is an auto-generated comment: release notes by coderabbit.ai
-->

* **New Features**
* Added a Charts Storybook E2E setup for ChartBar, including vertical
and horizontal examples plus a new temperature-range chart.
* Enabled theme-aware Cypress visual regression with Percy screenshot
uploads.
* **Bug Fixes**
* Improved ChartBar E2E visual assertions and added visual coverage for
the ChartBar data table modal.
* **Documentation**
* Updated the visual-test workflow to use `skyVisualTest` (theme
iteration and overlay capture rules).
  * Adjusted chart documentation grouping from `charts` to `chart-bar`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added interactive bar-chart examples covering vertical and horizontal layouts, stacked data, comparisons, currency values, and temperature ranges.
  * Added Storybook pages for previewing chart orientations and configurations.
* **Bug Fixes**
  * Improved horizontal chart sizing and spacing for grouped, single-series, and dense datasets.
* **Tests**
  * Added end-to-end and visual regression coverage across themes, orientations, and the chart data-table modal.
* **Documentation**
  * Updated chart documentation grouping and visual-test guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->