### PR TITLE
feat!: add style public API rules to recommended ESLint and Stylelint rulesets

### DIFF
--- a/libs/sdk/eslint-config-skyux/src/__snapshots__/index.test.ts.snap
+++ b/libs/sdk/eslint-config-skyux/src/__snapshots__/index.test.ts.snap
@@ -12435,6 +12435,7 @@ If a function does not access \`this\`, it can be annotated with \`this: void\`.
     ],
     "name": "skyux-eslint/ts-recommended",
     "rules": Object {
+      "skyux-eslint/no-invalid-sky-classnames": "error",
       "skyux-eslint/no-lambda-imports": "error",
       "skyux-eslint/no-sky-selectors": "error",
     },
@@ -14070,6 +14071,7 @@ For example, when set to \`true\` the following code will not fail for the \`alt
       "skyux-eslint-template/no-deprecated-directives": "error",
       "skyux-eslint-template/no-invalid-input-box-children": "error",
       "skyux-eslint-template/no-invalid-input-types": "error",
+      "skyux-eslint-template/no-invalid-sky-classnames": "error",
       "skyux-eslint-template/no-legacy-icons": "error",
       "skyux-eslint-template/no-radio-group-with-nested-list": "error",
       "skyux-eslint-template/no-unbound-id": "error",

--- a/libs/sdk/skyux-eslint/src/configs/template-recommended.ts
+++ b/libs/sdk/skyux-eslint/src/configs/template-recommended.ts
@@ -11,6 +11,7 @@ export default [
       'skyux-eslint-template/no-deprecated-directives': 'error',
       'skyux-eslint-template/no-invalid-input-box-children': 'error',
       'skyux-eslint-template/no-invalid-input-types': 'error',
+      'skyux-eslint-template/no-invalid-sky-classnames': 'error',
       'skyux-eslint-template/no-legacy-icons': 'error',
       'skyux-eslint-template/no-radio-group-with-nested-list': 'error',
       'skyux-eslint-template/no-unbound-id': 'error',

--- a/libs/sdk/skyux-eslint/src/configs/ts-recommended.ts
+++ b/libs/sdk/skyux-eslint/src/configs/ts-recommended.ts
@@ -7,6 +7,7 @@ export default [
   {
     name: 'skyux-eslint/ts-recommended',
     rules: {
+      'skyux-eslint/no-invalid-sky-classnames': 'error',
       'skyux-eslint/no-lambda-imports': 'error',
       'skyux-eslint/no-sky-selectors': 'error',
     },

--- a/libs/sdk/skyux-stylelint/README.md
+++ b/libs/sdk/skyux-stylelint/README.md
@@ -12,6 +12,8 @@ ng add skyux-stylelint
 export default {
   plugins: ['skyux-stylelint'],
   rules: {
+    'skyux-stylelint/no-deprecated-sky-scss-variables': true,
+    'skyux-stylelint/no-invalid-sky-custom-properties': true,
     'skyux-stylelint/no-ng-deep': true,
     'skyux-stylelint/no-sky-selectors': true,
     'skyux-stylelint/no-static-color-values': true,

--- a/libs/sdk/stylelint-config-skyux/src/index.ts
+++ b/libs/sdk/stylelint-config-skyux/src/index.ts
@@ -2,6 +2,8 @@ export default {
   extends: ['stylelint-config-recommended-scss'],
   plugins: ['skyux-stylelint'],
   rules: {
+    'skyux-stylelint/no-deprecated-sky-scss-variables': true,
+    'skyux-stylelint/no-invalid-sky-custom-properties': true,
     'skyux-stylelint/no-ng-deep': true,
     'skyux-stylelint/no-sky-selectors': true,
     'skyux-stylelint/no-static-color-values': true,


### PR DESCRIPTION
[AB#3958896](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3958896)

BREAKING CHANGE: the recommended ESLint and Stylelint configs now enable
`no-invalid-sky-classnames` (TS and template), `no-invalid-sky-custom-properties`,
and `no-deprecated-sky-scss-variables`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Recommended ESLint configurations now flag invalid SKY class names as errors.
  * Recommended Stylelint configurations now flag deprecated SKY SCSS variables and invalid SKY custom properties.

* **Documentation**
  * Updated Stylelint configuration examples to reflect the new validation rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->