### PR TITLE
fix(components/lookup): support signal forms in autocomplete, country field, and lookup

### DIFF
--- a/libs/components/lookup/src/lib/modules/autocomplete/autocomplete-input.directive.ts
+++ b/libs/components/lookup/src/lib/modules/autocomplete/autocomplete-input.directive.ts
@@ -119,31 +119,12 @@ export class SkyAutocompleteInputDirective
   }
 
   public set value(value: any) {
-    const isNewValue = value !== this.#_value;
-
-    /* istanbul ignore else */
-    if (isNewValue) {
-      this.#_value = value;
-      this.inputTextValue = this.#getValueByKey();
-      this.onChange(this.#_value);
-
-      // Do not mark the field as "dirty"
-      // if the field has been initialized with a value.
-      if (this.#isFirstChange && this.#control) {
-        this.#control.markAsPristine();
-      }
-
-      if (this.#isFirstChange && this.#_value) {
-        this.#isFirstChange = false;
-      }
-    }
+    this.#setValue(value, true);
   }
 
   #blur: Subject<void>;
 
   #blurObs: Observable<void>;
-
-  #control: AbstractControl | undefined;
 
   readonly #elementRef = inject(ElementRef);
 
@@ -229,7 +210,9 @@ export class SkyAutocompleteInputDirective
   }
 
   public writeValue(value: any): void {
-    this.value = value;
+    // Skip emitting `onChange` for the field's initial value so the field isn't marked
+    // dirty as soon as it's populated with a starting value.
+    this.#setValue(value, !this.#isFirstChange);
   }
 
   public registerOnChange(fn: (value: any) => void): void {
@@ -261,9 +244,6 @@ export class SkyAutocompleteInputDirective
   }
 
   public validate(control: AbstractControl): ValidationErrors | null {
-    if (!this.#control) {
-      this.#control = control;
-    }
     return null;
   }
 
@@ -326,5 +306,23 @@ export class SkyAutocompleteInputDirective
 
   #getValueByKey(): string {
     return this.value ? this.value[this.displayWith] : '';
+  }
+
+  #setValue(value: any, emitChange: boolean): void {
+    const isNewValue = value !== this.#_value;
+
+    /* istanbul ignore else */
+    if (isNewValue) {
+      this.#_value = value;
+      this.inputTextValue = this.#getValueByKey();
+
+      if (emitChange) {
+        this.onChange(this.#_value);
+      }
+
+      if (this.#isFirstChange && this.#_value) {
+        this.#isFirstChange = false;
+      }
+    }
   }
 }

--- a/libs/components/lookup/src/lib/modules/autocomplete/autocomplete-input.directive.ts
+++ b/libs/components/lookup/src/lib/modules/autocomplete/autocomplete-input.directive.ts
@@ -243,6 +243,9 @@ export class SkyAutocompleteInputDirective
     this.disabled = disabled;
   }
 
+  // Retained (rather than removed) for public-API compatibility; the `NG_VALIDATORS`
+  // provider it's registered through is otherwise vestigial now that value normalization
+  // moved to `#setValue`.
   public validate(control: AbstractControl): ValidationErrors | null {
     return null;
   }

--- a/libs/components/lookup/src/lib/modules/autocomplete/autocomplete.component.spec.ts
+++ b/libs/components/lookup/src/lib/modules/autocomplete/autocomplete.component.spec.ts
@@ -1,10 +1,12 @@
 import { ViewportRuler } from '@angular/cdk/overlay';
+import { Component, signal } from '@angular/core';
 import {
   ComponentFixture,
   TestBed,
   fakeAsync,
   tick,
 } from '@angular/core/testing';
+import { FormField, form } from '@angular/forms/signals';
 import { By } from '@angular/platform-browser';
 import { SkyAppTestUtility, expect, expectAsync } from '@skyux-sdk/testing';
 import { SKY_STACKING_CONTEXT, SkyLiveAnnouncerService } from '@skyux/core';
@@ -14,6 +16,7 @@ import { BehaviorSubject, Observable, Subject } from 'rxjs';
 import { SkyAutocompleteAdapterService } from './autocomplete-adapter.service';
 import { SkyAutocompleteInputDirective } from './autocomplete-input.directive';
 import { SkyAutocompleteComponent } from './autocomplete.component';
+import { SkyAutocompleteModule } from './autocomplete.module';
 import { SkyAutocompleteFixturesModule } from './fixtures/autocomplete-fixtures.module';
 import { SkyAutocompleteInputBoxFixtureComponent } from './fixtures/autocomplete-input-box.component.fixture';
 import { SkyAutocompleteReactiveFixtureComponent } from './fixtures/autocomplete-reactive.component.fixture';
@@ -2962,6 +2965,59 @@ describe('Autocomplete component', () => {
 
       expect(adapterSpy.calls.mostRecent().args[2]).toBeTrue();
       expect(adapterSpy.calls.count()).toEqual(1);
+    }));
+  });
+
+  describe('signal forms', () => {
+    @Component({
+      standalone: true,
+      imports: [FormField, SkyAutocompleteModule],
+      template: `<button id="testButton" type="button">Test button</button>
+        <sky-autocomplete [data]="data">
+          <input skyAutocomplete type="text" [formField]="autocompleteForm" />
+        </sky-autocomplete>`,
+    })
+    class AutocompleteSignalFormFixtureComponent {
+      public readonly data = [
+        { name: 'Red' },
+        { name: 'Green' },
+        { name: 'Blue' },
+      ];
+      public readonly model = signal<{ name: string } | undefined>(undefined);
+      public readonly autocompleteForm = form(this.model);
+    }
+
+    let fixture: ComponentFixture<AutocompleteSignalFormFixtureComponent>;
+    let testComponent: AutocompleteSignalFormFixtureComponent;
+    let inputEl: HTMLInputElement;
+
+    beforeEach(() => {
+      TestBed.configureTestingModule({
+        imports: [AutocompleteSignalFormFixtureComponent],
+      });
+
+      fixture = TestBed.createComponent(AutocompleteSignalFormFixtureComponent);
+      testComponent = fixture.componentInstance;
+      fixture.detectChanges();
+
+      inputEl = fixture.nativeElement.querySelector('input');
+    });
+
+    it('should not throw and should not mark the field dirty when a value is written into the model', () => {
+      expect(() => {
+        testComponent.model.set({ name: 'Red' });
+        fixture.detectChanges();
+      }).not.toThrow();
+
+      expect(inputEl.value).toBe('Red');
+      expect(testComponent.autocompleteForm().dirty()).toBeFalse();
+    });
+
+    it('should mark the field dirty when the user selects a search result', fakeAsync(() => {
+      searchAndSelect('Blue', 0, fixture);
+
+      expect(testComponent.autocompleteForm().dirty()).toBeTrue();
+      expect(inputEl.value).toBe('Blue');
     }));
   });
 });

--- a/libs/components/lookup/src/lib/modules/country-field/country-field.component.spec.ts
+++ b/libs/components/lookup/src/lib/modules/country-field/country-field.component.spec.ts
@@ -1,3 +1,4 @@
+import { Component, signal } from '@angular/core';
 import {
   ComponentFixture,
   TestBed,
@@ -5,6 +6,7 @@ import {
   tick,
 } from '@angular/core/testing';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { FormField, form } from '@angular/forms/signals';
 import { SkyAppTestUtility, expect, expectAsync } from '@skyux-sdk/testing';
 
 import { SkyCountryFieldModule } from './country-field.module';
@@ -12,6 +14,7 @@ import { CountryFieldInputBoxTestComponent } from './fixtures/country-field-inpu
 import { CountryFieldNoFormTestComponent } from './fixtures/country-field-no-form.component.fixture';
 import { CountryFieldReactiveTestComponent } from './fixtures/country-field-reactive.component.fixture';
 import { CountryFieldTestComponent } from './fixtures/country-field.component.fixture';
+import { SkyCountryFieldCountry } from './types/country';
 import { SKY_COUNTRY_FIELD_CONTEXT } from './types/country-field-context-token';
 
 /* spell-checker:ignore Austr, Κύπρος */
@@ -1608,5 +1611,83 @@ describe('Country Field Component', () => {
         expect(getInputElement().getAttribute('aria-label')).toBeNull();
       });
     });
+  });
+
+  describe('signal forms', () => {
+    @Component({
+      standalone: true,
+      imports: [FormField, SkyCountryFieldModule],
+      template: `<sky-country-field [formField]="countryForm" />`,
+    })
+    class CountryFieldSignalFormFixtureComponent {
+      public readonly model = signal<SkyCountryFieldCountry | undefined>(
+        undefined,
+      );
+      public readonly countryForm = form(this.model);
+    }
+
+    let fixture: ComponentFixture<CountryFieldSignalFormFixtureComponent>;
+    let testComponent: CountryFieldSignalFormFixtureComponent;
+
+    beforeEach(() => {
+      TestBed.configureTestingModule({
+        imports: [CountryFieldSignalFormFixtureComponent],
+      });
+
+      fixture = TestBed.createComponent(CountryFieldSignalFormFixtureComponent);
+      testComponent = fixture.componentInstance;
+    });
+
+    it('should not throw when initialized', () => {
+      expect(() => {
+        fixture.detectChanges();
+      }).not.toThrow();
+    });
+
+    it('should render a value written into the model and not mark the field dirty', fakeAsync(() => {
+      fixture.detectChanges();
+
+      testComponent.model.set({ name: 'United States', iso2: 'us' });
+      fixture.detectChanges();
+      tick();
+      fixture.detectChanges();
+
+      expect(getInputElement().value).toContain('United States');
+      expect(testComponent.countryForm().dirty()).toBeFalse();
+    }));
+
+    it('should mark the field dirty when the user selects a country', fakeAsync(() => {
+      fixture.detectChanges();
+      tick();
+      fixture.detectChanges();
+
+      const inputElement = getInputElement();
+      inputElement.value = 'Austr';
+      inputElement.focus();
+      SkyAppTestUtility.fireDomEvent(inputElement, 'focus');
+      SkyAppTestUtility.fireDomEvent(inputElement, 'input');
+      fixture.detectChanges();
+      tick();
+      fixture.detectChanges();
+      tick();
+      fixture.detectChanges();
+      tick();
+
+      const searchResults = getAutocompleteElement().querySelectorAll(
+        '.sky-autocomplete-result',
+      );
+      SkyAppTestUtility.fireDomEvent(inputElement, 'change');
+      SkyAppTestUtility.fireDomEvent(searchResults[0], 'click');
+      fixture.detectChanges();
+      SkyAppTestUtility.fireDomEvent(inputElement, 'blur');
+      fixture.detectChanges();
+      tick(25);
+      fixture.detectChanges();
+      tick();
+      fixture.detectChanges();
+
+      expect(testComponent.model()?.name).toBe('Australia');
+      expect(testComponent.countryForm().dirty()).toBeTrue();
+    }));
   });
 });

--- a/libs/components/lookup/src/lib/modules/country-field/country-field.component.spec.ts
+++ b/libs/components/lookup/src/lib/modules/country-field/country-field.component.spec.ts
@@ -211,6 +211,36 @@ describe('Country Field Component', () => {
         validateSelectedCountry(nativeElement, 'Australia');
       }));
 
+      it('should not mark the field dirty when the model is set programmatically', fakeAsync(() => {
+        fixture.detectChanges();
+        tick();
+        fixture.detectChanges();
+
+        fixture.componentRef.setInput('modelValue', {
+          name: 'United States',
+          iso2: 'us',
+        });
+        fixture.detectChanges();
+        tick();
+        fixture.detectChanges();
+
+        validateSelectedCountry(nativeElement, 'United States');
+        expect(component.ngModel.dirty).toBeFalse();
+      }));
+
+      it('should mark the field dirty when the user selects a country', fakeAsync(() => {
+        fixture.detectChanges();
+        tick();
+        fixture.detectChanges();
+
+        searchAndSelect('Austr', 0, fixture);
+
+        fixture.detectChanges();
+
+        validateSelectedCountry(nativeElement, 'Australia');
+        expect(component.ngModel.dirty).toBeTrue();
+      }));
+
       it('should change countries correctly via a model change', fakeAsync(() => {
         fixture.componentRef.setInput('modelValue', {
           name: 'United States',
@@ -715,6 +745,33 @@ describe('Country Field Component', () => {
         fixture.detectChanges();
 
         validateSelectedCountry(nativeElement, 'Australia');
+      }));
+
+      it('should not mark the field dirty when the control value is set programmatically', fakeAsync(() => {
+        fixture.detectChanges();
+        tick();
+        fixture.detectChanges();
+
+        component.setValue({ name: 'United States', iso2: 'us' });
+        fixture.detectChanges();
+        tick();
+        fixture.detectChanges();
+
+        validateSelectedCountry(nativeElement, 'United States');
+        expect(component.countryControl?.dirty).toBeFalse();
+      }));
+
+      it('should mark the field dirty when the user selects a country', fakeAsync(() => {
+        fixture.detectChanges();
+        tick();
+        fixture.detectChanges();
+
+        searchAndSelect('Austr', 0, fixture);
+
+        fixture.detectChanges();
+
+        validateSelectedCountry(nativeElement, 'Australia');
+        expect(component.countryControl?.dirty).toBeTrue();
       }));
 
       it('should change countries correctly via a model change, even when disabled', fakeAsync(() => {

--- a/libs/components/lookup/src/lib/modules/country-field/country-field.component.ts
+++ b/libs/components/lookup/src/lib/modules/country-field/country-field.component.ts
@@ -24,13 +24,14 @@ import {
   AbstractControl,
   ControlValueAccessor,
   NG_VALIDATORS,
+  NG_VALUE_ACCESSOR,
   NgControl,
   NgModel,
   UntypedFormControl,
   ValidationErrors,
   Validator,
 } from '@angular/forms';
-import { SkyInputBoxHostService } from '@skyux/forms';
+import { SkyInputBoxHostService, skyIsAbstractControl } from '@skyux/forms';
 import { SkyAppLocaleProvider } from '@skyux/i18n';
 
 import intlTelInput from 'intl-tel-input';
@@ -46,6 +47,12 @@ import { SKY_COUNTRY_FIELD_CONTEXT } from './types/country-field-context-token';
 
 const DEFAULT_COUNTRY_CODE = 'us';
 
+const SKY_COUNTRY_FIELD_VALUE_ACCESSOR = {
+  provide: NG_VALUE_ACCESSOR,
+  useExisting: forwardRef(() => SkyCountryFieldComponent),
+  multi: true,
+};
+
 const SKY_COUNTRY_FIELD_VALIDATOR = {
   provide: NG_VALIDATORS,
   useExisting: forwardRef(() => SkyCountryFieldComponent),
@@ -58,7 +65,7 @@ let uniqueId = 0;
   selector: 'sky-country-field',
   templateUrl: './country-field.component.html',
   styleUrls: ['./country-field.component.scss'],
-  providers: [SKY_COUNTRY_FIELD_VALIDATOR],
+  providers: [SKY_COUNTRY_FIELD_VALUE_ACCESSOR, SKY_COUNTRY_FIELD_VALIDATOR],
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
   standalone: false,
@@ -223,9 +230,7 @@ export class SkyCountryFieldComponent
       null,
     );
 
-    if (this.#ngControl) {
-      this.#ngControl.valueAccessor = this;
-    } else {
+    if (!this.#ngControl) {
       /**
        * The initial change boolean is to determine if the form is setting the value. When no form
        * is present we don't want to ignore the first change.
@@ -260,6 +265,11 @@ export class SkyCountryFieldComponent
    * @internal
    */
   public onCountrySelected(newCountry: SkyAutocompleteSelectionChange): void {
+    // A user selection is never the form's initial value, even if `writeValue`
+    // has not yet been called (which can happen under signal forms, where
+    // `writeValue` is skipped when the initial model value is `undefined`).
+    this.#isInitialChange = false;
+
     if (newCountry.selectedItem) {
       this.writeValue(
         this.countries().find(
@@ -330,7 +340,7 @@ export class SkyCountryFieldComponent
         if (resolved) {
           this.selectedCountryChange.emit(resolved);
         }
-      } else if (this.#ngControl?.control) {
+      } else if (skyIsAbstractControl(this.#ngControl?.control)) {
         // Do not mark the field as "dirty"
         // if the field has been initialized with a value.
         this.#ngControl.control.markAsPristine();

--- a/libs/components/lookup/src/lib/modules/country-field/country-field.component.ts
+++ b/libs/components/lookup/src/lib/modules/country-field/country-field.component.ts
@@ -265,9 +265,8 @@ export class SkyCountryFieldComponent
    * @internal
    */
   public onCountrySelected(newCountry: SkyAutocompleteSelectionChange): void {
-    // A user selection is never the form's initial value, even if `writeValue`
-    // has not yet been called (which can happen under signal forms, where
-    // `writeValue` is skipped when the initial model value is `undefined`).
+    // A user selection is never the form's initial value, even under signal
+    // forms where `writeValue` may not have run yet.
     this.#isInitialChange = false;
 
     if (newCountry.selectedItem) {

--- a/libs/components/lookup/src/lib/modules/country-field/country-field.component.ts
+++ b/libs/components/lookup/src/lib/modules/country-field/country-field.component.ts
@@ -265,18 +265,15 @@ export class SkyCountryFieldComponent
    * @internal
    */
   public onCountrySelected(newCountry: SkyAutocompleteSelectionChange): void {
-    // A user selection is never the form's initial value, even under signal
-    // forms where `writeValue` may not have run yet.
-    this.#isInitialChange = false;
-
     if (newCountry.selectedItem) {
-      this.writeValue(
+      this.#applyValue(
         this.countries().find(
           (countryInfo) => countryInfo.iso2 === newCountry.selectedItem.iso2,
         ),
+        true,
       );
     } else {
-      this.writeValue(undefined);
+      this.#applyValue(undefined, true);
     }
   }
 
@@ -327,11 +324,22 @@ export class SkyCountryFieldComponent
   }
 
   public writeValue(value: SkyCountryFieldCountry | undefined): void {
+    // `writeValue` is always an externally-driven write (model-to-view), never
+    // a user action, so it must never emit `onChange`/`onTouched` -- doing so
+    // marks the field dirty regardless of form flavor. `onCountrySelected`
+    // (the actual user-driven path) calls `#applyValue` directly instead.
+    this.#applyValue(value, false);
+  }
+
+  #applyValue(
+    value: SkyCountryFieldCountry | undefined,
+    emitChange: boolean,
+  ): void {
     const current = this.#_selectedIsoCountry();
     if (!this.#countriesAreEqual(current, value)) {
       this.#_selectedCountry.set(value);
 
-      if (!this.#isInitialChange) {
+      if (emitChange) {
         const resolved = this.#_selectedIsoCountry();
         this.onChange(resolved);
         this.onTouched();
@@ -339,7 +347,10 @@ export class SkyCountryFieldComponent
         if (resolved) {
           this.selectedCountryChange.emit(resolved);
         }
-      } else if (skyIsAbstractControl(this.#ngControl?.control)) {
+      } else if (
+        this.#isInitialChange &&
+        skyIsAbstractControl(this.#ngControl?.control)
+      ) {
         // Do not mark the field as "dirty"
         // if the field has been initialized with a value.
         this.#ngControl.control.markAsPristine();

--- a/libs/components/lookup/src/lib/modules/lookup/lookup.component.spec.ts
+++ b/libs/components/lookup/src/lib/modules/lookup/lookup.component.spec.ts
@@ -4376,6 +4376,26 @@ describe('Lookup component', function () {
           expect(selectedItems[0].name).toEqual('Isaac');
         }));
 
+        it('should update the bound signal on each sequential add, not just the first', fakeAsync(() => {
+          fixture.detectChanges();
+
+          performSearch('s', fixture);
+          selectSearchResult(0, fixture);
+
+          const afterFirstAdd = component.selectedFriends();
+          expect(afterFirstAdd?.length).toEqual(1);
+
+          performSearch('s', fixture);
+          selectSearchResult(1, fixture);
+
+          const afterSecondAdd = component.selectedFriends();
+          expect(afterSecondAdd?.length).toEqual(2);
+          // A `signal()`/`model()` binding only notifies consumers when it
+          // receives a new reference; reusing the same array on the second
+          // add would silently leave `selectedFriends()` unmoved.
+          expect(afterSecondAdd).not.toBe(afterFirstAdd);
+        }));
+
         it('should not collapse tokens if more than 5 items are selected with `enableShowMore` disabled', fakeAsync(() => {
           fixture.detectChanges();
           fixture.componentRef.setInput('selectedFriends', [

--- a/libs/components/lookup/src/lib/modules/lookup/lookup.component.spec.ts
+++ b/libs/components/lookup/src/lib/modules/lookup/lookup.component.spec.ts
@@ -1,3 +1,4 @@
+import { Component, signal } from '@angular/core';
 import {
   ComponentFixture,
   TestBed,
@@ -5,6 +6,7 @@ import {
   tick,
 } from '@angular/core/testing';
 import { NgModel } from '@angular/forms';
+import { FormField, form } from '@angular/forms/signals';
 import { By } from '@angular/platform-browser';
 import { SkyAppTestUtility, expect, expectAsync } from '@skyux-sdk/testing';
 import { SkyLogService } from '@skyux/core';
@@ -19,6 +21,7 @@ import { SkyLookupInputBoxTestComponent } from './fixtures/lookup-input-box.comp
 import { SkyLookupTemplateTestComponent } from './fixtures/lookup-template.component.fixture';
 import { SkyLookupTestComponent } from './fixtures/lookup.component.fixture';
 import { SkyLookupComponent } from './lookup.component';
+import { SkyLookupModule } from './lookup.module';
 import { SkyLookupSelectModeType } from './types/lookup-select-mode-type';
 
 describe('Lookup component', function () {
@@ -7850,5 +7853,87 @@ describe('Lookup component', function () {
         await expectAsync(document.body).toBeAccessible(axeConfig);
       });
     });
+  });
+
+  describe('signal forms', () => {
+    @Component({
+      standalone: true,
+      imports: [FormField, SkyLookupModule],
+      template: `<sky-lookup
+        idProperty="name"
+        selectMode="multiple"
+        [data]="data"
+        [formField]="lookupForm"
+      />`,
+    })
+    class LookupSignalFormFixtureComponent {
+      public readonly data = [
+        { name: 'Andy' },
+        { name: 'Beth' },
+        { name: 'Dan' },
+      ];
+      public readonly model = signal<{ name: string }[]>([]);
+      public readonly lookupForm = form(this.model);
+    }
+
+    let fixture: ComponentFixture<LookupSignalFormFixtureComponent>;
+    let testComponent: LookupSignalFormFixtureComponent;
+
+    beforeEach(() => {
+      TestBed.configureTestingModule({
+        imports: [LookupSignalFormFixtureComponent],
+      });
+
+      fixture = TestBed.createComponent(LookupSignalFormFixtureComponent);
+      testComponent = fixture.componentInstance;
+      fixture.detectChanges();
+    });
+
+    function getSignalFormsInputElement(): HTMLTextAreaElement {
+      return fixture.nativeElement.querySelector('textarea');
+    }
+
+    function searchAndSelect(searchText: string, index: number): void {
+      const inputElement = getSignalFormsInputElement();
+      inputElement.value = searchText;
+      inputElement.focus();
+      SkyAppTestUtility.fireDomEvent(inputElement, 'focus');
+      SkyAppTestUtility.fireDomEvent(inputElement, 'input');
+      fixture.detectChanges();
+      tick();
+      fixture.detectChanges();
+      tick();
+
+      const searchResults = document.querySelectorAll(
+        '.sky-autocomplete-result',
+      );
+      SkyAppTestUtility.fireDomEvent(searchResults[index], 'click');
+      fixture.detectChanges();
+      tick();
+    }
+
+    it('should not throw when initialized', () => {
+      expect(() => {
+        fixture.detectChanges();
+      }).not.toThrow();
+    });
+
+    it('should update the model and mark the field dirty as items are added one at a time', fakeAsync(() => {
+      searchAndSelect('Andy', 0);
+
+      const afterFirstAdd = testComponent.model();
+      expect(afterFirstAdd.map((item) => item.name)).toEqual(['Andy']);
+      expect(testComponent.lookupForm().dirty()).toBeTrue();
+
+      searchAndSelect('Beth', 0);
+
+      const afterSecondAdd = testComponent.model();
+      // The model must be a new array reference each time an item is added.
+      // Signal forms only propagates a value to consumers when it receives a
+      // new reference, so reusing the same array (even with the right
+      // contents) would leave every consumer holding stale data.
+      expect(afterSecondAdd).not.toBe(afterFirstAdd);
+      expect(afterSecondAdd.map((item) => item.name)).toEqual(['Andy', 'Beth']);
+    }));
   });
 });

--- a/libs/components/lookup/src/lib/modules/lookup/lookup.component.ts
+++ b/libs/components/lookup/src/lib/modules/lookup/lookup.component.ts
@@ -786,11 +786,7 @@ export class SkyLookupComponent
     if (this.selectMode === 'single') {
       selectedItems = [item];
     } else {
-      // Clone the array instead of mutating `value` in place. Signal forms'
-      // control-value signal only notifies consumers when it receives a new
-      // reference, so pushing onto the existing array silently drops the
-      // update under signal forms (though reactive/template forms don't
-      // check reference equality, so this went unnoticed there).
+      // Clone the array; signal forms only notify consumers on a new reference.
       selectedItems = [...value];
 
       const idProperty = this.idProperty || '';

--- a/libs/components/lookup/src/lib/modules/lookup/lookup.component.ts
+++ b/libs/components/lookup/src/lib/modules/lookup/lookup.component.ts
@@ -786,7 +786,12 @@ export class SkyLookupComponent
     if (this.selectMode === 'single') {
       selectedItems = [item];
     } else {
-      selectedItems = value;
+      // Clone the array instead of mutating `value` in place. Signal forms'
+      // control-value signal only notifies consumers when it receives a new
+      // reference, so pushing onto the existing array silently drops the
+      // update under signal forms (though reactive/template forms don't
+      // check reference equality, so this went unnoticed there).
+      selectedItems = [...value];
 
       const idProperty = this.idProperty || '';
 


### PR DESCRIPTION
Part 5 of 7 in the signal-forms support stack. Split out of #4629 (closed).
Stack: #4685 <- #4686 <- #4687 <- #4688 <- #4689 <- #4690 <- #4691.

[AB#4008241](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/4008241)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
