### PR TITLE
chore: release 14.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
 
+## [14.15.2](https://github.com/blackbaud/skyux/compare/14.15.1...14.15.2) (2026-08-24)
+
+
+### Bug Fixes
+
+* **components/indicators:** sky-tokens no longer prevents projected content from wrapping ([#4656](https://github.com/blackbaud/skyux/issues/4656)) ([44bc889](https://github.com/blackbaud/skyux/commit/44bc889bb06c492caefb1d50a4c640e673f65eb0))
+
 ## [14.15.1](https://github.com/blackbaud/skyux/compare/14.15.0...14.15.1) (2026-08-21)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,12 @@
 # Changelog
 
 
-## [14.15.2](https://github.com/blackbaud/skyux/compare/14.15.1...14.15.2) (2026-08-25)
+## [14.16.0](https://github.com/blackbaud/skyux/compare/14.15.1...14.16.0) (2026-08-26)
+
+
+### Features
+
+* add sky-btn-icon-borderless-on_prominent button class ([#4683](https://github.com/blackbaud/skyux/issues/4683)) ([6ac2af6](https://github.com/blackbaud/skyux/commit/6ac2af6b68e66026320f67a2509d81ea1448336a))
 
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 
-## [14.15.2](https://github.com/blackbaud/skyux/compare/14.15.1...14.15.2) (2026-08-24)
+## [14.15.2](https://github.com/blackbaud/skyux/compare/14.15.1...14.15.2) (2026-08-25)
 
 
 ### Bug Fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "skyux",
-  "version": "14.15.1",
+  "version": "14.15.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "skyux",
-      "version": "14.15.1",
+      "version": "14.15.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "skyux",
-  "version": "14.15.2",
+  "version": "14.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "skyux",
-      "version": "14.15.2",
+      "version": "14.16.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skyux",
-  "version": "14.15.2",
+  "version": "14.16.0",
   "license": "MIT",
   "scripts": {
     "ng": "nx",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skyux",
-  "version": "14.15.1",
+  "version": "14.15.2",
   "license": "MIT",
   "scripts": {
     "ng": "nx",


### PR DESCRIPTION
## [14.16.0](https://github.com/blackbaud/skyux/compare/14.15.1...14.16.0) (2026-08-26)


### Features

* add sky-btn-icon-borderless-on_prominent button class ([#4683](https://github.com/blackbaud/skyux/issues/4683)) ([6ac2af6](https://github.com/blackbaud/skyux/commit/6ac2af6b68e66026320f67a2509d81ea1448336a))


### Bug Fixes

* **components/indicators:** sky-tokens no longer prevents projected content from wrapping ([#4656](https://github.com/blackbaud/skyux/issues/4656)) ([44bc889](https://github.com/blackbaud/skyux/commit/44bc889bb06c492caefb1d50a4c640e673f65eb0))

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the `sky-btn-icon-borderless-on_prominent` button style.

* **Bug Fixes**
  * Fixed an issue with `sky-tokens` wrapping.

* **Release**
  * Updated the package to version 14.16.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->