### PR TITLE
fix: dark mode flyouts, summary action bars, and back to top bars have an edge border (#4633)

### DIFF
--- a/libs/components/action-bars/src/lib/modules/summary-action-bar/summary-action-bar.component.scss
+++ b/libs/components/action-bars/src/lib/modules/summary-action-bar/summary-action-bar.component.scss
@@ -6,6 +6,7 @@
   --sky-override-summary-action-bar-actions-padding: #{$sky-padding
     $sky-padding-double $sky-padding $sky-padding};
   --sky-override-summary-action-bar-background-color: #{$sky-color-white};
+  --sky-override-summary-action-border-top: none;
   --sky-override-summary-action-bar-box-shadow: 0 -3px 3px 0
     #{$sky-color-gray-20};
   --sky-override-summary-action-bar-details-expand-margin-right: #{$sky-margin};
@@ -35,6 +36,12 @@
   margin-top: var(--sky-override-summary-action-bar-margin-top, 0);
   position: fixed;
   bottom: var(--sky-dock-height, 0);
+  border-top: var(
+    --sky-override-summary-action-border-top,
+    var(--sky-border-width-container-base)
+      var(--sky-border-style-container-overlay)
+      var(--sky-color-border-container-base)
+  );
   transition-property: bottom;
   transition-duration: 60ms;
   transition-timing-function: ease-out;

--- a/libs/components/flyout/src/lib/modules/flyout/flyout.component.scss
+++ b/libs/components/flyout/src/lib/modules/flyout/flyout.component.scss
@@ -32,7 +32,12 @@
   );
   --sky-comp-override-list-header-background-color: initial;
 
-  border-left: var(--sky-override-flyout-border-left);
+  border-left: var(
+    --sky-override-flyout-border-left,
+    var(--sky-border-width-container-base)
+      var(--sky-border-style-container-overlay)
+      var(--sky-color-border-container-base)
+  );
 
   transform: translateX(100%);
   transition-duration: var(--sky-global-duration-medium);

--- a/libs/components/layout/src/lib/modules/back-to-top/back-to-top.component.scss
+++ b/libs/components/layout/src/lib/modules/back-to-top/back-to-top.component.scss
@@ -3,6 +3,7 @@
 @use 'libs/components/theme/src/lib/styles/compat-tokens-mixins' as compatMixins;
 
 @include compatMixins.sky-default-overrides('.sky-back-to-top') {
+  --sky-override-back-to-top-border-top: none;
   --sky-override-back-to-top-padding: var(--sky-margin-stacked-sm)
     var(--sky-margin-inline-lg);
   --sky-override-back-to-top-background-color: #{$sky-color-white};
@@ -15,6 +16,12 @@
   background-color: var(
     --sky-override-back-to-top-background-color,
     var(--sky-color-background-container-base)
+  );
+  border-top: var(
+    --sky-override-back-to-top-border-top,
+    var(--sky-border-width-container-base)
+      var(--sky-border-style-container-overlay)
+      var(--sky-color-border-container-base)
   );
   padding: var(
     --sky-override-back-to-top-padding,

--- a/libs/components/modals/src/lib/modules/modal/modal.component.html
+++ b/libs/components/modals/src/lib/modules/modal/modal.component.html
@@ -21,6 +21,9 @@
     <div
       class="sky-modal-header"
       [hidden]="headingHidden()"
+      [ngClass]="{
+        'sky-modal-header-shadow-enabled': scrollShadow?.topShadow !== 'none'
+      }"
       [ngStyle]="{
         'box-shadow': scrollShadow?.topShadow
       }"
@@ -83,6 +86,9 @@
     </div>
     <div
       class="sky-modal-footer"
+      [ngClass]="{
+        'sky-modal-footer-shadow-enabled': scrollShadow?.bottomShadow !== 'none'
+      }"
       [ngStyle]="{
         'box-shadow': scrollShadow?.bottomShadow
       }"

--- a/libs/components/modals/src/lib/modules/modal/modal.component.scss
+++ b/libs/components/modals/src/lib/modules/modal/modal.component.scss
@@ -9,6 +9,7 @@
   --sky-override-modal-dock-margin-left-right-bottom: #{-$sky-margin-plus-half};
   --sky-override-modal-dock-padding-top: #{$sky-padding-plus-half};
   --sky-override-modal-dock-width: calc(100% + 30px);
+  --sky-override-modal-footer-top-border: none;
   --sky-override-modal-full-page-margin-xs: 0;
   --sky-override-modal-full-page-margin: 0;
   --sky-override-modal-full-page-width: 100%;
@@ -226,6 +227,15 @@
 
   display: flex;
   align-items: var(--sky-override-modal-header-align-items, center);
+
+  &.sky-modal-header-shadow-enabled {
+    border-bottom: var(
+      --sky-override-modal-header-bottom-border,
+      var(--sky-border-width-container-base)
+        var(--sky-border-style-container-overlay)
+        var(--sky-color-border-container-base)
+    );
+  }
 }
 
 .sky-modal-header-buttons {
@@ -254,6 +264,15 @@
 .sky-modal-footer {
   flex-shrink: 0;
   z-index: 2;
+
+  &.sky-modal-footer-shadow-enabled {
+    border-top: var(
+      --sky-override-modal-footer-top-border,
+      var(--sky-border-width-container-base)
+        var(--sky-border-style-container-overlay)
+        var(--sky-color-border-container-base)
+    );
+  }
 }
 
 .sky-modal-full-page .sky-modal-content {

--- a/libs/components/packages/package.json
+++ b/libs/components/packages/package.json
@@ -104,7 +104,7 @@
     "typescript": "^6.0.3"
   },
   "dependencies": {
-    "@blackbaud/skyux-design-tokens": "7.0.0-alpha.1",
+    "@blackbaud/skyux-design-tokens": "7.0.0-alpha.3",
     "fs-extra": "11.3.6",
     "jsonc-parser": "3.3.1",
     "parse5": "7.3.0",

--- a/libs/components/theme/package.json
+++ b/libs/components/theme/package.json
@@ -20,7 +20,7 @@
     "@angular/core": "^22.1.2"
   },
   "dependencies": {
-    "@blackbaud/skyux-design-tokens": "7.0.0-alpha.1",
+    "@blackbaud/skyux-design-tokens": "7.0.0-alpha.3",
     "fontfaceobserver": "2.3.0",
     "tslib": "^2.8.1"
   },

--- a/libs/sdk/skyux-eslint/package.json
+++ b/libs/sdk/skyux-eslint/package.json
@@ -33,7 +33,7 @@
     "@typescript-eslint/utils": "^8.67.0"
   },
   "dependencies": {
-    "@blackbaud/skyux-design-tokens": "7.0.0-alpha.1",
+    "@blackbaud/skyux-design-tokens": "7.0.0-alpha.3",
     "@skyux-sdk/eslint-schematics": "0.0.0-PLACEHOLDER",
     "@skyux/manifest": "0.0.0-PLACEHOLDER",
     "tslib": "^2.8.1"

--- a/libs/sdk/skyux-stylelint/package.json
+++ b/libs/sdk/skyux-stylelint/package.json
@@ -23,7 +23,7 @@
     "stylelint": "^17.14.1"
   },
   "dependencies": {
-    "@blackbaud/skyux-design-tokens": "7.0.0-alpha.1",
+    "@blackbaud/skyux-design-tokens": "7.0.0-alpha.3",
     "tslib": "^2.8.1"
   },
   "type": "module",

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@angular/platform-browser-dynamic": "22.1.2",
         "@angular/router": "22.1.2",
         "@blackbaud/angular-tree-component": "1.0.0",
-        "@blackbaud/skyux-design-tokens": "7.0.0-alpha.1",
+        "@blackbaud/skyux-design-tokens": "7.0.0-alpha.3",
         "@eslint/js": "9.39.5",
         "@nx/angular": "23.1.1",
         "@skyux/icons": "11.4.0",
@@ -6030,9 +6030,9 @@
       }
     },
     "node_modules/@blackbaud/skyux-design-tokens": {
-      "version": "7.0.0-alpha.1",
-      "resolved": "https://registry.npmjs.org/@blackbaud/skyux-design-tokens/-/skyux-design-tokens-7.0.0-alpha.1.tgz",
-      "integrity": "sha512-7UN10d4Soi2ddfMRDR6bnpiCAjzNFWMIGnvKkDT4FYURoguyuXAyCZwbtIiSDA7zQFmVIGXOWOKADztxzfNHPQ==",
+      "version": "7.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@blackbaud/skyux-design-tokens/-/skyux-design-tokens-7.0.0-alpha.3.tgz",
+      "integrity": "sha512-1b0iDhafZ5eXpDKKaYgX7MLl3OSfDms+PWlTXrfUK8nFzIv8DNbThGPlsfOa0M3CGz9iQspgsQSpIDvco2E8SQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 4.2.1",

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "@angular/platform-browser-dynamic": "22.1.2",
     "@angular/router": "22.1.2",
     "@blackbaud/angular-tree-component": "1.0.0",
-    "@blackbaud/skyux-design-tokens": "7.0.0-alpha.1",
+    "@blackbaud/skyux-design-tokens": "7.0.0-alpha.3",
     "@eslint/js": "9.39.5",
     "@nx/angular": "23.1.1",
     "@skyux/icons": "11.4.0",


### PR DESCRIPTION
## Summary
- Cherry-pick of 447a90864dba77e95c965b3593ad82695e135517 (#4633) onto `main`
- Resolved conflicts in `package.json`, `package-lock.json`, and the `@blackbaud/skyux-design-tokens` dependency in `libs/components/packages`, `libs/components/theme`, `libs/sdk/skyux-eslint`, and `libs/sdk/skyux-stylelint` by pinning `@blackbaud/skyux-design-tokens` to `7.0.0-alpha.3`

## Test plan
- [ ] CI passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved border rendering across summary action bars, flyouts, and back-to-top controls, including theme-specific fallbacks.
  * Enhanced modal header and footer styling when scroll shadows are enabled.
  * Added support for modal footer border customization.

* **Chores**
  * Updated design token packages to the latest alpha release for consistent styling across components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->