### PR TITLE
fix(components/theme): `base` dark mode tokens are not overwritten by `blackbaud` light mode tokens (#4637)

### DIFF
--- a/libs/components/packages/package.json
+++ b/libs/components/packages/package.json
@@ -104,7 +104,7 @@
     "typescript": "^6.0.3"
   },
   "dependencies": {
-    "@blackbaud/skyux-design-tokens": "7.0.0-alpha.1",
+    "@blackbaud/skyux-design-tokens": "7.0.0-alpha.2",
     "fs-extra": "11.3.6",
     "jsonc-parser": "3.3.1",
     "parse5": "7.3.0",

--- a/libs/components/theme/package.json
+++ b/libs/components/theme/package.json
@@ -20,7 +20,7 @@
     "@angular/core": "^22.1.2"
   },
   "dependencies": {
-    "@blackbaud/skyux-design-tokens": "7.0.0-alpha.1",
+    "@blackbaud/skyux-design-tokens": "7.0.0-alpha.2",
     "fontfaceobserver": "2.3.0",
     "tslib": "^2.8.1"
   },

--- a/libs/sdk/skyux-eslint/package.json
+++ b/libs/sdk/skyux-eslint/package.json
@@ -33,7 +33,7 @@
     "@typescript-eslint/utils": "^8.67.0"
   },
   "dependencies": {
-    "@blackbaud/skyux-design-tokens": "7.0.0-alpha.1",
+    "@blackbaud/skyux-design-tokens": "7.0.0-alpha.2",
     "@skyux-sdk/eslint-schematics": "0.0.0-PLACEHOLDER",
     "@skyux/manifest": "0.0.0-PLACEHOLDER",
     "tslib": "^2.8.1"

--- a/libs/sdk/skyux-stylelint/package.json
+++ b/libs/sdk/skyux-stylelint/package.json
@@ -23,7 +23,7 @@
     "stylelint": "^17.14.1"
   },
   "dependencies": {
-    "@blackbaud/skyux-design-tokens": "7.0.0-alpha.1",
+    "@blackbaud/skyux-design-tokens": "7.0.0-alpha.2",
     "tslib": "^2.8.1"
   },
   "type": "module",

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@angular/platform-browser-dynamic": "22.1.2",
         "@angular/router": "22.1.2",
         "@blackbaud/angular-tree-component": "1.0.0",
-        "@blackbaud/skyux-design-tokens": "7.0.0-alpha.1",
+        "@blackbaud/skyux-design-tokens": "7.0.0-alpha.2",
         "@eslint/js": "9.39.5",
         "@nx/angular": "23.1.1",
         "@skyux/icons": "11.4.0",
@@ -6030,9 +6030,9 @@
       }
     },
     "node_modules/@blackbaud/skyux-design-tokens": {
-      "version": "7.0.0-alpha.1",
-      "resolved": "https://registry.npmjs.org/@blackbaud/skyux-design-tokens/-/skyux-design-tokens-7.0.0-alpha.1.tgz",
-      "integrity": "sha512-7UN10d4Soi2ddfMRDR6bnpiCAjzNFWMIGnvKkDT4FYURoguyuXAyCZwbtIiSDA7zQFmVIGXOWOKADztxzfNHPQ==",
+      "version": "7.0.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/@blackbaud/skyux-design-tokens/-/skyux-design-tokens-7.0.0-alpha.2.tgz",
+      "integrity": "sha512-91EDo0/koVe9uez/amixxKXYD4xcjopeESTKKBpYizRtY+m+CCPWDxeiwRqUaCnfBJqOgJ78BFjul3KbU9ws4A==",
       "license": "MIT",
       "engines": {
         "node": ">= 4.2.1",

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "@angular/platform-browser-dynamic": "22.1.2",
     "@angular/router": "22.1.2",
     "@blackbaud/angular-tree-component": "1.0.0",
-    "@blackbaud/skyux-design-tokens": "7.0.0-alpha.1",
+    "@blackbaud/skyux-design-tokens": "7.0.0-alpha.2",
     "@eslint/js": "9.39.5",
     "@nx/angular": "23.1.1",
     "@skyux/icons": "11.4.0",


### PR DESCRIPTION
[AB#4084722](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/4084722) 🍒 #4637


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the design tokens package to version 7.0.0-alpha.2 across the project.
  * Ensures components, themes, and development tooling use the latest design token updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->