### PR TITLE
feat(components/validation): add sky email and url signal validators

### DIFF
--- a/libs/components/validation/documentation.json
+++ b/libs/components/validation/documentation.json
@@ -7,7 +7,7 @@
           "SkyEmailValidationModule",
           "SkyEmailValidationDirective",
           "SkyValidators",
-          "skyEmailValidator"
+          "skyEmail"
         ],
         "primaryDocsId": "SkyEmailValidationModule"
       },
@@ -28,7 +28,7 @@
           "SkyUrlValidationDirective",
           "SkyUrlValidationOptions",
           "SkyValidators",
-          "skyUrlValidator"
+          "skyUrl"
         ],
         "primaryDocsId": "SkyUrlValidationModule"
       },

--- a/libs/components/validation/documentation.json
+++ b/libs/components/validation/documentation.json
@@ -6,7 +6,8 @@
         "docsIds": [
           "SkyEmailValidationModule",
           "SkyEmailValidationDirective",
-          "SkyValidators"
+          "SkyValidators",
+          "skyEmailValidator"
         ],
         "primaryDocsId": "SkyEmailValidationModule"
       },
@@ -26,7 +27,8 @@
           "SkyUrlValidationModule",
           "SkyUrlValidationDirective",
           "SkyUrlValidationOptions",
-          "SkyValidators"
+          "SkyValidators",
+          "skyUrlValidator"
         ],
         "primaryDocsId": "SkyUrlValidationModule"
       },

--- a/libs/components/validation/src/index.ts
+++ b/libs/components/validation/src/index.ts
@@ -2,10 +2,7 @@ export { SkyEmailValidationModule } from './lib/modules/email-validation/email-v
 export { SkyUrlValidationOptions } from './lib/modules/url-validation/url-validation-options';
 export { SkyUrlValidationModule } from './lib/modules/url-validation/url-validation.module';
 export { SkyValidation } from './lib/modules/validation/validation';
-export {
-  skyEmailValidator,
-  skyUrlValidator,
-} from './lib/modules/validators/signal-validators';
+export { skyEmail, skyUrl } from './lib/modules/validators/signal-validators';
 export { SkyValidators } from './lib/modules/validators/validators';
 
 // Components and directives must be exported to support Angular's "partial" Ivy compiler.

--- a/libs/components/validation/src/index.ts
+++ b/libs/components/validation/src/index.ts
@@ -2,6 +2,10 @@ export { SkyEmailValidationModule } from './lib/modules/email-validation/email-v
 export { SkyUrlValidationOptions } from './lib/modules/url-validation/url-validation-options';
 export { SkyUrlValidationModule } from './lib/modules/url-validation/url-validation.module';
 export { SkyValidation } from './lib/modules/validation/validation';
+export {
+  skyEmailValidator,
+  skyUrlValidator,
+} from './lib/modules/validators/signal-validators';
 export { SkyValidators } from './lib/modules/validators/validators';
 
 // Components and directives must be exported to support Angular's "partial" Ivy compiler.

--- a/libs/components/validation/src/lib/modules/validators/signal-validators.spec.ts
+++ b/libs/components/validation/src/lib/modules/validators/signal-validators.spec.ts
@@ -1,0 +1,102 @@
+import { signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { FieldTree, form } from '@angular/forms/signals';
+
+import { SkyUrlValidationOptions } from '../url-validation/url-validation-options';
+
+import { skyEmailValidator, skyUrlValidator } from './signal-validators';
+
+describe('Signal forms validators', () => {
+  describe('skyEmailValidator', () => {
+    function createForm(
+      value: string | undefined,
+    ): FieldTree<string | undefined> {
+      const model = signal(value);
+      return TestBed.runInInjectionContext(() =>
+        form(model, (p) => skyEmailValidator(p)),
+      );
+    }
+
+    it('should be valid on empty input (undefined)', () => {
+      const field = createForm(undefined);
+      expect(field().errors()).toEqual([]);
+    });
+
+    it('should be valid on empty input (empty string)', () => {
+      const field = createForm('');
+      expect(field().errors()).toEqual([]);
+    });
+
+    it('should be valid on correct input', () => {
+      const field = createForm('first.last@blackbaud.com');
+      expect(field().errors()).toEqual([]);
+    });
+
+    it('should be invalid on incorrect input', () => {
+      const field = createForm('[]abcdefgh0293abcd');
+      expect(field().errors()).toEqual([
+        jasmine.objectContaining({ kind: 'skyEmail' }),
+      ]);
+    });
+
+    it('should not set a message, so `sky-form-errors` renders its own localized text', () => {
+      const field = createForm('[]abcdefgh0293abcd');
+      expect(field().errors()[0].message).toBeUndefined();
+    });
+  });
+
+  describe('skyUrlValidator', () => {
+    function createForm(
+      value: string | undefined,
+      options?: SkyUrlValidationOptions,
+    ): FieldTree<string | undefined> {
+      const model = signal(value);
+      return TestBed.runInInjectionContext(() =>
+        form(model, (p) => skyUrlValidator(p, options)),
+      );
+    }
+
+    it('should be valid on empty input (undefined)', () => {
+      const field = createForm(undefined);
+      expect(field().errors()).toEqual([]);
+    });
+
+    it('should be valid on empty input (empty string)', () => {
+      const field = createForm('');
+      expect(field().errors()).toEqual([]);
+    });
+
+    it('should be valid on correct input', () => {
+      const field = createForm('https://blackbaud.com');
+      expect(field().errors()).toEqual([]);
+    });
+
+    it('should be invalid on text that is not a url', () => {
+      const field = createForm('[]abcdefgh0293abcd]');
+      expect(field().errors()).toEqual([
+        jasmine.objectContaining({ kind: 'skyUrl' }),
+      ]);
+    });
+
+    it('should honor the ruleset v1 option', () => {
+      const field = createForm('sub.domain,com/pagename', {
+        rulesetVersion: 1,
+      });
+      expect(field().errors()).toEqual([]);
+    });
+
+    it('should honor the ruleset v2 option', () => {
+      const field = createForm('sub.domain,com/pagename', {
+        rulesetVersion: 2,
+      });
+      expect(field().errors()).toEqual([
+        jasmine.objectContaining({ kind: 'skyUrl' }),
+      ]);
+    });
+
+    it('should not set a message, so `sky-form-errors` renders its own localized text', () => {
+      const field = createForm('[]abcdefgh0293abcd]');
+      expect(field().errors()[0].message).toBeUndefined();
+    });
+  });
+});

--- a/libs/components/validation/src/lib/modules/validators/signal-validators.spec.ts
+++ b/libs/components/validation/src/lib/modules/validators/signal-validators.spec.ts
@@ -4,7 +4,7 @@ import { FieldTree, form } from '@angular/forms/signals';
 
 import { SkyUrlValidationOptions } from '../url-validation/url-validation-options';
 
-import { skyEmailValidator, skyUrlValidator } from './signal-validators';
+import { skyEmail, skyUrl } from './signal-validators';
 
 describe('Signal forms validators', () => {
   describe('skyEmailValidator', () => {
@@ -13,7 +13,7 @@ describe('Signal forms validators', () => {
     ): FieldTree<string | undefined> {
       const model = signal(value);
       return TestBed.runInInjectionContext(() =>
-        form(model, (p) => skyEmailValidator(p)),
+        form(model, (p) => skyEmail(p)),
       );
     }
 
@@ -52,7 +52,7 @@ describe('Signal forms validators', () => {
     ): FieldTree<string | undefined> {
       const model = signal(value);
       return TestBed.runInInjectionContext(() =>
-        form(model, (p) => skyUrlValidator(p, options)),
+        form(model, (p) => skyUrl(p, options)),
       );
     }
 

--- a/libs/components/validation/src/lib/modules/validators/signal-validators.ts
+++ b/libs/components/validation/src/lib/modules/validators/signal-validators.ts
@@ -12,6 +12,7 @@ import { SkyValidation } from '../validation/validation';
  * Validates that a signal forms field contains a valid email address. Apply inside a
  * `form()` schema. Empty values pass; combine with Angular's `required` rule to require a
  * value.
+ * @preview
  */
 export function skyEmailValidator<TPathKind extends PathKind = PathKind.Root>(
   path: SchemaPath<string | undefined, SchemaPathRules.Supported, TPathKind>,
@@ -28,6 +29,7 @@ export function skyEmailValidator<TPathKind extends PathKind = PathKind.Root>(
 /**
  * Validates that a signal forms field contains a valid URL. Apply inside a `form()` schema.
  * Empty values pass; combine with Angular's `required` rule to require a value.
+ * @preview
  */
 export function skyUrlValidator<TPathKind extends PathKind = PathKind.Root>(
   path: SchemaPath<string | undefined, SchemaPathRules.Supported, TPathKind>,

--- a/libs/components/validation/src/lib/modules/validators/signal-validators.ts
+++ b/libs/components/validation/src/lib/modules/validators/signal-validators.ts
@@ -14,7 +14,7 @@ import { SkyValidation } from '../validation/validation';
  * value.
  * @preview
  */
-export function skyEmailValidator<TPathKind extends PathKind = PathKind.Root>(
+export function skyEmail<TPathKind extends PathKind = PathKind.Root>(
   path: SchemaPath<string | undefined, SchemaPathRules.Supported, TPathKind>,
 ): void {
   validate(path, ({ value }) => {
@@ -31,7 +31,7 @@ export function skyEmailValidator<TPathKind extends PathKind = PathKind.Root>(
  * Empty values pass; combine with Angular's `required` rule to require a value.
  * @preview
  */
-export function skyUrlValidator<TPathKind extends PathKind = PathKind.Root>(
+export function skyUrl<TPathKind extends PathKind = PathKind.Root>(
   path: SchemaPath<string | undefined, SchemaPathRules.Supported, TPathKind>,
   options?: SkyUrlValidationOptions,
 ): void {

--- a/libs/components/validation/src/lib/modules/validators/signal-validators.ts
+++ b/libs/components/validation/src/lib/modules/validators/signal-validators.ts
@@ -1,0 +1,43 @@
+import {
+  PathKind,
+  SchemaPath,
+  SchemaPathRules,
+  validate,
+} from '@angular/forms/signals';
+
+import { SkyUrlValidationOptions } from '../url-validation/url-validation-options';
+import { SkyValidation } from '../validation/validation';
+
+/**
+ * Validates that a signal forms field contains a valid email address. Apply inside a
+ * `form()` schema. Empty values pass; combine with Angular's `required` rule to require a
+ * value.
+ */
+export function skyEmailValidator<TPathKind extends PathKind = PathKind.Root>(
+  path: SchemaPath<string | undefined, SchemaPathRules.Supported, TPathKind>,
+): void {
+  validate(path, ({ value }) => {
+    const email = value();
+
+    return !email || SkyValidation.isEmail(email)
+      ? undefined
+      : { kind: 'skyEmail' };
+  });
+}
+
+/**
+ * Validates that a signal forms field contains a valid URL. Apply inside a `form()` schema.
+ * Empty values pass; combine with Angular's `required` rule to require a value.
+ */
+export function skyUrlValidator<TPathKind extends PathKind = PathKind.Root>(
+  path: SchemaPath<string | undefined, SchemaPathRules.Supported, TPathKind>,
+  options?: SkyUrlValidationOptions,
+): void {
+  validate(path, ({ value }) => {
+    const url = value();
+
+    return !url || SkyValidation.isUrl(url, options)
+      ? undefined
+      : { kind: 'skyUrl' };
+  });
+}


### PR DESCRIPTION
Part 1 of 7 in the signal-forms support stack. Split out of #4629 (closed).
Stack: #4685 <- #4686 <- #4687 <- #4688 <- #4689 <- #4690 <- #4691.

[AB#4008241](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/4008241)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added email and URL validators for signal-based forms.
  * Validators allow empty values and report validation errors for invalid entries.
  * URL validation supports configurable validation options and ruleset versions.
  * Exported the validators through the validation package.
* **Documentation**
  * Updated development documentation identifiers for the new validators.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->