### PR TITLE
feat(components/theme): add prominent header styles to the public API

### DIFF
--- a/libs/components/packages/package.json
+++ b/libs/components/packages/package.json
@@ -107,7 +107,7 @@
     "@angular/core": "^21.2.0"
   },
   "dependencies": {
-    "@blackbaud/skyux-design-tokens": "6.3.1",
+    "@blackbaud/skyux-design-tokens": "6.4.0",
     "fs-extra": "11.3.4",
     "jsonc-parser": "3.3.1",
     "parse5": "7.3.0",

--- a/libs/components/theme/package.json
+++ b/libs/components/theme/package.json
@@ -20,7 +20,7 @@
     "@angular/core": "^21.2.0"
   },
   "dependencies": {
-    "@blackbaud/skyux-design-tokens": "6.3.1",
+    "@blackbaud/skyux-design-tokens": "6.4.0",
     "fontfaceobserver": "2.3.0",
     "tslib": "^2.8.1"
   },

--- a/libs/sdk/skyux-eslint/package.json
+++ b/libs/sdk/skyux-eslint/package.json
@@ -33,7 +33,7 @@
     "@typescript-eslint/utils": "^8.56.1"
   },
   "dependencies": {
-    "@blackbaud/skyux-design-tokens": "6.3.1",
+    "@blackbaud/skyux-design-tokens": "6.4.0",
     "@skyux-sdk/eslint-schematics": "0.0.0-PLACEHOLDER",
     "@skyux/manifest": "0.0.0-PLACEHOLDER",
     "tslib": "^2.8.1"

--- a/libs/sdk/skyux-stylelint/package.json
+++ b/libs/sdk/skyux-stylelint/package.json
@@ -23,7 +23,7 @@
     "stylelint": "^17.14.1"
   },
   "dependencies": {
-    "@blackbaud/skyux-design-tokens": "6.3.1",
+    "@blackbaud/skyux-design-tokens": "6.4.0",
     "tslib": "^2.8.1"
   },
   "type": "module",

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@angular/platform-browser-dynamic": "21.2.0",
         "@angular/router": "21.2.0",
         "@blackbaud/angular-tree-component": "1.0.0",
-        "@blackbaud/skyux-design-tokens": "6.3.1",
+        "@blackbaud/skyux-design-tokens": "6.4.0",
         "@eslint/js": "9.39.3",
         "@nx/angular": "22.5.3",
         "@skyux/icons": "10.4.0",
@@ -3287,9 +3287,9 @@
       }
     },
     "node_modules/@blackbaud/skyux-design-tokens": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/@blackbaud/skyux-design-tokens/-/skyux-design-tokens-6.3.1.tgz",
-      "integrity": "sha512-u73GxyvJIYAQ81h00RxM7vDCHCwzAEFql2gYNyljrErYDyALCI0BAOaBcgL3S3CltTAFlrWAlVlhLz9Cq+W+Vw==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@blackbaud/skyux-design-tokens/-/skyux-design-tokens-6.4.0.tgz",
+      "integrity": "sha512-H9/OI4Sd3mkdfG4ZVNpz05RbYkl7CHBOX8m6R38/PGh2YFW4wU3doXepiE78Et6ycsgYB3CcBTy/4IqX9QXY+w==",
       "license": "MIT",
       "engines": {
         "node": ">= 4.2.1",

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "@angular/platform-browser-dynamic": "21.2.0",
     "@angular/router": "21.2.0",
     "@blackbaud/angular-tree-component": "1.0.0",
-    "@blackbaud/skyux-design-tokens": "6.3.1",
+    "@blackbaud/skyux-design-tokens": "6.4.0",
     "@eslint/js": "9.39.3",
     "@nx/angular": "22.5.3",
     "@skyux/icons": "10.4.0",


### PR DESCRIPTION
## Summary
- Bumps `@blackbaud/skyux-design-tokens` from `6.3.1` to `6.4.0`
- Updated in `package.json` at the root and in `libs/sdk/skyux-stylelint`, `libs/sdk/skyux-eslint`, `libs/components/theme`, and `libs/components/packages`
- Regenerated `package-lock.json` via `npm install`

## Test plan
- [ ] CI build/lint/test suite passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the design tokens package to version 6.4.0 across the project.
  * Ensured components, themes, and styling tools use the latest compatible design tokens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->