### PR TITLE
fix(components/datetime): support signal forms in datepicker and timepicker

### DIFF
--- a/libs/components/datetime/src/lib/modules/datepicker/datepicker-input.directive.ts
+++ b/libs/components/datetime/src/lib/modules/datepicker/datepicker-input.directive.ts
@@ -21,6 +21,7 @@ import {
   ValidationErrors,
   Validator,
 } from '@angular/forms';
+import { skyIsAbstractControl } from '@skyux/forms';
 import { SkyAppLocaleProvider } from '@skyux/i18n';
 
 import moment from 'moment';
@@ -345,16 +346,24 @@ export class SkyDatepickerInputDirective
     this.#_value = value;
     this.#onChange(value);
 
-    this.#control?.setErrors({
-      skyDate: {
-        invalid: value,
-      },
-    });
+    if (skyIsAbstractControl(this.#control)) {
+      this.#control.setErrors({
+        skyDate: {
+          invalid: value,
+        },
+      });
+    } else {
+      // Signal forms' interop control doesn't support `setErrors`, so trigger revalidation
+      // instead; `validate()` returns the `skyDate` error for this same malformed value.
+      this.#onValidatorChange();
+    }
   }
 
   @HostListener('input')
   public onInput(): void {
-    this.#control?.markAsDirty();
+    if (skyIsAbstractControl(this.#control)) {
+      this.#control.markAsDirty();
+    }
   }
 
   @HostListener('keydown', ['$event'])
@@ -370,7 +379,7 @@ export class SkyDatepickerInputDirective
   }
 
   public validate(control: AbstractControl): ValidationErrors | null {
-    if (!this.#control) {
+    if (!this.#control && skyIsAbstractControl(control)) {
       this.#control = control;
       // Account for any date conversion that may have occurred prior to validation.
       if (this.#control.value !== this.#value) {
@@ -394,7 +403,7 @@ export class SkyDatepickerInputDirective
       if (!isDateValid) {
         // Mark the invalid control as touched so that the input's invalid CSS styles appear.
         // (This is only required when the invalid value is set by the FormControl constructor.)
-        this.#control.markAsTouched();
+        this.#control?.markAsTouched();
 
         return {
           skyDate: {
@@ -441,7 +450,7 @@ export class SkyDatepickerInputDirective
     } else {
       // Mark the invalid control as touched so that the input's invalid CSS styles appear.
       // (This is only required when the invalid value is set by the FormControl constructor.)
-      this.#control.markAsTouched();
+      this.#control?.markAsTouched();
 
       return {
         skyDate: {

--- a/libs/components/datetime/src/lib/modules/datepicker/datepicker-input.directive.ts
+++ b/libs/components/datetime/src/lib/modules/datepicker/datepicker-input.directive.ts
@@ -403,7 +403,9 @@ export class SkyDatepickerInputDirective
       if (!isDateValid) {
         // Mark the invalid control as touched so that the input's invalid CSS styles appear.
         // (This is only required when the invalid value is set by the FormControl constructor.)
-        this.#control?.markAsTouched();
+        if (skyIsAbstractControl(this.#control)) {
+          this.#control.markAsTouched();
+        }
 
         return {
           skyDate: {
@@ -450,7 +452,9 @@ export class SkyDatepickerInputDirective
     } else {
       // Mark the invalid control as touched so that the input's invalid CSS styles appear.
       // (This is only required when the invalid value is set by the FormControl constructor.)
-      this.#control?.markAsTouched();
+      if (skyIsAbstractControl(this.#control)) {
+        this.#control.markAsTouched();
+      }
 
       return {
         skyDate: {
@@ -614,8 +618,8 @@ export class SkyDatepickerInputDirective
       this.#_value = value;
       if (emitEvent) {
         this.#onChange(this.#_value);
-      } else {
-        this.#control?.setValue(this.#_value, { emitEvent: false });
+      } else if (skyIsAbstractControl(this.#control)) {
+        this.#control.setValue(this.#_value, { emitEvent: false });
       }
 
       this.#datepickerComponent.selectedDate = this.#_value;
@@ -635,8 +639,8 @@ export class SkyDatepickerInputDirective
         this.#_value = dateValue || value;
         if (emitEvent) {
           this.#onChange(this.#_value);
-        } else {
-          this.#control?.setValue(this.#_value, { emitEvent: false });
+        } else if (skyIsAbstractControl(this.#control)) {
+          this.#control.setValue(this.#_value, { emitEvent: false });
         }
 
         this.#datepickerComponent.selectedDate = this.#_value;

--- a/libs/components/datetime/src/lib/modules/datepicker/datepicker.component.spec.ts
+++ b/libs/components/datetime/src/lib/modules/datepicker/datepicker.component.spec.ts
@@ -1,3 +1,4 @@
+import { Component, signal } from '@angular/core';
 import {
   ComponentFixture,
   TestBed,
@@ -6,6 +7,7 @@ import {
   tick,
 } from '@angular/core/testing';
 import { NgModel } from '@angular/forms';
+import { FormField, form } from '@angular/forms/signals';
 import { By } from '@angular/platform-browser';
 import { SkyAppTestUtility, expect, expectAsync } from '@skyux-sdk/testing';
 import { SKY_STACKING_CONTEXT } from '@skyux/core';
@@ -24,6 +26,7 @@ import { BehaviorSubject, Observable, of } from 'rxjs';
 
 import { SkyDatepickerConfigService } from './datepicker-config.service';
 import { SkyDatepickerComponent } from './datepicker.component';
+import { SkyDatepickerModule } from './datepicker.module';
 import { DatepickerInputBoxTestComponent } from './fixtures/datepicker-input-box.component.fixture';
 import { DatepickerNoFormatTestComponent } from './fixtures/datepicker-no-format.component.fixture';
 import { DatepickerReactiveTestComponent } from './fixtures/datepicker-reactive.component.fixture';
@@ -2094,5 +2097,70 @@ describe('datepicker', () => {
 
       expect(hintText).toEqual('Select a date. Use the format DD/MM/YY.');
     }));
+  });
+
+  describe('signal forms', () => {
+    @Component({
+      standalone: true,
+      imports: [FormField, SkyDatepickerModule],
+      template: `<sky-datepicker>
+        <input skyDatepickerInput [formField]="dateForm" />
+      </sky-datepicker>`,
+    })
+    class DatepickerSignalFormFixtureComponent {
+      public readonly model = signal<Date | string | undefined>(undefined);
+      public readonly dateForm = form(this.model);
+    }
+
+    let fixture: ComponentFixture<DatepickerSignalFormFixtureComponent>;
+    let testComponent: DatepickerSignalFormFixtureComponent;
+    let inputEl: HTMLInputElement;
+
+    beforeEach(() => {
+      TestBed.configureTestingModule({
+        imports: [DatepickerSignalFormFixtureComponent],
+      });
+
+      fixture = TestBed.createComponent(DatepickerSignalFormFixtureComponent);
+      testComponent = fixture.componentInstance;
+      fixture.detectChanges();
+
+      inputEl = fixture.nativeElement.querySelector('input');
+    });
+
+    it('should not throw and should report the skyDate error when an invalid date is typed', () => {
+      expect(() => {
+        inputEl.value = 'not-a-date';
+        inputEl.dispatchEvent(new Event('input'));
+        inputEl.dispatchEvent(new Event('change'));
+        fixture.detectChanges();
+      }).not.toThrow();
+
+      const errors = testComponent.dateForm().errors();
+      expect(errors.some((error) => error.kind === 'skyDate')).toBeTrue();
+    });
+
+    it('should mark the field dirty when the user types in the input', () => {
+      inputEl.value = '1/1/2024';
+      inputEl.dispatchEvent(new Event('input'));
+      inputEl.dispatchEvent(new Event('change'));
+      fixture.detectChanges();
+
+      expect(testComponent.dateForm().dirty()).toBeTrue();
+    });
+
+    it('should not mark the field dirty when a value is written into the model', () => {
+      testComponent.model.set(new Date('2024-01-01'));
+      fixture.detectChanges();
+
+      expect(testComponent.dateForm().dirty()).toBeFalse();
+    });
+
+    it('should mark the field touched when the input loses focus', () => {
+      inputEl.dispatchEvent(new Event('focus'));
+      inputEl.dispatchEvent(new Event('focusout'));
+
+      expect(testComponent.dateForm().touched()).toBeTrue();
+    });
   });
 });

--- a/libs/components/datetime/src/lib/modules/timepicker/timepicker.component.spec.ts
+++ b/libs/components/datetime/src/lib/modules/timepicker/timepicker.component.spec.ts
@@ -1031,13 +1031,14 @@ describe('Timepicker', () => {
       expect(testComponent.timeForm().dirty()).toBeTrue();
     });
 
-    it('should not throw when a value is written into the model', () => {
+    it('should not mark the field dirty when a value is written into the model', () => {
       expect(() => {
         testComponent.model.set('3:00 PM');
         fixture.detectChanges();
       }).not.toThrow();
 
       expect(inputEl.value).toBe('3:00 PM');
+      expect(testComponent.timeForm().dirty()).toBeFalse();
     });
   });
 });

--- a/libs/components/datetime/src/lib/modules/timepicker/timepicker.component.spec.ts
+++ b/libs/components/datetime/src/lib/modules/timepicker/timepicker.component.spec.ts
@@ -1,3 +1,4 @@
+import { Component, signal } from '@angular/core';
 import {
   ComponentFixture,
   TestBed,
@@ -11,6 +12,7 @@ import {
   ReactiveFormsModule,
   Validators,
 } from '@angular/forms';
+import { FormField, form } from '@angular/forms/signals';
 import { By } from '@angular/platform-browser';
 import { SkyAppTestUtility, expect, expectAsync } from '@skyux-sdk/testing';
 import { SKY_STACKING_CONTEXT } from '@skyux/core';
@@ -974,5 +976,68 @@ describe('Timepicker', () => {
 
       expect(pickerButton.getAttribute('aria-label')).toBe('Choose time');
     }));
+  });
+
+  describe('signal forms', () => {
+    @Component({
+      standalone: true,
+      imports: [FormField, SkyTimepickerModule],
+      template: `<sky-timepicker #timePicker>
+        <input
+          aria-label="Time"
+          type="text"
+          [skyTimepickerInput]="timePicker"
+          [formField]="timeForm"
+        />
+      </sky-timepicker>`,
+    })
+    class TimepickerSignalFormFixtureComponent {
+      public readonly model = signal<string | undefined>(undefined);
+      public readonly timeForm = form(this.model);
+    }
+
+    let fixture: ComponentFixture<TimepickerSignalFormFixtureComponent>;
+    let testComponent: TimepickerSignalFormFixtureComponent;
+    let inputEl: HTMLInputElement;
+
+    beforeEach(() => {
+      TestBed.configureTestingModule({
+        imports: [TimepickerSignalFormFixtureComponent],
+      });
+
+      fixture = TestBed.createComponent(TimepickerSignalFormFixtureComponent);
+      testComponent = fixture.componentInstance;
+      fixture.detectChanges();
+
+      inputEl = fixture.nativeElement.querySelector('input');
+    });
+
+    it('should not throw and should report the skyTime error when an invalid time is typed', () => {
+      expect(() => {
+        inputEl.value = 'not-a-time';
+        inputEl.dispatchEvent(new Event('change'));
+        fixture.detectChanges();
+      }).not.toThrow();
+
+      const errors = testComponent.timeForm().errors();
+      expect(errors.some((error) => error.kind === 'skyTime')).toBeTrue();
+    });
+
+    it('should mark the field dirty when the user changes the input', () => {
+      inputEl.value = '3:00 PM';
+      inputEl.dispatchEvent(new Event('change'));
+      fixture.detectChanges();
+
+      expect(testComponent.timeForm().dirty()).toBeTrue();
+    });
+
+    it('should not throw when a value is written into the model', () => {
+      expect(() => {
+        testComponent.model.set('3:00 PM');
+        fixture.detectChanges();
+      }).not.toThrow();
+
+      expect(inputEl.value).toBe('3:00 PM');
+    });
   });
 });

--- a/libs/components/datetime/src/lib/modules/timepicker/timepicker.directive.ts
+++ b/libs/components/datetime/src/lib/modules/timepicker/timepicker.directive.ts
@@ -124,7 +124,20 @@ export class SkyTimepickerInputDirective
     return this.#_modelValue;
   }
 
-  set #modelValue(value: SkyTimepickerTimeOutput | undefined) {
+  // Only calls the registered `onChange` for user-driven changes (`emitChange`).
+  // Calling it from an externally-driven write (`writeValue`, not triggered by
+  // the user) always marks the field dirty, for every form flavor -- Angular's
+  // own `setUpViewChangePipeline` sets `_pendingDirty` on every invocation of a
+  // registered `onChange`, and signal forms' `controlValue.set()` does the
+  // same. For a reactive/template-driven control, normalize its raw value to
+  // the full `SkyTimepickerTimeOutput` object by writing directly to the
+  // control instead (bypassing `onChange`, so it doesn't mark the field
+  // dirty); signal forms' interop control has no `setValue`, so its field
+  // keeps whatever raw value the consumer bound until the user changes it.
+  #setModelValue(
+    value: SkyTimepickerTimeOutput | undefined,
+    emitChange: boolean,
+  ): void {
     // A retained invalid entry must be cleaned up even when the model value is
     // unchanged (e.g. a form reset while `undefined` is the model value).
     if (value !== this.#_modelValue || this.#hasRetainedInvalidValue) {
@@ -133,7 +146,15 @@ export class SkyTimepickerInputDirective
       this.#updateTimepickerInput();
       this.#setInputValue(value);
       this.#_validatorChange();
-      this.#_onChange(value);
+
+      if (emitChange) {
+        this.#_onChange(value);
+      } else if (
+        skyIsAbstractControl(this.#control) &&
+        this.#control.value !== value
+      ) {
+        this.#control.setValue(value, { emitEvent: false });
+      }
     }
   }
 
@@ -155,7 +176,8 @@ export class SkyTimepickerInputDirective
     this.pickerChangedSubscription =
       this.skyTimepickerInput?.selectedTimeChanged.subscribe(
         (newTime: string) => {
-          this.writeValue(newTime);
+          // A time selected in the picker dialog is a user-driven change.
+          this.#applyValue(newTime, true);
           this.#_onTouched();
         },
       );
@@ -192,7 +214,8 @@ export class SkyTimepickerInputDirective
 
   @HostListener('change', ['$event'])
   public onChange(event: any): void {
-    this.writeValue(event.target.value);
+    // A native `change` event is a user-driven change.
+    this.#applyValue(event.target.value, true);
   }
 
   /* istanbul ignore next */
@@ -216,20 +239,7 @@ export class SkyTimepickerInputDirective
   }
 
   public writeValue(value: any): void {
-    const formatted = this.#formatter(value);
-
-    // Keep invalid entries in the input instead of clearing them so the user
-    // can see and correct their entry (matching the datepicker's behavior).
-    if (
-      typeof value === 'string' &&
-      value.length > 0 &&
-      formatted.local === 'Invalid date'
-    ) {
-      this.#applyInvalidValue(value);
-      return;
-    }
-
-    this.#modelValue = formatted;
+    this.#applyValue(value, false);
   }
 
   public validate(control: AbstractControl): ValidationErrors | null {
@@ -248,7 +258,9 @@ export class SkyTimepickerInputDirective
       if (this.#formatter(value).local === 'Invalid date') {
         // Mark as touched so the invalid CSS styles appear even when the value
         // is set programmatically.
-        this.#control?.markAsTouched();
+        if (skyIsAbstractControl(this.#control)) {
+          this.#control.markAsTouched();
+        }
 
         return { skyTime: { invalid: value } };
       }
@@ -264,7 +276,27 @@ export class SkyTimepickerInputDirective
     return null;
   }
 
-  #applyInvalidValue(rawValue: string): void {
+  // Applies a value regardless of its source: `writeValue` (external, `emitChange`
+  // false) or a user-driven change (native `change` event, picker selection;
+  // `emitChange` true).
+  #applyValue(value: any, emitChange: boolean): void {
+    const formatted = this.#formatter(value);
+
+    // Keep invalid entries in the input instead of clearing them so the user
+    // can see and correct their entry (matching the datepicker's behavior).
+    if (
+      typeof value === 'string' &&
+      value.length > 0 &&
+      formatted.local === 'Invalid date'
+    ) {
+      this.#applyInvalidValue(value, emitChange);
+      return;
+    }
+
+    this.#setModelValue(formatted, emitChange);
+  }
+
+  #applyInvalidValue(rawValue: string, emitChange: boolean): void {
     // There is no valid model value while an invalid entry is retained.
     this.#_modelValue = undefined;
     this.#hasRetainedInvalidValue = true;
@@ -275,7 +307,9 @@ export class SkyTimepickerInputDirective
     // Push the raw string to the form control and re-run validation. The
     // validator supplies the `skyTime` error, so we avoid calling `setErrors`
     // here to preserve any errors contributed by other validators.
-    this.#_onChange(rawValue);
+    if (emitChange) {
+      this.#_onChange(rawValue);
+    }
     this.#_validatorChange();
   }
 

--- a/libs/components/datetime/src/lib/modules/timepicker/timepicker.directive.ts
+++ b/libs/components/datetime/src/lib/modules/timepicker/timepicker.directive.ts
@@ -21,6 +21,7 @@ import {
   ValidationErrors,
   Validator,
 } from '@angular/forms';
+import { skyIsAbstractControl } from '@skyux/forms';
 
 import moment from 'moment';
 import { Subscription } from 'rxjs';
@@ -232,7 +233,7 @@ export class SkyTimepickerInputDirective
   }
 
   public validate(control: AbstractControl): ValidationErrors | null {
-    if (!this.#control) {
+    if (!this.#control && skyIsAbstractControl(control)) {
       this.#control = control;
     }
 
@@ -247,7 +248,7 @@ export class SkyTimepickerInputDirective
       if (this.#formatter(value).local === 'Invalid date') {
         // Mark as touched so the invalid CSS styles appear even when the value
         // is set programmatically.
-        this.#control.markAsTouched();
+        this.#control?.markAsTouched();
 
         return { skyTime: { invalid: value } };
       }


### PR DESCRIPTION
Part 4 of 7 in the signal-forms support stack. Split out of #4629 (closed).
Stack: #4685 <- #4686 <- #4687 <- #4688 <- #4689 <- #4690 <- #4691.

[AB#4008241](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/4008241)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
