### PR TITLE
feat(components/datetime): set datepicker value to today when F3 is pressed

### DIFF
--- a/libs/components/datetime/src/lib/modules/datepicker/datepicker-input.directive.ts
+++ b/libs/components/datetime/src/lib/modules/datepicker/datepicker-input.directive.ts
@@ -30,6 +30,7 @@ import { distinctUntilChanged, takeUntil } from 'rxjs/operators';
 import { SkyDateFormatter } from './date-formatter';
 import { SkyDatepickerConfigService } from './datepicker-config.service';
 import { SkyDatepickerHostService } from './datepicker-host.service';
+import { isSetToTodayKey } from './datepicker-set-to-today-key';
 import { SkyDatepickerComponent } from './datepicker.component';
 
 const SKY_DATEPICKER_VALUE_ACCESSOR = {
@@ -354,6 +355,14 @@ export class SkyDatepickerInputDirective
   @HostListener('input')
   public onInput(): void {
     this.#control?.markAsDirty();
+  }
+
+  @HostListener('keydown', ['$event'])
+  public onKeydown(event: KeyboardEvent): void {
+    if (isSetToTodayKey(event)) {
+      event.preventDefault();
+      this.#datepickerComponent.selectToday();
+    }
   }
 
   public writeValue(value: any): void {

--- a/libs/components/datetime/src/lib/modules/datepicker/datepicker-input.directive.ts
+++ b/libs/components/datetime/src/lib/modules/datepicker/datepicker-input.directive.ts
@@ -30,7 +30,7 @@ import { distinctUntilChanged, takeUntil } from 'rxjs/operators';
 import { SkyDateFormatter } from './date-formatter';
 import { SkyDatepickerConfigService } from './datepicker-config.service';
 import { SkyDatepickerHostService } from './datepicker-host.service';
-import { isSetToTodayKey } from './datepicker-set-to-today-key';
+import { datepickerIsSetToTodayKey } from './datepicker-set-to-today-key';
 import { SkyDatepickerComponent } from './datepicker.component';
 
 const SKY_DATEPICKER_VALUE_ACCESSOR = {
@@ -359,7 +359,7 @@ export class SkyDatepickerInputDirective
 
   @HostListener('keydown', ['$event'])
   public onKeydown(event: KeyboardEvent): void {
-    if (isSetToTodayKey(event)) {
+    if (datepickerIsSetToTodayKey(event)) {
       event.preventDefault();
       this.#datepickerComponent.selectToday();
     }

--- a/libs/components/datetime/src/lib/modules/datepicker/datepicker-set-to-today-key.ts
+++ b/libs/components/datetime/src/lib/modules/datepicker/datepicker-set-to-today-key.ts
@@ -2,6 +2,6 @@
  * Whether the keyboard event is the shortcut for setting the datepicker value to today's date.
  * @internal
  */
-export function isSetToTodayKey(event: KeyboardEvent): boolean {
+export function datepickerIsSetToTodayKey(event: KeyboardEvent): boolean {
   return event.key === 'F3';
 }

--- a/libs/components/datetime/src/lib/modules/datepicker/datepicker-set-to-today-key.ts
+++ b/libs/components/datetime/src/lib/modules/datepicker/datepicker-set-to-today-key.ts
@@ -1,0 +1,7 @@
+/**
+ * Whether the keyboard event is the shortcut for setting the datepicker value to today's date.
+ * @internal
+ */
+export function isSetToTodayKey(event: KeyboardEvent): boolean {
+  return event.key === 'F3';
+}

--- a/libs/components/datetime/src/lib/modules/datepicker/datepicker.component.html
+++ b/libs/components/datetime/src/lib/modules/datepicker/datepicker.component.html
@@ -35,6 +35,7 @@
       "
       [disabled]="disabled"
       (click)="onTriggerButtonClick()"
+      (keydown)="onTriggerButtonKeydown($event)"
     >
       <sky-icon iconName="calendar-ltr" iconSize="l" />
     </button>

--- a/libs/components/datetime/src/lib/modules/datepicker/datepicker.component.spec.ts
+++ b/libs/components/datetime/src/lib/modules/datepicker/datepicker.component.spec.ts
@@ -217,6 +217,18 @@ function getSelectedCalendarItem(): HTMLElement | null {
     '.sky-datepicker-btn-selected',
   ) as HTMLElement | null;
 }
+
+function pressSetToTodayKey(
+  element: Element | null,
+  fixture: ComponentFixture<unknown>,
+): void {
+  SkyAppTestUtility.fireDomEvent(element, 'keydown', {
+    customEventInit: {
+      key: 'F3',
+    },
+  });
+  detectChanges(fixture);
+}
 // #endregion
 
 describe('datepicker', () => {
@@ -979,6 +991,140 @@ describe('datepicker', () => {
 
         const firstDayCol = getCalendarColumn(0, fixture);
         expect(firstDayCol).toHaveText('Fr');
+      }));
+    });
+
+    describe('set to today', () => {
+      const today = new Date('5/15/2017');
+
+      it('should set the value to today when pressed in the input', fakeAsync(() => {
+        jasmine.clock().mockDate(today);
+
+        pressSetToTodayKey(getInputElement(fixture), fixture);
+
+        expect(component.selectedDate()).toEqual(new Date(2017, 4, 15));
+        expect(getInputElementValue(fixture)).toBe('05/15/2017');
+      }));
+
+      it('should set the value to today when pressed on the trigger button', fakeAsync(() => {
+        jasmine.clock().mockDate(today);
+
+        pressSetToTodayKey(getTriggerButton(fixture), fixture);
+
+        expect(component.selectedDate()).toEqual(new Date(2017, 4, 15));
+        expect(getInputElementValue(fixture)).toBe('05/15/2017');
+      }));
+
+      it('should ignore other keys pressed on the trigger button', fakeAsync(() => {
+        jasmine.clock().mockDate(today);
+
+        SkyAppTestUtility.fireDomEvent(getTriggerButton(fixture), 'keydown', {
+          customEventInit: {
+            key: 'Enter',
+          },
+        });
+        detectChanges(fixture);
+
+        expect(component.selectedDate()).toBeUndefined();
+      }));
+
+      it('should ignore other keys pressed in the input', fakeAsync(() => {
+        jasmine.clock().mockDate(today);
+
+        SkyAppTestUtility.fireDomEvent(getInputElement(fixture), 'keydown', {
+          customEventInit: {
+            key: 'Enter',
+          },
+        });
+        detectChanges(fixture);
+
+        expect(component.selectedDate()).toBeUndefined();
+      }));
+
+      it('should set the value to today and close the picker when pressed in the calendar', fakeAsync(() => {
+        jasmine.clock().mockDate(today);
+
+        clickTrigger(fixture);
+        expect(getCalendar()).not.toBeNull();
+
+        pressSetToTodayKey(getCalendar(), fixture);
+
+        expect(component.selectedDate()).toEqual(new Date(2017, 4, 15));
+        expect(getInputElementValue(fixture)).toBe('05/15/2017');
+        expect(getCalendar()).toBeNull();
+      }));
+
+      it('should do nothing when today is before the minimum date', fakeAsync(() => {
+        jasmine.clock().mockDate(today);
+        fixture.componentRef.setInput('minDate', new Date('5/16/2017'));
+        detectChanges(fixture);
+
+        pressSetToTodayKey(getInputElement(fixture), fixture);
+
+        expect(component.selectedDate()).toBeUndefined();
+      }));
+
+      it('should set the value to today when today is on the minimum date', fakeAsync(() => {
+        jasmine.clock().mockDate(today);
+        fixture.componentRef.setInput('minDate', new Date('5/15/2017'));
+        detectChanges(fixture);
+
+        pressSetToTodayKey(getInputElement(fixture), fixture);
+
+        expect(component.selectedDate()).toEqual(new Date(2017, 4, 15));
+      }));
+
+      it('should do nothing when today is after the maximum date', fakeAsync(() => {
+        jasmine.clock().mockDate(today);
+        fixture.componentRef.setInput('maxDate', new Date('5/14/2017'));
+        detectChanges(fixture);
+
+        pressSetToTodayKey(getInputElement(fixture), fixture);
+
+        expect(component.selectedDate()).toBeUndefined();
+      }));
+
+      it('should set the value to today when today is on the maximum date', fakeAsync(() => {
+        jasmine.clock().mockDate(today);
+        fixture.componentRef.setInput('maxDate', new Date('5/15/2017'));
+        detectChanges(fixture);
+
+        pressSetToTodayKey(getInputElement(fixture), fixture);
+
+        expect(component.selectedDate()).toEqual(new Date(2017, 4, 15));
+      }));
+
+      it('should do nothing when today is a disabled custom date', fakeAsync(() => {
+        jasmine.clock().mockDate(today);
+        component.datepicker.customDates = [
+          { date: new Date(2017, 4, 15), disabled: true },
+        ];
+
+        pressSetToTodayKey(getInputElement(fixture), fixture);
+
+        expect(component.selectedDate()).toBeUndefined();
+      }));
+
+      it('should set the value to today when today has a non-disabled custom date', fakeAsync(() => {
+        jasmine.clock().mockDate(today);
+        component.datepicker.customDates = [
+          { date: new Date(2017, 4, 15), disabled: false },
+        ];
+
+        pressSetToTodayKey(getInputElement(fixture), fixture);
+
+        expect(component.selectedDate()).toEqual(new Date(2017, 4, 15));
+      }));
+
+      it('should set the value to today when custom dates do not include today', fakeAsync(() => {
+        jasmine.clock().mockDate(today);
+        component.datepicker.customDates = [
+          { date: new Date(2017, 4, 16), disabled: true },
+        ];
+
+        pressSetToTodayKey(getInputElement(fixture), fixture);
+
+        expect(component.selectedDate()).toEqual(new Date(2017, 4, 15));
       }));
     });
 

--- a/libs/components/datetime/src/lib/modules/datepicker/datepicker.component.spec.ts
+++ b/libs/components/datetime/src/lib/modules/datepicker/datepicker.component.spec.ts
@@ -1105,6 +1105,17 @@ describe('datepicker', () => {
         expect(component.selectedDate()).toBeUndefined();
       }));
 
+      it('should do nothing when today is a disabled custom date with a time component', fakeAsync(() => {
+        jasmine.clock().mockDate(today);
+        component.datepicker.customDates = [
+          { date: new Date(2017, 4, 15, 12), disabled: true },
+        ];
+
+        pressSetToTodayKey(getInputElement(fixture), fixture);
+
+        expect(component.selectedDate()).toBeUndefined();
+      }));
+
       it('should set the value to today when today has a non-disabled custom date', fakeAsync(() => {
         jasmine.clock().mockDate(today);
         component.datepicker.customDates = [

--- a/libs/components/datetime/src/lib/modules/datepicker/datepicker.component.ts
+++ b/libs/components/datetime/src/lib/modules/datepicker/datepicker.component.ts
@@ -41,6 +41,7 @@ import { SkyDatepickerCalendarChange } from './calendar/datepicker-calendar-chan
 import { SkyDatepickerCalendarComponent } from './calendar/datepicker-calendar.component';
 import { SkyDatepickerCustomDate } from './datepicker-custom-date';
 import { SkyDatepickerHostService } from './datepicker-host.service';
+import { isSetToTodayKey } from './datepicker-set-to-today-key';
 
 let nextId = 0;
 
@@ -161,7 +162,7 @@ export class SkyDatepickerComponent
     if (value) {
       this.#_calendarRef = value;
 
-      this.#addKeyupListener();
+      this.#addKeyEventListeners();
 
       // Wait for the calendar component to render before gauging dimensions.
       setTimeout(() => {
@@ -219,6 +220,8 @@ export class SkyDatepickerComponent
   #ngUnsubscribe = new Subject<void>();
 
   #overlay: SkyOverlayInstance | undefined;
+
+  #overlayKeydownListener: Subscription | undefined;
 
   #overlayKeyupListener: Subscription | undefined;
 
@@ -310,6 +313,37 @@ export class SkyDatepickerComponent
       this.#closePicker();
     } else {
       this.#openPicker();
+    }
+  }
+
+  /**
+   * Sets the datepicker value to today's date, if today is selectable.
+   * @internal
+   */
+  public selectToday(): void {
+    const now = new Date();
+    const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+
+    if (!this.#isSelectable(today)) {
+      return;
+    }
+
+    this.calendarDateChange.emit(today);
+    this.dateChange.emit(today);
+
+    if (this.isOpen) {
+      this.#closePicker();
+    }
+  }
+
+  /**
+   * Sets the datepicker value to today's date when the trigger button has focus.
+   * @internal
+   */
+  public onTriggerButtonKeydown(event: KeyboardEvent): void {
+    if (isSetToTodayKey(event)) {
+      event.preventDefault();
+      this.selectToday();
     }
   }
 
@@ -465,7 +499,7 @@ export class SkyDatepickerComponent
     }
   }
 
-  #addKeyupListener(): void {
+  #addKeyEventListeners(): void {
     const datepickerCalendarElement = this.calendarRef?.nativeElement;
 
     if (datepickerCalendarElement) {
@@ -480,6 +514,18 @@ export class SkyDatepickerComponent
             this.#closePicker();
           }
         });
+
+      this.#overlayKeydownListener = fromEvent<KeyboardEvent>(
+        datepickerCalendarElement,
+        'keydown',
+      )
+        .pipe(takeUntil(this.#ngUnsubscribe))
+        .subscribe((event) => {
+          if (isSetToTodayKey(event)) {
+            event.preventDefault();
+            this.selectToday();
+          }
+        });
     }
   }
 
@@ -488,6 +534,41 @@ export class SkyDatepickerComponent
     this.#calendarUnsubscribe.complete();
     this.#calendarUnsubscribe = new Subject<void>();
     this.#overlayKeyupListener?.unsubscribe();
+    this.#overlayKeydownListener?.unsubscribe();
+  }
+
+  #isSelectable(date: Date): boolean {
+    const minDateCompare =
+      this.minDate &&
+      date.getTime() <
+        new Date(
+          this.minDate.getFullYear(),
+          this.minDate.getMonth(),
+          this.minDate.getDate(),
+        ).getTime();
+
+    if (minDateCompare) {
+      return false;
+    }
+
+    const maxDateCompare =
+      this.maxDate &&
+      date.getTime() >
+        new Date(
+          this.maxDate.getFullYear(),
+          this.maxDate.getMonth(),
+          this.maxDate.getDate(),
+        ).getTime();
+
+    if (maxDateCompare) {
+      return false;
+    }
+
+    const customDate = this.customDates?.find(
+      (item) => item.date.getTime() === date.getTime(),
+    );
+
+    return !customDate?.disabled;
   }
 
   #cancelCustomDatesSubscription(): void {

--- a/libs/components/datetime/src/lib/modules/datepicker/datepicker.component.ts
+++ b/libs/components/datetime/src/lib/modules/datepicker/datepicker.component.ts
@@ -41,7 +41,7 @@ import { SkyDatepickerCalendarChange } from './calendar/datepicker-calendar-chan
 import { SkyDatepickerCalendarComponent } from './calendar/datepicker-calendar.component';
 import { SkyDatepickerCustomDate } from './datepicker-custom-date';
 import { SkyDatepickerHostService } from './datepicker-host.service';
-import { isSetToTodayKey } from './datepicker-set-to-today-key';
+import { datepickerIsSetToTodayKey } from './datepicker-set-to-today-key';
 
 let nextId = 0;
 
@@ -341,7 +341,7 @@ export class SkyDatepickerComponent
    * @internal
    */
   public onTriggerButtonKeydown(event: KeyboardEvent): void {
-    if (isSetToTodayKey(event)) {
+    if (datepickerIsSetToTodayKey(event)) {
       event.preventDefault();
       this.selectToday();
     }
@@ -521,7 +521,7 @@ export class SkyDatepickerComponent
       )
         .pipe(takeUntil(this.#ngUnsubscribe))
         .subscribe((event) => {
-          if (isSetToTodayKey(event)) {
+          if (datepickerIsSetToTodayKey(event)) {
             event.preventDefault();
             this.selectToday();
           }

--- a/libs/components/datetime/src/lib/modules/datepicker/datepicker.component.ts
+++ b/libs/components/datetime/src/lib/modules/datepicker/datepicker.component.ts
@@ -565,7 +565,10 @@ export class SkyDatepickerComponent
     }
 
     const customDate = this.customDates?.find(
-      (item) => item.date.getTime() === date.getTime(),
+      (item) =>
+        item.date.getFullYear() === date.getFullYear() &&
+        item.date.getMonth() === date.getMonth() &&
+        item.date.getDate() === date.getDate(),
     );
 
     return !customDate?.disabled;

--- a/libs/components/datetime/src/lib/modules/datepicker/fuzzy/datepicker-input-fuzzy.directive.ts
+++ b/libs/components/datetime/src/lib/modules/datepicker/fuzzy/datepicker-input-fuzzy.directive.ts
@@ -29,6 +29,7 @@ import { distinctUntilChanged, takeUntil } from 'rxjs/operators';
 import { SkyDateFormatter } from '../date-formatter';
 import { SkyDatepickerConfigService } from '../datepicker-config.service';
 import { SkyDatepickerHostService } from '../datepicker-host.service';
+import { isSetToTodayKey } from '../datepicker-set-to-today-key';
 import { SkyDatepickerComponent } from '../datepicker.component';
 
 import { SkyFuzzyDate } from './fuzzy-date';
@@ -373,6 +374,14 @@ export class SkyFuzzyDatepickerInputDirective
   @HostListener('input')
   public onInput(): void {
     this.#control?.markAsDirty();
+  }
+
+  @HostListener('keydown', ['$event'])
+  public onKeydown(event: KeyboardEvent): void {
+    if (isSetToTodayKey(event)) {
+      event.preventDefault();
+      this.#datepickerComponent.selectToday();
+    }
   }
 
   public writeValue(value: any): void {

--- a/libs/components/datetime/src/lib/modules/datepicker/fuzzy/datepicker-input-fuzzy.directive.ts
+++ b/libs/components/datetime/src/lib/modules/datepicker/fuzzy/datepicker-input-fuzzy.directive.ts
@@ -29,7 +29,7 @@ import { distinctUntilChanged, takeUntil } from 'rxjs/operators';
 import { SkyDateFormatter } from '../date-formatter';
 import { SkyDatepickerConfigService } from '../datepicker-config.service';
 import { SkyDatepickerHostService } from '../datepicker-host.service';
-import { isSetToTodayKey } from '../datepicker-set-to-today-key';
+import { datepickerIsSetToTodayKey } from '../datepicker-set-to-today-key';
 import { SkyDatepickerComponent } from '../datepicker.component';
 
 import { SkyFuzzyDate } from './fuzzy-date';
@@ -378,7 +378,7 @@ export class SkyFuzzyDatepickerInputDirective
 
   @HostListener('keydown', ['$event'])
   public onKeydown(event: KeyboardEvent): void {
-    if (isSetToTodayKey(event)) {
+    if (datepickerIsSetToTodayKey(event)) {
       event.preventDefault();
       this.#datepickerComponent.selectToday();
     }

--- a/libs/components/datetime/src/lib/modules/datepicker/fuzzy/fuzzy-datepicker.component.spec.ts
+++ b/libs/components/datetime/src/lib/modules/datepicker/fuzzy/fuzzy-datepicker.component.spec.ts
@@ -1217,6 +1217,43 @@ describe('fuzzy datepicker input', () => {
       }));
     });
 
+    describe('set to today', () => {
+      it('should set the value to today when pressed in the input', fakeAsync(() => {
+        jasmine.clock().mockDate(new Date('5/15/2017'));
+
+        SkyAppTestUtility.fireDomEvent(getInputElement(fixture), 'keydown', {
+          customEventInit: {
+            key: 'F3',
+          },
+        });
+        detectChanges(fixture);
+
+        expect(component.selectedDate()).toEqual({
+          day: 15,
+          month: 5,
+          year: 2017,
+        });
+        expect(getInputElementValue(fixture)).toBe('05/15/2017');
+
+        flush();
+      }));
+
+      it('should ignore other keys pressed in the input', fakeAsync(() => {
+        jasmine.clock().mockDate(new Date('5/15/2017'));
+
+        SkyAppTestUtility.fireDomEvent(getInputElement(fixture), 'keydown', {
+          customEventInit: {
+            key: 'Enter',
+          },
+        });
+        detectChanges(fixture);
+
+        expect(component.selectedDate()).toBeUndefined();
+
+        flush();
+      }));
+    });
+
     describe('startAtDate', () => {
       it('should be passed to calendar', fakeAsync(() => {
         setInputProperty(undefined, component, fixture);


### PR DESCRIPTION
[AB#4033124](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/4033124)

Adds a keyboard shortcut to the datepicker input, trigger button, and open
calendar so pressing F3 sets the value to today's date, if selectable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an **F3 keyboard shortcut** to set the datepicker value to today.
  - The shortcut works from the date input, trigger button, calendar, and fuzzy date input.
  - Today is selected only when allowed by minimum, maximum, and disabled-date settings.
  - The datepicker closes after selecting today or choosing a calendar date.

- **Bug Fixes**
  - Unrecognized keyboard shortcuts continue to be ignored.
  - Disabled dates are handled correctly regardless of time values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->