### PR TITLE
feat(components/forms): support signal forms

### DIFF
--- a/apps/playground/src/app/components/forms/input-box/input-box-routing.module.ts
+++ b/apps/playground/src/app/components/forms/input-box/input-box-routing.module.ts
@@ -4,6 +4,7 @@ import { RouterModule } from '@angular/router';
 import { ComponentRouteInfo } from '../../../shared/component-info/component-route-info';
 
 import { InputBoxDisabledComponent } from './input-box-disabled.component';
+import { InputBoxSignalFormsComponent } from './input-box-signal-forms.component';
 import { InputBoxComponent } from './input-box.component';
 
 const routes: ComponentRouteInfo[] = [
@@ -21,6 +22,15 @@ const routes: ComponentRouteInfo[] = [
     component: InputBoxDisabledComponent,
     data: {
       name: 'Input box (disabled)',
+      icon: 'form',
+      library: 'forms',
+    },
+  },
+  {
+    path: 'signal-forms',
+    component: InputBoxSignalFormsComponent,
+    data: {
+      name: 'Input box (signal forms)',
       icon: 'form',
       library: 'forms',
     },

--- a/apps/playground/src/app/components/forms/input-box/input-box-signal-forms.component.html
+++ b/apps/playground/src/app/components/forms/input-box/input-box-signal-forms.component.html
@@ -1,0 +1,310 @@
+<div class="input-box-signal-forms sky-theme-padding-inset-balanced-m">
+  <h1>Input box with signal forms</h1>
+  <p>
+    Every control below is bound with the <code>[formField]</code> directive
+    from <code>&#64;angular/forms/signals</code>. Choose
+    <strong>Mark all as touched</strong> to reveal the validation messages that
+    <code>sky-input-box</code> renders from the signal-forms field state.
+  </p>
+
+  <button
+    class="sky-btn sky-btn-default"
+    type="button"
+    (click)="markAllAsTouched()"
+  >
+    Mark all as touched
+  </button>
+
+  <h2>Native controls</h2>
+  <p>
+    The control types allowed inside an input box are listed in
+    <code
+      >libs/sdk/skyux-eslint/src/rules/template/utils/input-box-types.ts</code
+    >.
+  </p>
+
+  <div class="input-box-signal-forms-section" id="signal-forms-native">
+    <sky-input-box labelText="Name" [stacked]="true">
+      <input type="text" [formField]="signalForm.native.name" />
+    </sky-input-box>
+
+    <sky-input-box
+      helpPopoverContent="Enter a valid email address."
+      labelText="Email"
+      [stacked]="true"
+    >
+      <input type="email" [formField]="signalForm.native.email" />
+    </sky-input-box>
+
+    <sky-input-box
+      hintText="Between 18 and 120."
+      labelText="Age"
+      [stacked]="true"
+    >
+      <input type="number" [formField]="signalForm.native.age" />
+    </sky-input-box>
+
+    <sky-input-box labelText="Password" [stacked]="true">
+      <input type="password" [formField]="signalForm.native.password" />
+    </sky-input-box>
+
+    <sky-input-box labelText="Confirm password" [stacked]="true">
+      <input type="password" [formField]="signalForm.native.confirmPassword" />
+    </sky-input-box>
+
+    <sky-input-box labelText="Website" [stacked]="true">
+      <input type="url" [formField]="signalForm.native.website" />
+    </sky-input-box>
+
+    <sky-input-box labelText="Favorite color" [stacked]="true">
+      <select [formField]="signalForm.native.favoriteColor">
+        <option value="">Select a color</option>
+        <option value="red">Red</option>
+        <option value="green">Green</option>
+        <option value="blue">Blue</option>
+        <option value="invalid">Invalid color</option>
+      </select>
+    </sky-input-box>
+
+    <!--
+      The character counter reads the `maxLength()` rule from the schema. Setting
+      the `characterLimit` input on a signal-forms control has no effect and logs
+      a warning, since signal-forms fields own their validation.
+    -->
+    <sky-input-box labelText="Bio" [stacked]="true">
+      <textarea [formField]="signalForm.native.bio"></textarea>
+    </sky-input-box>
+  </div>
+
+  <h2>SKY components</h2>
+  <p>
+    These components are <code>ControlValueAccessor</code>-based.
+    <code>[formField]</code> reaches them through the interop
+    <code>NgControl</code> it provides, but that interop control is not an
+    <code>AbstractControl</code>. All the components below now guard against
+    that, so they work with <code>[formField]</code>; one small remaining
+    behavior difference is noted inline.
+  </p>
+
+  <div class="input-box-signal-forms-section" id="signal-forms-sky-components">
+    <!--
+      GAP: writing a date-string shortcut (for example, typing "today")
+      directly into the model does not reconcile back to the parsed `Date`.
+      `datepicker-input.directive.ts` only patches that resolved value back
+      onto a real `AbstractControl`, which `[formField]`'s interop control is
+      not. The input still displays the formatted date; only the model's raw
+      value differs from what reactive/template forms would produce.
+    -->
+    <sky-input-box
+      hintText="Must be in the next 30 days."
+      labelText="Start date"
+      [stacked]="true"
+    >
+      <sky-datepicker>
+        <input skyDatepickerInput [formField]="signalForm.sky.startDate" />
+      </sky-datepicker>
+    </sky-input-box>
+
+    <sky-input-box labelText="Start time" [stacked]="true">
+      <sky-timepicker #timepicker>
+        <input
+          [formField]="signalForm.sky.startTime"
+          [skyTimepickerInput]="timepicker"
+        />
+      </sky-timepicker>
+    </sky-input-box>
+
+    <sky-input-box labelText="Phone number" [stacked]="true">
+      <sky-phone-field defaultCountry="us">
+        <input skyPhoneFieldInput [formField]="signalForm.sky.phone" />
+      </sky-phone-field>
+    </sky-input-box>
+
+    <sky-input-box labelText="Country" [stacked]="true">
+      <sky-country-field [formField]="signalForm.sky.country" />
+    </sky-input-box>
+
+    <sky-input-box labelText="Favorite fruit" [stacked]="true">
+      <sky-autocomplete [data]="fruits">
+        <input
+          type="text"
+          skyAutocomplete
+          [formField]="signalForm.sky.favoriteFruit"
+        />
+      </sky-autocomplete>
+    </sky-input-box>
+
+    <sky-input-box labelText="Team lead" [stacked]="true">
+      <sky-lookup
+        idProperty="name"
+        selectMode="single"
+        [data]="people"
+        [formField]="signalForm.sky.teamLead"
+      />
+    </sky-input-box>
+
+    <sky-input-box
+      hintText="Choose at least two."
+      labelText="Team members"
+      [stacked]="true"
+    >
+      <sky-lookup
+        idProperty="name"
+        selectMode="multiple"
+        [data]="people"
+        [formField]="signalForm.sky.teamMembers"
+      />
+    </sky-input-box>
+  </div>
+
+  <h2>Validators</h2>
+  <p>
+    Input box renders <code>required</code>, <code>email</code>,
+    <code>minLength</code>, and <code>maxLength</code> errors automatically, and
+    renders any other error that carries a <code>message</code>. Errors without
+    a message need a <code>sky-form-error</code> in the input box content.
+  </p>
+
+  <div class="input-box-signal-forms-section" id="signal-forms-validators">
+    <sky-input-box
+      hintText="Three letters, a dash, and four digits (for example, ABC-1234)."
+      labelText="Coupon code"
+      [stacked]="true"
+    >
+      <input type="text" [formField]="signalForm.validators.couponCode" />
+    </sky-input-box>
+
+    <sky-input-box
+      hintText="Between 1 and 10."
+      labelText="Quantity"
+      [stacked]="true"
+    >
+      <input type="number" [formField]="signalForm.validators.quantity" />
+    </sky-input-box>
+
+    <!--
+      A custom `validate()` error with a `message` renders automatically.
+    -->
+    <sky-input-box
+      hintText="Cannot contain spaces."
+      labelText="Nickname"
+      [stacked]="true"
+    >
+      <input type="text" [formField]="signalForm.validators.nickname" />
+    </sky-input-box>
+
+    <!--
+      A custom `validate()` error without a `message` needs its own
+      `sky-form-error`, matched on the error `kind`.
+    -->
+    <sky-input-box
+      hintText="Cannot be a reserved word."
+      labelText="Project name"
+      [stacked]="true"
+    >
+      <input type="text" [formField]="signalForm.validators.projectName" />
+      @if (projectNameReserved()) {
+        <sky-form-error
+          errorName="reserved"
+          errorText="That project name is reserved."
+        />
+      }
+    </sky-input-box>
+
+    <sky-input-box
+      hintText="Try 'admin' or 'root' to see the async error."
+      labelText="Username"
+      [stacked]="true"
+    >
+      <input type="text" [formField]="signalForm.validators.username" />
+    </sky-input-box>
+  </div>
+
+  <h2>Field logic</h2>
+  <p>
+    <code>disabled()</code>, <code>readonly()</code>, and
+    <code>hidden()</code> control field state from the schema. Input box
+    reflects the disabled and required state that the field reports.
+  </p>
+
+  <div class="input-box-signal-forms-section" id="signal-forms-logic">
+    <sky-input-box
+      hintText="Choosing 'Yes' enables the newsletter address and shows the referral code."
+      labelText="Subscribe to the newsletter"
+      [stacked]="true"
+    >
+      <select [formField]="signalForm.logic.subscribed">
+        <option value="no">No</option>
+        <option value="yes">Yes</option>
+      </select>
+    </sky-input-box>
+
+    <sky-input-box labelText="Newsletter address" [stacked]="true">
+      <input type="email" [formField]="signalForm.logic.newsletterEmail" />
+    </sky-input-box>
+
+    <sky-input-box labelText="Account ID (read-only)" [stacked]="true">
+      <input type="text" [formField]="signalForm.logic.accountId" />
+    </sky-input-box>
+
+    <!--
+      Hidden fields must be removed from the DOM; signal forms logs a warning if
+      a hidden field is still rendered.
+    -->
+    @if (!signalForm.logic.referralCode().hidden()) {
+      <sky-input-box labelText="Referral code" [stacked]="true">
+        <input type="text" [formField]="signalForm.logic.referralCode" />
+      </sky-input-box>
+    }
+  </div>
+
+  <h2>Submit</h2>
+  <p>
+    <code>submit()</code> marks the form as submitted, runs the action, and maps
+    the errors the action returns onto the fields they belong to.
+  </p>
+
+  <div class="input-box-signal-forms-section" id="signal-forms-submit">
+    <sky-input-box
+      hintText="Submitting 'taken' returns a server error for this field."
+      labelText="Display name"
+      [stacked]="true"
+    >
+      <input type="text" [formField]="submitForm.displayName" />
+    </sky-input-box>
+
+    <button
+      class="sky-btn sky-btn-primary"
+      type="button"
+      [disabled]="submitForm().submitting()"
+      (click)="onSubmit()"
+    >
+      @if (submitForm().submitting()) {
+        Saving...
+      } @else {
+        Save
+      }
+    </button>
+
+    @if (submitMessage(); as message) {
+      <p class="input-box-signal-forms-submit-message">{{ message }}</p>
+    }
+  </div>
+</div>
+<div class="input-box-signal-forms sky-theme-padding-inset-balanced-m">
+  <h2>Form state</h2>
+  <dl class="signal-forms-state">
+    <dt>Touched</dt>
+    <dd>{{ signalForm().touched() }}</dd>
+    <dt>Dirty</dt>
+    <dd>{{ signalForm().dirty() }}</dd>
+    <dt>Valid</dt>
+    <dd>{{ signalForm().valid() }}</dd>
+    <dt>Pending</dt>
+    <dd>{{ signalForm().pending() }}</dd>
+    <dt>Value</dt>
+    <dd>
+      <pre>{{ formValue() }}</pre>
+    </dd>
+  </dl>
+</div>

--- a/apps/playground/src/app/components/forms/input-box/input-box-signal-forms.component.ts
+++ b/apps/playground/src/app/components/forms/input-box/input-box-signal-forms.component.ts
@@ -1,0 +1,378 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  Injector,
+  computed,
+  inject,
+  resource,
+  signal,
+} from '@angular/core';
+import type {
+  ReadonlyFieldTree,
+  ValidationError,
+} from '@angular/forms/signals';
+import {
+  FormField,
+  disabled,
+  email,
+  form,
+  hidden,
+  max,
+  maxDate,
+  maxLength,
+  min,
+  minDate,
+  minLength,
+  pattern,
+  readonly,
+  required,
+  submit,
+  validate,
+  validateAsync,
+  validateTree,
+} from '@angular/forms/signals';
+import type { SkyTimepickerTimeOutput } from '@skyux/datetime';
+import { SkyDatepickerModule, SkyTimepickerModule } from '@skyux/datetime';
+import { SkyFormErrorModule, SkyInputBoxModule } from '@skyux/forms';
+import type { SkyCountryFieldCountry } from '@skyux/lookup';
+import {
+  SkyAutocompleteModule,
+  SkyCountryFieldModule,
+  SkyLookupModule,
+} from '@skyux/lookup';
+import { SkyPhoneFieldModule } from '@skyux/phone-field';
+
+interface DemoItem {
+  name: string;
+}
+
+interface DemoModel {
+  native: {
+    name: string;
+    email: string;
+    age: number | null;
+    password: string;
+    confirmPassword: string;
+    website: string;
+    favoriteColor: string;
+    bio: string;
+  };
+  sky: {
+    startDate: Date | null;
+    startTime: SkyTimepickerTimeOutput | string | null;
+    phone: string;
+    country: SkyCountryFieldCountry | null;
+    favoriteFruit: DemoItem | string | null;
+    teamLead: DemoItem[];
+    teamMembers: DemoItem[];
+  };
+  validators: {
+    couponCode: string;
+    quantity: number | null;
+    nickname: string;
+    projectName: string;
+    username: string;
+  };
+  logic: {
+    subscribed: string;
+    newsletterEmail: string;
+    accountId: string;
+    referralCode: string;
+  };
+}
+
+const DAY_IN_MS = 24 * 60 * 60 * 1000;
+const RESERVED_PROJECT_NAMES = ['admin', 'system'];
+const TAKEN_USERNAMES = ['admin', 'root'];
+
+/**
+ * Targets a validation error at a specific field, for validators that can
+ * report errors anywhere in the tree. The cast works around an
+ * `@angular/forms/signals` typing gap: a `ReadonlyFieldTree` for a primitive
+ * value isn't assignable to the `ReadonlyFieldTree<unknown>` that `fieldTree`
+ * declares.
+ */
+function targetError(
+  fieldTree: unknown,
+  error: ValidationError,
+): ValidationError.WithOptionalFieldTree {
+  return { ...error, fieldTree: fieldTree as ReadonlyFieldTree<unknown> };
+}
+
+function createModel(): DemoModel {
+  return {
+    native: {
+      name: '',
+      email: '',
+      age: null,
+      password: '',
+      confirmPassword: '',
+      website: '',
+      favoriteColor: '',
+      bio: '',
+    },
+    sky: {
+      startDate: null,
+      startTime: null,
+      phone: '',
+      country: null,
+      favoriteFruit: null,
+      teamLead: [],
+      teamMembers: [],
+    },
+    validators: {
+      couponCode: '',
+      quantity: null,
+      nickname: '',
+      projectName: '',
+      username: '',
+    },
+    logic: {
+      subscribed: 'no',
+      newsletterEmail: '',
+      accountId: 'ACC-000123',
+      referralCode: '',
+    },
+  };
+}
+
+@Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [
+    FormField,
+    SkyAutocompleteModule,
+    SkyCountryFieldModule,
+    SkyDatepickerModule,
+    SkyFormErrorModule,
+    SkyInputBoxModule,
+    SkyLookupModule,
+    SkyPhoneFieldModule,
+    SkyTimepickerModule,
+  ],
+  styles: `
+    :host {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: var(--sky-space-inline-xl);
+      height: 100%;
+    }
+
+    .input-box-signal-forms {
+      max-height: 100%;
+      overflow-y: auto;
+    }
+
+    .input-box-signal-forms-section {
+      margin-bottom: 30px;
+    }
+  `,
+  templateUrl: './input-box-signal-forms.component.html',
+})
+export class InputBoxSignalFormsComponent {
+  readonly #injector = inject(Injector);
+  readonly #today = new Date(new Date().setHours(0, 0, 0, 0));
+  readonly #thirtyDaysOut = new Date(Date.now() + 30 * DAY_IN_MS);
+
+  protected readonly fruits: DemoItem[] = [
+    { name: 'Apple' },
+    { name: 'Banana' },
+    { name: 'Cherry' },
+    { name: 'Grape' },
+    { name: 'Orange' },
+  ];
+
+  protected readonly people: DemoItem[] = [
+    { name: 'Alice' },
+    { name: 'Bob' },
+    { name: 'Carol' },
+    { name: 'David' },
+    { name: 'Erin' },
+    { name: 'Frank' },
+  ];
+
+  protected readonly model = signal(createModel());
+
+  protected readonly signalForm = form(this.model, (p) => {
+    required(p.native.name);
+    maxLength(p.native.name, 50);
+
+    required(p.native.email);
+    email(p.native.email);
+
+    min(p.native.age, 18, { message: 'Age must be at least 18.' });
+    max(p.native.age, 120, { message: 'Age must be 120 or less.' });
+
+    required(p.native.password);
+    minLength(p.native.password, 8);
+
+    // A custom validator can read a sibling field through `valueOf`.
+    validate(p.native.confirmPassword, ({ value, valueOf }) =>
+      value() && value() !== valueOf(p.native.password)
+        ? { kind: 'passwordMismatch', message: 'The passwords do not match.' }
+        : undefined,
+    );
+
+    pattern(p.native.website, /^https:\/\/.+/, {
+      message: 'The website must start with https://.',
+    });
+
+    required(p.native.favoriteColor);
+    validate(p.native.favoriteColor, ({ value }) =>
+      value() === 'invalid'
+        ? { kind: 'invalidColor', message: 'Invalid color is not a color.' }
+        : undefined,
+    );
+
+    maxLength(p.native.bio, 200);
+
+    required(p.sky.startDate);
+    minDate(p.sky.startDate, this.#today, {
+      message: 'The start date cannot be in the past.',
+    });
+    maxDate(p.sky.startDate, this.#thirtyDaysOut, {
+      message: 'The start date must be within the next 30 days.',
+    });
+
+    required(p.sky.startTime);
+    required(p.sky.phone);
+    required(p.sky.country);
+    required(p.sky.favoriteFruit);
+
+    // `required` treats an empty array as a value, and `minLength` reports a
+    // character-count message, so array-valued controls need their own message.
+    validate(p.sky.teamLead, ({ value }) =>
+      value().length === 0
+        ? { kind: 'noTeamLead', message: 'Select a team lead.' }
+        : undefined,
+    );
+    validate(p.sky.teamMembers, ({ value }) =>
+      value().length < 2
+        ? {
+            kind: 'notEnoughMembers',
+            message: 'Select at least two team members.',
+          }
+        : undefined,
+    );
+
+    pattern(p.validators.couponCode, /^[A-Z]{3}-\d{4}$/, {
+      message: 'Enter a coupon code in the format ABC-1234.',
+    });
+
+    min(p.validators.quantity, 1, { message: 'Order at least 1.' });
+    max(p.validators.quantity, 10, { message: 'Order no more than 10.' });
+
+    validate(p.validators.nickname, ({ value }) =>
+      value().includes(' ')
+        ? { kind: 'noSpaces', message: 'The nickname cannot contain spaces.' }
+        : undefined,
+    );
+
+    // This error carries no `message`, so the template renders its own
+    // `sky-form-error` for it.
+    validate(p.validators.projectName, ({ value }) =>
+      RESERVED_PROJECT_NAMES.includes(value().toLowerCase())
+        ? { kind: 'reserved' }
+        : undefined,
+    );
+
+    validateAsync(p.validators.username, {
+      params: ({ value }) => value(),
+      debounce: 500,
+      factory: (username) =>
+        resource({
+          injector: this.#injector,
+          params: () => username(),
+          loader: async ({ params }) => {
+            await new Promise((resolve) => setTimeout(resolve, 750));
+
+            return !TAKEN_USERNAMES.includes((params ?? '').toLowerCase());
+          },
+        }),
+      onSuccess: (isAvailable) =>
+        isAvailable
+          ? undefined
+          : {
+              kind: 'usernameTaken',
+              message: 'That username is already taken.',
+            },
+      onError: () => ({
+        kind: 'usernameCheckFailed',
+        message: 'The username could not be verified. Try again.',
+      }),
+    });
+
+    // A tree validator sees the whole group and can target its error at any
+    // field within it.
+    validateTree(p.native, ({ value, fieldTreeOf }) => {
+      const { name, password } = value();
+
+      return name && password.toLowerCase().includes(name.toLowerCase())
+        ? targetError(fieldTreeOf(p.native.password), {
+            kind: 'passwordContainsName',
+            message: 'The password cannot contain the name.',
+          })
+        : undefined;
+    });
+
+    disabled(
+      p.logic.newsletterEmail,
+      ({ valueOf }) =>
+        valueOf(p.logic.subscribed) === 'no' &&
+        'Subscribe to the newsletter to enter an address.',
+    );
+    required(p.logic.newsletterEmail);
+    email(p.logic.newsletterEmail);
+
+    readonly(p.logic.accountId);
+
+    hidden(p.logic.referralCode, ({ valueOf }) => {
+      return valueOf(p.logic.subscribed) === 'no';
+    });
+  });
+
+  protected readonly submitModel = signal({ displayName: '' });
+
+  protected readonly submitForm = form(this.submitModel, (p) => {
+    required(p.displayName);
+  });
+
+  protected readonly submitMessage = signal<string | undefined>(undefined);
+
+  protected readonly projectNameReserved = computed(() => {
+    const state = this.signalForm.validators.projectName();
+
+    return (state.touched() || state.dirty()) && !!state.getError('reserved');
+  });
+
+  protected readonly formValue = computed(() =>
+    JSON.stringify(this.signalForm().value(), undefined, 2),
+  );
+
+  protected markAllAsTouched(): void {
+    this.signalForm().markAsTouched();
+    this.submitForm().markAsTouched();
+  }
+
+  protected async onSubmit(): Promise<void> {
+    this.submitMessage.set(undefined);
+
+    const succeeded = await submit(this.submitForm, async (f) => {
+      await new Promise((resolve) => setTimeout(resolve, 750));
+
+      if (f().value().displayName.toLowerCase() === 'taken') {
+        return [
+          targetError(this.submitForm.displayName, {
+            kind: 'server',
+            message: 'That display name is already in use.',
+          }),
+        ];
+      }
+
+      return undefined;
+    });
+
+    this.submitMessage.set(
+      succeeded ? 'Saved.' : 'The form could not be saved.',
+    );
+  }
+}

--- a/apps/playground/src/app/components/forms/input-box/input-box.module.ts
+++ b/apps/playground/src/app/components/forms/input-box/input-box.module.ts
@@ -11,6 +11,7 @@ import { SkyIconModule } from '@skyux/icon';
 import { SkyStatusIndicatorModule } from '@skyux/indicators';
 
 import { InputBoxRoutingModule } from './input-box-routing.module';
+import { InputBoxSignalFormsComponent } from './input-box-signal-forms.component';
 import { InputBoxVisualHostComponent } from './input-box-visual-host.component';
 import { InputBoxComponent } from './input-box.component';
 
@@ -19,6 +20,7 @@ import { InputBoxComponent } from './input-box.component';
   imports: [
     FormsModule,
     InputBoxRoutingModule,
+    InputBoxSignalFormsComponent,
     ReactiveFormsModule,
     SkyCharacterCounterModule,
     SkyFormErrorsModule,

--- a/libs/components/code-examples/routes/src/index.ts
+++ b/libs/components/code-examples/routes/src/index.ts
@@ -534,6 +534,13 @@ export const routes: Routes = [
       ),
   },
   {
+    path: 'FormsInputBoxSignalFormsExample',
+    loadComponent: () =>
+      import('@skyux/code-examples').then(
+        ({ FormsInputBoxSignalFormsExample: c }) => c,
+      ),
+  },
+  {
     path: 'FormsInputBoxWithCustomFormErrorsExampleComponent',
     loadComponent: () =>
       import('@skyux/code-examples').then(

--- a/libs/components/code-examples/src/index.ts
+++ b/libs/components/code-examples/src/index.ts
@@ -74,6 +74,7 @@ export { FormsFileDropHelpKeyExampleComponent } from './lib/modules/forms/file-d
 export { FormsInputBoxBasicExampleComponent } from './lib/modules/forms/input-box/basic/example.component';
 export { FormsInputBoxCharacterLimitExample } from './lib/modules/forms/input-box/character-limit/example';
 export { FormsInputBoxWithCustomFormErrorsExampleComponent } from './lib/modules/forms/input-box/custom-form-errors/example.component';
+export { FormsInputBoxSignalFormsExample } from './lib/modules/forms/input-box/signal-forms/example';
 export { FormsRadioHelpKeyExampleComponent } from './lib/modules/forms/radio/help-key/example.component';
 export { FormsRadioIconExampleComponent } from './lib/modules/forms/radio/icon/example.component';
 export { FormsRadioStandardExampleComponent } from './lib/modules/forms/radio/standard/example.component';

--- a/libs/components/code-examples/src/lib/modules/forms/input-box/signal-forms/example.html
+++ b/libs/components/code-examples/src/lib/modules/forms/input-box/signal-forms/example.html
@@ -1,0 +1,81 @@
+<div class="sky-theme-padding-inset-balanced-l">
+  <sky-fluid-grid gutterSize="small" [disableMargin]="false">
+    <sky-row>
+      <sky-column [screenSmall]="12">
+        <h2>New member form (signal forms)</h2>
+      </sky-column>
+    </sky-row>
+    <sky-row>
+      <sky-column [screenSmall]="12" [screenMedium]="6">
+        <sky-input-box
+          data-sky-id="input-box-first-name"
+          labelText="First name"
+          stacked="true"
+        >
+          <input
+            spellcheck="false"
+            type="text"
+            [formField]="memberForm.firstName"
+          />
+        </sky-input-box>
+      </sky-column>
+      <sky-column [screenSmall]="12" [screenMedium]="6">
+        <sky-input-box
+          data-sky-id="input-box-last-name"
+          labelText="Last name"
+          stacked="true"
+        >
+          <input
+            class="last-name-input-box"
+            spellcheck="false"
+            type="text"
+            [formField]="memberForm.lastName"
+          />
+        </sky-input-box>
+      </sky-column>
+    </sky-row>
+    <sky-row>
+      <sky-column [screenSmall]="12">
+        <sky-input-box
+          data-sky-id="input-box-bio"
+          hintText="A brief description of the member's background, such as hometown, school, hobbies, etc."
+          labelText="Bio"
+          stacked="true"
+        >
+          <textarea [formField]="memberForm.bio"></textarea>
+        </sky-input-box>
+      </sky-column>
+    </sky-row>
+    <sky-row>
+      <sky-column [screenSmall]="12" [screenMedium]="6">
+        <sky-input-box
+          data-sky-id="input-box-email"
+          labelText="Email address"
+          stacked="true"
+        >
+          <input type="text" [formField]="memberForm.email" />
+        </sky-input-box>
+      </sky-column>
+      <sky-column [screenSmall]="12" [screenMedium]="6">
+        <sky-input-box
+          data-sky-id="input-box-favorite-color"
+          labelText="Favorite color"
+        >
+          <select
+            class="input-box-favorite-color-select"
+            [formField]="memberForm.favoriteColor"
+          >
+            <option value="none">None</option>
+            <option value="red">Red</option>
+            <option value="orange">Orange</option>
+            <option value="yellow">Yellow</option>
+            <option value="green">Green</option>
+            <option value="blue">Blue</option>
+            <option value="purple">Purple</option>
+            <option value="invalid">Invalid Color</option>
+          </select>
+        </sky-input-box>
+      </sky-column>
+    </sky-row>
+  </sky-fluid-grid>
+</div>

--- a/libs/components/code-examples/src/lib/modules/forms/input-box/signal-forms/example.spec.ts
+++ b/libs/components/code-examples/src/lib/modules/forms/input-box/signal-forms/example.spec.ts
@@ -1,0 +1,137 @@
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { SkyInputBoxHarness } from '@skyux/forms/testing';
+
+import { FormsInputBoxSignalFormsExample } from './example';
+
+describe('Signal forms input box example', () => {
+  async function setupTest(options: { dataSkyId: string }): Promise<{
+    fixture: ComponentFixture<FormsInputBoxSignalFormsExample>;
+    inputBoxHarness: SkyInputBoxHarness;
+  }> {
+    const fixture = TestBed.createComponent(FormsInputBoxSignalFormsExample);
+    const loader = TestbedHarnessEnvironment.loader(fixture);
+
+    const inputBoxHarness = await loader.getHarness(
+      SkyInputBoxHarness.with({ dataSkyId: options.dataSkyId }),
+    );
+
+    return { fixture, inputBoxHarness };
+  }
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [FormsInputBoxSignalFormsExample],
+    });
+  });
+
+  describe('first name field', () => {
+    it('should have the expected label text and stacked values', async () => {
+      const { fixture, inputBoxHarness } = await setupTest({
+        dataSkyId: 'input-box-first-name',
+      });
+
+      fixture.detectChanges();
+
+      await expectAsync(inputBoxHarness.getLabelText()).toBeResolvedTo(
+        'First name',
+      );
+
+      await expectAsync(inputBoxHarness.getStacked()).toBeResolvedTo(true);
+    });
+  });
+
+  describe('last name field', () => {
+    it('should have last name required', async () => {
+      const { fixture, inputBoxHarness } = await setupTest({
+        dataSkyId: 'input-box-last-name',
+      });
+
+      fixture.detectChanges();
+
+      const inputEl = await inputBoxHarness.querySelector(
+        '.last-name-input-box',
+      );
+
+      await inputEl.setInputValue('');
+      await inputEl.blur();
+
+      await expectAsync(inputBoxHarness.hasRequiredError()).toBeResolvedTo(
+        true,
+      );
+    });
+  });
+
+  describe('bio field', () => {
+    it('should have a character limit of 250', async () => {
+      const { fixture, inputBoxHarness } = await setupTest({
+        dataSkyId: 'input-box-bio',
+      });
+
+      fixture.detectChanges();
+
+      const characterCounter = await inputBoxHarness.getCharacterCounter();
+
+      await expectAsync(characterCounter.getCharacterCount()).toBeResolvedTo(0);
+      await expectAsync(
+        characterCounter.getCharacterCountLimit(),
+      ).toBeResolvedTo(250);
+    });
+
+    it('should show hint text', async () => {
+      const { fixture, inputBoxHarness } = await setupTest({
+        dataSkyId: 'input-box-bio',
+      });
+
+      fixture.detectChanges();
+
+      await expectAsync(inputBoxHarness.getHintText()).toBeResolvedTo(
+        `A brief description of the member's background, such as hometown, school, hobbies, etc.`,
+      );
+    });
+  });
+
+  describe('email field', () => {
+    it('should require a valid email address', async () => {
+      const { fixture, inputBoxHarness } = await setupTest({
+        dataSkyId: 'input-box-email',
+      });
+
+      fixture.detectChanges();
+
+      const inputEl = await inputBoxHarness.querySelector('input');
+
+      await inputEl.setInputValue('not-an-email');
+      // Native inputs only notify [formField] of value changes via the
+      // "input" event; setInputValue only sets the DOM value directly.
+      await inputEl.dispatchEvent('input');
+      await inputEl.blur();
+      fixture.detectChanges();
+
+      await expectAsync(inputBoxHarness.hasEmailError()).toBeResolvedTo(true);
+    });
+  });
+
+  describe('favorite color field', () => {
+    it('should not allow invalid color to be selected', async () => {
+      const { fixture, inputBoxHarness } = await setupTest({
+        dataSkyId: 'input-box-favorite-color',
+      });
+
+      fixture.detectChanges();
+
+      const selectEl = await inputBoxHarness.querySelector('select');
+
+      // Select the "invalid" option. Native <select> elements only dispatch
+      // an "input" event (not "change") to notify [formField] of the update.
+      await selectEl.selectOptions(7);
+      await selectEl.dispatchEvent('input');
+      await selectEl.blur();
+      fixture.detectChanges();
+
+      await expectAsync(
+        inputBoxHarness.hasCustomFormError('invalidColor'),
+      ).toBeResolvedTo(true);
+    });
+  });
+});

--- a/libs/components/code-examples/src/lib/modules/forms/input-box/signal-forms/example.ts
+++ b/libs/components/code-examples/src/lib/modules/forms/input-box/signal-forms/example.ts
@@ -1,0 +1,43 @@
+import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
+import {
+  FormField,
+  email,
+  form,
+  maxLength,
+  required,
+  validate,
+} from '@angular/forms/signals';
+import { SkyInputBoxModule } from '@skyux/forms';
+import { SkyFluidGridModule } from '@skyux/layout';
+
+/**
+ * @title Input box with signal forms
+ */
+@Component({
+  selector: 'app-forms-input-box-signal-forms-example',
+  templateUrl: './example.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [FormField, SkyFluidGridModule, SkyInputBoxModule],
+})
+export class FormsInputBoxSignalFormsExample {
+  protected model = signal({
+    firstName: '',
+    lastName: '',
+    bio: '',
+    email: '',
+    favoriteColor: 'none',
+  });
+
+  protected memberForm = form(this.model, (p) => {
+    required(p.firstName);
+    required(p.lastName);
+    maxLength(p.bio, 250);
+    required(p.email);
+    email(p.email);
+    validate(p.favoriteColor, ({ value }) =>
+      value() === 'invalid'
+        ? { kind: 'invalidColor', message: 'Invalid color is not a color' }
+        : undefined,
+    );
+  });
+}

--- a/libs/components/forms/documentation.json
+++ b/libs/components/forms/documentation.json
@@ -155,6 +155,7 @@
           "FormsInputBoxBasicExampleComponent",
           "FormsInputBoxCharacterLimitExample",
           "FormsInputBoxWithCustomFormErrorsExampleComponent",
+          "FormsInputBoxSignalFormsExample",
           "LookupCountryFieldBasicExampleComponent",
           "DatetimeDatepickerBasicExampleComponent",
           "LookupSingleSelectExampleComponent",

--- a/libs/components/forms/src/index.ts
+++ b/libs/components/forms/src/index.ts
@@ -37,6 +37,7 @@ export { SkyRadioType } from './lib/modules/radio/types/radio-type';
 export { SkyRequiredStateDirective } from './lib/modules/required-state/required-state.directive';
 
 export { skyIsAbstractControl } from './lib/modules/shared/is-abstract-control';
+export { skyWatchFormFieldChanges } from './lib/modules/shared/watch-form-field-changes';
 
 export { SkySelectionBoxModule } from './lib/modules/selection-box/selection-box.module';
 export { SkySelectionBoxGridAlignItems } from './lib/modules/selection-box/types/selection-box-grid-align-items';

--- a/libs/components/forms/src/lib/modules/form-error/form-errors.component.html
+++ b/libs/components/forms/src/lib/modules/form-error/form-errors.component.html
@@ -17,6 +17,16 @@
       />
     }
 
+    @if (errors?.['minLength']; as signalMinLengthError) {
+      <sky-form-error
+        errorName="minlength"
+        [errorText]="
+          'skyux_form_error_minlength'
+            | skyLibResources: labelText : signalMinLengthError.minLength
+        "
+      />
+    }
+
     @if (errors?.['skyDate'] && errors?.['skyDate']['invalid']) {
       <sky-form-error
         errorName="invalidDate"
@@ -100,6 +110,13 @@
       />
     }
 
+    @if (errors?.['email']) {
+      <sky-form-error
+        errorName="email"
+        [errorText]="'skyux_form_error_email' | skyLibResources"
+      />
+    }
+
     @if (errors?.['skyPhoneField']) {
       <sky-form-error
         errorName="phone"
@@ -120,6 +137,13 @@
         [errorText]="'skyux_form_error_url' | skyLibResources"
       />
     }
+
+    @for (customError of customMessageErrors; track customError.kind) {
+      <sky-form-error
+        [errorName]="customError.kind"
+        [errorText]="customError.message"
+      />
+    }
   }
 
   @if (touched || dirty) {
@@ -129,6 +153,16 @@
         [errorText]="
           'skyux_form_error_maxlength'
             | skyLibResources: labelText : maxLengthError.requiredLength
+        "
+      />
+    }
+
+    @if (errors?.['maxLength']; as signalMaxLengthError) {
+      <sky-form-error
+        errorName="maxlength"
+        [errorText]="
+          'skyux_form_error_maxlength'
+            | skyLibResources: labelText : signalMaxLengthError.maxLength
         "
       />
     }

--- a/libs/components/forms/src/lib/modules/form-error/form-errors.component.spec.ts
+++ b/libs/components/forms/src/lib/modules/form-error/form-errors.component.spec.ts
@@ -5,6 +5,7 @@ import { expect } from '@skyux-sdk/testing';
 
 import { SkyFormErrorModule } from './form-error.module';
 import { SKY_FORM_ERRORS_ENABLED } from './form-errors-enabled-token';
+import { SKY_HANDLED_SIGNAL_ERROR_KINDS } from './form-errors.component';
 import { SkyFormErrorsModule } from './form-errors.module';
 
 @Component({
@@ -97,6 +98,55 @@ describe('Form errors component', () => {
     });
   });
 
+  it('should render signal-forms camelCase error kinds (minLength, maxLength, email)', () => {
+    fixture.componentRef.setInput('errors', {
+      minLength: { kind: 'minLength', minLength: 5 },
+      maxLength: { kind: 'maxLength', maxLength: 10 },
+      email: true,
+    });
+    fixture.componentRef.setInput('touched', true);
+    fixture.componentRef.setInput('dirty', true);
+    fixture.detectChanges();
+
+    ['minlength', 'maxlength', 'email'].forEach((errorName) => {
+      const formError = fixture.nativeElement.querySelector(
+        `sky-form-error[errorName='${errorName}']`,
+      );
+      expect(formError).toExist();
+      expect(formError).toBeVisible();
+    });
+  });
+
+  it('should render a custom sky-form-error for any unknown error kind with a message', () => {
+    fixture.componentRef.setInput('errors', {
+      customValidator: { message: 'Custom validator message' },
+    });
+    fixture.componentRef.setInput('touched', true);
+    fixture.detectChanges();
+
+    const formError = fixture.nativeElement.querySelector(
+      `sky-form-error[data-error-name='customValidator']`,
+    );
+
+    expect(formError).toExist();
+    expect(formError).toBeVisible();
+    expect(formError.textContent).toContain('Custom validator message');
+  });
+
+  it('should not render a custom sky-form-error for an unknown error kind without a message', () => {
+    fixture.componentRef.setInput('errors', {
+      customValidator: { invalid: true },
+    });
+    fixture.componentRef.setInput('touched', true);
+    fixture.detectChanges();
+
+    const formError = fixture.nativeElement.querySelector(
+      `sky-form-error[data-error-name='customValidator']`,
+    );
+
+    expect(formError).toBeNull();
+  });
+
   it('should include the minimum or maximum date in the date error messages', () => {
     fixture.componentRef.setInput('errors', {
       skyDate: {
@@ -169,6 +219,58 @@ describe('Form errors component', () => {
 
     expect(formError).toExist();
     expect(formError).toBeVisible();
+  });
+
+  it('should not render a duplicate custom error for a kind handled by a dedicated template block', () => {
+    // The dedicated block for each kind binds its own errorName (lowercase for
+    // required/email, camelCase for minLength/maxLength), so a duplicate render from
+    // `customMessageErrors` would show up as a second element sharing that same
+    // `data-error-name`, not a differently-named one.
+    for (const kind of SKY_HANDLED_SIGNAL_ERROR_KINDS) {
+      fixture.componentRef.setInput('errors', {
+        [kind]: {
+          kind,
+          message: 'Consumer message',
+          minLength: 5,
+          maxLength: 10,
+        },
+      });
+      fixture.componentRef.setInput('touched', true);
+      fixture.componentRef.setInput('dirty', true);
+      fixture.detectChanges();
+
+      const matchingErrors = fixture.nativeElement.querySelectorAll(
+        `sky-form-error[errorname='${kind.toLowerCase()}']`,
+      );
+
+      expect(matchingErrors.length).toBe(1);
+      expect(matchingErrors[0].textContent).not.toContain('Consumer message');
+    }
+  });
+
+  it('should not render custom errors for reactive-forms error values', () => {
+    fixture.componentRef.setInput('errors', {
+      required: true,
+      minlength: { requiredLength: 5, actualLength: 2 },
+      maxlength: { requiredLength: 5, actualLength: 9 },
+      skyDate: { invalid: true },
+      skyFuzzyDate: { invalid: true },
+      skyEmail: { invalid: 'x' },
+      skyPhoneField: { invalid: 'x' },
+      skyTime: { invalid: true },
+      skyUrl: { invalid: 'x' },
+    });
+    fixture.componentRef.setInput('touched', true);
+    fixture.componentRef.setInput('dirty', true);
+    fixture.detectChanges();
+
+    // None of these values carry a `message`, so `customMessageErrors` should exclude all
+    // of them regardless of `SKY_HANDLED_SIGNAL_ERROR_KINDS`. Each kind's dedicated block
+    // (or sub-block, for the compound skyDate/skyFuzzyDate errors) should render exactly
+    // once, plus the projected 'custom' error from the host template.
+    expect(
+      fixture.nativeElement.querySelectorAll('sky-form-error').length,
+    ).toBe(10);
   });
 
   it('should not render any errors when they are passed but labelText is undefined', () => {

--- a/libs/components/forms/src/lib/modules/form-error/form-errors.component.ts
+++ b/libs/components/forms/src/lib/modules/form-error/form-errors.component.ts
@@ -13,6 +13,23 @@ import { SkyFormsResourcesModule } from '../shared/sky-forms-resources.module';
 import { SkyFormErrorComponent } from './form-error.component';
 
 /**
+ * Angular signal-forms error kinds that have a dedicated block in this component's template.
+ * Errors of these kinds are skipped by `customMessageErrors` so a consumer-supplied
+ * `message` doesn't render alongside the SKY message.
+ *
+ * SKY-owned error kinds (`skyDate`, `skyEmail`, `skyTime`, etc.) are deliberately absent:
+ * SKY validators never set `message` — their text comes from `skyLibResources` — so
+ * `customMessageErrors` already excludes them. A `message` on an error means a consumer
+ * authored that text.
+ */
+export const SKY_HANDLED_SIGNAL_ERROR_KINDS = new Set([
+  'required',
+  'minLength',
+  'maxLength',
+  'email',
+]);
+
+/**
  * @internal
  */
 @Component({
@@ -55,4 +72,28 @@ export class SkyFormErrorsComponent {
 
   @HostBinding('attr.aria-relevant')
   protected readonly ariaRelevant = 'all';
+
+  /**
+   * Signal-forms validation errors (e.g. from a custom `validate()` rule) that aren't
+   * mapped to a built-in SKY message. These are rendered automatically as custom errors
+   * when they carry a `message`.
+   */
+  protected get customMessageErrors(): { kind: string; message: string }[] {
+    const errors = this.errors;
+
+    if (!errors) {
+      return [];
+    }
+
+    return Object.entries(errors)
+      .filter(
+        ([kind, error]) =>
+          !SKY_HANDLED_SIGNAL_ERROR_KINDS.has(kind) &&
+          typeof (error as { message?: unknown })?.message === 'string',
+      )
+      .map(([kind, error]) => ({
+        kind,
+        message: (error as { message: string }).message,
+      }));
+  }
 }

--- a/libs/components/forms/src/lib/modules/form-error/form-errors.component.ts
+++ b/libs/components/forms/src/lib/modules/form-error/form-errors.component.ts
@@ -12,15 +12,13 @@ import { SkyFormsResourcesModule } from '../shared/sky-forms-resources.module';
 
 import { SkyFormErrorComponent } from './form-error.component';
 
+// Angular signal-forms error kinds that have a dedicated block in this component's
+// template; skipped by `customMessageErrors` so a consumer-supplied `message` doesn't
+// render alongside the SKY message. SKY-owned error kinds (`skyDate`, `skyEmail`,
+// `skyTime`, etc.) are deliberately absent — SKY validators never set `message`, so
+// `customMessageErrors` already excludes them by construction.
 /**
- * Angular signal-forms error kinds that have a dedicated block in this component's template.
- * Errors of these kinds are skipped by `customMessageErrors` so a consumer-supplied
- * `message` doesn't render alongside the SKY message.
- *
- * SKY-owned error kinds (`skyDate`, `skyEmail`, `skyTime`, etc.) are deliberately absent:
- * SKY validators never set `message` — their text comes from `skyLibResources` — so
- * `customMessageErrors` already excludes them. A `message` on an error means a consumer
- * authored that text.
+ * @internal
  */
 export const SKY_HANDLED_SIGNAL_ERROR_KINDS = new Set([
   'required',
@@ -73,11 +71,9 @@ export class SkyFormErrorsComponent {
   @HostBinding('attr.aria-relevant')
   protected readonly ariaRelevant = 'all';
 
-  /**
-   * Signal-forms validation errors (e.g. from a custom `validate()` rule) that aren't
-   * mapped to a built-in SKY message. These are rendered automatically as custom errors
-   * when they carry a `message`.
-   */
+  // Signal-forms validation errors (e.g. from a custom `validate()` rule) that aren't
+  // mapped to a built-in SKY message; rendered automatically as custom errors when they
+  // carry a `message`.
   protected get customMessageErrors(): { kind: string; message: string }[] {
     const errors = this.errors;
 

--- a/libs/components/forms/src/lib/modules/input-box/input-box.component.html
+++ b/libs/components/forms/src/lib/modules/input-box/input-box.component.html
@@ -80,11 +80,13 @@
     <label
       class="sky-control-label"
       [attr.aria-label]="
-        characterLimit !== undefined
+        characterLimitComputed !== undefined
           ? labelText +
             ' ' +
             ('skyux_character_count_message'
-              | skyLibResources: characterCountScreenReader : characterLimit)
+              | skyLibResources
+                : characterCountScreenReader
+                : characterLimitComputed)
           : null
       "
       [for]="controlId"
@@ -111,10 +113,10 @@
 </ng-template>
 
 <ng-template #characterCountTemplate>
-  @if (characterLimit !== undefined) {
+  @if (characterLimitComputed !== undefined) {
     <sky-input-box-character-limit
       [characterCount]="controlDir?.value?.length ?? 0"
-      [characterLimit]="characterLimit"
+      [characterLimit]="characterLimitComputed"
     />
   }
   <ng-content select="sky-character-counter-indicator" />

--- a/libs/components/forms/src/lib/modules/input-box/input-box.component.spec.ts
+++ b/libs/components/forms/src/lib/modules/input-box/input-box.component.spec.ts
@@ -1698,7 +1698,7 @@ describe('Input box component', () => {
       const { inputBoxEl } = getInputBoxSignalFormEls();
 
       const characterCountEl = inputBoxEl.querySelector(
-        'sky-character-counter-indicator',
+        'sky-input-box-character-limit',
       );
 
       expect(characterCountEl).toBeTruthy();
@@ -1716,7 +1716,7 @@ describe('Input box component', () => {
 
       const { inputBoxEl } = getInputBoxSignalFormEls();
       const characterCountEl = inputBoxEl.querySelector(
-        'sky-character-counter-indicator',
+        'sky-input-box-character-limit',
       );
 
       expect(characterCountEl?.textContent).toContain('10');

--- a/libs/components/forms/src/lib/modules/input-box/input-box.component.spec.ts
+++ b/libs/components/forms/src/lib/modules/input-box/input-box.component.spec.ts
@@ -1,4 +1,5 @@
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { Component, signal } from '@angular/core';
 import {
   ComponentFixture,
   TestBed,
@@ -6,9 +7,10 @@ import {
   tick,
 } from '@angular/core/testing';
 import { AbstractControl } from '@angular/forms';
+import { FormField, form, maxLength, required } from '@angular/forms/signals';
 import { By } from '@angular/platform-browser';
 import { SkyAppTestUtility, expect, expectAsync } from '@skyux-sdk/testing';
-import { provideNoopSkyAnimations } from '@skyux/core';
+import { SkyLogService, provideNoopSkyAnimations } from '@skyux/core';
 import {
   SkyHelpTestingController,
   SkyHelpTestingModule,
@@ -29,6 +31,7 @@ import { InputBoxFixturesModule } from './fixtures/input-box.module.fixture';
 import { SkyInputBoxAdapterService } from './input-box-adapter.service';
 import { SkyInputBoxHostService } from './input-box-host.service';
 import { SkyInputBoxComponent } from './input-box.component';
+import { SkyInputBoxModule } from './input-box.module';
 
 interface InputBoxA11yTestingOptions {
   disabled?: boolean;
@@ -1617,6 +1620,178 @@ describe('Input box component', () => {
 
     describe('a11y', () => {
       a11yTests();
+    });
+  });
+
+  describe('signal forms', () => {
+    @Component({
+      standalone: true,
+      imports: [FormField, SkyInputBoxModule],
+      template: `<sky-input-box
+        labelText="Easy mode"
+        [characterLimit]="characterLimit"
+      >
+        <input type="text" [formField]="easyModeForm" />
+      </sky-input-box>`,
+    })
+    class InputBoxSignalFormFixtureComponent {
+      public readonly model = signal('');
+      public readonly easyModeForm = form(this.model, (p) => {
+        required(p);
+        maxLength(p, 10);
+      });
+      public characterLimit: number | undefined;
+    }
+
+    let fixture: ComponentFixture<InputBoxSignalFormFixtureComponent>;
+    let testComponent: InputBoxSignalFormFixtureComponent;
+
+    function getInputBoxSignalFormEls(): {
+      inputBoxEl: HTMLElement;
+      inputEl: HTMLInputElement;
+      labelEl: HTMLLabelElement | null;
+    } {
+      const inputBoxEl = fixture.nativeElement.querySelector('sky-input-box');
+      return {
+        inputBoxEl,
+        inputEl: inputBoxEl.querySelector('input'),
+        labelEl: inputBoxEl.querySelector('label'),
+      };
+    }
+
+    beforeEach(() => {
+      TestBed.configureTestingModule({
+        imports: [InputBoxSignalFormFixtureComponent],
+        providers: [provideNoopSkyAnimations()],
+      });
+
+      fixture = TestBed.createComponent(InputBoxSignalFormFixtureComponent);
+      testComponent = fixture.componentInstance;
+      fixture.detectChanges();
+    });
+
+    it('should add the required attributes when the field is required', () => {
+      const { inputEl, labelEl } = getInputBoxSignalFormEls();
+
+      expect(inputEl.ariaRequired).toBe('true');
+      expect(labelEl).toHaveCssClass('sky-control-label-required');
+    });
+
+    it('should display an error message when the field is touched and invalid', () => {
+      const { inputBoxEl, inputEl } = getInputBoxSignalFormEls();
+
+      testComponent.easyModeForm().markAsTouched();
+      fixture.detectChanges();
+
+      expect(inputEl.getAttribute('aria-invalid')).toBe('true');
+      expect(inputEl.getAttribute('aria-errormessage')).toBeTruthy();
+      expect(inputBoxEl.querySelector('sky-form-error')).toBeVisible();
+    });
+
+    it('should not display an error message when the field is untouched', () => {
+      const { inputEl } = getInputBoxSignalFormEls();
+
+      expect(inputEl.getAttribute('aria-invalid')).toBeNull();
+    });
+
+    it('should use the schema maxLength rule for the character counter', () => {
+      const { inputBoxEl } = getInputBoxSignalFormEls();
+
+      const characterCountEl = inputBoxEl.querySelector(
+        'sky-character-counter-indicator',
+      );
+
+      expect(characterCountEl).toBeTruthy();
+    });
+
+    it('should not mutate the field validators when characterLimit is set', () => {
+      testComponent.characterLimit = 5;
+
+      expect(() => fixture.detectChanges()).not.toThrow();
+    });
+
+    it('should prefer the schema maxLength rule over the characterLimit input', () => {
+      testComponent.characterLimit = 5;
+      fixture.detectChanges();
+
+      const { inputBoxEl } = getInputBoxSignalFormEls();
+      const characterCountEl = inputBoxEl.querySelector(
+        'sky-character-counter-indicator',
+      );
+
+      expect(characterCountEl?.textContent).toContain('10');
+    });
+
+    it('should not warn when the schema maxLength rule is zero', () => {
+      @Component({
+        standalone: true,
+        imports: [FormField, SkyInputBoxModule],
+        template: `<sky-input-box labelText="Easy mode" [characterLimit]="5">
+          <input type="text" [formField]="easyModeForm" />
+        </sky-input-box>`,
+      })
+      class InputBoxSignalFormZeroMaxLengthFixtureComponent {
+        public readonly model = signal('');
+        public readonly easyModeForm = form(this.model, (p) => {
+          maxLength(p, 0);
+        });
+      }
+
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({
+        imports: [InputBoxSignalFormZeroMaxLengthFixtureComponent],
+        providers: [provideNoopSkyAnimations()],
+      });
+
+      const warnSpy = spyOn(TestBed.inject(SkyLogService), 'warn');
+
+      const zeroMaxLengthFixture = TestBed.createComponent(
+        InputBoxSignalFormZeroMaxLengthFixtureComponent,
+      );
+      zeroMaxLengthFixture.detectChanges();
+
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it('should update aria-invalid to false once the field becomes valid', () => {
+      const { inputEl } = getInputBoxSignalFormEls();
+
+      testComponent.easyModeForm().markAsTouched();
+      testComponent.model.set('valid');
+      fixture.detectChanges();
+
+      expect(inputEl.getAttribute('aria-invalid')).toBeNull();
+    });
+
+    it('should warn when characterLimit is set without a schema maxLength rule', () => {
+      @Component({
+        standalone: true,
+        imports: [FormField, SkyInputBoxModule],
+        template: `<sky-input-box labelText="Easy mode" [characterLimit]="5">
+          <input type="text" [formField]="easyModeForm" />
+        </sky-input-box>`,
+      })
+      class InputBoxSignalFormNoMaxLengthFixtureComponent {
+        public readonly model = signal('');
+        public readonly easyModeForm = form(this.model);
+      }
+
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({
+        imports: [InputBoxSignalFormNoMaxLengthFixtureComponent],
+        providers: [provideNoopSkyAnimations()],
+      });
+
+      const warnSpy = spyOn(TestBed.inject(SkyLogService), 'warn');
+
+      const noMaxLengthFixture = TestBed.createComponent(
+        InputBoxSignalFormNoMaxLengthFixtureComponent,
+      );
+      noMaxLengthFixture.detectChanges();
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        jasmine.stringMatching(/characterLimit.*has no effect/),
+      );
     });
   });
 });

--- a/libs/components/forms/src/lib/modules/input-box/input-box.component.ts
+++ b/libs/components/forms/src/lib/modules/input-box/input-box.component.ts
@@ -224,19 +224,14 @@ export class SkyInputBoxComponent
   })
   public inputRef: ElementRef | undefined;
 
-  /**
-   * The signal-forms `FormField` directive bound to the content control, if any.
-   * `FormField` provides a fake `NgControl` via DI (read below), which lets input box
-   * derive most of its state through the existing `controlDir` accessors. This is used
-   * as a fallback for state that isn't exposed through that interop control, such as the
-   * field's `maxLength` metadata.
-   */
+  // `FormField` provides a fake `NgControl` via DI (`signalControl` below), which lets
+  // input box derive most of its state through the existing `controlDir` accessors. This
+  // is used as a fallback for state that isn't exposed through that interop control, such
+  // as the field's `maxLength` metadata.
   protected formField = contentChild(FormField);
 
-  /**
-   * Falls back to the `NgControl` provided by a signal-forms `FormField` directive when
-   * none of `formControl`, `formControlByName`, or `ngModel` are present.
-   */
+  // Falls back to the `NgControl` provided by a signal-forms `FormField` directive when
+  // none of `formControl`, `formControlByName`, or `ngModel` are present.
   protected signalControl = contentChild(NgControl);
 
   protected controlDir: AbstractControlDirective | undefined;
@@ -266,10 +261,8 @@ export class SkyInputBoxComponent
     );
   }
 
-  /**
-   * The character limit to display in the character counter. Prefers the signal-forms
-   * field's `maxLength` rule (if bound with `[formField]`) over the `characterLimit` input.
-   */
+  // Prefers the signal-forms field's `maxLength` rule (if bound with `[formField]`) over
+  // the `characterLimit` input.
   protected get characterLimitComputed(): number | undefined {
     const schemaLimit = this.formField()?.state().maxLength?.();
 
@@ -467,21 +460,26 @@ export class SkyInputBoxComponent
       // Signal-forms controls don't support imperative validator mutation; they own their
       // validation through the schema passed to `form()`. The character counter instead
       // reads the field's `maxLength` rule directly (see `characterLimitComputed`).
+      if (this.characterLimit === undefined) {
+        return;
+      }
+
+      let maxLength: number | undefined;
       try {
-        if (
-          this.characterLimit !== undefined &&
-          formField.state().maxLength?.() === undefined
-        ) {
-          this.#logger.warn(
-            'The `characterLimit` input has no effect on signal-forms ' +
-              `controls. Add \`maxLength(field, ${this.characterLimit})\` to the schema function ` +
-              'passed to `form()` instead.',
-          );
-        }
+        maxLength = formField.state().maxLength?.();
       } catch {
         // The `FormField` directive's own `field` input may not have a value yet if this
         // runs before its host binding has been processed (e.g. `characterLimit` is set
         // during the input box's initial input processing, ahead of content projection).
+        return;
+      }
+
+      if (maxLength === undefined) {
+        this.#logger.warn(
+          'The `characterLimit` input has no effect on signal-forms ' +
+            `controls. Add \`maxLength(field, ${this.characterLimit})\` to the schema function ` +
+            'passed to `form()` instead.',
+        );
       }
       return;
     }

--- a/libs/components/forms/src/lib/modules/input-box/input-box.component.ts
+++ b/libs/components/forms/src/lib/modules/input-box/input-box.component.ts
@@ -18,21 +18,30 @@ import {
   Renderer2,
   TemplateRef,
   ViewEncapsulation,
+  contentChild,
   inject,
 } from '@angular/core';
 import {
   AbstractControlDirective,
   FormControlDirective,
   FormControlName,
+  NgControl,
   NgModel,
   ValidatorFn,
   Validators,
 } from '@angular/forms';
-import { SkyContentInfoProvider, SkyIdService } from '@skyux/core';
+import { FormField } from '@angular/forms/signals';
+import {
+  SkyContentInfoProvider,
+  SkyIdService,
+  SkyLogService,
+} from '@skyux/core';
 
 import { ReplaySubject, Subject, takeUntil } from 'rxjs';
 
 import { SKY_FORM_ERRORS_ENABLED } from '../form-error/form-errors-enabled-token';
+import { skyIsAbstractControl } from '../shared/is-abstract-control';
+import { skyWatchFormFieldChanges } from '../shared/watch-form-field-changes';
 
 import { SkyInputBoxAdapterService } from './input-box-adapter.service';
 import { SkyInputBoxControlDirective } from './input-box-control.directive';
@@ -70,6 +79,7 @@ export class SkyInputBoxComponent
   #idSvc = inject(SkyIdService);
   #elementRef = inject(ElementRef);
   #renderer = inject(Renderer2);
+  #logger = inject(SkyLogService);
 
   /**
    * Whether to visually highlight the input box in an error state. If not specified, the input box
@@ -214,6 +224,21 @@ export class SkyInputBoxComponent
   })
   public inputRef: ElementRef | undefined;
 
+  /**
+   * The signal-forms `FormField` directive bound to the content control, if any.
+   * `FormField` provides a fake `NgControl` via DI (read below), which lets input box
+   * derive most of its state through the existing `controlDir` accessors. This is used
+   * as a fallback for state that isn't exposed through that interop control, such as the
+   * field's `maxLength` metadata.
+   */
+  protected formField = contentChild(FormField);
+
+  /**
+   * Falls back to the `NgControl` provided by a signal-forms `FormField` directive when
+   * none of `formControl`, `formControlByName`, or `ngModel` are present.
+   */
+  protected signalControl = contentChild(NgControl);
+
   protected controlDir: AbstractControlDirective | undefined;
 
   protected get isDisabled(): boolean {
@@ -233,11 +258,22 @@ export class SkyInputBoxComponent
   }
 
   protected get required(): boolean {
-    return (
+    return !!(
       this.#hasRequiredValidator() ||
       this.inputRef?.nativeElement.required ||
-      this.#requiredByFormField
+      this.#requiredByFormField ||
+      this.formField()?.state().required()
     );
+  }
+
+  /**
+   * The character limit to display in the character counter. Prefers the signal-forms
+   * field's `maxLength` rule (if bound with `[formField]`) over the `characterLimit` input.
+   */
+  protected get characterLimitComputed(): number | undefined {
+    const schemaLimit = this.formField()?.state().maxLength?.();
+
+    return schemaLimit === undefined ? this.characterLimit : schemaLimit;
   }
 
   protected characterCountScreenReader = 0;
@@ -249,6 +285,16 @@ export class SkyInputBoxComponent
   #previousInputRef: ElementRef | undefined;
   #previousMaxLengthValidator: ValidatorFn | undefined;
   #ngUnsubscribe = new Subject<void>();
+
+  constructor() {
+    // Refreshes the input box whenever a bound signal-forms field's state changes. This is
+    // necessary because the `[formField]` binding lives in the consumer's template, so a
+    // signal write there doesn't automatically mark this component's view for check.
+    skyWatchFormFieldChanges(this.formField, this.#changeRef, (state) => {
+      state.maxLength?.();
+      state.value();
+    });
+  }
 
   public ngOnInit(): void {
     this.#inputBoxHostSvc.init(this);
@@ -263,7 +309,10 @@ export class SkyInputBoxComponent
 
   public ngAfterContentChecked(): void {
     this.controlDir =
-      this.formControl || this.formControlByName || this.ngModel;
+      this.formControl ||
+      this.formControlByName ||
+      this.ngModel ||
+      this.signalControl();
 
     if (!this.formControlHasFocus) {
       this.characterCountScreenReader = this.controlDir?.value?.length || 0;
@@ -412,13 +461,41 @@ export class SkyInputBoxComponent
 
   #updateMaxLengthValidator(): void {
     const control = this.controlDir?.control;
+    const formField = this.formField();
+
+    if (formField) {
+      // Signal-forms controls don't support imperative validator mutation; they own their
+      // validation through the schema passed to `form()`. The character counter instead
+      // reads the field's `maxLength` rule directly (see `characterLimitComputed`).
+      try {
+        if (
+          this.characterLimit !== undefined &&
+          formField.state().maxLength?.() === undefined
+        ) {
+          this.#logger.warn(
+            'The `characterLimit` input has no effect on signal-forms ' +
+              `controls. Add \`maxLength(field, ${this.characterLimit})\` to the schema function ` +
+              'passed to `form()` instead.',
+          );
+        }
+      } catch {
+        // The `FormField` directive's own `field` input may not have a value yet if this
+        // runs before its host binding has been processed (e.g. `characterLimit` is set
+        // during the input box's initial input processing, ahead of content projection).
+      }
+      return;
+    }
+
+    if (!skyIsAbstractControl(control)) {
+      return;
+    }
 
     if (this.#previousMaxLengthValidator) {
-      control?.removeValidators(this.#previousMaxLengthValidator);
+      control.removeValidators(this.#previousMaxLengthValidator);
       this.#previousMaxLengthValidator = undefined;
     }
 
-    if (control && this.characterLimit !== undefined) {
+    if (this.characterLimit !== undefined) {
       this.#previousMaxLengthValidator = Validators.maxLength(
         this.characterLimit,
       );

--- a/libs/components/forms/src/lib/modules/shared/is-abstract-control.ts
+++ b/libs/components/forms/src/lib/modules/shared/is-abstract-control.ts
@@ -3,11 +3,9 @@ import { AbstractControl } from '@angular/forms';
 // Components that call mutation methods (`setValue`, `markAsDirty`, `markAsTouched`,
 // `setErrors`, etc.) on a control captured from `validate()` or an injected `NgControl`
 // should guard those calls with this function, since the read-only interop control that
-// signal forms' `[field]` directive provides through `NgControl` has no such methods.
+// signal forms' `[formField]` directive provides through `NgControl` has no such methods.
 /**
- * Reports whether `control` is a real `AbstractControl`, as opposed to the read-only
- * interop control that `@angular/forms/signals`' `[field]` directive provides through
- * `NgControl`.
+ * Reports whether `control` is a real `AbstractControl`.
  * @internal
  */
 export function skyIsAbstractControl(

--- a/libs/components/forms/src/lib/modules/shared/watch-form-field-changes.spec.ts
+++ b/libs/components/forms/src/lib/modules/shared/watch-form-field-changes.spec.ts
@@ -1,0 +1,121 @@
+import {
+  ChangeDetectorRef,
+  Component,
+  contentChild,
+  inject,
+  signal,
+} from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormField, disabled, form, required } from '@angular/forms/signals';
+import { By } from '@angular/platform-browser';
+
+import { skyWatchFormFieldChanges } from './watch-form-field-changes';
+
+// Mirrors how real consumers (e.g. `SkyInputBoxComponent`) call `skyWatchFormFieldChanges`:
+// the watched `[formField]` binding lives in a separately-rendered consumer template that's
+// projected in, not in this component's own template.
+@Component({
+  standalone: true,
+  selector: 'watch-form-field-changes-host',
+  template: `<ng-content />`,
+})
+class WatchFormFieldChangesHostComponent {
+  public readonly changeRef = inject(ChangeDetectorRef);
+  public readonly readValues: unknown[] = [];
+
+  protected readonly formField = contentChild(FormField);
+
+  constructor() {
+    skyWatchFormFieldChanges(this.formField, this.changeRef, (state) => {
+      this.readValues.push(state.value());
+    });
+  }
+}
+
+@Component({
+  standalone: true,
+  imports: [FormField, WatchFormFieldChangesHostComponent],
+  template: `<watch-form-field-changes-host>
+    <input [formField]="testForm" />
+  </watch-form-field-changes-host>`,
+})
+class WatchFormFieldChangesFixtureComponent {
+  public readonly model = signal('');
+  public readonly isDisabled = signal(false);
+  public readonly testForm = form(this.model, (p) => {
+    required(p);
+    disabled(p, { when: () => this.isDisabled() });
+  });
+}
+
+@Component({
+  standalone: true,
+  imports: [WatchFormFieldChangesHostComponent],
+  template: `<watch-form-field-changes-host />`,
+})
+class WatchFormFieldChangesNoFieldFixtureComponent {}
+
+describe('skyWatchFormFieldChanges', () => {
+  let fixture: ComponentFixture<WatchFormFieldChangesFixtureComponent>;
+  let testComponent: WatchFormFieldChangesFixtureComponent;
+  let host: WatchFormFieldChangesHostComponent;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [WatchFormFieldChangesFixtureComponent],
+    });
+
+    fixture = TestBed.createComponent(WatchFormFieldChangesFixtureComponent);
+    testComponent = fixture.componentInstance;
+    fixture.detectChanges();
+
+    host = fixture.debugElement.query(
+      By.directive(WatchFormFieldChangesHostComponent),
+    ).componentInstance as WatchFormFieldChangesHostComponent;
+  });
+
+  it('marks the change detector for check when the field becomes touched', () => {
+    const markForCheckSpy = spyOn(
+      host.changeRef,
+      'markForCheck',
+    ).and.callThrough();
+
+    testComponent.testForm().markAsTouched();
+    fixture.detectChanges();
+
+    expect(markForCheckSpy).toHaveBeenCalled();
+  });
+
+  it('marks the change detector for check when the field becomes disabled', () => {
+    const markForCheckSpy = spyOn(
+      host.changeRef,
+      'markForCheck',
+    ).and.callThrough();
+
+    testComponent.isDisabled.set(true);
+    fixture.detectChanges();
+
+    expect(markForCheckSpy).toHaveBeenCalled();
+  });
+
+  it('invokes the readAdditionalSignals callback with the field state', () => {
+    testComponent.model.set('a value');
+    fixture.detectChanges();
+
+    expect(host.readValues).toContain('a value');
+  });
+
+  it('does not throw when no formField is bound', () => {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      imports: [WatchFormFieldChangesNoFieldFixtureComponent],
+    });
+
+    expect(() => {
+      const noFieldFixture = TestBed.createComponent(
+        WatchFormFieldChangesNoFieldFixtureComponent,
+      );
+      noFieldFixture.detectChanges();
+    }).not.toThrow();
+  });
+});

--- a/libs/components/forms/src/lib/modules/shared/watch-form-field-changes.ts
+++ b/libs/components/forms/src/lib/modules/shared/watch-form-field-changes.ts
@@ -1,11 +1,10 @@
 import { ChangeDetectorRef, effect } from '@angular/core';
 import { FormField } from '@angular/forms/signals';
 
+// Call from a component's constructor so `effect()` picks up the current injection context.
 /**
- * Marks `changeDetector` for check whenever `formField`'s state changes, since the
- * `[formField]` binding lives in the consumer's template and a signal write there doesn't
- * automatically mark the host component's view for check. Call from a component's
- * constructor so `effect()` picks up the current injection context.
+ * Marks `changeDetector` for check whenever `formField`'s state changes, since a signal
+ * write in the consumer's template doesn't automatically mark the host view for check.
  * @internal
  */
 export function skyWatchFormFieldChanges(

--- a/libs/components/forms/src/lib/modules/shared/watch-form-field-changes.ts
+++ b/libs/components/forms/src/lib/modules/shared/watch-form-field-changes.ts
@@ -1,0 +1,37 @@
+import { ChangeDetectorRef, effect } from '@angular/core';
+import { FormField } from '@angular/forms/signals';
+
+/**
+ * Marks `changeDetector` for check whenever `formField`'s state changes, since the
+ * `[formField]` binding lives in the consumer's template and a signal write there doesn't
+ * automatically mark the host component's view for check. Call from a component's
+ * constructor so `effect()` picks up the current injection context.
+ * @internal
+ */
+export function skyWatchFormFieldChanges(
+  formField: () => FormField<unknown> | null | undefined,
+  changeDetector: ChangeDetectorRef,
+  readAdditionalSignals?: (
+    state: ReturnType<FormField<unknown>['state']>,
+  ) => void,
+): void {
+  effect(() => {
+    const field = formField();
+
+    if (!field) {
+      return;
+    }
+
+    const state = field.state();
+
+    state.errors();
+    state.touched();
+    state.dirty();
+    state.disabled();
+    state.required();
+
+    readAdditionalSignals?.(state);
+
+    changeDetector.markForCheck();
+  });
+}

--- a/libs/components/forms/src/lib/modules/shared/watch-form-field-changes.ts
+++ b/libs/components/forms/src/lib/modules/shared/watch-form-field-changes.ts
@@ -1,10 +1,11 @@
 import { ChangeDetectorRef, effect } from '@angular/core';
 import { FormField } from '@angular/forms/signals';
 
-// Call from a component's constructor so `effect()` picks up the current injection context.
 /**
  * Marks `changeDetector` for check whenever `formField`'s state changes, since a signal
  * write in the consumer's template doesn't automatically mark the host view for check.
+ * Must be called from a component's constructor (or another injection context) so the
+ * `effect()` it creates can pick one up; calling it elsewhere throws `NG0203`.
  * @internal
  */
 export function skyWatchFormFieldChanges(


### PR DESCRIPTION
Part 3 of 7 in the signal-forms support stack. Split out of #4629 (closed).
Stack: #4685 <- #4686 <- #4687 <- #4688 <- #4689 <- #4690 <- #4691.

[AB#4008241](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/4008241)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
