### PR TITLE
feat: add sky-btn-icon-borderless-on_prominent button class

### DIFF
--- a/apps/e2e/theme-storybook/src/app/buttons/buttons.component.html
+++ b/apps/e2e/theme-storybook/src/app/buttons/buttons.component.html
@@ -92,6 +92,18 @@
     </div>
   </div>
 
+  <div
+    class="sky-buttons-demo-screenshot-prominent sky-theme-color-background-container-header-prominent"
+  >
+    <button
+      aria-label="More actions"
+      class="sky-btn sky-btn-icon-borderless-on_prominent"
+      type="button"
+    >
+      <sky-icon iconName="more-actions" />
+    </button>
+  </div>
+
   <ng-container
     *ngTemplateOutlet="blockBtn; context: { disabled: undefined }"
   />
@@ -258,6 +270,27 @@
         </button>
       </div>
     </div>
+  </div>
+
+  <div
+    class="sky-buttons-demo-screenshot-prominent sky-theme-color-background-container-header-prominent"
+  >
+    <button
+      aria-label="More actions"
+      class="sky-btn sky-btn-icon-borderless-on_prominent sky-btn-disabled sky-theme-margin-right-xs"
+      type="button"
+    >
+      <sky-icon iconName="more-actions" />
+    </button>
+
+    <button
+      aria-label="More actions"
+      class="sky-btn sky-btn-icon-borderless-on_prominent"
+      type="button"
+      disabled
+    >
+      <sky-icon iconName="more-actions" />
+    </button>
   </div>
 
   <ng-container *ngTemplateOutlet="blockBtn; context: { disabled: true }" />

--- a/apps/e2e/theme-storybook/src/app/buttons/buttons.component.scss
+++ b/apps/e2e/theme-storybook/src/app/buttons/buttons.component.scss
@@ -2,3 +2,8 @@
   display: block;
   padding: 10px;
 }
+
+.sky-buttons-demo-screenshot-prominent {
+  max-width: 500px;
+  padding: 15px;
+}

--- a/apps/playground/src/app/components/theme/buttons/buttons.component.html
+++ b/apps/playground/src/app/components/theme/buttons/buttons.component.html
@@ -105,6 +105,18 @@
         </div>
       </div>
     </div>
+
+    <div
+      class="sky-buttons-demo-screenshot-wrapper buttons-demo-prominent sky-theme-color-background-container-header-prominent"
+    >
+      <button
+        aria-label="More actions"
+        class="sky-btn sky-btn-icon-borderless-on_prominent"
+        type="button"
+      >
+        <sky-icon iconName="more-actions" />
+      </button>
+    </div>
   </div>
 
   <div class="sky-buttons-demo-screenshot-wrapper buttons-demo-block">
@@ -305,6 +317,27 @@
           </button>
         </div>
       </div>
+    </div>
+
+    <div
+      class="sky-buttons-demo-screenshot-wrapper buttons-demo-prominent sky-theme-color-background-container-header-prominent"
+    >
+      <button
+        aria-label="More actions"
+        class="sky-btn sky-btn-icon-borderless-on_prominent sky-btn-disabled sky-theme-margin-right-xs"
+        type="button"
+      >
+        <sky-icon iconName="more-actions" />
+      </button>
+
+      <button
+        aria-label="More actions"
+        class="sky-btn sky-btn-icon-borderless-on_prominent"
+        type="button"
+        disabled
+      >
+        <sky-icon iconName="more-actions" />
+      </button>
     </div>
 
     <div class="sky-buttons-demo-screenshot-wrapper buttons-demo-block">

--- a/apps/playground/src/app/components/theme/buttons/buttons.component.scss
+++ b/apps/playground/src/app/components/theme/buttons/buttons.component.scss
@@ -13,3 +13,7 @@
 .buttons-demo-block {
   max-width: 500px;
 }
+
+.buttons-demo-prominent {
+  max-width: 500px;
+}

--- a/libs/components/packages/package.json
+++ b/libs/components/packages/package.json
@@ -107,7 +107,7 @@
     "@angular/core": "^21.2.0"
   },
   "dependencies": {
-    "@blackbaud/skyux-design-tokens": "6.3.1",
+    "@blackbaud/skyux-design-tokens": "6.5.1",
     "fs-extra": "11.3.4",
     "jsonc-parser": "3.3.1",
     "parse5": "7.3.0",

--- a/libs/components/theme/package.json
+++ b/libs/components/theme/package.json
@@ -20,7 +20,7 @@
     "@angular/core": "^21.2.0"
   },
   "dependencies": {
-    "@blackbaud/skyux-design-tokens": "6.3.1",
+    "@blackbaud/skyux-design-tokens": "6.5.1",
     "fontfaceobserver": "2.3.0",
     "tslib": "^2.8.1"
   },

--- a/libs/components/theme/src/lib/styles/_buttons.scss
+++ b/libs/components/theme/src/lib/styles/_buttons.scss
@@ -245,6 +245,53 @@ a.sky-btn {
   padding: 0;
 }
 
+.sky-btn-icon-borderless-on_prominent {
+  background-color: transparent;
+  border: 1px solid transparent;
+  color: $sky-color-white;
+  cursor: pointer;
+  height: 26px;
+  padding: 0;
+  text-align: center;
+  width: 26px;
+
+  &:hover {
+    background-color: #42597e;
+    border: 1px solid #aac4ee;
+    color: $sky-color-white;
+  }
+
+  &:active,
+  &.sky-btn-active {
+    background-color: #536f9d;
+    border: 1px solid #aac4ee;
+    box-shadow: none;
+    color: $sky-color-white;
+  }
+
+  &:focus-visible:not(:active) {
+    background-color: transparent;
+    border: 1px solid #aac4ee;
+    outline: none;
+  }
+
+  &.sky-btn-disabled,
+  &[disabled] {
+    &,
+    &:hover,
+    &:focus-visible,
+    &:active,
+    &.sky-btn-active {
+      background-color: #51555c;
+      border: 1px solid #3b4047;
+      color: #c2c4c6;
+      // The default theme dims disabled buttons, but the colors above already
+      // account for the disabled state.
+      opacity: 1;
+    }
+  }
+}
+
 .sky-btn-block {
   display: block;
   overflow: hidden;

--- a/libs/components/theme/src/lib/styles/themes/modern/_buttons.scss
+++ b/libs/components/theme/src/lib/styles/themes/modern/_buttons.scss
@@ -35,6 +35,7 @@
   .sky-btn-link,
   .sky-btn-borderless,
   .sky-btn-icon-borderless,
+  .sky-btn-icon-borderless-on_prominent,
   .sky-btn-icon,
   .sky-btn-link-inline,
   .sky-btn-borderless-inline {
@@ -309,7 +310,8 @@
     color: var(--sky-color-icon-deemphasized);
   }
 
-  .sky-btn-icon-borderless {
+  .sky-btn-icon-borderless,
+  .sky-btn-icon-borderless-on_prominent {
     padding: var(--sky-comp-button-borderless-space-inset-top)
       var(--sky-comp-button-borderless-space-inset-right)
       var(--sky-comp-button-borderless-space-inset-bottom)
@@ -392,6 +394,69 @@
               var(--sky-elevation-action-tertiary-disabled)
             );
         }
+      }
+    }
+  }
+
+  .sky-btn-icon-borderless-on_prominent {
+    background-color: var(
+      --sky-color-background-action-tertiary-on_prominent-base
+    );
+    box-shadow:
+      inset 0 0 0 var(--sky-border-width-action-base)
+        var(--sky-color-border-action-tertiary-on_prominent-base),
+      var(--sky-elevation-action-tertiary-base);
+    color: var(--sky-color-icon-on_prominent-base);
+
+    &:hover {
+      background-color: var(
+        --sky-color-background-action-tertiary-on_prominent-hover
+      );
+      box-shadow:
+        inset 0 0 0 var(--sky-border-width-action-hover)
+          var(--sky-color-border-action-tertiary-on_prominent-hover),
+        var(--sky-elevation-action-tertiary-hover);
+      color: var(--sky-color-icon-on_prominent-base);
+    }
+
+    &:active,
+    &.sky-btn-active {
+      background-color: var(
+        --sky-color-background-action-tertiary-on_prominent-active
+      );
+      box-shadow:
+        inset 0 0 0 var(--sky-border-width-action-active)
+          var(--sky-color-border-action-tertiary-on_prominent-active),
+        var(--sky-elevation-action-tertiary-active);
+      transition: none;
+    }
+
+    &:focus-visible:not(:active) {
+      background-color: var(
+        --sky-color-background-action-tertiary-on_prominent-focus
+      );
+      box-shadow:
+        inset 0 0 0 var(--sky-border-width-action-focus)
+          var(--sky-color-border-action-tertiary-on_prominent-focus),
+        var(--sky-elevation-action-tertiary-focus);
+    }
+
+    &.sky-btn-disabled,
+    &[disabled] {
+      &,
+      &:hover,
+      &:focus-visible,
+      &.sky-btn-focus,
+      &:active,
+      &.sky-btn-active {
+        background-color: var(
+          --sky-color-background-action-tertiary-on_prominent-disabled
+        );
+        box-shadow:
+          inset 0 0 0 var(--sky-border-width-action-disabled)
+            var(--sky-color-border-action-tertiary-on_prominent-disabled),
+          var(--sky-elevation-action-tertiary-disabled);
+        color: var(--sky-color-icon-on_prominent-disabled);
       }
     }
   }

--- a/libs/sdk/skyux-eslint/package.json
+++ b/libs/sdk/skyux-eslint/package.json
@@ -33,7 +33,7 @@
     "@typescript-eslint/utils": "^8.56.1"
   },
   "dependencies": {
-    "@blackbaud/skyux-design-tokens": "6.3.1",
+    "@blackbaud/skyux-design-tokens": "6.5.1",
     "@skyux-sdk/eslint-schematics": "0.0.0-PLACEHOLDER",
     "@skyux/manifest": "0.0.0-PLACEHOLDER",
     "tslib": "^2.8.1"

--- a/libs/sdk/skyux-eslint/src/rules/utils/style-public-api.ts
+++ b/libs/sdk/skyux-eslint/src/rules/utils/style-public-api.ts
@@ -61,6 +61,7 @@ export const WHITELISTED_SKY_CLASSES: Set<string> = new Set([
   'sky-btn-default',
   'sky-btn-icon',
   'sky-btn-icon-borderless',
+  'sky-btn-icon-borderless-on_prominent',
   'sky-btn-link',
   'sky-btn-link-inline',
   'sky-btn-primary',

--- a/libs/sdk/skyux-stylelint/package.json
+++ b/libs/sdk/skyux-stylelint/package.json
@@ -23,7 +23,7 @@
     "stylelint": "^17.14.1"
   },
   "dependencies": {
-    "@blackbaud/skyux-design-tokens": "6.3.1",
+    "@blackbaud/skyux-design-tokens": "6.5.1",
     "tslib": "^2.8.1"
   },
   "type": "module",

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@angular/platform-browser-dynamic": "21.2.0",
         "@angular/router": "21.2.0",
         "@blackbaud/angular-tree-component": "1.0.0",
-        "@blackbaud/skyux-design-tokens": "6.3.1",
+        "@blackbaud/skyux-design-tokens": "6.5.1",
         "@eslint/js": "9.39.3",
         "@nx/angular": "22.5.3",
         "@skyux/icons": "10.4.0",
@@ -3287,9 +3287,9 @@
       }
     },
     "node_modules/@blackbaud/skyux-design-tokens": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/@blackbaud/skyux-design-tokens/-/skyux-design-tokens-6.3.1.tgz",
-      "integrity": "sha512-u73GxyvJIYAQ81h00RxM7vDCHCwzAEFql2gYNyljrErYDyALCI0BAOaBcgL3S3CltTAFlrWAlVlhLz9Cq+W+Vw==",
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@blackbaud/skyux-design-tokens/-/skyux-design-tokens-6.5.1.tgz",
+      "integrity": "sha512-NPtv8lSBxx+kN8qp7vkQiIVLy4vDdax5D+R+YNRicd6nEvot1NirgPFSftO74P8k2JSJ+Ojwj3VGEdCwbvPRpg==",
       "license": "MIT",
       "engines": {
         "node": ">= 4.2.1",

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "@angular/platform-browser-dynamic": "21.2.0",
     "@angular/router": "21.2.0",
     "@blackbaud/angular-tree-component": "1.0.0",
-    "@blackbaud/skyux-design-tokens": "6.3.1",
+    "@blackbaud/skyux-design-tokens": "6.5.1",
     "@eslint/js": "9.39.3",
     "@nx/angular": "22.5.3",
     "@skyux/icons": "10.4.0",


### PR DESCRIPTION
## Summary

Adds a new public button class, `.sky-btn-icon-borderless-on_prominent`, for icon-only buttons that sit on a prominent-styled (dark) container header.

## Changes

**Modern theme** — [`themes/modern/_buttons.scss`](../blob/prominent-header-btns/libs/components/theme/src/lib/styles/themes/modern/_buttons.scss)
- Shares `.sky-btn-icon-borderless`'s borderless padding/auto sizing and the common border/outline reset.
- Own state block for base/hover/active/focus/disabled driven by `--sky-color-background-action-tertiary-on_prominent-*`, `--sky-color-border-action-tertiary-on_prominent-*`, `--sky-border-width-action-*`, and `--sky-elevation-action-tertiary-*`.
- Icon color `--sky-color-icon-on_prominent-base`, dropping to `--sky-color-icon-on_prominent-disabled` when disabled.

**Default theme** — [`_buttons.scss`](../blob/prominent-header-btns/libs/components/theme/src/lib/styles/_buttons.scss)
- The default theme has no prominent-container tokens, so the values are hardcoded to match design's spec. Follows the default-theme paradigm: `1px solid` borders instead of an inset box-shadow, no elevation, and border-radius left to inherit `$sky-border-radius` from `.sky-btn`.
- `opacity: 1` on the disabled state, since the default theme's usual `0.65` dimming would wash out the explicit disabled colors.

**Supporting**
- `skyux-eslint`: added the class to `WHITELISTED_SKY_CLASSES` so consumers aren't flagged until it lands in the design-tokens style API.
- Bumped `@blackbaud/skyux-design-tokens` to `6.5.1` — the `on_prominent` tokens the modern theme relies on are new in that line.

## Demos / visual tests

Added to the playground and the `theme-storybook` Percy story. In both, the button is icon-only and lives in its own `sky-theme-color-background-container-header-prominent` container with no other button types in it — base in the default-appearance section, disabled-by-class and disabled-by-attribute in the disabled-states section.

## Token status

Both discrepancies found while building this were fixed in design tokens `6.5.0`, so the two themes now agree:

| Token | 6.4.0 | 6.5.0 |
| --- | --- | --- |
| `border-action-tertiary-on_prominent-hover` / `-active` / `-focus` | `slate-300` `#bac5d8` | `blue-300` `#aac4ee` |
| `background-action-tertiary-on_prominent-disabled` | `background-disabled` (`#eeeeef` light / `#51555c` dark) | `gray-700` `#51555c` |
| `border-action-tertiary-on_prominent-disabled` | `border-disabled` (`#c2c4c6` light / `#3b4047` dark) | `gray-800` `#3b4047` |

The disabled background/border are now mode-independent, matching what the default theme hardcodes.

### One remaining inconsistency

`6.5.1` renamed `--sky-color-icon-on_prominent` to `-base` and added `--sky-color-icon-on_prominent-disabled`; the modern theme now uses both. The new disabled token resolves to `--bb-color-gray-600` (`#666b70`) in **both** modes, and the disabled chip is `#51555c`, so the disabled icon sits at about **1.4:1** contrast:

| | disabled icon | contrast on `#51555c` chip |
| --- | --- | --- |
| modern, before `6.5.1` (light) | `#666b70` | 1.39:1 |
| modern, before `6.5.1` (dark) | `#c2c4c6` | 4.28:1 |
| modern, now (both modes) | `#666b70` | 1.39:1 |
| default theme (hardcoded) | `#c2c4c6` | 4.28:1 |

So the disabled icon color is now mode-independent, but at the low-contrast value — dark mode regressed. Disabled controls are exempt from WCAG contrast minimums, and this is a known follow-up on design's side, so it's left as-is rather than worked around here.

The default theme keeps its `#c2c4c6` hardcode, which is why the two themes still differ on this one value. For reference, the tokens package's own default-theme fallback (`--sky-theme-color-icon-on_prominent-disabled` in `:root`) is `#686c73` — also low-contrast against the chip. Happy to align the default theme either way once design settles the value.

## Verification

- `nx build theme-storybook` — passes
- `nx run-many -t lint -p theme-storybook playground skyux-eslint` — clean
- `nx test skyux-eslint` — 307/307
- Compiled the SCSS standalone and rendered all six states in both themes to confirm they match the mockups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added borderless “More actions” icon buttons for prominent backgrounds.
  - Added support for enabled and disabled button states, including both supported disabled configurations.
- **Documentation**
  - Updated component showcase and playground examples to demonstrate prominent-background buttons.
- **Style**
  - Improved hover, active, focus, and disabled styling across supported themes.
  - Added consistent visual contrast, sizing, spacing, and disabled-state treatment for buttons on prominent backgrounds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->