### PR TITLE
fix(components/colorpicker): support signal forms

### DIFF
--- a/.github/instructions/signal-forms-custom-controls.instructions.md
+++ b/.github/instructions/signal-forms-custom-controls.instructions.md
@@ -1,32 +1,35 @@
 ---
 applyTo: '**/libs/components/**/*.directive.ts, **/libs/components/**/*.component.ts'
-description: 'Pitfalls when adding `@angular/forms/signals` (`FormValueControl`/`FormCheckboxControl`) support to an existing custom form control directive or component.'
+description: 'Pitfalls when adding `@angular/forms/signals` (`FormField`) support to an existing custom form control directive or component.'
 ---
 
 # SKY UX Instructions: Signal Forms Support on Existing Custom Controls
 
 ## Background
 
-`blackbaud/skyux#4629` (support for `@angular/forms/signals`' `Field`
+`blackbaud/skyux#4629` (support for `@angular/forms/signals`' `FormField`
 directive) introduced this pattern once already, in
 `colorpicker-input.directive.ts`, and broke text-editor's toolbar
-(`text-editor:test:ci`) in the process. Read this before adding
-`FormValueControl`/`FormCheckboxControl` support to another directive or
-component that already implements `ControlValueAccessor`.
+(`text-editor:test:ci`) in the process. Read this before adding signal-forms
+support to another directive or component that already implements
+`ControlValueAccessor`.
+
+All line references below are to `@angular/forms`'
+`fesm2022/signals.mjs`/`fesm2022/_validation_errors-chunk.mjs` as shipped in
+`22.1.2`; re-check them against the installed version if behavior seems off.
 
 ## The pitfall: dropping `ControlValueAccessor` breaks existing consumers, silently
 
 Do **not** replace an existing `ControlValueAccessor` (`NG_VALUE_ACCESSOR` /
 `NG_VALIDATORS` providers) with `FormValueControl`-only support (`value`/
 `disabled`/`touch` as `model()`/`input()`/`output()`, plus the `ngNoCva` host
-attribute). `FormValueControl` is designed for the new `[field]` (`Field`)
-directive from `@angular/forms/signals` — it is **not** a drop-in replacement
-for classic reactive (`[formControl]`, `formControlName`) or template-driven
-(`[ngModel]`) forms.
+attribute). `FormValueControl` is designed for controls with no pre-existing
+CVA — it is **not** a drop-in replacement for classic reactive
+(`[formControl]`, `formControlName`) or template-driven (`[ngModel]`) forms.
 
 Consumers using the classic form directives on a `FormValueControl`-only
 control do not error. They silently stop syncing (or, worse, partially sync
-and corrupt state — see the reentrancy gotcha below). No exception, no
+and corrupt state — see the dirty-on-write gotcha below). No exception, no
 console warning. The only way this surfaced was a downstream consumer's own
 test suite (`text-editor.component.spec.ts`) failing on an assertion about
 rendered DOM state, days/commits removed from the actual regression.
@@ -34,15 +37,15 @@ rendered DOM state, days/commits removed from the actual regression.
 **Before removing a CVA, grep the whole repo for consumers of the directive
 first** (`grep -rn '<yourDirectiveSelector>' libs/ apps/`). A component's own
 spec suite is not sufficient evidence of safety — this PR's own colorpicker
-spec suite exercised `[formControl]` and `[field]`, but never `[ngModel]`,
+spec suite exercised `[formControl]` and `[formField]`, but never `[ngModel]`,
 and passed 99/99 while the regression was live.
 
-## The fix: implement both, side by side
+## The fix: keep the CVA; do not also implement `FormValueControl`
 
 Keep the existing `ControlValueAccessor`/`Validator` implementation
 (`writeValue`, `registerOnChange`, `registerOnTouched`, `setDisabledState`,
-`validate`) and _add_ the `FormValueControl` surface (`value` as a
-`model()`, `touch` as an `output()`) alongside it. Do not add `ngNoCva`.
+`validate`) untouched. Do **not** add `FormValueControl`'s `value`/`touch`
+surface alongside it, and do not add `ngNoCva`.
 
 This works because Angular already has a well-established dual-support
 mechanism for exactly this case:
@@ -52,50 +55,110 @@ mechanism for exactly this case:
   (`selectValueAccessor` in `@angular/forms` picks the custom accessor over
   any built-in one), so `formControlName`/`[formControl]`/`[ngModel]` keep
   working unchanged.
-- `@angular/forms/signals`' `Field` directive checks for a
-  `ControlValueAccessor` first (`ɵngControlCreate`) and, when present, uses
-  `cvaControlCreate` to bridge it to the field automatically — it only falls
-  back to the `FormValueControl` (`customControlCreate`) path when no CVA is
-  registered.
+- `@angular/forms/signals`' `FormField` directive checks for a
+  `ControlValueAccessor` first (`FormField.ɵngControlCreate`,
+  `signals.mjs:1381-1394`): `if (this.controlValueAccessor) →
+cvaControlCreate(...)`. It only falls back to the `FormValueControl` path
+  (`customControlCreate`) when no CVA is registered.
 
-In other words: once a CVA is present, it becomes the single source of sync
-for _all three_ form flavors. The `value`/`touch` (and any other
-`FormUiControl` inputs) mainly exist to satisfy `FormValueControl`'s TypeScript
-contract for callers that inspect it directly; the CVA methods do the real
-work.
+Once a CVA is present, it becomes the single source of sync for _all three_
+form flavors, through `cvaControlCreate` (`signals.mjs:990-1043`): it calls
+`registerOnChange`/`registerOnTouched`, bridges `NG_VALIDATORS` (including
+`registerOnValidatorChange`), calls `writeValue` when the field's value
+changes, and calls `setDisabledState` when `disabled` changes.
+
+**Do not additionally implement `FormValueControl`/`FormCheckboxControl` on a
+class that has a CVA.** It has no effect and is actively misleading:
+`cvaControlCreate` never calls `listenToCustomControlModel`,
+`listenToCustomControlOutput('touch', …)`, or `setCustomControlModelInput` —
+those only exist inside `customControlCreate` (`signals.mjs:958-968`), the
+no-CVA branch. A `value = model()` or `touch = output()` added next to a CVA
+is simply dead: `value` is never read by the framework (nothing sets it
+under signal forms), and `touch` never fires from `[formField]`. Treat any such
+member found during review as public-API debt to remove, not as
+signal-forms support.
+
+The **only** legitimate use of `FormValueControl`/`FormCheckboxControl` is a
+control with no pre-existing CVA at all.
 
 ## Gotchas hit while doing this
 
-1. **A `value`-mirroring `effect()` in the constructor can clobber a
+1. **`onChange` unconditionally marks a signal-forms field dirty — never call
+   it from a write path that isn't user-driven.** `cvaControlCreate`'s
+   registered `onChange` feeds `state().controlValue`, and that signal's
+   `set`/`update` always calls `markAsDirty()` before syncing
+   (`_validation_errors-chunk.mjs:1539-1553` in the underlying field-node
+   implementation) — there is no "silent" `onChange` under signal forms, unlike
+   reactive forms' `{ emitEvent: false }`. Calling `onChange` (or the
+   registered callback) from `writeValue`, `setDisabledState`, or any other
+   externally-driven code path will mark the field dirty as soon as it loads.
+   Only call it in response to an actual user action (typed input, selection,
+   blur-triggered normalization the user caused, etc.).
+
+2. **A `value`-mirroring `effect()` in the constructor can clobber a
    CVA-applied value.** If you keep an `effect(() => applyIncomingValue(this.value()))` from before the CVA existed, it still fires once
    with the model's default (usually `undefined`) — but only _after_
    `writeValue` has already applied the real starting value, because effects
    flush after the constructor runs, not during it. Delete this effect once
    a CVA exists; `writeValue` now owns applying incoming values for every
-   form flavor.
+   form flavor, and (per the previous section) there is no `value` model to
+   mirror in the first place once `FormValueControl` is dropped.
 
-2. **An `input()` named exactly `disabled` collides with classic
-   `FormControlName`/`FormGroupDirective` setup.** With a CVA _and_ a
-   sibling `disabled = input(false)` on the same directive, `_FormGroupDirective.addControl`/`FormControlName._setUpControl` can call
-   `setDisabledState(true)` during initial setup, before the test or
-   consumer ever calls `.disable()` — silently starting the control
-   disabled. Once a CVA exists, drop the `disabled` input(); `setDisabledState`
-   (called for every form flavor once a CVA is registered, including signal
-   forms' `cvaControlCreate`) is sufficient.
+3. **An `input()` named exactly `disabled` collides with classic
+   `FormControlName`/`FormGroupDirective` setup — not with signal forms.**
+   With a CVA _and_ a sibling `disabled = input(false)` on the same directive,
+   `FormGroupDirective.addControl`/`FormControlName._setUpControl` can call
+   `setDisabledState(true)` during initial setup, before the test or consumer
+   ever calls `.disable()` — silently starting the control disabled. This is a
+   classic-forms-only hazard: under signal forms, `cvaControlCreate` reads the
+   field's `disabled` state and calls both `setInputOnDirectives('disabled',
+value)` and `setDisabledState(value)` symmetrically
+   (`signals.mjs:1037-1041`), so a `disabled` input alongside a CVA is not
+   itself a problem there. Still, once a CVA exists, prefer dropping the
+   `disabled` input(); `setDisabledState` (called for every form flavor once a
+   CVA is registered) is sufficient and avoids the classic-forms collision
+   entirely.
 
-3. **Eagerly injecting `@Self() NgControl` in the constructor plus providing
-   `NG_VALUE_ACCESSOR` creates a circular dependency for `[field]` (signal
-   forms) bindings.** `[field]`'s `NgControl` compatibility shim itself
-   depends on resolving the host's value accessor first, so constructing
-   both at once deadlocks (`NG0200: Circular dependency detected for
-NgControl`). Resolve `NgControl` lazily instead — inject `Injector` in
+4. **Eagerly injecting `@Self() NgControl` in the constructor plus providing
+   `NG_VALUE_ACCESSOR` creates a circular dependency for `[formField]` (signal
+   forms) bindings.** `FormField`'s `controlValueAccessor` getter itself
+   calls `_selectValueAccessor(this.interopNgControl, ...)`
+   (`signals.mjs:1311-1315`) to resolve the host's value accessor, so
+   constructing both at once deadlocks (`NG0200: Circular dependency detected
+for NgControl`). Resolve `NgControl` lazily instead — inject `Injector` in
    the constructor and call `injector.get(NgControl, null, { optional: true, self: true })` from within the method that needs it (e.g. inside
    `writeValue`), not as an eagerly-injected field.
 
+## Consuming field state without reaching through `NgControl`
+
+For state you need to _read_ (errors, touched, dirty, required, disabled, and
+more — the full list is `signals.mjs`'s `FIELD_STATE_KEY_TO_CONTROL_BINDING`),
+`cvaControlCreate` already pushes it to the host as directive inputs via
+`host.setInputOnDirectives(name, value)` for every key in that map
+(`signals.mjs:1035-1041`). Declaring an `input()` with a matching name
+(`errors`, `touched`, `dirty`, `required`, `invalid`, `readonly`, `min`,
+`max`, `minLength`, `maxLength`, `pattern`, `name`, `hidden`, `pending`) is
+often simpler and more idiomatic than injecting `NgControl`, duck-typing it
+with `skyIsAbstractControl`, and manually triggering change detection with
+`skyWatchFormFieldChanges` — reach for the latter only when the control
+already has established imperative logic built around `NgControl` that isn't
+worth restructuring.
+
+When you do need to distinguish a real `AbstractControl` from the read-only
+interop object `[formField]` provides through `NgControl`
+(`InteropNgControl`, `signals.mjs:717-777`): that object does not extend
+`AbstractControl` and simply has no `markAsTouched`, `markAsDirty`,
+`markAsPristine`, `setValue`, or `setErrors` methods (it does not throw when
+you call one that doesn't exist — the property is `undefined`, so calling it
+throws a plain `TypeError`, not something specific to signal forms).
+`skyIsAbstractControl` (`@skyux/forms`) checks this with `instanceof
+AbstractControl`, which is exact — prefer it over duck-typing on any one
+method.
+
 ## Test coverage to add
 
-When adding `FormValueControl` support to an existing control, add (or
-verify) test coverage for **all three** form flavors it must still support:
+When adding signal-forms support to an existing control, add (or verify)
+test coverage for **all three** form flavors it must still support:
 reactive (`[formControl]`/`formControlName`), template-driven (`[ngModel]`),
-and signal forms (`[field]`). Passing signal-forms and reactive-forms tests
+and signal forms (`[formField]`). Passing signal-forms and reactive-forms tests
 alone is not sufficient evidence that template-driven forms still work.

--- a/.github/instructions/signal-forms-custom-controls.instructions.md
+++ b/.github/instructions/signal-forms-custom-controls.instructions.md
@@ -1,0 +1,101 @@
+---
+applyTo: '**/libs/components/**/*.directive.ts, **/libs/components/**/*.component.ts'
+description: 'Pitfalls when adding `@angular/forms/signals` (`FormValueControl`/`FormCheckboxControl`) support to an existing custom form control directive or component.'
+---
+
+# SKY UX Instructions: Signal Forms Support on Existing Custom Controls
+
+## Background
+
+`blackbaud/skyux#4629` (support for `@angular/forms/signals`' `Field`
+directive) introduced this pattern once already, in
+`colorpicker-input.directive.ts`, and broke text-editor's toolbar
+(`text-editor:test:ci`) in the process. Read this before adding
+`FormValueControl`/`FormCheckboxControl` support to another directive or
+component that already implements `ControlValueAccessor`.
+
+## The pitfall: dropping `ControlValueAccessor` breaks existing consumers, silently
+
+Do **not** replace an existing `ControlValueAccessor` (`NG_VALUE_ACCESSOR` /
+`NG_VALIDATORS` providers) with `FormValueControl`-only support (`value`/
+`disabled`/`touch` as `model()`/`input()`/`output()`, plus the `ngNoCva` host
+attribute). `FormValueControl` is designed for the new `[field]` (`Field`)
+directive from `@angular/forms/signals` — it is **not** a drop-in replacement
+for classic reactive (`[formControl]`, `formControlName`) or template-driven
+(`[ngModel]`) forms.
+
+Consumers using the classic form directives on a `FormValueControl`-only
+control do not error. They silently stop syncing (or, worse, partially sync
+and corrupt state — see the reentrancy gotcha below). No exception, no
+console warning. The only way this surfaced was a downstream consumer's own
+test suite (`text-editor.component.spec.ts`) failing on an assertion about
+rendered DOM state, days/commits removed from the actual regression.
+
+**Before removing a CVA, grep the whole repo for consumers of the directive
+first** (`grep -rn '<yourDirectiveSelector>' libs/ apps/`). A component's own
+spec suite is not sufficient evidence of safety — this PR's own colorpicker
+spec suite exercised `[formControl]` and `[field]`, but never `[ngModel]`,
+and passed 99/99 while the regression was live.
+
+## The fix: implement both, side by side
+
+Keep the existing `ControlValueAccessor`/`Validator` implementation
+(`writeValue`, `registerOnChange`, `registerOnTouched`, `setDisabledState`,
+`validate`) and _add_ the `FormValueControl` surface (`value` as a
+`model()`, `touch` as an `output()`) alongside it. Do not add `ngNoCva`.
+
+This works because Angular already has a well-established dual-support
+mechanism for exactly this case:
+
+- A directive's own `NG_VALUE_ACCESSOR` is preferred over the native
+  `DefaultValueAccessor` that would otherwise match the host element
+  (`selectValueAccessor` in `@angular/forms` picks the custom accessor over
+  any built-in one), so `formControlName`/`[formControl]`/`[ngModel]` keep
+  working unchanged.
+- `@angular/forms/signals`' `Field` directive checks for a
+  `ControlValueAccessor` first (`ɵngControlCreate`) and, when present, uses
+  `cvaControlCreate` to bridge it to the field automatically — it only falls
+  back to the `FormValueControl` (`customControlCreate`) path when no CVA is
+  registered.
+
+In other words: once a CVA is present, it becomes the single source of sync
+for _all three_ form flavors. The `value`/`touch` (and any other
+`FormUiControl` inputs) mainly exist to satisfy `FormValueControl`'s TypeScript
+contract for callers that inspect it directly; the CVA methods do the real
+work.
+
+## Gotchas hit while doing this
+
+1. **A `value`-mirroring `effect()` in the constructor can clobber a
+   CVA-applied value.** If you keep an `effect(() => applyIncomingValue(this.value()))` from before the CVA existed, it still fires once
+   with the model's default (usually `undefined`) — but only _after_
+   `writeValue` has already applied the real starting value, because effects
+   flush after the constructor runs, not during it. Delete this effect once
+   a CVA exists; `writeValue` now owns applying incoming values for every
+   form flavor.
+
+2. **An `input()` named exactly `disabled` collides with classic
+   `FormControlName`/`FormGroupDirective` setup.** With a CVA _and_ a
+   sibling `disabled = input(false)` on the same directive, `_FormGroupDirective.addControl`/`FormControlName._setUpControl` can call
+   `setDisabledState(true)` during initial setup, before the test or
+   consumer ever calls `.disable()` — silently starting the control
+   disabled. Once a CVA exists, drop the `disabled` input(); `setDisabledState`
+   (called for every form flavor once a CVA is registered, including signal
+   forms' `cvaControlCreate`) is sufficient.
+
+3. **Eagerly injecting `@Self() NgControl` in the constructor plus providing
+   `NG_VALUE_ACCESSOR` creates a circular dependency for `[field]` (signal
+   forms) bindings.** `[field]`'s `NgControl` compatibility shim itself
+   depends on resolving the host's value accessor first, so constructing
+   both at once deadlocks (`NG0200: Circular dependency detected for
+NgControl`). Resolve `NgControl` lazily instead — inject `Injector` in
+   the constructor and call `injector.get(NgControl, null, { optional: true, self: true })` from within the method that needs it (e.g. inside
+   `writeValue`), not as an eagerly-injected field.
+
+## Test coverage to add
+
+When adding `FormValueControl` support to an existing control, add (or
+verify) test coverage for **all three** form flavors it must still support:
+reactive (`[formControl]`/`formControlName`), template-driven (`[ngModel]`),
+and signal forms (`[field]`). Passing signal-forms and reactive-forms tests
+alone is not sufficient evidence that template-driven forms still work.

--- a/.github/instructions/signal-forms-custom-controls.instructions.md
+++ b/.github/instructions/signal-forms-custom-controls.instructions.md
@@ -20,12 +20,17 @@ All line references below are to `@angular/forms`'
 
 ## The pitfall: dropping `ControlValueAccessor` breaks existing consumers, silently
 
-Do **not** replace an existing `ControlValueAccessor` (`NG_VALUE_ACCESSOR` /
-`NG_VALIDATORS` providers) with `FormValueControl`-only support (`value`/
+Do **not** replace an existing `ControlValueAccessor` (registered via
+`NG_VALUE_ACCESSOR`) with `FormValueControl`-only support (`value`/
 `disabled`/`touch` as `model()`/`input()`/`output()`, plus the `ngNoCva` host
 attribute). `FormValueControl` is designed for controls with no pre-existing
 CVA — it is **not** a drop-in replacement for classic reactive
 (`[formControl]`, `formControlName`) or template-driven (`[ngModel]`) forms.
+A sibling `NG_VALIDATORS` provider is a separate concern: it registers the
+directive's `Validator` (`validate`/`registerOnValidatorChange`) so schema-
+and template-driven validation both run, but it plays no part in _selecting_
+the value accessor for the signal-forms path — that selection is
+`NG_VALUE_ACCESSOR`-only, per `selectValueAccessor` below.
 
 Consumers using the classic form directives on a `FormValueControl`-only
 control do not error. They silently stop syncing (or, worse, partially sync

--- a/.github/instructions/signal-forms-custom-controls.instructions.md
+++ b/.github/instructions/signal-forms-custom-controls.instructions.md
@@ -83,17 +83,31 @@ control with no pre-existing CVA at all.
 
 ## Gotchas hit while doing this
 
-1. **`onChange` unconditionally marks a signal-forms field dirty — never call
-   it from a write path that isn't user-driven.** `cvaControlCreate`'s
-   registered `onChange` feeds `state().controlValue`, and that signal's
-   `set`/`update` always calls `markAsDirty()` before syncing
-   (`_validation_errors-chunk.mjs:1539-1553` in the underlying field-node
-   implementation) — there is no "silent" `onChange` under signal forms, unlike
-   reactive forms' `{ emitEvent: false }`. Calling `onChange` (or the
+1. **Calling the registered `onChange` unconditionally marks the field dirty —
+   for every form flavor, not just signal forms — so never call it from a
+   write path that isn't user-driven.** Under signal forms,
+   `cvaControlCreate`'s registered `onChange` feeds `state().controlValue`,
+   and that signal's `set`/`update` always calls `markAsDirty()` before
+   syncing (`_validation_errors-chunk.mjs:1539-1553` in the underlying
+   field-node implementation). This is **not** a signal-forms-specific
+   surprise: reactive/template-driven forms have the exact same behavior.
+   `@angular/forms`' `setUpViewChangePipeline` (`forms.mjs`) is what
+   `registerOnChange` wires up for `formControlName`/`[formControl]`/
+   `[ngModel]`, and it sets `control._pendingDirty = true` on **every**
+   invocation of the registered callback, then `updateControl()` calls
+   `control.markAsDirty()` unconditionally — the `{ emitEvent: false }`
+   escape hatch only exists on `AbstractControl.setValue()`, not on the
+   registered `onChange` callback itself. So calling `onChange` (or the
    registered callback) from `writeValue`, `setDisabledState`, or any other
-   externally-driven code path will mark the field dirty as soon as it loads.
-   Only call it in response to an actual user action (typed input, selection,
-   blur-triggered normalization the user caused, etc.).
+   externally-driven code path marks the field dirty as soon as it loads,
+   under every form flavor — only call it in response to an actual user
+   action (typed input, selection, blur-triggered normalization the user
+   caused, etc.). To normalize an externally-written value for
+   reactive/template-driven forms without marking it dirty, write directly to
+   the bound `AbstractControl` instead: `control.setValue(value, { emitEvent: false })`, guarded by `skyIsAbstractControl` (see below). Signal
+   forms' interop control has no `setValue`, so it has no equivalent
+   normalization path — its field keeps whatever raw value the consumer
+   bound until the user changes it.
 
 2. **A `value`-mirroring `effect()` in the constructor can clobber a
    CVA-applied value.** If you keep an `effect(() => applyIncomingValue(this.value()))` from before the CVA existed, it still fires once

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,10 @@ scope:
 - [visual-testing.instructions.md](.github/instructions/visual-testing.instructions.md)
   (`apps/e2e/*-storybook/src/app/**/*.stories.ts`) — authoring Storybook
   visual-test stories for Percy snapshots.
+- [signal-forms-custom-controls.instructions.md](.github/instructions/signal-forms-custom-controls.instructions.md)
+  (`**/libs/components/**/*.directive.ts, **/libs/components/**/*.component.ts`)
+  — pitfalls when adding `@angular/forms/signals` support to a directive or
+  component that already implements `ControlValueAccessor`.
 
 ## Reviewer Persona
 

--- a/apps/playground/src/app/components/colorpicker/colorpicker/colorpicker-routing.module.ts
+++ b/apps/playground/src/app/components/colorpicker/colorpicker/colorpicker-routing.module.ts
@@ -3,6 +3,7 @@ import { RouterModule } from '@angular/router';
 
 import { ComponentRouteInfo } from '../../../shared/component-info/component-route-info';
 
+import { ColorpickerSignalFormsComponent } from './colorpicker-signal-forms.component';
 import { ColorpickerComponent } from './colorpicker.component';
 
 const routes: ComponentRouteInfo[] = [
@@ -11,6 +12,15 @@ const routes: ComponentRouteInfo[] = [
     component: ColorpickerComponent,
     data: {
       name: 'Color picker',
+      icon: 'paint-brush',
+      library: 'colorpicker',
+    },
+  },
+  {
+    path: 'signal-forms',
+    component: ColorpickerSignalFormsComponent,
+    data: {
+      name: 'Color picker (signal forms)',
       icon: 'paint-brush',
       library: 'colorpicker',
     },

--- a/apps/playground/src/app/components/colorpicker/colorpicker/colorpicker-signal-forms.component.html
+++ b/apps/playground/src/app/components/colorpicker/colorpicker/colorpicker-signal-forms.component.html
@@ -1,0 +1,121 @@
+<div class="sky-theme-padding-inset-balanced-m">
+  <h1>Color picker (form-flavor spike)</h1>
+  <p>
+    Baseline for the <code>FormValueControl</code> prototype: one colorpicker,
+    bound three ways. Compare <code>required</code>, disabled, value sync, and
+    touched behavior across each column, both before and after
+    <code>SkyColorpickerInputDirective</code> drops
+    <code>ControlValueAccessor</code>.
+  </p>
+
+  <button
+    class="sky-btn sky-btn-default"
+    type="button"
+    (click)="markAllTouched()"
+  >
+    Mark signal/reactive as touched
+  </button>
+</div>
+
+<div class="sky-theme-padding-inset-balanced-m">
+  <h2>Signal forms</h2>
+  <sky-colorpicker
+    #signalPicker
+    data-sky-id="signal-favorite-color"
+    labelText="Favorite color"
+    [stacked]="true"
+  >
+    <input
+      type="text"
+      [formField]="signalForm.favoriteColor"
+      [presetColors]="swatches"
+      [skyColorpickerInput]="signalPicker"
+    />
+  </sky-colorpicker>
+
+  <dl>
+    <dt>Value</dt>
+    <dd>{{ signalForm().value().favoriteColor }}</dd>
+    <dt>Required</dt>
+    <dd>{{ signalForm.favoriteColor().required() }}</dd>
+    <dt>Touched</dt>
+    <dd>{{ signalForm.favoriteColor().touched() }}</dd>
+    <dt>Valid</dt>
+    <dd>{{ signalForm.favoriteColor().valid() }}</dd>
+  </dl>
+</div>
+
+<div class="sky-theme-padding-inset-balanced-m">
+  <h2>Reactive forms</h2>
+  <form [formGroup]="reactiveForm">
+    <sky-colorpicker
+      #reactivePicker
+      data-sky-id="reactive-favorite-color"
+      labelText="Favorite color"
+      [stacked]="true"
+    >
+      <input
+        formControlName="favoriteColor"
+        type="text"
+        [presetColors]="swatches"
+        [skyColorpickerInput]="reactivePicker"
+      />
+    </sky-colorpicker>
+  </form>
+
+  <button
+    class="sky-btn sky-btn-default"
+    type="button"
+    (click)="toggleReactiveRequired()"
+  >
+    Toggle required
+  </button>
+
+  <dl>
+    <dt>Value</dt>
+    <dd>{{ favoriteColor.value }}</dd>
+    <dt>Required</dt>
+    <dd>{{ reactiveRequired() }}</dd>
+    <dt>Touched</dt>
+    <dd>{{ favoriteColor.touched }}</dd>
+    <dt>Valid</dt>
+    <dd>{{ favoriteColor.valid }}</dd>
+  </dl>
+</div>
+
+<div class="sky-theme-padding-inset-balanced-m">
+  <h2>Template-driven forms</h2>
+  <!--
+    `NgModel`'s `shouldBindRequired` is `false` in @angular/forms's custom-control
+    interop (verified in forms.mjs), so a `required` attribute here will NOT
+    flow into a `FormValueControl`'s `required()` input the way reactive forms
+    does. Watch this column closely once the directive drops its CVA.
+  -->
+  <form>
+    <sky-colorpicker
+      #templatePicker
+      data-sky-id="template-favorite-color"
+      labelText="Favorite color"
+      [stacked]="true"
+    >
+      <input
+        #templateModel="ngModel"
+        name="favoriteColor"
+        required
+        type="text"
+        [presetColors]="swatches"
+        [skyColorpickerInput]="templatePicker"
+        [(ngModel)]="templateDrivenColor"
+      />
+    </sky-colorpicker>
+  </form>
+
+  <dl>
+    <dt>Value</dt>
+    <dd>{{ templateDrivenColor }}</dd>
+    <dt>Touched</dt>
+    <dd>{{ templateModel.touched }}</dd>
+    <dt>Valid</dt>
+    <dd>{{ templateModel.valid }}</dd>
+  </dl>
+</div>

--- a/apps/playground/src/app/components/colorpicker/colorpicker/colorpicker-signal-forms.component.html
+++ b/apps/playground/src/app/components/colorpicker/colorpicker/colorpicker-signal-forms.component.html
@@ -1,12 +1,11 @@
 <div class="sky-theme-padding-inset-balanced-m">
   <h1>Color picker (form-flavor spike)</h1>
   <p>
-    Baseline for the <code>FormValueControl</code> prototype: one colorpicker,
-    bound three ways. Compare <code>required</code>, disabled, value sync, and
-    touched behavior across each column.
-    <code>SkyColorpickerInputDirective</code> implements both
-    <code>ControlValueAccessor</code> and <code>FormValueControl</code>, so all
-    three columns sync through <code>ControlValueAccessor</code>.
+    Baseline for signal-forms support: one colorpicker, bound three ways.
+    Compare <code>required</code>, disabled, value sync, and touched behavior
+    across each column. <code>SkyColorpickerInputDirective</code> implements
+    only <code>ControlValueAccessor</code>, so all three columns sync through
+    it.
   </p>
 
   <button

--- a/apps/playground/src/app/components/colorpicker/colorpicker/colorpicker-signal-forms.component.html
+++ b/apps/playground/src/app/components/colorpicker/colorpicker/colorpicker-signal-forms.component.html
@@ -3,9 +3,10 @@
   <p>
     Baseline for the <code>FormValueControl</code> prototype: one colorpicker,
     bound three ways. Compare <code>required</code>, disabled, value sync, and
-    touched behavior across each column, both before and after
-    <code>SkyColorpickerInputDirective</code> drops
-    <code>ControlValueAccessor</code>.
+    touched behavior across each column.
+    <code>SkyColorpickerInputDirective</code> implements both
+    <code>ControlValueAccessor</code> and <code>FormValueControl</code>, so all
+    three columns sync through <code>ControlValueAccessor</code>.
   </p>
 
   <button
@@ -85,12 +86,6 @@
 
 <div class="sky-theme-padding-inset-balanced-m">
   <h2>Template-driven forms</h2>
-  <!--
-    `NgModel`'s `shouldBindRequired` is `false` in @angular/forms's custom-control
-    interop (verified in forms.mjs), so a `required` attribute here will NOT
-    flow into a `FormValueControl`'s `required()` input the way reactive forms
-    does. Watch this column closely once the directive drops its CVA.
-  -->
   <form>
     <sky-colorpicker
       #templatePicker

--- a/apps/playground/src/app/components/colorpicker/colorpicker/colorpicker-signal-forms.component.ts
+++ b/apps/playground/src/app/components/colorpicker/colorpicker/colorpicker-signal-forms.component.ts
@@ -10,11 +10,13 @@ import { FormField, form, required } from '@angular/forms/signals';
 import { SkyColorpickerModule } from '@skyux/colorpicker';
 
 /**
- * Spike harness for the `SkyColorpickerInputDirective` → `FormValueControl`
- * prototype (blackbaud/skyux#4629, review comment about `FormValueControl`).
+ * Spike harness for `SkyColorpickerInputDirective`'s `FormValueControl`
+ * support (blackbaud/skyux#4629, review comment about `FormValueControl`).
  * Binds one colorpicker three ways so `required`/disabled/value/touched
  * behavior can be compared across signal, reactive, and template-driven
- * forms before and after the refactor.
+ * forms. The directive implements both `ControlValueAccessor` and
+ * `FormValueControl`, so all three columns go through `ControlValueAccessor`
+ * (which `Field` and reactive/template-driven forms all prefer when present).
  */
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/apps/playground/src/app/components/colorpicker/colorpicker/colorpicker-signal-forms.component.ts
+++ b/apps/playground/src/app/components/colorpicker/colorpicker/colorpicker-signal-forms.component.ts
@@ -1,0 +1,74 @@
+import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
+import {
+  FormsModule,
+  ReactiveFormsModule,
+  UntypedFormControl,
+  UntypedFormGroup,
+  Validators,
+} from '@angular/forms';
+import { FormField, form, required } from '@angular/forms/signals';
+import { SkyColorpickerModule } from '@skyux/colorpicker';
+
+/**
+ * Spike harness for the `SkyColorpickerInputDirective` → `FormValueControl`
+ * prototype (blackbaud/skyux#4629, review comment about `FormValueControl`).
+ * Binds one colorpicker three ways so `required`/disabled/value/touched
+ * behavior can be compared across signal, reactive, and template-driven
+ * forms before and after the refactor.
+ */
+@Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [FormField, FormsModule, ReactiveFormsModule, SkyColorpickerModule],
+  styles: `
+    :host {
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+      gap: var(--sky-space-inline-xl);
+    }
+  `,
+  templateUrl: './colorpicker-signal-forms.component.html',
+})
+export class ColorpickerSignalFormsComponent {
+  protected readonly swatches: string[] = [
+    '#BD4040',
+    '#617FC2',
+    '#60AC68',
+    '#3486BA',
+    '#E87134',
+    '#DA9C9C',
+  ];
+
+  // --- Signal forms ---
+  protected readonly signalModel = signal({ favoriteColor: '' });
+  protected readonly signalForm = form(this.signalModel, (p) => {
+    required(p.favoriteColor, { message: 'A favorite color is required.' });
+  });
+
+  // --- Reactive forms ---
+  protected readonly favoriteColor = new UntypedFormControl('');
+  protected readonly reactiveForm = new UntypedFormGroup({
+    favoriteColor: this.favoriteColor,
+  });
+  readonly #reactiveRequired = signal(false);
+  protected readonly reactiveRequired = this.#reactiveRequired.asReadonly();
+
+  // --- Template-driven forms ---
+  protected templateDrivenColor = '';
+
+  protected toggleReactiveRequired(): void {
+    const nextRequired = !this.#reactiveRequired();
+
+    if (nextRequired) {
+      this.favoriteColor.addValidators(Validators.required);
+    } else {
+      this.favoriteColor.removeValidators(Validators.required);
+    }
+    this.favoriteColor.updateValueAndValidity();
+    this.#reactiveRequired.set(nextRequired);
+  }
+
+  protected markAllTouched(): void {
+    this.signalForm().markAsTouched();
+    this.reactiveForm.markAllAsTouched();
+  }
+}

--- a/apps/playground/src/app/components/colorpicker/colorpicker/colorpicker-signal-forms.component.ts
+++ b/apps/playground/src/app/components/colorpicker/colorpicker/colorpicker-signal-forms.component.ts
@@ -10,13 +10,13 @@ import { FormField, form, required } from '@angular/forms/signals';
 import { SkyColorpickerModule } from '@skyux/colorpicker';
 
 /**
- * Spike harness for `SkyColorpickerInputDirective`'s `FormValueControl`
- * support (blackbaud/skyux#4629, review comment about `FormValueControl`).
- * Binds one colorpicker three ways so `required`/disabled/value/touched
- * behavior can be compared across signal, reactive, and template-driven
- * forms. The directive implements both `ControlValueAccessor` and
- * `FormValueControl`, so all three columns go through `ControlValueAccessor`
- * (which `Field` and reactive/template-driven forms all prefer when present).
+ * Spike harness for `SkyColorpickerInputDirective`'s signal-forms support
+ * (blackbaud/skyux#4629). Binds one colorpicker three ways so
+ * `required`/disabled/value/touched behavior can be compared across signal,
+ * reactive, and template-driven forms. The directive implements only
+ * `ControlValueAccessor`, so all three columns go through it (`FormField`
+ * and reactive/template-driven forms all prefer a `ControlValueAccessor`
+ * when one is present).
  */
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/apps/playground/src/app/components/colorpicker/colorpicker/colorpicker.module.ts
+++ b/apps/playground/src/app/components/colorpicker/colorpicker/colorpicker.module.ts
@@ -3,6 +3,7 @@ import { ReactiveFormsModule } from '@angular/forms';
 import { SkyColorpickerModule } from '@skyux/colorpicker';
 
 import { ColorpickerRoutingModule } from './colorpicker-routing.module';
+import { ColorpickerSignalFormsComponent } from './colorpicker-signal-forms.component';
 import { ColorpickerComponent } from './colorpicker.component';
 
 @NgModule({
@@ -11,6 +12,7 @@ import { ColorpickerComponent } from './colorpicker.component';
     ReactiveFormsModule,
     SkyColorpickerModule,
     ColorpickerRoutingModule,
+    ColorpickerSignalFormsComponent,
   ],
 })
 export class ColorpickerModule {

--- a/libs/components/colorpicker/src/lib/modules/colorpicker/colorpicker-input.directive.ts
+++ b/libs/components/colorpicker/src/lib/modules/colorpicker/colorpicker-input.directive.ts
@@ -403,16 +403,21 @@ export class SkyColorpickerInputDirective
       if (value === this.#renderedValue) {
         // Already showing exactly this string, most commonly this
         // directive's own prior write (`#applyColor`) echoing back through
-        // `value`. Skip before formatting: re-parsing isn't needed, and
-        // could fail for a value the current `alphaChannel`/`outputFormat`
-        // settings can no longer parse (for example, a 6-digit hex string
-        // once `alphaChannel` is `hex8`, which only accepts 8 digits).
+        // `value`. Skip re-rendering before formatting: re-parsing isn't
+        // needed, and could fail for a value the current
+        // `alphaChannel`/`outputFormat` settings can no longer parse (for
+        // example, a 6-digit hex string once `alphaChannel` is `hex8`,
+        // which only accepts 8 digits). The bound control still needs
+        // normalizing below, since a reactive/template-driven consumer may
+        // have just written this same raw string directly.
+        this.#normalizeControlValue(this.#formatter(value));
         return;
       }
     } else if (value === this.#modelValue) {
       // Already showing exactly this `SkyColorpickerOutput` object, most
       // commonly this directive's own prior write (`#applyColor`) echoing
       // back through `value`.
+      this.#normalizeControlValue(value);
       return;
     }
 
@@ -420,6 +425,7 @@ export class SkyColorpickerInputDirective
     const output = this.#toOutputString(formattedValue);
 
     if (output === this.#renderedValue) {
+      this.#normalizeControlValue(formattedValue);
       return;
     }
 
@@ -427,19 +433,7 @@ export class SkyColorpickerInputDirective
     this.#modelValue = formattedValue;
     this.#writeModelValue(formattedValue);
 
-    // For reactive/template-driven forms, normalize the bound control's
-    // value to the full `SkyColorpickerOutput` object, restoring this
-    // directive's pre-signal-forms contract for those consumers. Written
-    // directly to the control (not through `onChange`) so it doesn't mark
-    // the field dirty; the control's own change detection then reflects the
-    // normalized object back for us. `[formField]` (signal forms) bindings
-    // also expose an `NgControl` (for interop with APIs that expect one),
-    // but it's a read-only compatibility shim with no `setValue`, so this
-    // only ever applies to real reactive/template-driven form controls.
-    const control = this.#ngControl?.control;
-    if (skyIsAbstractControl(control) && control.value !== formattedValue) {
-      control.setValue(formattedValue, { emitEvent: false });
-    }
+    this.#normalizeControlValue(formattedValue);
 
     // The initial-color bookkeeping only deals in color strings, so a
     // `SkyColorpickerOutput` incoming value uses its normalized output
@@ -451,6 +445,24 @@ export class SkyColorpickerInputDirective
       this.skyColorpickerInput.initialColor = initialColorValue;
     }
     this.skyColorpickerInput.lastAppliedColor = initialColorValue;
+  }
+
+  // For reactive/template-driven forms, normalizes the bound control's
+  // value to the full `SkyColorpickerOutput` object, restoring this
+  // directive's pre-signal-forms contract for those consumers (so
+  // `control.value.hex`, `control.value.rgba.alpha`, etc. are always
+  // available, even if the consumer bound a raw string). Written directly
+  // to the control (not through `onChange`) so it doesn't mark the field
+  // dirty; the control's own change detection then reflects the normalized
+  // object back for us. `[formField]` (signal forms) bindings also expose
+  // an `NgControl` (for interop with APIs that expect one), but it's a
+  // read-only compatibility shim with no `setValue`, so this only ever
+  // applies to real reactive/template-driven form controls.
+  #normalizeControlValue(formattedValue: SkyColorpickerOutput): void {
+    const control = this.#ngControl?.control;
+    if (skyIsAbstractControl(control) && control.value !== formattedValue) {
+      control.setValue(formattedValue, { emitEvent: false });
+    }
   }
 
   // Applies a color the user selected (through the native input or the

--- a/libs/components/colorpicker/src/lib/modules/colorpicker/colorpicker-input.directive.ts
+++ b/libs/components/colorpicker/src/lib/modules/colorpicker/colorpicker-input.directive.ts
@@ -1,18 +1,25 @@
 import {
   Directive,
   ElementRef,
+  Injector,
   Input,
   OnChanges,
   OnDestroy,
   OnInit,
   Renderer2,
-  effect,
+  forwardRef,
   inject,
-  input,
   model,
   output,
 } from '@angular/core';
-import { NgControl } from '@angular/forms';
+import {
+  ControlValueAccessor,
+  NG_VALIDATORS,
+  NG_VALUE_ACCESSOR,
+  NgControl,
+  ValidationErrors,
+  Validator,
+} from '@angular/forms';
 import type { FormValueControl } from '@angular/forms/signals';
 import { SkyRequiredStateDirective } from '@skyux/forms';
 import { SkyLibResourcesService } from '@skyux/i18n';
@@ -24,25 +31,37 @@ import { SkyColorpickerComponent } from './colorpicker.component';
 import { SkyColorpickerService } from './colorpicker.service';
 import { SkyColorpickerOutput } from './types/colorpicker-output';
 
+const SKY_COLORPICKER_VALUE_ACCESSOR = {
+  provide: NG_VALUE_ACCESSOR,
+  useExisting: forwardRef(() => SkyColorpickerInputDirective),
+  multi: true,
+};
+
+const SKY_COLORPICKER_VALIDATOR = {
+  provide: NG_VALIDATORS,
+  useExisting: forwardRef(() => SkyColorpickerInputDirective),
+  multi: true,
+};
+
 const SKY_COLORPICKER_DEFAULT_COLOR = '#FFFFFF';
 
-// Implements `FormValueControl` (from `@angular/forms/signals`) instead of
-// `ControlValueAccessor`. Angular's signal-forms interop lets a
-// `FormValueControl` work with signal, reactive, and template-driven forms
-// without any CVA-specific code, so this directive no longer needs a
-// `NG_VALUE_ACCESSOR` provider.
-//
-// The host element is a native `<input>`, so Angular's built-in
-// `DefaultValueAccessor` still matches a `formControlName`/`formControl`/
-// `ngModel` binding there. The `ngNoCva` host attribute tells
-// `@angular/forms` to ignore that built-in accessor at runtime and use this
-// directive's custom-control (`value`/`valueChange`) interop instead, for
-// every form flavor.
+// Implements both `ControlValueAccessor` (classic reactive/template-driven
+// forms) and `FormValueControl` (from `@angular/forms/signals`). Angular
+// prefers a directive's own `NG_VALUE_ACCESSOR` over the native
+// `DefaultValueAccessor` that would otherwise match this host `<input>`, so
+// `formControlName`/`formControl`/`ngModel` keep working through the CVA
+// methods below. `@angular/forms/signals`' `Field` directive also checks for
+// a `ControlValueAccessor` first and, when present, bridges it to the field
+// automatically — so the `value`/`touch` members exist mainly to satisfy the
+// `FormValueControl` contract's typing for `Field` consumers; the actual
+// sync for every form flavor (including `disabled`, via `setDisabledState`)
+// happens through the CVA methods.
 /**
  * Creates the colorpicker element and dropdown.
  */
 @Directive({
   selector: '[skyColorpickerInput]',
+  providers: [SKY_COLORPICKER_VALUE_ACCESSOR, SKY_COLORPICKER_VALIDATOR],
   hostDirectives: [
     {
       directive: SkyRequiredStateDirective,
@@ -52,15 +71,16 @@ const SKY_COLORPICKER_DEFAULT_COLOR = '#FFFFFF';
   host: {
     class: 'sky-colorpicker-input',
     readonly: 'true',
-    ngNoCva: '',
     '(input)': 'changeInput()',
     '(change)': 'onChange()',
-    '(blur)': 'touch.emit()',
+    '(blur)': 'onBlur()',
   },
 })
 export class SkyColorpickerInputDirective
   implements
     FormValueControl<SkyColorpickerOutput | string | undefined>,
+    ControlValueAccessor,
+    Validator,
     OnInit,
     OnChanges,
     OnDestroy
@@ -162,20 +182,6 @@ export class SkyColorpickerInputDirective
     undefined,
   );
 
-  // Implemented as part of `FormUiControl`. Replaces the
-  // `ControlValueAccessor.setDisabledState` callback, which only reactive
-  // and template-driven forms called. Does not touch
-  // `backgroundColorForDisplay` — that's always driven by the current value
-  // (`#applyIncomingValue`/`#applyColor` → `#writeModelValue`), so the
-  // swatch keeps showing its real color, dimmed by
-  // `.sky-colorpicker-disabled`'s opacity, rather than being forced to a
-  // flat, theme-inconsistent white.
-  /**
-   * Whether the colorpicker is disabled.
-   * @preview
-   */
-  public readonly disabled = input(false);
-
   // Implemented as part of `FormUiControl`. Emitted on native `blur`, and
   // relayed from `SkyColorpickerComponent` when the user opens the picker
   // dialog via the trigger button. `Field`/`NgControl` listen to this
@@ -204,37 +210,35 @@ export class SkyColorpickerInputDirective
 
   #_initialColor: string | undefined;
 
-  // Only populated for reactive/template-driven form bindings
+  // Resolved lazily (not injected in the constructor) because this
+  // directive also provides `NG_VALUE_ACCESSOR` for itself: eagerly
+  // injecting `NgControl` here would create a circular dependency for
+  // `[formField]` (signal forms) bindings, whose `NgControl` compatibility
+  // shim itself depends on resolving this directive's value accessor
+  // first. Only populated for reactive/template-driven form bindings
   // (`formControlName`, `[formControl]`, `[ngModel]`) — `[formField]`
-  // (signal forms) bindings have no `NgControl`. Used solely to normalize
-  // a bound `AbstractControl`'s value into the full `SkyColorpickerOutput`
-  // object those pre-existing consumers already depend on
-  // (`control.value.hex`, `control.value.rgba.alpha`, etc.), matching this
-  // directive's previous `ControlValueAccessor`-based contract. Written to
-  // directly (bypassing `value.set()`), since `value.set()` always marks
-  // the field dirty, even for values that didn't originate from the user.
-  readonly #ngControl = inject(NgControl, { optional: true, self: true });
+  // bindings have no `NgControl`. Used solely to normalize a bound
+  // `AbstractControl`'s value into the full `SkyColorpickerOutput` object
+  // those pre-existing consumers already depend on (`control.value.hex`,
+  // `control.value.rgba.alpha`, etc.), matching this directive's previous
+  // `ControlValueAccessor`-based contract. Written to directly (bypassing
+  // `value.set()`), since `value.set()` always marks the field dirty, even
+  // for values that didn't originate from the user.
+  readonly #injector = inject(Injector);
+  get #ngControl(): NgControl | null {
+    return this.#injector.get(NgControl, null, { optional: true, self: true });
+  }
 
   readonly #colorpickerInputSvc = inject(SkyColorpickerInputService);
   readonly #ngUnsubscribe = new Subject<void>();
 
-  constructor() {
-    // Reflects the bound field's value onto the colorpicker whenever it
-    // changes (for example, a schema rule, a `reset()`, a sibling control,
-    // or this directive's own prior write coming back through `value`).
-    // `#applyIncomingValue` compares the normalized value against
-    // `#renderedValue` and no-ops when they match, so this effect can't
-    // loop on its own writes, but still re-renders for any value that
-    // isn't already showing (fixing writes that were previously dropped
-    // because they matched a stale, format-mismatched guard).
-    effect(() => {
-      this.#applyIncomingValue(this.value());
-    });
-
-    effect(() => {
-      this.skyColorpickerInput.disabled = this.disabled();
-    });
-  }
+  // Populated by `registerOnChange`/`registerOnTouched` for
+  // `formControlName`/`[formControl]`/`[ngModel]` consumers. `@angular/forms/
+  // signals`' `Field` directive registers these too when it detects this
+  // `ControlValueAccessor`, so they cover every form flavor alongside the
+  // `value`/`touch` members above.
+  #onChange: ((value: SkyColorpickerOutput) => void) | undefined;
+  #onTouched: (() => void) | undefined;
 
   public changeInput(): void {
     const value = this.#elementRef.nativeElement.value;
@@ -245,6 +249,52 @@ export class SkyColorpickerInputDirective
   public onChange(): void {
     const newValue = this.#elementRef.nativeElement.value;
     this.#applyColor(this.#formatter(newValue));
+  }
+
+  public onBlur(): void {
+    this.#markTouched();
+  }
+
+  /**
+   * Implemented as part of `ControlValueAccessor`.
+   */
+  public writeValue(value: SkyColorpickerOutput | string | undefined): void {
+    this.#applyIncomingValue(value);
+  }
+
+  /**
+   * Implemented as part of `ControlValueAccessor`.
+   */
+  public registerOnChange(fn: (value: SkyColorpickerOutput) => void): void {
+    this.#onChange = fn;
+  }
+
+  /**
+   * Implemented as part of `ControlValueAccessor`.
+   */
+  public registerOnTouched(fn: () => void): void {
+    this.#onTouched = fn;
+  }
+
+  /**
+   * Implemented as part of `ControlValueAccessor`.
+   */
+  public setDisabledState(isDisabled: boolean): void {
+    this.skyColorpickerInput.disabled = isDisabled;
+  }
+
+  /**
+   * Implemented as part of `Validator`. This directive contributes no
+   * validation of its own — `required` is handled by the `SkyRequiredStateDirective`
+   * host directive instead.
+   */
+  public validate(): ValidationErrors | null {
+    return null;
+  }
+
+  #markTouched(): void {
+    this.touch.emit();
+    this.#onTouched?.();
   }
 
   public ngOnInit(): void {
@@ -292,7 +342,7 @@ export class SkyColorpickerInputDirective
 
     this.#colorpickerInputSvc.touch
       .pipe(takeUntil(this.#ngUnsubscribe))
-      .subscribe(() => this.touch.emit());
+      .subscribe(() => this.#markTouched());
 
     // A color the user applied through the picker dialog's Apply button.
     // This is a user-driven change, so it's written through to the bound
@@ -443,8 +493,10 @@ export class SkyColorpickerInputDirective
   }
 
   // Applies a color the user selected (through the native input or the
-  // picker dialog) and propagates it to `value`, so it reaches whatever
-  // form this directive is bound to.
+  // picker dialog) and propagates it to `value` and, for
+  // `formControlName`/`[formControl]`/`[ngModel]` consumers, the registered
+  // `onChange` callback — so it reaches whatever form this directive is
+  // bound to.
   #applyColor(formattedValue: SkyColorpickerOutput): void {
     const output = this.#toOutputString(formattedValue);
 
@@ -453,6 +505,7 @@ export class SkyColorpickerInputDirective
     this.#writeModelValue(formattedValue);
 
     this.value.set(formattedValue);
+    this.#onChange?.(formattedValue);
   }
 
   // Clears the displayed color when the bound field's value is empty (for

--- a/libs/components/colorpicker/src/lib/modules/colorpicker/colorpicker-input.directive.ts
+++ b/libs/components/colorpicker/src/lib/modules/colorpicker/colorpicker-input.directive.ts
@@ -1,23 +1,19 @@
 import {
   Directive,
   ElementRef,
-  Injector,
   Input,
   OnChanges,
   OnDestroy,
   OnInit,
   Renderer2,
-  forwardRef,
+  effect,
   inject,
+  input,
+  model,
+  output,
 } from '@angular/core';
-import {
-  ControlValueAccessor,
-  NG_VALIDATORS,
-  NG_VALUE_ACCESSOR,
-  NgControl,
-  ValidationErrors,
-  Validator,
-} from '@angular/forms';
+import { NgControl } from '@angular/forms';
+import type { FormValueControl } from '@angular/forms/signals';
 import { SkyRequiredStateDirective } from '@skyux/forms';
 import { SkyLibResourcesService } from '@skyux/i18n';
 
@@ -28,26 +24,26 @@ import { SkyColorpickerComponent } from './colorpicker.component';
 import { SkyColorpickerService } from './colorpicker.service';
 import { SkyColorpickerOutput } from './types/colorpicker-output';
 
-const SKY_COLORPICKER_VALUE_ACCESSOR = {
-  provide: NG_VALUE_ACCESSOR,
-  useExisting: forwardRef(() => SkyColorpickerInputDirective),
-  multi: true,
-};
-
-const SKY_COLORPICKER_VALIDATOR = {
-  provide: NG_VALIDATORS,
-  useExisting: forwardRef(() => SkyColorpickerInputDirective),
-  multi: true,
-};
-
 const SKY_COLORPICKER_DEFAULT_COLOR = '#FFFFFF';
 
 /**
  * Creates the colorpicker element and dropdown.
+ *
+ * Implements `FormValueControl` (from `@angular/forms/signals`) instead of
+ * `ControlValueAccessor`. Angular's signal-forms interop lets a
+ * `FormValueControl` work with signal, reactive, and template-driven forms
+ * without any CVA-specific code, so this directive no longer needs a
+ * `NG_VALUE_ACCESSOR` provider.
+ *
+ * The host element is a native `<input>`, so Angular's built-in
+ * `DefaultValueAccessor` still matches a `formControlName`/`formControl`/
+ * `ngModel` binding there. The `ngNoCva` host attribute tells
+ * `@angular/forms` to ignore that built-in accessor at runtime and use this
+ * directive's custom-control (`value`/`valueChange`) interop instead, for
+ * every form flavor.
  */
 @Directive({
   selector: '[skyColorpickerInput]',
-  providers: [SKY_COLORPICKER_VALUE_ACCESSOR, SKY_COLORPICKER_VALIDATOR],
   hostDirectives: [
     {
       directive: SkyRequiredStateDirective,
@@ -57,12 +53,18 @@ const SKY_COLORPICKER_DEFAULT_COLOR = '#FFFFFF';
   host: {
     class: 'sky-colorpicker-input',
     readonly: 'true',
+    ngNoCva: '',
     '(input)': 'changeInput()',
     '(change)': 'onChange()',
+    '(blur)': 'touch.emit()',
   },
 })
 export class SkyColorpickerInputDirective
-  implements OnInit, OnChanges, ControlValueAccessor, Validator, OnDestroy
+  implements
+    FormValueControl<SkyColorpickerOutput | string | undefined>,
+    OnInit,
+    OnChanges,
+    OnDestroy
 {
   /**
    * Creates the colorpicker element and dropdown. Place this attribute on an `input` element
@@ -84,7 +86,7 @@ export class SkyColorpickerInputDirective
   public set initialColor(value: string | undefined) {
     /* istanbul ignore else */
     if (!this.#_initialColor && !this.#modelValue) {
-      this.writeValue(value);
+      this.#applyIncomingValue(value);
     }
 
     this.#_initialColor = value;
@@ -146,20 +148,93 @@ export class SkyColorpickerInputDirective
   @Input()
   public allowTransparency = true;
 
+  /**
+   * Implemented as part of `FormValueControl`. Accepts either a color string
+   * or a `SkyColorpickerOutput` object as an incoming value (matching the
+   * loose contract the previous `ControlValueAccessor.writeValue(value: any)`
+   * accepted), but always emits a full `SkyColorpickerOutput` object back to
+   * the bound `[formField]`, `formControl`/`formControlName`, or `ngModel`
+   * when the user selects a color. This preserves the pre-existing contract
+   * where consumers read properties such as `value.hex` or
+   * `value.rgba.alpha` off the bound control's value.
+   */
+  public readonly value = model<SkyColorpickerOutput | string | undefined>(
+    undefined,
+  );
+
+  /**
+   * Implemented as part of `FormUiControl`. Reflects the bound field's
+   * disabled state onto the colorpicker dialog. Replaces the
+   * `ControlValueAccessor.setDisabledState` callback, which only reactive and
+   * template-driven forms called. Does not touch `backgroundColorForDisplay`
+   * — that's always driven by the current value (`#applyIncomingValue`/
+   * `#applyColor` → `#writeModelValue`), so the swatch keeps showing its
+   * real color, dimmed by `.sky-colorpicker-disabled`'s opacity, rather than
+   * being forced to a flat, theme-inconsistent white.
+   */
+  public readonly disabled = input(false);
+
+  /**
+   * Implemented as part of `FormUiControl`. Emitted on native `blur`, and
+   * relayed from `SkyColorpickerComponent` when the user opens the picker
+   * dialog via the trigger button. `Field`/`NgControl` listen to this output
+   * to mark the bound field as touched, for every form flavor.
+   */
+  public readonly touch = output<void>();
+
   #modelValue: SkyColorpickerOutput | undefined;
+  /**
+   * The normalized output string (per `outputFormat`) most recently rendered
+   * into the native input element and colorpicker dialog, regardless of
+   * whether it came from a user action (`#applyColor`) or from outside this
+   * directive (`#applyIncomingValue`). This is the single source of truth
+   * for whether an incoming value is actually a change, replacing the two
+   * separate (and easily desynced) trackers this directive used to keep:
+   * a self-emitted-value guard and `SkyColorpickerComponent.lastAppliedColor`.
+   */
+  #renderedValue: string | undefined;
   readonly #elementRef = inject(ElementRef);
   readonly #renderer = inject(Renderer2);
   readonly #svc = inject(SkyColorpickerService);
   readonly #resourcesSvc = inject(SkyLibResourcesService);
-  readonly #injector = inject(Injector);
   #inputIdSubscription: Subscription | undefined;
   #labelText: string | undefined;
 
-  #_disabled: boolean | undefined;
   #_initialColor: string | undefined;
+
+  /**
+   * Only populated for reactive/template-driven form bindings
+   * (`formControlName`, `[formControl]`, `[ngModel]`) — `[formField]`
+   * (signal forms) bindings have no `NgControl`. Used solely to normalize
+   * a bound `AbstractControl`'s value into the full `SkyColorpickerOutput`
+   * object those pre-existing consumers already depend on
+   * (`control.value.hex`, `control.value.rgba.alpha`, etc.), matching this
+   * directive's previous `ControlValueAccessor`-based contract. Written to
+   * directly (bypassing `value.set()`), since `value.set()` always marks
+   * the field dirty, even for values that didn't originate from the user.
+   */
+  readonly #ngControl = inject(NgControl, { optional: true, self: true });
 
   readonly #colorpickerInputSvc = inject(SkyColorpickerInputService);
   readonly #ngUnsubscribe = new Subject<void>();
+
+  constructor() {
+    // Reflects the bound field's value onto the colorpicker whenever it
+    // changes (for example, a schema rule, a `reset()`, a sibling control,
+    // or this directive's own prior write coming back through `value`).
+    // `#applyIncomingValue` compares the normalized value against
+    // `#renderedValue` and no-ops when they match, so this effect can't
+    // loop on its own writes, but still re-renders for any value that
+    // isn't already showing (fixing writes that were previously dropped
+    // because they matched a stale, format-mismatched guard).
+    effect(() => {
+      this.#applyIncomingValue(this.value());
+    });
+
+    effect(() => {
+      this.skyColorpickerInput.disabled = this.disabled();
+    });
+  }
 
   public changeInput(): void {
     const value = this.#elementRef.nativeElement.value;
@@ -169,9 +244,7 @@ export class SkyColorpickerInputDirective
 
   public onChange(): void {
     const newValue = this.#elementRef.nativeElement.value;
-    const formattedValue = this.#formatter(newValue);
-    this.#modelValue = formattedValue;
-    this.#writeModelValue(formattedValue);
+    this.#applyColor(this.#formatter(newValue));
   }
 
   public ngOnInit(): void {
@@ -180,18 +253,6 @@ export class SkyColorpickerInputDirective
     this.#renderer.addClass(element, 'sky-form-control');
     this.skyColorpickerInput.initialColor = this.initialColor;
     this.skyColorpickerInput.returnFormat = this.returnFormat;
-
-    this.skyColorpickerInput.selectedColorChanged
-      .pipe(takeUntil(this.#ngUnsubscribe))
-      .subscribe((newColor: SkyColorpickerOutput) => {
-        /* istanbul ignore else */
-        if (newColor) {
-          this.#modelValue = this.#formatter(newColor);
-
-          // Write the new value to the reactive form control, which will update the template model
-          this.writeValue(newColor);
-        }
-      });
 
     this.#colorpickerInputSvc.labelText
       .pipe(takeUntil(this.#ngUnsubscribe))
@@ -229,13 +290,36 @@ export class SkyColorpickerInputDirective
         }
       });
 
-    this.skyColorpickerInput.updatePickerValues(this.initialColor);
+    this.#colorpickerInputSvc.touch
+      .pipe(takeUntil(this.#ngUnsubscribe))
+      .subscribe(() => this.touch.emit());
 
-    /* Sanity check */
-    /* istanbul ignore else */
-    if (!this.#_disabled) {
-      this.skyColorpickerInput.backgroundColorForDisplay = this.initialColor;
-    }
+    // A color the user applied through the picker dialog's Apply button.
+    // This is a user-driven change, so it's written through to the bound
+    // field via `#applyColor` (which calls `value.set()` and marks the
+    // field dirty).
+    this.#colorpickerInputSvc.colorApplied
+      .pipe(takeUntil(this.#ngUnsubscribe))
+      .subscribe((newColor) => {
+        /* istanbul ignore else */
+        if (newColor) {
+          this.#applyColor(this.#formatter(newColor));
+        }
+      });
+
+    // A programmatic reset (the `SkyColorpickerMessageType.Reset` message,
+    // sent either by a consumer or by the picker's own reset button).
+    // Reset always reverts to `initialColor`, the field's pristine value,
+    // so it's applied through `#applyIncomingValue` rather than
+    // `#applyColor`, which would otherwise mark the field dirty.
+    this.#colorpickerInputSvc.reset
+      .pipe(takeUntil(this.#ngUnsubscribe))
+      .subscribe((value) => {
+        this.#applyIncomingValue(value);
+      });
+
+    this.skyColorpickerInput.updatePickerValues(this.initialColor);
+    this.skyColorpickerInput.backgroundColorForDisplay = this.initialColor;
 
     /// Set aria-label as default, if not set
     if (!element.getAttribute('aria-label')) {
@@ -274,85 +358,156 @@ export class SkyColorpickerInputDirective
     this.setColorPickerDefaults();
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
-  public registerOnChange(): void {}
-
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
-  public registerOnTouched(): void {}
-
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
-  public registerOnValidatorChange(): void {}
-
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  public writeValue(value: any): void {
-    if (
-      this.skyColorpickerInput &&
-      value &&
-      value !== this.skyColorpickerInput.lastAppliedColor
-    ) {
-      const formattedValue = this.#formatter(value);
-
-      this.#modelValue = formattedValue;
-      this.#writeModelValue(formattedValue);
-
-      if (!this.#_initialColor) {
-        this.#_initialColor = value;
-        this.skyColorpickerInput.initialColor = value;
-      }
-      this.skyColorpickerInput.lastAppliedColor = value;
-
-      const control = this.#injector.get<NgControl>(NgControl, undefined, {
-        optional: true,
-      })?.control;
-
-      if (control) {
-        control.setValue(this.#modelValue, { emitEvent: false });
-      }
+  /**
+   * Applies a value that originated outside this directive (the bound
+   * field's initial value, a schema-driven reset, `initialColor`, a
+   * programmatic `SkyColorpickerMessageType.Reset` message, etc.). Unlike
+   * `#applyColor`, this does not call `value.set()`, since the value
+   * already came from there (or from a deprecated input that only seeds
+   * the field before it has a value), and `value.set()` always marks the
+   * field dirty, which an externally-driven value shouldn't do. For
+   * reactive/template-driven forms only, a string value is still
+   * normalized into the full `SkyColorpickerOutput` object by writing
+   * directly to the bound `NgControl`'s `AbstractControl` instead.
+   *
+   * Normalizes `value` and compares it against `#renderedValue` (the last
+   * value actually rendered, from any source) rather than a separate
+   * self-emitted-value tracker. This keeps the comparison correct even
+   * when this directive's own prior write comes back through `value`
+   * (skipped, since it's already rendered) or when a new incoming value
+   * happens to match one this directive previously emitted itself, but in
+   * a different format (still rendered, since `#renderedValue` reflects
+   * what's currently displayed, not what was last sent to the form).
+   */
+  #applyIncomingValue(value: SkyColorpickerOutput | string | undefined): void {
+    if (!this.skyColorpickerInput) {
+      return;
     }
-  }
 
-  public validate(): ValidationErrors | null {
-    return null;
+    if (!value) {
+      this.#clearRenderedValue();
+      return;
+    }
+
+    if (typeof value === 'string') {
+      if (value === this.#renderedValue) {
+        // Already showing exactly this string, most commonly this
+        // directive's own prior write (`#applyColor`) echoing back through
+        // `value`. Skip before formatting: re-parsing isn't needed, and
+        // could fail for a value the current `alphaChannel`/`outputFormat`
+        // settings can no longer parse (for example, a 6-digit hex string
+        // once `alphaChannel` is `hex8`, which only accepts 8 digits).
+        return;
+      }
+    } else if (value === this.#modelValue) {
+      // Already showing exactly this `SkyColorpickerOutput` object, most
+      // commonly this directive's own prior write (`#applyColor`) echoing
+      // back through `value`.
+      return;
+    }
+
+    const formattedValue = this.#formatter(value);
+    const output = this.#toOutputString(formattedValue);
+
+    if (output === this.#renderedValue) {
+      return;
+    }
+
+    this.#renderedValue = output;
+    this.#modelValue = formattedValue;
+    this.#writeModelValue(formattedValue);
+
+    // For reactive/template-driven forms, normalize the bound control's
+    // value to the full `SkyColorpickerOutput` object, restoring this
+    // directive's pre-signal-forms contract for those consumers. Written
+    // directly to the control (not `value.set()`) so it doesn't mark the
+    // field dirty; the control's own change detection then reflects the
+    // normalized object back into `value` for us. `[formField]` (signal
+    // forms) bindings also expose an `NgControl` (for interop with APIs
+    // that expect one), but it's a read-only compatibility shim with no
+    // `setValue`, so this only ever applies to real reactive/template-
+    // driven form controls.
+    const control = this.#ngControl?.control;
+    if (
+      control &&
+      typeof control.setValue === 'function' &&
+      control.value !== formattedValue
+    ) {
+      control.setValue(formattedValue, { emitEvent: false });
+    }
+
+    // The initial-color bookkeeping only deals in color strings, so a
+    // `SkyColorpickerOutput` incoming value uses its normalized output
+    // string here instead of the raw object.
+    const initialColorValue = typeof value === 'string' ? value : output;
+
+    if (!this.#_initialColor) {
+      this.#_initialColor = initialColorValue;
+      this.skyColorpickerInput.initialColor = initialColorValue;
+    }
+    this.skyColorpickerInput.lastAppliedColor = initialColorValue;
   }
 
   /**
-   * Implemented as part of ControlValueAccessor.
+   * Applies a color the user selected (through the native input or the
+   * picker dialog) and propagates it to `value`, so it reaches whatever form
+   * this directive is bound to.
    */
-  public setDisabledState(isDisabled: boolean): void {
-    this.#_disabled = isDisabled;
-    this.skyColorpickerInput.disabled = isDisabled;
-    if (this.#_disabled) {
-      this.skyColorpickerInput.backgroundColorForDisplay = '#fff';
-    } else if (this.#modelValue) {
-      this.skyColorpickerInput.backgroundColorForDisplay = this.#modelValue.hex;
+  #applyColor(formattedValue: SkyColorpickerOutput): void {
+    const output = this.#toOutputString(formattedValue);
+
+    this.#renderedValue = output;
+    this.#modelValue = formattedValue;
+    this.#writeModelValue(formattedValue);
+
+    this.value.set(formattedValue);
+  }
+
+  /**
+   * Clears the displayed color when the bound field's value is empty (for
+   * example, `model.set(undefined)` or `form.reset()` on a field with no
+   * value). Resets the input element, swatch, and dialog back to their
+   * pre-value state rather than leaving a stale color displayed.
+   */
+  #clearRenderedValue(): void {
+    if (this.#renderedValue === undefined) {
+      return;
     }
+
+    this.#renderedValue = undefined;
+    this.#modelValue = undefined;
+
+    const element = this.#elementRef.nativeElement;
+    this.#renderer.removeStyle(element, 'background-color');
+    this.#renderer.setProperty(element, 'value', '');
+
+    this.skyColorpickerInput.updatePickerValues(SKY_COLORPICKER_DEFAULT_COLOR);
+    this.skyColorpickerInput.backgroundColorForDisplay = undefined;
   }
 
   #writeModelValue(model: SkyColorpickerOutput): void {
     const setElementValue = model.rgbaText;
     const element = this.#elementRef.nativeElement;
-
-    let output: string;
-    switch (this.outputFormat) {
-      case 'hsla':
-        output = model.hslaText;
-        break;
-      case 'cmyk':
-        output = model.cmykText;
-        break;
-      case 'hex':
-        output = model.hex;
-        break;
-      default:
-        output = model.rgbaText;
-        break;
-    }
+    const output = this.#toOutputString(model);
 
     this.skyColorpickerInput.updatePickerValues(output);
     this.skyColorpickerInput.backgroundColorForDisplay = output;
 
     this.#renderer.setStyle(element, 'background-color', setElementValue);
     this.#renderer.setProperty(element, 'value', output);
+  }
+
+  #toOutputString(model: SkyColorpickerOutput): string {
+    switch (this.outputFormat) {
+      case 'hsla':
+        return model.hslaText;
+      case 'cmyk':
+        return model.cmykText;
+      case 'hex':
+        return model.hex;
+      default:
+        return model.rgbaText;
+    }
   }
 
   #formatter(

--- a/libs/components/colorpicker/src/lib/modules/colorpicker/colorpicker-input.directive.ts
+++ b/libs/components/colorpicker/src/lib/modules/colorpicker/colorpicker-input.directive.ts
@@ -26,21 +26,20 @@ import { SkyColorpickerOutput } from './types/colorpicker-output';
 
 const SKY_COLORPICKER_DEFAULT_COLOR = '#FFFFFF';
 
+// Implements `FormValueControl` (from `@angular/forms/signals`) instead of
+// `ControlValueAccessor`. Angular's signal-forms interop lets a
+// `FormValueControl` work with signal, reactive, and template-driven forms
+// without any CVA-specific code, so this directive no longer needs a
+// `NG_VALUE_ACCESSOR` provider.
+//
+// The host element is a native `<input>`, so Angular's built-in
+// `DefaultValueAccessor` still matches a `formControlName`/`formControl`/
+// `ngModel` binding there. The `ngNoCva` host attribute tells
+// `@angular/forms` to ignore that built-in accessor at runtime and use this
+// directive's custom-control (`value`/`valueChange`) interop instead, for
+// every form flavor.
 /**
  * Creates the colorpicker element and dropdown.
- *
- * Implements `FormValueControl` (from `@angular/forms/signals`) instead of
- * `ControlValueAccessor`. Angular's signal-forms interop lets a
- * `FormValueControl` work with signal, reactive, and template-driven forms
- * without any CVA-specific code, so this directive no longer needs a
- * `NG_VALUE_ACCESSOR` provider.
- *
- * The host element is a native `<input>`, so Angular's built-in
- * `DefaultValueAccessor` still matches a `formControlName`/`formControl`/
- * `ngModel` binding there. The `ngNoCva` host attribute tells
- * `@angular/forms` to ignore that built-in accessor at runtime and use this
- * directive's custom-control (`value`/`valueChange`) interop instead, for
- * every form flavor.
  */
 @Directive({
   selector: '[skyColorpickerInput]',
@@ -148,50 +147,53 @@ export class SkyColorpickerInputDirective
   @Input()
   public allowTransparency = true;
 
+  // Implemented as part of `FormValueControl`. Accepts either a color string
+  // or a `SkyColorpickerOutput` object as an incoming value (matching the
+  // loose contract the previous `ControlValueAccessor.writeValue(value: any)`
+  // accepted), but always emits a full `SkyColorpickerOutput` object back to
+  // the bound control when the user selects a color. This preserves the
+  // pre-existing contract where consumers read properties such as
+  // `value.hex` or `value.rgba.alpha` off the bound control's value.
   /**
-   * Implemented as part of `FormValueControl`. Accepts either a color string
-   * or a `SkyColorpickerOutput` object as an incoming value (matching the
-   * loose contract the previous `ControlValueAccessor.writeValue(value: any)`
-   * accepted), but always emits a full `SkyColorpickerOutput` object back to
-   * the bound `[formField]`, `formControl`/`formControlName`, or `ngModel`
-   * when the user selects a color. This preserves the pre-existing contract
-   * where consumers read properties such as `value.hex` or
-   * `value.rgba.alpha` off the bound control's value.
+   * The selected color, as a `SkyColorpickerOutput` object or a color string.
+   * @preview
    */
   public readonly value = model<SkyColorpickerOutput | string | undefined>(
     undefined,
   );
 
+  // Implemented as part of `FormUiControl`. Replaces the
+  // `ControlValueAccessor.setDisabledState` callback, which only reactive
+  // and template-driven forms called. Does not touch
+  // `backgroundColorForDisplay` — that's always driven by the current value
+  // (`#applyIncomingValue`/`#applyColor` → `#writeModelValue`), so the
+  // swatch keeps showing its real color, dimmed by
+  // `.sky-colorpicker-disabled`'s opacity, rather than being forced to a
+  // flat, theme-inconsistent white.
   /**
-   * Implemented as part of `FormUiControl`. Reflects the bound field's
-   * disabled state onto the colorpicker dialog. Replaces the
-   * `ControlValueAccessor.setDisabledState` callback, which only reactive and
-   * template-driven forms called. Does not touch `backgroundColorForDisplay`
-   * — that's always driven by the current value (`#applyIncomingValue`/
-   * `#applyColor` → `#writeModelValue`), so the swatch keeps showing its
-   * real color, dimmed by `.sky-colorpicker-disabled`'s opacity, rather than
-   * being forced to a flat, theme-inconsistent white.
+   * Whether the colorpicker is disabled.
+   * @preview
    */
   public readonly disabled = input(false);
 
+  // Implemented as part of `FormUiControl`. Emitted on native `blur`, and
+  // relayed from `SkyColorpickerComponent` when the user opens the picker
+  // dialog via the trigger button. `Field`/`NgControl` listen to this
+  // output to mark the bound field as touched, for every form flavor.
   /**
-   * Implemented as part of `FormUiControl`. Emitted on native `blur`, and
-   * relayed from `SkyColorpickerComponent` when the user opens the picker
-   * dialog via the trigger button. `Field`/`NgControl` listen to this output
-   * to mark the bound field as touched, for every form flavor.
+   * Emits when the colorpicker input is touched.
+   * @preview
    */
   public readonly touch = output<void>();
 
   #modelValue: SkyColorpickerOutput | undefined;
-  /**
-   * The normalized output string (per `outputFormat`) most recently rendered
-   * into the native input element and colorpicker dialog, regardless of
-   * whether it came from a user action (`#applyColor`) or from outside this
-   * directive (`#applyIncomingValue`). This is the single source of truth
-   * for whether an incoming value is actually a change, replacing the two
-   * separate (and easily desynced) trackers this directive used to keep:
-   * a self-emitted-value guard and `SkyColorpickerComponent.lastAppliedColor`.
-   */
+  // The normalized output string (per `outputFormat`) most recently rendered
+  // into the native input element and colorpicker dialog, regardless of
+  // whether it came from a user action (`#applyColor`) or from outside this
+  // directive (`#applyIncomingValue`). This is the single source of truth
+  // for whether an incoming value is actually a change, replacing the two
+  // separate (and easily desynced) trackers this directive used to keep:
+  // a self-emitted-value guard and `SkyColorpickerComponent.lastAppliedColor`.
   #renderedValue: string | undefined;
   readonly #elementRef = inject(ElementRef);
   readonly #renderer = inject(Renderer2);
@@ -202,17 +204,15 @@ export class SkyColorpickerInputDirective
 
   #_initialColor: string | undefined;
 
-  /**
-   * Only populated for reactive/template-driven form bindings
-   * (`formControlName`, `[formControl]`, `[ngModel]`) — `[formField]`
-   * (signal forms) bindings have no `NgControl`. Used solely to normalize
-   * a bound `AbstractControl`'s value into the full `SkyColorpickerOutput`
-   * object those pre-existing consumers already depend on
-   * (`control.value.hex`, `control.value.rgba.alpha`, etc.), matching this
-   * directive's previous `ControlValueAccessor`-based contract. Written to
-   * directly (bypassing `value.set()`), since `value.set()` always marks
-   * the field dirty, even for values that didn't originate from the user.
-   */
+  // Only populated for reactive/template-driven form bindings
+  // (`formControlName`, `[formControl]`, `[ngModel]`) — `[formField]`
+  // (signal forms) bindings have no `NgControl`. Used solely to normalize
+  // a bound `AbstractControl`'s value into the full `SkyColorpickerOutput`
+  // object those pre-existing consumers already depend on
+  // (`control.value.hex`, `control.value.rgba.alpha`, etc.), matching this
+  // directive's previous `ControlValueAccessor`-based contract. Written to
+  // directly (bypassing `value.set()`), since `value.set()` always marks
+  // the field dirty, even for values that didn't originate from the user.
   readonly #ngControl = inject(NgControl, { optional: true, self: true });
 
   readonly #colorpickerInputSvc = inject(SkyColorpickerInputService);
@@ -358,27 +358,21 @@ export class SkyColorpickerInputDirective
     this.setColorPickerDefaults();
   }
 
-  /**
-   * Applies a value that originated outside this directive (the bound
-   * field's initial value, a schema-driven reset, `initialColor`, a
-   * programmatic `SkyColorpickerMessageType.Reset` message, etc.). Unlike
-   * `#applyColor`, this does not call `value.set()`, since the value
-   * already came from there (or from a deprecated input that only seeds
-   * the field before it has a value), and `value.set()` always marks the
-   * field dirty, which an externally-driven value shouldn't do. For
-   * reactive/template-driven forms only, a string value is still
-   * normalized into the full `SkyColorpickerOutput` object by writing
-   * directly to the bound `NgControl`'s `AbstractControl` instead.
-   *
-   * Normalizes `value` and compares it against `#renderedValue` (the last
-   * value actually rendered, from any source) rather than a separate
-   * self-emitted-value tracker. This keeps the comparison correct even
-   * when this directive's own prior write comes back through `value`
-   * (skipped, since it's already rendered) or when a new incoming value
-   * happens to match one this directive previously emitted itself, but in
-   * a different format (still rendered, since `#renderedValue` reflects
-   * what's currently displayed, not what was last sent to the form).
-   */
+  // Applies a value that originated outside this directive (the bound
+  // field's initial value, a schema-driven reset, `initialColor`, a
+  // programmatic `SkyColorpickerMessageType.Reset` message, etc.). Unlike
+  // `#applyColor`, this does not call `value.set()`, since the value
+  // already came from there (or from a deprecated input that only seeds
+  // the field before it has a value), and `value.set()` always marks the
+  // field dirty, which an externally-driven value shouldn't do. For
+  // reactive/template-driven forms only, a string value is still
+  // normalized into the full `SkyColorpickerOutput` object by writing
+  // directly to the bound `NgControl`'s `AbstractControl` instead.
+  //
+  // Compares the normalized value against `#renderedValue` (the last value
+  // actually rendered, from any source) rather than a separate
+  // self-emitted-value tracker, so this can't loop on the directive's own
+  // writes but still re-renders any value that isn't already showing.
   #applyIncomingValue(value: SkyColorpickerOutput | string | undefined): void {
     if (!this.skyColorpickerInput) {
       return;
@@ -448,11 +442,9 @@ export class SkyColorpickerInputDirective
     this.skyColorpickerInput.lastAppliedColor = initialColorValue;
   }
 
-  /**
-   * Applies a color the user selected (through the native input or the
-   * picker dialog) and propagates it to `value`, so it reaches whatever form
-   * this directive is bound to.
-   */
+  // Applies a color the user selected (through the native input or the
+  // picker dialog) and propagates it to `value`, so it reaches whatever
+  // form this directive is bound to.
   #applyColor(formattedValue: SkyColorpickerOutput): void {
     const output = this.#toOutputString(formattedValue);
 
@@ -463,12 +455,10 @@ export class SkyColorpickerInputDirective
     this.value.set(formattedValue);
   }
 
-  /**
-   * Clears the displayed color when the bound field's value is empty (for
-   * example, `model.set(undefined)` or `form.reset()` on a field with no
-   * value). Resets the input element, swatch, and dialog back to their
-   * pre-value state rather than leaving a stale color displayed.
-   */
+  // Clears the displayed color when the bound field's value is empty (for
+  // example, `model.set(undefined)` or `form.reset()` on a field with no
+  // value). Resets the input element, swatch, and dialog back to their
+  // pre-value state rather than leaving a stale color displayed.
   #clearRenderedValue(): void {
     if (this.#renderedValue === undefined) {
       return;

--- a/libs/components/colorpicker/src/lib/modules/colorpicker/colorpicker-input.directive.ts
+++ b/libs/components/colorpicker/src/lib/modules/colorpicker/colorpicker-input.directive.ts
@@ -9,8 +9,6 @@ import {
   Renderer2,
   forwardRef,
   inject,
-  model,
-  output,
 } from '@angular/core';
 import {
   ControlValueAccessor,
@@ -20,8 +18,7 @@ import {
   ValidationErrors,
   Validator,
 } from '@angular/forms';
-import type { FormValueControl } from '@angular/forms/signals';
-import { SkyRequiredStateDirective } from '@skyux/forms';
+import { SkyRequiredStateDirective, skyIsAbstractControl } from '@skyux/forms';
 import { SkyLibResourcesService } from '@skyux/i18n';
 
 import { Subject, Subscription, distinctUntilChanged, takeUntil } from 'rxjs';
@@ -45,17 +42,15 @@ const SKY_COLORPICKER_VALIDATOR = {
 
 const SKY_COLORPICKER_DEFAULT_COLOR = '#FFFFFF';
 
-// Implements both `ControlValueAccessor` (classic reactive/template-driven
-// forms) and `FormValueControl` (from `@angular/forms/signals`). Angular
-// prefers a directive's own `NG_VALUE_ACCESSOR` over the native
-// `DefaultValueAccessor` that would otherwise match this host `<input>`, so
-// `formControlName`/`formControl`/`ngModel` keep working through the CVA
-// methods below. `@angular/forms/signals`' `Field` directive also checks for
-// a `ControlValueAccessor` first and, when present, bridges it to the field
-// automatically — so the `value`/`touch` members exist mainly to satisfy the
-// `FormValueControl` contract's typing for `Field` consumers; the actual
-// sync for every form flavor (including `disabled`, via `setDisabledState`)
-// happens through the CVA methods.
+// Implements `ControlValueAccessor` only (classic reactive/template-driven
+// forms). Angular prefers a directive's own `NG_VALUE_ACCESSOR` over the
+// native `DefaultValueAccessor` that would otherwise match this host
+// `<input>`, so `formControlName`/`formControl`/`ngModel` keep working
+// through the CVA methods below. `@angular/forms/signals`' `Field` directive
+// also checks for a `ControlValueAccessor` first and, when present, bridges
+// it to the field automatically — so sync for every form flavor (including
+// `disabled`, via `setDisabledState`) happens through the CVA methods below,
+// with no need for a separate `FormValueControl` implementation.
 /**
  * Creates the colorpicker element and dropdown.
  */
@@ -77,13 +72,7 @@ const SKY_COLORPICKER_DEFAULT_COLOR = '#FFFFFF';
   },
 })
 export class SkyColorpickerInputDirective
-  implements
-    FormValueControl<SkyColorpickerOutput | string | undefined>,
-    ControlValueAccessor,
-    Validator,
-    OnInit,
-    OnChanges,
-    OnDestroy
+  implements ControlValueAccessor, Validator, OnInit, OnChanges, OnDestroy
 {
   /**
    * Creates the colorpicker element and dropdown. Place this attribute on an `input` element
@@ -167,31 +156,6 @@ export class SkyColorpickerInputDirective
   @Input()
   public allowTransparency = true;
 
-  // Implemented as part of `FormValueControl`. Accepts either a color string
-  // or a `SkyColorpickerOutput` object as an incoming value (matching the
-  // loose contract the previous `ControlValueAccessor.writeValue(value: any)`
-  // accepted), but always emits a full `SkyColorpickerOutput` object back to
-  // the bound control when the user selects a color. This preserves the
-  // pre-existing contract where consumers read properties such as
-  // `value.hex` or `value.rgba.alpha` off the bound control's value.
-  /**
-   * The selected color, as a `SkyColorpickerOutput` object or a color string.
-   * @preview
-   */
-  public readonly value = model<SkyColorpickerOutput | string | undefined>(
-    undefined,
-  );
-
-  // Implemented as part of `FormUiControl`. Emitted on native `blur`, and
-  // relayed from `SkyColorpickerComponent` when the user opens the picker
-  // dialog via the trigger button. `Field`/`NgControl` listen to this
-  // output to mark the bound field as touched, for every form flavor.
-  /**
-   * Emits when the colorpicker input is touched.
-   * @preview
-   */
-  public readonly touch = output<void>();
-
   #modelValue: SkyColorpickerOutput | undefined;
   // The normalized output string (per `outputFormat`) most recently rendered
   // into the native input element and colorpicker dialog, regardless of
@@ -215,15 +179,18 @@ export class SkyColorpickerInputDirective
   // injecting `NgControl` here would create a circular dependency for
   // `[formField]` (signal forms) bindings, whose `NgControl` compatibility
   // shim itself depends on resolving this directive's value accessor
-  // first. Only populated for reactive/template-driven form bindings
-  // (`formControlName`, `[formControl]`, `[ngModel]`) — `[formField]`
-  // bindings have no `NgControl`. Used solely to normalize a bound
-  // `AbstractControl`'s value into the full `SkyColorpickerOutput` object
-  // those pre-existing consumers already depend on (`control.value.hex`,
+  // first. `[formField]` bindings do provide an `NgControl` (a read-only
+  // interop shim, `InteropNgControl`, with no `setValue`), so
+  // `skyIsAbstractControl` guards every use of `#ngControl.control` below.
+  // The `AbstractControl` normalization this getter enables only actually
+  // applies to reactive/template-driven form bindings (`formControlName`,
+  // `[formControl]`, `[ngModel]`): normalizing a bound `AbstractControl`'s
+  // value into the full `SkyColorpickerOutput` object those pre-existing
+  // consumers already depend on (`control.value.hex`,
   // `control.value.rgba.alpha`, etc.), matching this directive's previous
   // `ControlValueAccessor`-based contract. Written to directly (bypassing
-  // `value.set()`), since `value.set()` always marks the field dirty, even
-  // for values that didn't originate from the user.
+  // `onChange`), since calling `onChange` under signal forms always marks
+  // the field dirty, even for values that didn't originate from the user.
   readonly #injector = inject(Injector);
   get #ngControl(): NgControl | null {
     return this.#injector.get(NgControl, null, { optional: true, self: true });
@@ -234,9 +201,8 @@ export class SkyColorpickerInputDirective
 
   // Populated by `registerOnChange`/`registerOnTouched` for
   // `formControlName`/`[formControl]`/`[ngModel]` consumers. `@angular/forms/
-  // signals`' `Field` directive registers these too when it detects this
-  // `ControlValueAccessor`, so they cover every form flavor alongside the
-  // `value`/`touch` members above.
+  // signals`' `FormField` directive registers these too when it detects this
+  // `ControlValueAccessor`, so they cover every form flavor.
   #onChange: ((value: SkyColorpickerOutput) => void) | undefined;
   #onTouched: (() => void) | undefined;
 
@@ -293,7 +259,6 @@ export class SkyColorpickerInputDirective
   }
 
   #markTouched(): void {
-    this.touch.emit();
     this.#onTouched?.();
   }
 
@@ -346,8 +311,8 @@ export class SkyColorpickerInputDirective
 
     // A color the user applied through the picker dialog's Apply button.
     // This is a user-driven change, so it's written through to the bound
-    // field via `#applyColor` (which calls `value.set()` and marks the
-    // field dirty).
+    // field via `#applyColor` (which calls `onChange` and marks the field
+    // dirty).
     this.#colorpickerInputSvc.colorApplied
       .pipe(takeUntil(this.#ngUnsubscribe))
       .subscribe((newColor) => {
@@ -411,13 +376,14 @@ export class SkyColorpickerInputDirective
   // Applies a value that originated outside this directive (the bound
   // field's initial value, a schema-driven reset, `initialColor`, a
   // programmatic `SkyColorpickerMessageType.Reset` message, etc.). Unlike
-  // `#applyColor`, this does not call `value.set()`, since the value
-  // already came from there (or from a deprecated input that only seeds
-  // the field before it has a value), and `value.set()` always marks the
-  // field dirty, which an externally-driven value shouldn't do. For
-  // reactive/template-driven forms only, a string value is still
-  // normalized into the full `SkyColorpickerOutput` object by writing
-  // directly to the bound `NgControl`'s `AbstractControl` instead.
+  // `#applyColor`, this does not call `onChange`, since under signal forms
+  // that always marks the field dirty — which an externally-driven value
+  // shouldn't do. For reactive/template-driven forms only, a string value
+  // is still normalized into the full `SkyColorpickerOutput` object by
+  // writing directly to the bound `NgControl`'s `AbstractControl` instead;
+  // a signal-forms field bound to a string keeps that raw string until the
+  // user selects a color, at which point `#applyColor` writes the full
+  // object back through `onChange`.
   //
   // Compares the normalized value against `#renderedValue` (the last value
   // actually rendered, from any source) rather than a separate
@@ -464,19 +430,14 @@ export class SkyColorpickerInputDirective
     // For reactive/template-driven forms, normalize the bound control's
     // value to the full `SkyColorpickerOutput` object, restoring this
     // directive's pre-signal-forms contract for those consumers. Written
-    // directly to the control (not `value.set()`) so it doesn't mark the
-    // field dirty; the control's own change detection then reflects the
-    // normalized object back into `value` for us. `[formField]` (signal
-    // forms) bindings also expose an `NgControl` (for interop with APIs
-    // that expect one), but it's a read-only compatibility shim with no
-    // `setValue`, so this only ever applies to real reactive/template-
-    // driven form controls.
+    // directly to the control (not through `onChange`) so it doesn't mark
+    // the field dirty; the control's own change detection then reflects the
+    // normalized object back for us. `[formField]` (signal forms) bindings
+    // also expose an `NgControl` (for interop with APIs that expect one),
+    // but it's a read-only compatibility shim with no `setValue`, so this
+    // only ever applies to real reactive/template-driven form controls.
     const control = this.#ngControl?.control;
-    if (
-      control &&
-      typeof control.setValue === 'function' &&
-      control.value !== formattedValue
-    ) {
+    if (skyIsAbstractControl(control) && control.value !== formattedValue) {
       control.setValue(formattedValue, { emitEvent: false });
     }
 
@@ -493,10 +454,10 @@ export class SkyColorpickerInputDirective
   }
 
   // Applies a color the user selected (through the native input or the
-  // picker dialog) and propagates it to `value` and, for
-  // `formControlName`/`[formControl]`/`[ngModel]` consumers, the registered
-  // `onChange` callback — so it reaches whatever form this directive is
-  // bound to.
+  // picker dialog) and propagates it, via the registered `onChange`
+  // callback, to whatever form this directive is bound to (reactive,
+  // template-driven, or signal forms, all of which register `onChange`
+  // through this CVA).
   #applyColor(formattedValue: SkyColorpickerOutput): void {
     const output = this.#toOutputString(formattedValue);
 
@@ -504,7 +465,6 @@ export class SkyColorpickerInputDirective
     this.#modelValue = formattedValue;
     this.#writeModelValue(formattedValue);
 
-    this.value.set(formattedValue);
     this.#onChange?.(formattedValue);
   }
 

--- a/libs/components/colorpicker/src/lib/modules/colorpicker/colorpicker-input.service.ts
+++ b/libs/components/colorpicker/src/lib/modules/colorpicker/colorpicker-input.service.ts
@@ -14,32 +14,26 @@ export class SkyColorpickerInputService implements OnDestroy {
   public ariaError = new ReplaySubject<{ hasError: boolean; errorId: string }>(
     1,
   );
-  /**
-   * Relays a touch signal from `SkyColorpickerComponent` (for example, when
-   * the trigger button opens the picker dialog) to the bound
-   * `SkyColorpickerInputDirective`, which re-emits it through its own `touch`
-   * output. `Field`/`NgControl` listen to that output to mark the field
-   * touched, so this works the same way across signal, reactive, and
-   * template-driven forms.
-   */
+  // Relays a touch signal from `SkyColorpickerComponent` (for example, when
+  // the trigger button opens the picker dialog) to the bound
+  // `SkyColorpickerInputDirective`, which re-emits it through its own
+  // `touch` output, so touch handling works the same across all form
+  // flavors.
   public touch = new Subject<void>();
 
-  /**
-   * Relays a color the user applied through the picker dialog's **Apply**
-   * button to the bound `SkyColorpickerInputDirective`. The directive treats
-   * this as a user-driven change: it writes the color through to the bound
-   * field via `value.set()`, which marks the field dirty. Contrast with
-   * `reset`, which reverts the display without touching the field.
-   */
+  // Relays a color the user applied through the picker dialog's **Apply**
+  // button to the bound `SkyColorpickerInputDirective`. The directive
+  // treats this as a user-driven change: it writes the color through to
+  // the bound field via `value.set()`, which marks the field dirty.
+  // Contrast with `reset`, which reverts the display without touching the
+  // field.
   public colorApplied = new Subject<SkyColorpickerOutput>();
 
-  /**
-   * Relays a programmatic reset (the `SkyColorpickerMessageType.Reset`
-   * message) to the bound `SkyColorpickerInputDirective`. The directive
-   * re-renders the display to match `initialColor` without calling
-   * `value.set()`, so a reset triggered by a consumer (rather than the
-   * reset button, which is a user action) doesn't mark the field dirty.
-   */
+  // Relays a programmatic reset (the `SkyColorpickerMessageType.Reset`
+  // message) to the bound `SkyColorpickerInputDirective`. The directive
+  // re-renders the display to match `initialColor` without calling
+  // `value.set()`, so a reset triggered by a consumer (rather than the
+  // reset button, which is a user action) doesn't mark the field dirty.
   public reset = new Subject<string | undefined>();
 
   public ngOnDestroy(): void {

--- a/libs/components/colorpicker/src/lib/modules/colorpicker/colorpicker-input.service.ts
+++ b/libs/components/colorpicker/src/lib/modules/colorpicker/colorpicker-input.service.ts
@@ -16,24 +16,24 @@ export class SkyColorpickerInputService implements OnDestroy {
   );
   // Relays a touch signal from `SkyColorpickerComponent` (for example, when
   // the trigger button opens the picker dialog) to the bound
-  // `SkyColorpickerInputDirective`, which re-emits it through its own
-  // `touch` output, so touch handling works the same across all form
+  // `SkyColorpickerInputDirective`, which relays it to the registered
+  // `onTouched` callback, so touch handling works the same across all form
   // flavors.
   public touch = new Subject<void>();
 
   // Relays a color the user applied through the picker dialog's **Apply**
   // button to the bound `SkyColorpickerInputDirective`. The directive
   // treats this as a user-driven change: it writes the color through to
-  // the bound field via `value.set()`, which marks the field dirty.
-  // Contrast with `reset`, which reverts the display without touching the
-  // field.
+  // the bound field via the registered `onChange` callback, which marks
+  // the field dirty. Contrast with `reset`, which reverts the display
+  // without touching the field.
   public colorApplied = new Subject<SkyColorpickerOutput>();
 
   // Relays a programmatic reset (the `SkyColorpickerMessageType.Reset`
   // message) to the bound `SkyColorpickerInputDirective`. The directive
   // re-renders the display to match `initialColor` without calling
-  // `value.set()`, so a reset triggered by a consumer (rather than the
-  // reset button, which is a user action) doesn't mark the field dirty.
+  // `onChange`, so a reset triggered by a consumer (rather than the reset
+  // button, which is a user action) doesn't mark the field dirty.
   public reset = new Subject<string | undefined>();
 
   public ngOnDestroy(): void {

--- a/libs/components/colorpicker/src/lib/modules/colorpicker/colorpicker-input.service.ts
+++ b/libs/components/colorpicker/src/lib/modules/colorpicker/colorpicker-input.service.ts
@@ -1,6 +1,8 @@
 import { Injectable, OnDestroy } from '@angular/core';
 
-import { ReplaySubject } from 'rxjs';
+import { ReplaySubject, Subject } from 'rxjs';
+
+import { SkyColorpickerOutput } from './types/colorpicker-output';
 
 /**
  * @internal
@@ -12,10 +14,40 @@ export class SkyColorpickerInputService implements OnDestroy {
   public ariaError = new ReplaySubject<{ hasError: boolean; errorId: string }>(
     1,
   );
+  /**
+   * Relays a touch signal from `SkyColorpickerComponent` (for example, when
+   * the trigger button opens the picker dialog) to the bound
+   * `SkyColorpickerInputDirective`, which re-emits it through its own `touch`
+   * output. `Field`/`NgControl` listen to that output to mark the field
+   * touched, so this works the same way across signal, reactive, and
+   * template-driven forms.
+   */
+  public touch = new Subject<void>();
+
+  /**
+   * Relays a color the user applied through the picker dialog's **Apply**
+   * button to the bound `SkyColorpickerInputDirective`. The directive treats
+   * this as a user-driven change: it writes the color through to the bound
+   * field via `value.set()`, which marks the field dirty. Contrast with
+   * `reset`, which reverts the display without touching the field.
+   */
+  public colorApplied = new Subject<SkyColorpickerOutput>();
+
+  /**
+   * Relays a programmatic reset (the `SkyColorpickerMessageType.Reset`
+   * message) to the bound `SkyColorpickerInputDirective`. The directive
+   * re-renders the display to match `initialColor` without calling
+   * `value.set()`, so a reset triggered by a consumer (rather than the
+   * reset button, which is a user action) doesn't mark the field dirty.
+   */
+  public reset = new Subject<string | undefined>();
 
   public ngOnDestroy(): void {
     this.inputId.complete();
     this.labelText.complete();
     this.ariaError.complete();
+    this.touch.complete();
+    this.colorApplied.complete();
+    this.reset.complete();
   }
 }

--- a/libs/components/colorpicker/src/lib/modules/colorpicker/colorpicker.component.html
+++ b/libs/components/colorpicker/src/lib/modules/colorpicker/colorpicker.component.html
@@ -54,7 +54,7 @@
     [disabled]="disabled"
     [class.sky-colorpicker-button-disabled]="disabled"
     [class.sky-colorpicker-error]="
-      (ngControl?.touched || ngControl?.dirty) && ngControl?.errors
+      (ngControl?.touched || ngControl?.dirty) && !!ngControl?.errors
     "
     [style.background-color]="backgroundColorForDisplay"
     (click)="onTriggerButtonClick()"

--- a/libs/components/colorpicker/src/lib/modules/colorpicker/colorpicker.component.spec.ts
+++ b/libs/components/colorpicker/src/lib/modules/colorpicker/colorpicker.component.spec.ts
@@ -1516,6 +1516,29 @@ describe('Colorpicker Component', () => {
       expect(component.colorForm.get('colorModel')?.value.hex).toBe('#2b7230');
     }));
 
+    it('should normalize the reactive form control value even when the incoming value already matches the rendered display', fakeAsync(() => {
+      component.selectedOutputFormat = 'hex';
+      fixture.detectChanges();
+      tick();
+
+      component.colorControl.setValue('#0000ff');
+      fixture.detectChanges();
+      tick();
+
+      const renderedHex = component.colorControl.value.hex;
+      expect(renderedHex).toBeTruthy();
+
+      // Writes the exact string the control is already displaying (as
+      // could happen after `form.reset({ value: renderedHex })`), which
+      // takes the directive's early-return path that skips re-rendering.
+      component.colorControl.setValue(renderedHex);
+      fixture.detectChanges();
+      tick();
+
+      expect(component.colorControl.value.hex).toBe(renderedHex);
+      expect(component.colorControl.value.rgba.alpha).toBe(1);
+    }));
+
     it('should reset colorpicker via reset button.', fakeAsync(async () => {
       fixture.detectChanges();
       const spyOnResetColorPicker = spyOn(

--- a/libs/components/colorpicker/src/lib/modules/colorpicker/colorpicker.component.spec.ts
+++ b/libs/components/colorpicker/src/lib/modules/colorpicker/colorpicker.component.spec.ts
@@ -1,4 +1,4 @@
-import { DebugElement } from '@angular/core';
+import { Component, DebugElement, signal } from '@angular/core';
 import {
   ComponentFixture,
   TestBed,
@@ -6,6 +6,7 @@ import {
   flush,
   tick,
 } from '@angular/core/testing';
+import { FormField, disabled, form } from '@angular/forms/signals';
 import { By } from '@angular/platform-browser';
 import { SkyAppTestUtility, expect, expectAsync } from '@skyux-sdk/testing';
 import { SkyAffixer, SkyIdService, SkyOverlayService } from '@skyux/core';
@@ -18,15 +19,17 @@ import {
   SkyThemeSettingsChange,
 } from '@skyux/theme';
 
-import { BehaviorSubject } from 'rxjs';
+import { BehaviorSubject, Subject } from 'rxjs';
 import { sampleTime } from 'rxjs/operators';
 
 import { SkyColorpickerInputDirective } from './colorpicker-input.directive';
 import { SkyColorpickerComponent } from './colorpicker.component';
+import { SkyColorpickerModule } from './colorpicker.module';
 import { ColorpickerTestComponent } from './fixtures/colorpicker-component.fixture';
 import { SkyColorpickerFixturesModule } from './fixtures/colorpicker-fixtures.module';
 import { ColorpickerReactiveTestComponent } from './fixtures/colorpicker-reactive-component.fixture';
 import { SkyColorpickerMessageType } from './types/colorpicker-message-type';
+import { SkyColorpickerOutput } from './types/colorpicker-output';
 
 interface ColorpickerInputElements {
   hex: HTMLInputElement;
@@ -361,34 +364,18 @@ describe('Colorpicker Component', () => {
       component.colorModel = '#00f';
       fixture.detectChanges();
       tick();
+      fixture.detectChanges();
       expect(component.colorpickerComponent.initialColor).toBe('#00f');
-      expect(component.colorpickerComponent.lastAppliedColor as any).toEqual({
-        cmykText: 'cmyk(100%,100%,0%,0%)',
-        hslaText: 'hsla(240,100%,50%,1)',
-        rgbaText: 'rgba(0,0,255,1)',
-        hsva: { hue: 240, saturation: 100, value: 100, alpha: 1 },
-        rgba: { red: 0, green: 0, blue: 255, alpha: 1 },
-        hsla: { hue: 240, saturation: 100, lightness: 50, alpha: 1 },
-        cmyk: { cyan: 100, magenta: 100, yellow: 0, key: 0 },
-        hex: '#00f',
-      });
+      expect(component.colorpickerComponent.lastAppliedColor).toEqual('#00f');
     }));
 
     it('should populate correct information if model is given but an initial color is also given', fakeAsync(() => {
       component.colorModel = '#00f';
       fixture.detectChanges();
       tick();
+      fixture.detectChanges();
       expect(component.colorpickerComponent.initialColor).toBe('#2889e5');
-      expect(component.colorpickerComponent.lastAppliedColor as any).toEqual({
-        cmykText: 'cmyk(100%,100%,0%,0%)',
-        hslaText: 'hsla(240,100%,50%,1)',
-        rgbaText: 'rgba(0,0,255,1)',
-        hsva: { hue: 240, saturation: 100, value: 100, alpha: 1 },
-        rgba: { red: 0, green: 0, blue: 255, alpha: 1 },
-        hsla: { hue: 240, saturation: 100, lightness: 50, alpha: 1 },
-        cmyk: { cyan: 100, magenta: 100, yellow: 0, key: 0 },
-        hex: '#00f',
-      });
+      expect(component.colorpickerComponent.lastAppliedColor).toEqual('#00f');
     }));
 
     it('should add aria-label and title attributes to button if not specified', fakeAsync(() => {
@@ -1339,6 +1326,79 @@ describe('Colorpicker Component', () => {
       expect(outermostDiv).not.toHaveCssClass('sky-colorpicker-disabled');
     });
 
+    it('should keep displaying the bound color on the swatch and icon when disabled', async () => {
+      component.pickerButtonIcon = 'color-line';
+      component.colorModel = '#000000';
+
+      fixture.detectChanges();
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      fixture.componentRef.setInput('disabled', true);
+
+      fixture.detectChanges();
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      expect(getColorpickerButtonBackgroundColor(nativeElement)).toBe(
+        'rgb(0, 0, 0)',
+      );
+      expect(getColorpickerIcon()?.style.color).toBe('rgb(255, 255, 255)');
+    });
+
+    it('should restore the bound color after a disable/enable round trip', async () => {
+      component.colorModel = '#000000';
+
+      fixture.detectChanges();
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      fixture.componentRef.setInput('disabled', true);
+      fixture.detectChanges();
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      expect(getColorpickerButtonBackgroundColor(nativeElement)).toBe(
+        'rgb(0, 0, 0)',
+      );
+
+      fixture.componentRef.setInput('disabled', false);
+      fixture.detectChanges();
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      expect(getColorpickerButtonBackgroundColor(nativeElement)).toBe(
+        'rgb(0, 0, 0)',
+      );
+    });
+
+    it('should retain alpha in the rgba output format across a disable/enable cycle', fakeAsync(async () => {
+      openColorpicker(nativeElement);
+      await setInputElementValue(nativeElement, 'red', '163');
+      await setInputElementValue(nativeElement, 'green', '19');
+      await setInputElementValue(nativeElement, 'blue', '84');
+      await setInputElementValue(nativeElement, 'alpha', '0.3');
+      applyColorpicker();
+
+      const appliedBackgroundColor =
+        getColorpickerButtonBackgroundColor(nativeElement);
+      expect(appliedBackgroundColor).toBe('rgba(163, 19, 84, 0.3)');
+
+      fixture.componentRef.setInput('disabled', true);
+      fixture.detectChanges();
+      tick();
+      fixture.detectChanges();
+
+      fixture.componentRef.setInput('disabled', false);
+      fixture.detectChanges();
+      tick();
+      fixture.detectChanges();
+
+      expect(getColorpickerButtonBackgroundColor(nativeElement)).toBe(
+        appliedBackgroundColor,
+      );
+    }));
+
     it('should apply the selected color when Enter is pressed', fakeAsync(async () => {
       component.selectedOutputFormat = 'hex';
       fixture.detectChanges();
@@ -1805,6 +1865,153 @@ describe('Colorpicker Component', () => {
       const colorpickerContainer = getColorpickerContainer();
 
       await expectAsync(colorpickerContainer).toBeAccessible(axeConfig);
+    });
+  });
+
+  describe('signal forms', () => {
+    @Component({
+      standalone: true,
+      imports: [FormField, SkyColorpickerModule],
+      template: `<sky-colorpicker
+        #colorPickerTest
+        labelText="Color"
+        [messageStream]="messageStream"
+      >
+        <input
+          type="text"
+          [skyColorpickerInput]="colorPickerTest"
+          [formField]="colorForm"
+        />
+      </sky-colorpicker>`,
+    })
+    class ColorpickerSignalFormFixtureComponent {
+      public readonly model = signal<SkyColorpickerOutput | string | undefined>(
+        undefined,
+      );
+      public readonly isDisabled = signal(false);
+      public readonly colorForm = form(this.model, (path) => {
+        disabled(path, { when: () => this.isDisabled() });
+      });
+      public readonly messageStream = new Subject<{
+        type: SkyColorpickerMessageType;
+      }>();
+    }
+
+    let fixture: ComponentFixture<ColorpickerSignalFormFixtureComponent>;
+    let testComponent: ColorpickerSignalFormFixtureComponent;
+    let inputEl: HTMLInputElement;
+
+    beforeEach(() => {
+      TestBed.configureTestingModule({
+        imports: [ColorpickerSignalFormFixtureComponent],
+      });
+
+      fixture = TestBed.createComponent(ColorpickerSignalFormFixtureComponent);
+      testComponent = fixture.componentInstance;
+      fixture.detectChanges();
+
+      inputEl = fixture.nativeElement.querySelector('input');
+    });
+
+    it('should not throw when a value is written into the model', () => {
+      expect(() => {
+        testComponent.model.set('#ff0000');
+        fixture.detectChanges();
+      }).not.toThrow();
+
+      expect(inputEl.value).toBe('rgba(255,0,0,1)');
+    });
+
+    it('should accept a `SkyColorpickerOutput` object as the field value, matching the pre-signal-forms contract', () => {
+      const output: SkyColorpickerOutput = {
+        hslaText: 'hsla(0,100%,50%,1)',
+        rgbaText: 'rgba(255,0,0,1)',
+        cmykText: 'cmyk(0%,100%,100%,0%)',
+        hsva: { hue: 0, saturation: 100, value: 100, alpha: 1 },
+        rgba: { red: 255, green: 0, blue: 0, alpha: 1 },
+        hsla: { hue: 0, saturation: 100, lightness: 50, alpha: 1 },
+        cmyk: { cyan: 0, magenta: 100, yellow: 100, key: 0 },
+        hex: '#f00',
+      };
+
+      testComponent.model.set(output);
+      fixture.detectChanges();
+
+      expect(inputEl.value).toBe('rgba(255,0,0,1)');
+    });
+
+    it('should mark the field dirty and touched when the user applies a color change', () => {
+      inputEl.value = '#00ff00';
+      inputEl.dispatchEvent(new Event('change'));
+      fixture.detectChanges();
+
+      expect(testComponent.colorForm().dirty()).toBeTrue();
+
+      inputEl.dispatchEvent(new Event('blur'));
+      fixture.detectChanges();
+
+      expect(testComponent.colorForm().touched()).toBeTrue();
+    });
+
+    it('should disable the colorpicker trigger button when the field is disabled', () => {
+      testComponent.isDisabled.set(true);
+      fixture.detectChanges();
+
+      const triggerButton = fixture.nativeElement.querySelector(
+        '.sky-colorpicker-button',
+      ) as HTMLButtonElement;
+
+      expect(triggerButton.disabled).toBeTrue();
+    });
+
+    it('should re-apply a field value that matches a color the user previously applied in a different format', () => {
+      // User applies green through the native input (rgba format).
+      inputEl.value = '#00ff00';
+      inputEl.dispatchEvent(new Event('change'));
+      fixture.detectChanges();
+
+      expect(inputEl.value).toBe('rgba(0,255,0,1)');
+
+      // The field is set to a different color.
+      testComponent.model.set('#0000ff');
+      fixture.detectChanges();
+
+      expect(inputEl.value).toBe('rgba(0,0,255,1)');
+
+      // The field is set back to green, but in hex format (the format the
+      // user's edit didn't originally use). Without a fix, this would be
+      // silently dropped because the directive only guarded against its
+      // own previously emitted value in the same format.
+      testComponent.model.set('#00ff00');
+      fixture.detectChanges();
+
+      expect(inputEl.value).toBe('rgba(0,255,0,1)');
+    });
+
+    it('should clear the displayed color when the field value is cleared', () => {
+      testComponent.model.set('#00ff00');
+      fixture.detectChanges();
+
+      expect(inputEl.value).toBe('rgba(0,255,0,1)');
+
+      testComponent.model.set(undefined);
+      fixture.detectChanges();
+
+      expect(inputEl.value).toBe('');
+    });
+
+    it('should not mark a pristine field dirty when a Reset message is sent', () => {
+      testComponent.model.set('#00ff00');
+      fixture.detectChanges();
+
+      expect(testComponent.colorForm().dirty()).toBeFalse();
+
+      testComponent.messageStream.next({
+        type: SkyColorpickerMessageType.Reset,
+      });
+      fixture.detectChanges();
+
+      expect(testComponent.colorForm().dirty()).toBeFalse();
     });
   });
 });

--- a/libs/components/colorpicker/src/lib/modules/colorpicker/colorpicker.component.spec.ts
+++ b/libs/components/colorpicker/src/lib/modules/colorpicker/colorpicker.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component, DebugElement, signal } from '@angular/core';
+import { Component, DebugElement, ViewChild, signal } from '@angular/core';
 import {
   ComponentFixture,
   TestBed,
@@ -6,6 +6,7 @@ import {
   flush,
   tick,
 } from '@angular/core/testing';
+import { FormsModule, NgModel } from '@angular/forms';
 import { FormField, disabled, form } from '@angular/forms/signals';
 import { By } from '@angular/platform-browser';
 import { SkyAppTestUtility, expect, expectAsync } from '@skyux-sdk/testing';
@@ -2013,5 +2014,79 @@ describe('Colorpicker Component', () => {
 
       expect(testComponent.colorForm().dirty()).toBeFalse();
     });
+  });
+
+  describe('template-driven forms', () => {
+    @Component({
+      standalone: true,
+      imports: [FormsModule, SkyColorpickerModule],
+      template: `<sky-colorpicker #colorPickerTest labelText="Color">
+        <input
+          #ngModelRef="ngModel"
+          type="text"
+          [skyColorpickerInput]="colorPickerTest"
+          [ngModelOptions]="{ standalone: true }"
+          [(ngModel)]="model"
+        />
+      </sky-colorpicker>`,
+    })
+    class ColorpickerNgModelFixtureComponent {
+      public model: SkyColorpickerOutput | string | undefined;
+      @ViewChild('ngModelRef')
+      public ngModelRef!: NgModel;
+    }
+
+    let fixture: ComponentFixture<ColorpickerNgModelFixtureComponent>;
+    let testComponent: ColorpickerNgModelFixtureComponent;
+    let inputEl: HTMLInputElement;
+
+    beforeEach(() => {
+      TestBed.configureTestingModule({
+        imports: [ColorpickerNgModelFixtureComponent],
+      });
+
+      fixture = TestBed.createComponent(ColorpickerNgModelFixtureComponent);
+      testComponent = fixture.componentInstance;
+
+      inputEl = fixture.nativeElement.querySelector('input');
+    });
+
+    it('should render a color bound through ngModel', fakeAsync(() => {
+      testComponent.model = '#ff0000';
+      fixture.detectChanges();
+      tick();
+      fixture.detectChanges();
+
+      expect(inputEl.value).toBe('rgba(255,0,0,1)');
+    }));
+
+    it('should update the bound ngModel property when the user applies a color change', fakeAsync(() => {
+      fixture.detectChanges();
+      tick();
+
+      inputEl.value = '#00ff00';
+      inputEl.dispatchEvent(new Event('change'));
+      fixture.detectChanges();
+      tick();
+
+      expect((testComponent.model as SkyColorpickerOutput).rgbaText).toBe(
+        'rgba(0,255,0,1)',
+      );
+    }));
+
+    it('should disable the colorpicker trigger button when ngModel is disabled', fakeAsync(() => {
+      fixture.detectChanges();
+      tick();
+
+      testComponent.ngModelRef.control.disable();
+      fixture.detectChanges();
+      tick();
+
+      const triggerButton = fixture.nativeElement.querySelector(
+        '.sky-colorpicker-button',
+      ) as HTMLButtonElement;
+
+      expect(triggerButton.disabled).toBeTrue();
+    }));
   });
 });

--- a/libs/components/colorpicker/src/lib/modules/colorpicker/colorpicker.component.ts
+++ b/libs/components/colorpicker/src/lib/modules/colorpicker/colorpicker.component.ts
@@ -360,11 +360,11 @@ export class SkyColorpickerComponent
   }
 
   // Resolves whatever form-binding directive is on the content-projected
-  // `[skyColorpickerInput]` element: reactive, template-driven, or (once
-  // that directive drops `ControlValueAccessor`) the `NgControl` a
-  // signal-forms `[formField]` binding provides. All three expose the same
-  // `AbstractControlDirective` surface (`touched`, `dirty`, `valid`,
-  // `errors`), so a single query covers every form flavor.
+  // `[skyColorpickerInput]` element: reactive, template-driven, or the
+  // read-only interop `NgControl` a signal-forms `[formField]` binding
+  // provides. All three expose the same `AbstractControlDirective` surface
+  // (`touched`, `dirty`, `valid`, `errors`), so a single query covers every
+  // form flavor.
   @ContentChild(NgControl)
   protected set ngControlDirective(value: NgControl | undefined) {
     if (value) {
@@ -556,7 +556,8 @@ export class SkyColorpickerComponent
       // message sent through `messageStream`), so it's relayed through
       // `colorApplied` rather than `reset`. The bound
       // `SkyColorpickerInputDirective` writes the color through to the
-      // bound field via `value.set()`, which marks the field dirty.
+      // bound field via the registered `onChange` callback, which marks
+      // the field dirty.
       this.#colorpickerInputSvc.colorApplied.next(this.selectedColor);
     }
   }
@@ -668,8 +669,8 @@ export class SkyColorpickerComponent
         // This reset is programmatic (a consumer sent the message), not a
         // user action, so it's relayed through `reset` rather than
         // `colorApplied`. The bound `SkyColorpickerInputDirective` reverts
-        // its display to `initialColor` without calling `value.set()`,
-        // which would otherwise mark the bound field dirty.
+        // its display to `initialColor` without calling `onChange`, which
+        // would otherwise mark the bound field dirty.
         this.#colorpickerInputSvc.reset.next(this.initialColor);
         break;
 
@@ -822,7 +823,8 @@ export class SkyColorpickerComponent
       // This is a user action (the dialog's Apply button), so it's relayed
       // through `colorApplied` rather than `reset`. The bound
       // `SkyColorpickerInputDirective` writes the color through to the
-      // bound field via `value.set()`, which marks the field dirty.
+      // bound field via the registered `onChange` callback, which marks
+      // the field dirty.
       this.#colorpickerInputSvc.colorApplied.next(this.selectedColor);
     }
 

--- a/libs/components/colorpicker/src/lib/modules/colorpicker/colorpicker.component.ts
+++ b/libs/components/colorpicker/src/lib/modules/colorpicker/colorpicker.component.ts
@@ -20,12 +20,7 @@ import {
   booleanAttribute,
   inject,
 } from '@angular/core';
-import {
-  AbstractControlDirective,
-  FormControlDirective,
-  FormControlName,
-  NgModel,
-} from '@angular/forms';
+import { NgControl } from '@angular/forms';
 import {
   SkyAffixAutoFitContext,
   SkyAffixService,
@@ -364,24 +359,17 @@ export class SkyColorpickerComponent
     return this.#_colorpickerRef;
   }
 
-  @ContentChild(FormControlDirective)
-  protected set formControl(value: FormControlDirective | undefined) {
-    if (value) {
-      this.ngControl = value;
-      this.#changeDetector.markForCheck();
-    }
-  }
-
-  @ContentChild(FormControlName)
-  protected set formControlByName(value: FormControlName | undefined) {
-    if (value) {
-      this.ngControl = value;
-      this.#changeDetector.markForCheck();
-    }
-  }
-
-  @ContentChild(NgModel)
-  protected set ngModel(value: NgModel | undefined) {
+  /**
+   * Resolves whatever form-binding directive is on the content-projected
+   * `[skyColorpickerInput]` element: a reactive `formControl`/`formControlName`,
+   * a template-driven `ngModel`, or (once that directive drops
+   * `ControlValueAccessor`) the `NgControl` that a signal-forms `[formField]`
+   * binding provides. All four expose the same `AbstractControlDirective`
+   * surface (`touched`, `dirty`, `valid`, `errors`), so a single query covers
+   * every form flavor.
+   */
+  @ContentChild(NgControl)
+  protected set ngControlDirective(value: NgControl | undefined) {
     if (value) {
       this.ngControl = value;
       this.#changeDetector.markForCheck();
@@ -409,7 +397,7 @@ export class SkyColorpickerComponent
   protected selectedColor: SkyColorpickerOutput | undefined;
   protected iconColor: string | undefined;
   protected isPickerVisible: boolean | undefined;
-  protected ngControl: AbstractControlDirective | undefined;
+  protected ngControl: NgControl | undefined;
 
   #idIndex: number;
   #alphaChannel: string | undefined;
@@ -528,7 +516,13 @@ export class SkyColorpickerComponent
   }
 
   public onTriggerButtonClick(): void {
-    this.ngControl?.control?.markAsTouched();
+    // Signals the bound `[skyColorpickerInput]` directive to report a touch,
+    // which the `Field` directive (signal forms) or `NgControl` (reactive and
+    // template-driven forms) then use to mark the field as touched. Routing
+    // this through the directive rather than mutating `ngControl.control`
+    // directly means this works identically across all three form flavors,
+    // now that the directive no longer implements `ControlValueAccessor`.
+    this.#colorpickerInputSvc.touch.next();
 
     this.#sendMessage(SkyColorpickerMessageType.Open);
   }
@@ -558,7 +552,19 @@ export class SkyColorpickerComponent
   }
 
   public onResetClick(): void {
-    this.#sendMessage(SkyColorpickerMessageType.Reset);
+    this.updatePickerValues(this.initialColor);
+    this.backgroundColorForDisplay = this.initialColor;
+
+    if (this.selectedColor) {
+      this.selectedColorChanged.emit(this.selectedColor);
+      this.selectedColorApplied.emit({ color: this.selectedColor });
+      // The reset button is a user action (unlike a programmatic Reset
+      // message sent through `messageStream`), so it's relayed through
+      // `colorApplied` rather than `reset`. The bound
+      // `SkyColorpickerInputDirective` writes the color through to the
+      // bound field via `value.set()`, which marks the field dirty.
+      this.#colorpickerInputSvc.colorApplied.next(this.selectedColor);
+    }
   }
 
   public updatePickerValues(value: string | undefined): void {
@@ -654,6 +660,12 @@ export class SkyColorpickerComponent
         // TODO: This code assumed non-null pre-strict mode. Reevaluate in the future?
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         this.selectedColorApplied.emit({ color: this.selectedColor! });
+        // This reset is programmatic (a consumer sent the message), not a
+        // user action, so it's relayed through `reset` rather than
+        // `colorApplied`. The bound `SkyColorpickerInputDirective` reverts
+        // its display to `initialColor` without calling `value.set()`,
+        // which would otherwise mark the bound field dirty.
+        this.#colorpickerInputSvc.reset.next(this.initialColor);
         break;
 
       case SkyColorpickerMessageType.ToggleResetButton:
@@ -802,6 +814,11 @@ export class SkyColorpickerComponent
       this.lastAppliedColor = this.selectedColor.rgbaText;
       this.updatePickerValues(this.lastAppliedColor);
       this.backgroundColorForDisplay = this.selectedColor.rgbaText;
+      // This is a user action (the dialog's Apply button), so it's relayed
+      // through `colorApplied` rather than `reset`. The bound
+      // `SkyColorpickerInputDirective` writes the color through to the
+      // bound field via `value.set()`, which marks the field dirty.
+      this.#colorpickerInputSvc.colorApplied.next(this.selectedColor);
     }
 
     this.closePicker();

--- a/libs/components/colorpicker/src/lib/modules/colorpicker/colorpicker.component.ts
+++ b/libs/components/colorpicker/src/lib/modules/colorpicker/colorpicker.component.ts
@@ -514,11 +514,11 @@ export class SkyColorpickerComponent
 
   public onTriggerButtonClick(): void {
     // Signals the bound `[skyColorpickerInput]` directive to report a touch,
-    // which the `Field` directive (signal forms) or `NgControl` (reactive and
-    // template-driven forms) then use to mark the field as touched. Routing
-    // this through the directive rather than mutating `ngControl.control`
-    // directly means this works identically across all three form flavors,
-    // now that the directive no longer implements `ControlValueAccessor`.
+    // which its `ControlValueAccessor` relays to the registered `onTouched`
+    // callback. Routing this through the directive rather than mutating
+    // `ngControl.control` directly means this works identically across all
+    // three form flavors, since `cvaControlCreate` wires up `onTouched` for
+    // `[formField]` too whenever a `ControlValueAccessor` is present.
     this.#colorpickerInputSvc.touch.next();
 
     this.#sendMessage(SkyColorpickerMessageType.Open);
@@ -644,10 +644,11 @@ export class SkyColorpickerComponent
   #resetToInitialColor(): void {
     this.updatePickerValues(this.initialColor);
     this.backgroundColorForDisplay = this.initialColor;
-    this.selectedColorChanged.emit(this.selectedColor);
-    // TODO: This code assumed non-null pre-strict mode. Reevaluate in the future?
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    this.selectedColorApplied.emit({ color: this.selectedColor! });
+
+    if (this.selectedColor) {
+      this.selectedColorChanged.emit(this.selectedColor);
+      this.selectedColorApplied.emit({ color: this.selectedColor });
+    }
   }
 
   #handleIncomingMessages(message: SkyColorpickerMessage): void {

--- a/libs/components/colorpicker/src/lib/modules/colorpicker/colorpicker.component.ts
+++ b/libs/components/colorpicker/src/lib/modules/colorpicker/colorpicker.component.ts
@@ -359,15 +359,12 @@ export class SkyColorpickerComponent
     return this.#_colorpickerRef;
   }
 
-  /**
-   * Resolves whatever form-binding directive is on the content-projected
-   * `[skyColorpickerInput]` element: a reactive `formControl`/`formControlName`,
-   * a template-driven `ngModel`, or (once that directive drops
-   * `ControlValueAccessor`) the `NgControl` that a signal-forms `[formField]`
-   * binding provides. All four expose the same `AbstractControlDirective`
-   * surface (`touched`, `dirty`, `valid`, `errors`), so a single query covers
-   * every form flavor.
-   */
+  // Resolves whatever form-binding directive is on the content-projected
+  // `[skyColorpickerInput]` element: reactive, template-driven, or (once
+  // that directive drops `ControlValueAccessor`) the `NgControl` a
+  // signal-forms `[formField]` binding provides. All three expose the same
+  // `AbstractControlDirective` surface (`touched`, `dirty`, `valid`,
+  // `errors`), so a single query covers every form flavor.
   @ContentChild(NgControl)
   protected set ngControlDirective(value: NgControl | undefined) {
     if (value) {
@@ -552,12 +549,9 @@ export class SkyColorpickerComponent
   }
 
   public onResetClick(): void {
-    this.updatePickerValues(this.initialColor);
-    this.backgroundColorForDisplay = this.initialColor;
+    this.#resetToInitialColor();
 
     if (this.selectedColor) {
-      this.selectedColorChanged.emit(this.selectedColor);
-      this.selectedColorApplied.emit({ color: this.selectedColor });
       // The reset button is a user action (unlike a programmatic Reset
       // message sent through `messageStream`), so it's relayed through
       // `colorApplied` rather than `reset`. The bound
@@ -639,6 +633,22 @@ export class SkyColorpickerComponent
     this.messageStream.next({ type });
   }
 
+  // Shared by `onResetClick()` and the `Reset` message handler, so the two
+  // reset entry points (a user clicking the reset button vs. a consumer
+  // sending a programmatic message) can't drift apart on how the picker
+  // itself is reverted. Each caller still relays the reset to
+  // `SkyColorpickerInputDirective` through its own subject (`colorApplied`
+  // vs. `reset`), since only a user-driven reset should mark the bound
+  // field dirty.
+  #resetToInitialColor(): void {
+    this.updatePickerValues(this.initialColor);
+    this.backgroundColorForDisplay = this.initialColor;
+    this.selectedColorChanged.emit(this.selectedColor);
+    // TODO: This code assumed non-null pre-strict mode. Reevaluate in the future?
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    this.selectedColorApplied.emit({ color: this.selectedColor! });
+  }
+
   #handleIncomingMessages(message: SkyColorpickerMessage): void {
     switch (message.type) {
       case SkyColorpickerMessageType.Open:
@@ -654,12 +664,7 @@ export class SkyColorpickerComponent
         break;
 
       case SkyColorpickerMessageType.Reset:
-        this.updatePickerValues(this.initialColor);
-        this.backgroundColorForDisplay = this.initialColor;
-        this.selectedColorChanged.emit(this.selectedColor);
-        // TODO: This code assumed non-null pre-strict mode. Reevaluate in the future?
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        this.selectedColorApplied.emit({ color: this.selectedColor! });
+        this.#resetToInitialColor();
         // This reset is programmatic (a consumer sent the message), not a
         // user action, so it's relayed through `reset` rather than
         // `colorApplied`. The bound `SkyColorpickerInputDirective` reverts

--- a/libs/components/colorpicker/testing/src/legacy/colorpicker-fixture.spec.ts
+++ b/libs/components/colorpicker/testing/src/legacy/colorpicker-fixture.spec.ts
@@ -55,7 +55,12 @@ describe('Colorpicker fixture', () => {
 
     const colorpicker = new SkyColorpickerFixture(fixture, 'test-colorpicker');
 
+    // NgModel defers its initial write to the bound control via a
+    // resolved-promise microtask (see `NgModel._updateValue` in
+    // `@angular/forms`), so an extra change-detection pass is needed
+    // after `whenStable()` to flush that write into the rendered value.
     await fixture.whenStable();
+    fixture.detectChanges();
     expect(colorpicker.value).toEqual(fixture.componentInstance.hexColor);
   });
 
@@ -68,6 +73,7 @@ describe('Colorpicker fixture', () => {
     const colorpicker = new SkyColorpickerFixture(fixture, 'test-colorpicker');
 
     await fixture.whenStable();
+    fixture.detectChanges();
     expect(colorpicker.value).toEqual(fixture.componentInstance.hexColor);
 
     await colorpicker.setValueFromHex(newColor);
@@ -90,6 +96,7 @@ describe('Colorpicker fixture', () => {
     const colorpicker = new SkyColorpickerFixture(fixture, 'test-colorpicker');
 
     await fixture.whenStable();
+    fixture.detectChanges();
     expect(colorpicker.value).toEqual(currentColor);
 
     await colorpicker.setValueFromRGBA(25, 25, 25, 1);
@@ -107,6 +114,7 @@ describe('Colorpicker fixture', () => {
     const colorpicker = new SkyColorpickerFixture(fixture, 'test-colorpicker');
 
     await fixture.whenStable();
+    fixture.detectChanges();
     expect(colorpicker.value).toEqual(fixture.componentInstance.hexColor);
 
     await colorpicker.setValueFromPresets(3);
@@ -126,6 +134,7 @@ describe('Colorpicker fixture', () => {
     const colorpicker = new SkyColorpickerFixture(fixture, 'test-colorpicker');
 
     await fixture.whenStable();
+    fixture.detectChanges();
     expect(colorpicker.value).toEqual(fixture.componentInstance.hexColor);
 
     await colorpicker.setValueFromPresets(6);

--- a/libs/components/forms/src/index.ts
+++ b/libs/components/forms/src/index.ts
@@ -36,6 +36,8 @@ export { SkyRadioType } from './lib/modules/radio/types/radio-type';
 
 export { SkyRequiredStateDirective } from './lib/modules/required-state/required-state.directive';
 
+export { skyIsAbstractControl } from './lib/modules/shared/is-abstract-control';
+
 export { SkySelectionBoxModule } from './lib/modules/selection-box/selection-box.module';
 export { SkySelectionBoxGridAlignItems } from './lib/modules/selection-box/types/selection-box-grid-align-items';
 export { SkySelectionBoxGridAlignItemsType } from './lib/modules/selection-box/types/selection-box-grid-align-items-type';

--- a/libs/components/forms/src/lib/modules/shared/is-abstract-control.spec.ts
+++ b/libs/components/forms/src/lib/modules/shared/is-abstract-control.spec.ts
@@ -1,0 +1,25 @@
+import { AbstractControl, FormControl } from '@angular/forms';
+
+import { skyIsAbstractControl } from './is-abstract-control';
+
+describe('skyIsAbstractControl', () => {
+  it('returns true for a real AbstractControl', () => {
+    expect(skyIsAbstractControl(new FormControl())).toBeTrue();
+  });
+
+  it('returns false for undefined', () => {
+    expect(skyIsAbstractControl(undefined)).toBeFalse();
+  });
+
+  it('returns false for null', () => {
+    expect(skyIsAbstractControl(null)).toBeFalse();
+  });
+
+  it('returns false for a signal-forms interop control (shaped like an AbstractControl, but not an instance)', () => {
+    expect(
+      skyIsAbstractControl({
+        value: 'foo',
+      } as unknown as AbstractControl),
+    ).toBeFalse();
+  });
+});

--- a/libs/components/forms/src/lib/modules/shared/is-abstract-control.ts
+++ b/libs/components/forms/src/lib/modules/shared/is-abstract-control.ts
@@ -1,0 +1,17 @@
+import { AbstractControl } from '@angular/forms';
+
+// Components that call mutation methods (`setValue`, `markAsDirty`, `markAsTouched`,
+// `setErrors`, etc.) on a control captured from `validate()` or an injected `NgControl`
+// should guard those calls with this function, since the read-only interop control that
+// signal forms' `[field]` directive provides through `NgControl` has no such methods.
+/**
+ * Reports whether `control` is a real `AbstractControl`, as opposed to the read-only
+ * interop control that `@angular/forms/signals`' `[field]` directive provides through
+ * `NgControl`.
+ * @internal
+ */
+export function skyIsAbstractControl(
+  control: AbstractControl | null | undefined,
+): control is AbstractControl {
+  return control instanceof AbstractControl;
+}


### PR DESCRIPTION
Part 2 of 7 in the signal-forms support stack. Split out of #4629 (closed).
Stack: #4685 <- #4686 <- #4687 <- #4688 <- #4689 <- #4690 <- #4691.

[AB#4008241](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/4008241)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added signal-forms support to the color picker while preserving compatibility with reactive and template-driven forms.
  * Added a playground page demonstrating values, validation, touched states, resets, and dynamic required validation across form types.

* **Bug Fixes**
  * Improved value synchronization, reset handling, touch tracking, validation states, clearing, and disabled-control behavior.
  * Expanded coverage for form state updates and legacy value handling.

* **Documentation**
  * Added guidance for custom controls using signal forms and Angular form APIs, including value-accessor and validation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->