### PR TITLE
fix(components/core): dispatch change event during `SkyAppTestUtility.setInputValue`

### DIFF
--- a/libs/components/core/testing/src/modules/test-utility/test-utility.spec.ts
+++ b/libs/components/core/testing/src/modules/test-utility/test-utility.spec.ts
@@ -146,10 +146,7 @@ describe('Test utility', () => {
   });
 
   it('should set the value of an input', () => {
-    const dispatchEventSpy = spyOn(
-      inputEl,
-      'dispatchEvent',
-    ).and.callThrough();
+    const dispatchEventSpy = spyOn(inputEl, 'dispatchEvent').and.callThrough();
     expect(inputEl.value).toEqual('');
     SkyAppTestUtility.setInputValue(inputEl, 'foobar');
     expect(inputEl.value).toEqual('foobar');

--- a/libs/components/core/testing/src/modules/test-utility/test-utility.spec.ts
+++ b/libs/components/core/testing/src/modules/test-utility/test-utility.spec.ts
@@ -146,9 +146,11 @@ describe('Test utility', () => {
   });
 
   it('should set the value of an input', () => {
+    spyOn(inputEl, 'dispatchEvent').and.callThrough();
     expect(inputEl.value).toEqual('');
     SkyAppTestUtility.setInputValue(inputEl, 'foobar');
     expect(inputEl.value).toEqual('foobar');
+    expect(inputEl.dispatchEvent).toHaveBeenCalledTimes(2);
   });
 
   it('should throw and error if `fireDomEvent` is called with an null element', () => {

--- a/libs/components/core/testing/src/modules/test-utility/test-utility.spec.ts
+++ b/libs/components/core/testing/src/modules/test-utility/test-utility.spec.ts
@@ -146,11 +146,19 @@ describe('Test utility', () => {
   });
 
   it('should set the value of an input', () => {
-    spyOn(inputEl, 'dispatchEvent').and.callThrough();
+    const dispatchEventSpy = spyOn(
+      inputEl,
+      'dispatchEvent',
+    ).and.callThrough();
     expect(inputEl.value).toEqual('');
     SkyAppTestUtility.setInputValue(inputEl, 'foobar');
     expect(inputEl.value).toEqual('foobar');
-    expect(inputEl.dispatchEvent).toHaveBeenCalledTimes(2);
+
+    const dispatchedEventTypes = dispatchEventSpy.calls
+      .allArgs()
+      .map(([event]) => event.type);
+
+    expect(dispatchedEventTypes).toEqual(['input', 'change']);
   });
 
   it('should throw and error if `fireDomEvent` is called with an null element', () => {

--- a/libs/components/core/testing/src/modules/test-utility/test-utility.ts
+++ b/libs/components/core/testing/src/modules/test-utility/test-utility.ts
@@ -90,6 +90,7 @@ export class SkyAppTestUtility {
     element.value = value;
 
     element.dispatchEvent(inputEvent);
+    element.dispatchEvent(changeEvent);
   }
 
   /**


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated input value handling to dispatch both `input` and `change` events, ensuring changes are recognized consistently.
* **Tests**
  * Added coverage verifying that both events are dispatched when an input value is set.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->