### PR TITLE
fix(components/phone-field): support signal forms

### DIFF
--- a/libs/components/phone-field/src/lib/modules/phone-field/phone-field-input.directive.ts
+++ b/libs/components/phone-field/src/lib/modules/phone-field/phone-field-input.directive.ts
@@ -150,9 +150,13 @@ export class SkyPhoneFieldInputDirective
       .get('countrySearch')
       ?.valueChanges.pipe(takeUntil(this.#ngUnsubscribe), take(1))
       .subscribe(() => {
-        if (skyIsAbstractControl(this.#control)) {
-          this.#control.markAsDirty();
-        }
+        // Interacting with the country search box is a user action, so it
+        // marks the field dirty for every form flavor, the same way typing
+        // in the phone number input does -- `#notifyChange` marks a
+        // signal-forms field dirty unconditionally, and Angular's own
+        // reactive/template-driven forms plumbing does the same for the
+        // registered `onChange` callback.
+        this.#notifyChange?.(this.#getValue());
         this.#notifyTouched?.();
       });
   }
@@ -205,19 +209,40 @@ export class SkyPhoneFieldInputDirective
     this.#setValue(rawValue);
     const newValue = this.#getValue();
 
+    // `writeValue` is always an externally-driven write (model-to-view),
+    // never a user action, so it must never call `#notifyChange` --
+    // `#notifyChange` marks the field dirty unconditionally, for every form
+    // flavor. Normalize a reactive/template-driven control's value to the
+    // formatted number by writing directly to it instead, which doesn't
+    // mark it dirty. `emitModelToViewChange: false` is required (not just
+    // `emitEvent: false`) to avoid `writeValue` recursively re-running:
+    // `AbstractControl.setValue()` calls back into the CVA's `writeValue`
+    // unless that's explicitly suppressed. Signal forms' interop control
+    // has no `setValue`, so its field keeps the raw value until the user
+    // edits it.
     if (rawValue !== newValue) {
-      // If the value is set before the control is initialized, wait for the
-      // first cycle to complete before triggering a value change event.
-      // (This occurs when the control is initialized with an unformatted value
-      // but is formatted into a new value immediately in the `writeValue`
-      // method.)
       if (!this.#control) {
+        // `validate()` (which captures `#control`) may not have run yet on
+        // the very first `writeValue` call -- wait for the current cycle to
+        // complete before normalizing.
         setTimeout(() => {
-          this.#notifyChange?.(newValue);
+          this.#normalizeControlValue(newValue);
         });
       } else {
-        this.#notifyChange?.(newValue);
+        this.#normalizeControlValue(newValue);
       }
+    }
+  }
+
+  #normalizeControlValue(newValue: string): void {
+    if (
+      skyIsAbstractControl(this.#control) &&
+      this.#control.value !== newValue
+    ) {
+      this.#control.setValue(newValue, {
+        emitEvent: false,
+        emitModelToViewChange: false,
+      });
     }
   }
 

--- a/libs/components/phone-field/src/lib/modules/phone-field/phone-field-input.directive.ts
+++ b/libs/components/phone-field/src/lib/modules/phone-field/phone-field-input.directive.ts
@@ -17,6 +17,7 @@ import {
   ValidationErrors,
   Validator,
 } from '@angular/forms';
+import { skyIsAbstractControl } from '@skyux/forms';
 
 import {
   PhoneNumber,
@@ -149,8 +150,10 @@ export class SkyPhoneFieldInputDirective
       .get('countrySearch')
       ?.valueChanges.pipe(takeUntil(this.#ngUnsubscribe), take(1))
       .subscribe(() => {
-        this.#control?.markAsDirty();
-        this.#control?.markAsTouched();
+        if (skyIsAbstractControl(this.#control)) {
+          this.#control.markAsDirty();
+        }
+        this.#notifyTouched?.();
       });
   }
 
@@ -172,7 +175,9 @@ export class SkyPhoneFieldInputDirective
   }
 
   public validate(control: AbstractControl): ValidationErrors | null {
-    this.#control ??= control;
+    if (!this.#control && skyIsAbstractControl(control)) {
+      this.#control = control;
+    }
 
     const value = control.value;
 

--- a/libs/components/phone-field/src/lib/modules/phone-field/phone-field.component.spec.ts
+++ b/libs/components/phone-field/src/lib/modules/phone-field/phone-field.component.spec.ts
@@ -2671,5 +2671,70 @@ describe('Phone Field Component', () => {
 
       expect(testComponent.phoneForm().dirty()).toBeFalse();
     });
+
+    it('should mark the field dirty when the user selects a country that reformats the number', fakeAsync(() => {
+      testComponent.model.set('6675555309');
+      fixture.detectChanges();
+      tick();
+      fixture.detectChanges();
+
+      expect(testComponent.phoneForm().dirty()).toBeFalse();
+
+      const countryToggleButton = fixture.nativeElement.querySelector(
+        '.sky-phone-field-country-btn .sky-btn-default',
+      ) as HTMLButtonElement;
+      countryToggleButton.click();
+      fixture.detectChanges();
+      tick();
+
+      const countrySearchInput = fixture.nativeElement.querySelector(
+        'textarea',
+      ) as HTMLTextAreaElement;
+      countrySearchInput.value = 'Albania';
+      SkyAppTestUtility.fireDomEvent(countrySearchInput, 'input');
+      fixture.detectChanges();
+      tick();
+
+      SkyAppTestUtility.fireDomEvent(
+        document.querySelector('.sky-autocomplete-result:first-child'),
+        'click',
+      );
+      fixture.detectChanges();
+      tick();
+
+      expect(testComponent.phoneForm().dirty()).toBeTrue();
+    }));
+
+    it('should mark the field dirty when the user interacts with the country search, even when reformatting does not change an empty number', fakeAsync(() => {
+      fixture.detectChanges();
+      tick();
+      fixture.detectChanges();
+
+      expect(testComponent.phoneForm().dirty()).toBeFalse();
+
+      const countryToggleButton = fixture.nativeElement.querySelector(
+        '.sky-phone-field-country-btn .sky-btn-default',
+      ) as HTMLButtonElement;
+      countryToggleButton.click();
+      fixture.detectChanges();
+      tick();
+
+      const countrySearchInput = fixture.nativeElement.querySelector(
+        'textarea',
+      ) as HTMLTextAreaElement;
+      countrySearchInput.value = 'Albania';
+      SkyAppTestUtility.fireDomEvent(countrySearchInput, 'input');
+      fixture.detectChanges();
+      tick();
+
+      SkyAppTestUtility.fireDomEvent(
+        document.querySelector('.sky-autocomplete-result:first-child'),
+        'click',
+      );
+      fixture.detectChanges();
+      tick();
+
+      expect(testComponent.phoneForm().dirty()).toBeTrue();
+    }));
   });
 });

--- a/libs/components/phone-field/src/lib/modules/phone-field/phone-field.component.spec.ts
+++ b/libs/components/phone-field/src/lib/modules/phone-field/phone-field.component.spec.ts
@@ -1,3 +1,4 @@
+import { Component, signal } from '@angular/core';
 import {
   ComponentFixture,
   TestBed,
@@ -5,12 +6,14 @@ import {
   tick,
 } from '@angular/core/testing';
 import { NgModel, UntypedFormControl } from '@angular/forms';
+import { FormField, form } from '@angular/forms/signals';
 import { By } from '@angular/platform-browser';
 import { SkyAppTestUtility, expect, expectAsync } from '@skyux-sdk/testing';
 
 import { PhoneFieldInputBoxTestComponent } from './fixtures/phone-field-input-box.component.fixture';
 import { PhoneFieldReactiveTestComponent } from './fixtures/phone-field-reactive.component.fixture';
 import { PhoneFieldTestComponent } from './fixtures/phone-field.component.fixture';
+import { SkyPhoneFieldModule } from './phone-field.module';
 
 describe('Phone Field Component', () => {
   function checkCountrySearchToggleButtonFlag(
@@ -2609,6 +2612,64 @@ describe('Phone Field Component', () => {
           expect(isCountryFieldVisible(fixture)).toBeFalse();
         }));
       });
+    });
+  });
+
+  describe('signal forms', () => {
+    @Component({
+      standalone: true,
+      imports: [FormField, SkyPhoneFieldModule],
+      template: `<sky-phone-field>
+        <input skyPhoneFieldInput [formField]="phoneForm" />
+      </sky-phone-field>`,
+    })
+    class PhoneFieldSignalFormFixtureComponent {
+      public readonly model = signal<string | undefined>(undefined);
+      public readonly phoneForm = form(this.model);
+    }
+
+    let fixture: ComponentFixture<PhoneFieldSignalFormFixtureComponent>;
+    let testComponent: PhoneFieldSignalFormFixtureComponent;
+    let inputEl: HTMLInputElement;
+
+    beforeEach(() => {
+      TestBed.configureTestingModule({
+        imports: [PhoneFieldSignalFormFixtureComponent],
+      });
+
+      fixture = TestBed.createComponent(PhoneFieldSignalFormFixtureComponent);
+      testComponent = fixture.componentInstance;
+      fixture.detectChanges();
+
+      inputEl = fixture.nativeElement.querySelector('input');
+    });
+
+    it('should not throw and should report the skyPhoneField error for an invalid number', fakeAsync(() => {
+      expect(() => {
+        inputEl.value = '123';
+        inputEl.dispatchEvent(new Event('input'));
+        inputEl.dispatchEvent(new Event('change'));
+        tick();
+        fixture.detectChanges();
+      }).not.toThrow();
+
+      const errors = testComponent.phoneForm().errors();
+      expect(errors.some((error) => error.kind === 'skyPhoneField')).toBeTrue();
+    }));
+
+    it('should mark the field touched when the input loses focus', () => {
+      inputEl.dispatchEvent(new Event('focus'));
+      inputEl.dispatchEvent(new Event('blur'));
+      fixture.detectChanges();
+
+      expect(testComponent.phoneForm().touched()).toBeTrue();
+    });
+
+    it('should not mark the field dirty when a value is written into the model', () => {
+      testComponent.model.set('(555) 555-5555');
+      fixture.detectChanges();
+
+      expect(testComponent.phoneForm().dirty()).toBeFalse();
     });
   });
 });


### PR DESCRIPTION
Part 6 of 7 in the signal-forms support stack. Split out of #4629 (closed).
Stack: #4685 <- #4686 <- #4687 <- #4688 <- #4689 <- #4690 <- #4691.

[AB#4008241](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/4008241)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
