### PR TITLE
fix(components/charts): do not skip category labels for horizontal bar charts

### DIFF
--- a/libs/components/charts/src/lib/chart-js/cartesian-utils.spec.ts
+++ b/libs/components/charts/src/lib/chart-js/cartesian-utils.spec.ts
@@ -10,6 +10,7 @@ type ScaleProbe = {
   stacked: boolean;
   min: number | undefined;
   max: number | undefined;
+  ticks: { autoSkip: boolean };
 };
 
 describe('buildCartesianScales', () => {
@@ -41,11 +42,12 @@ describe('buildCartesianScales', () => {
     scaleType: SkyChartValueScaleType,
     stacked?: boolean,
     bounds?: { min?: number; max?: number },
+    isHorizontal = false,
   ): Record<string, ScaleProbe> {
     return buildCartesianScales({
       categoryAxis: createCategoryAxis(),
       valueAxis: createValueAxis(scaleType, bounds),
-      isHorizontal: false,
+      isHorizontal,
       isStacked: stacked,
       themeStyles: createThemeStylesFixture(),
     }) as unknown as Record<string, ScaleProbe>;
@@ -70,5 +72,17 @@ describe('buildCartesianScales', () => {
 
     expect(scales['value'].min).toBeUndefined();
     expect(scales['value'].max).toBeUndefined();
+  });
+
+  it('should show every category label on a horizontal chart', () => {
+    const scales = build('linear', false, undefined, true);
+
+    expect(scales['category'].ticks.autoSkip).toBeFalse();
+  });
+
+  it('should skip crowded category labels on a vertical chart', () => {
+    const scales = build('linear');
+
+    expect(scales['category'].ticks.autoSkip).toBeTrue();
   });
 });

--- a/libs/components/charts/src/lib/chart-js/cartesian-utils.ts
+++ b/libs/components/charts/src/lib/chart-js/cartesian-utils.ts
@@ -239,9 +239,12 @@ export function buildCartesianScales(options: {
     isStacked = false,
     themeStyles,
   } = options;
+
   const indexAxis = isHorizontal ? 'y' : 'x';
   const valueDirection = isHorizontal ? 'x' : 'y';
+
   const base = buildThemedScaleStyle(themeStyles);
+
   const formatValue = valueAxis.formatValue();
   const scaleType = valueAxis.scaleType();
 
@@ -265,7 +268,10 @@ export function buildCartesianScales(options: {
       },
       ticks: {
         ...base.ticks,
-        major: { enabled: true },
+        // A horizontal chart's height grows with its category count, so every
+        // label is guaranteed room and none may be dropped. A vertical chart's
+        // width is fixed, so its labels must still be skipped when they crowd.
+        autoSkip: !isHorizontal,
       },
       title: {
         display: !categoryAxis.labelHidden(),


### PR DESCRIPTION
[AB#4094199](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/4094199)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Horizontal charts now display all category-axis labels without automatically skipping ticks.
  * Vertical charts continue to skip crowded labels for improved readability.

* **Tests**
  * Added coverage confirming the expected label behavior for horizontal and vertical charts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->