### PR TITLE
fix(components/router): add documentation for exported types (#4661)

### DIFF
--- a/libs/components/router/src/lib/modules/href/href-resolver.service.ts
+++ b/libs/components/router/src/lib/modules/href/href-resolver.service.ts
@@ -5,10 +5,15 @@ import { SkyHref } from './types/href';
 import { SkyHrefResolverArgs } from './types/href-resolver.args';
 
 /**
- * Return the link as-is.
+ * The resolver used by the `skyHref` directive. This default implementation returns the link
+ * as-is and grants access to every user. Provide your own implementation to control how links
+ * are resolved.
  */
 @Injectable()
 export class SkyHrefResolverService implements SkyHrefResolver {
+  /**
+   * Resolves a link's final URL and whether the current user may access it.
+   */
   public resolveHref(args: SkyHrefResolverArgs): Promise<SkyHref> {
     return Promise.resolve<SkyHref>({
       url: args.url,

--- a/libs/components/router/src/lib/modules/href/href-resolver.ts
+++ b/libs/components/router/src/lib/modules/href/href-resolver.ts
@@ -1,5 +1,12 @@
 import { SkyHref } from './types/href';
+import { SkyHrefResolverArgs } from './types/href-resolver.args';
 
+/**
+ * A contract for resolving the links used by the `skyHref` directive.
+ */
 export interface SkyHrefResolver {
-  resolveHref(param: { url: string }): Promise<SkyHref>;
+  /**
+   * Resolves a link's final URL and whether the current user may access it.
+   */
+  resolveHref(args: SkyHrefResolverArgs): Promise<SkyHref>;
 }

--- a/libs/components/router/src/lib/modules/href/href.module.ts
+++ b/libs/components/router/src/lib/modules/href/href.module.ts
@@ -2,6 +2,9 @@ import { NgModule } from '@angular/core';
 
 import { SkyHrefDirective } from './href.directive';
 
+/**
+ * Provides the `skyHref` directive.
+ */
 @NgModule({
   declarations: [SkyHrefDirective],
   exports: [SkyHrefDirective],

--- a/libs/components/router/src/lib/modules/href/types/href-change.ts
+++ b/libs/components/router/src/lib/modules/href/types/href-change.ts
@@ -1,3 +1,9 @@
+/**
+ * The change event emitted when a link's availability changes.
+ */
 export interface SkyHrefChange {
+  /**
+   * Whether the current user may access the link.
+   */
   userHasAccess: boolean;
 }

--- a/libs/components/router/src/lib/modules/href/types/href-resolver.args.ts
+++ b/libs/components/router/src/lib/modules/href/types/href-resolver.args.ts
@@ -1,3 +1,9 @@
+/**
+ * Parameters for resolving a link.
+ */
 export interface SkyHrefResolverArgs {
+  /**
+   * The link to resolve.
+   */
   url: string;
 }

--- a/libs/components/router/src/lib/modules/href/types/href.ts
+++ b/libs/components/router/src/lib/modules/href/types/href.ts
@@ -1,7 +1,23 @@
+/**
+ * A resolved link for the `skyHref` directive.
+ */
 export interface SkyHref {
+  /**
+   * The name of the app that owns the route.
+   */
   app?: string;
+  /**
+   * The app-relative path of the route. The path may contain `:`-prefixed parameter
+   * placeholders, which a resolver substitutes with values from the requested link.
+   */
   route?: string;
+  /**
+   * The link's resolved URL.
+   */
   url: string;
+  /**
+   * Whether the current user may access the link.
+   */
   userHasAccess?: boolean;
   aliases?: string[];
 }

--- a/libs/components/router/src/lib/modules/link/link-query-params.ts
+++ b/libs/components/router/src/lib/modules/link/link-query-params.ts
@@ -1,1 +1,4 @@
+/**
+ * A collection of query URL parameters.
+ */
 export type SkyAppLinkQueryParams = Record<string, any>;

--- a/libs/components/router/src/lib/modules/link/link.module.ts
+++ b/libs/components/router/src/lib/modules/link/link.module.ts
@@ -3,6 +3,9 @@ import { NgModule } from '@angular/core';
 import { SkyAppLinkExternalDirective } from './link-external.directive';
 import { SkyAppLinkDirective } from './link.directive';
 
+/**
+ * Provides the `skyAppLink` and `skyAppLinkExternal` directives.
+ */
 @NgModule({
   declarations: [SkyAppLinkDirective, SkyAppLinkExternalDirective],
   exports: [SkyAppLinkDirective, SkyAppLinkExternalDirective],


### PR DESCRIPTION
:cherries: Cherry picked from #4661 [fix(components/router): add documentation for exported types](https://github.com/blackbaud/skyux/pull/4661)

[AB#4088898](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/4088898) 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified how links are resolved, including default behavior and access-aware URL handling.
  - Documented link availability changes and access information.
  - Added descriptions for link properties, query parameters, directives, and resolver inputs.
  - Improved guidance for configuring and using routing and link components.

- **Refactor**
  - Standardized link resolution inputs for clearer and more consistent API usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->