### PR TITLE
fix(components/text-editor): support signal forms

### DIFF
--- a/libs/components/text-editor/src/lib/modules/text-editor/text-editor.component.spec.ts
+++ b/libs/components/text-editor/src/lib/modules/text-editor/text-editor.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component, DebugElement, Provider, Type } from '@angular/core';
+import { Component, DebugElement, Provider, Type, signal } from '@angular/core';
 import {
   ComponentFixture,
   TestBed,
@@ -12,6 +12,7 @@ import {
   UntypedFormControl,
   Validators,
 } from '@angular/forms';
+import { FormField, form, required } from '@angular/forms/signals';
 import { By } from '@angular/platform-browser';
 import { RouterTestingModule } from '@angular/router/testing';
 import { SkyAppTestUtility, expect, expectAsync } from '@skyux-sdk/testing';
@@ -925,6 +926,48 @@ describe('Text editor', () => {
 
       // Firefox backColor bug: https://bugzilla.mozilla.org/show_bug.cgi?id=547848
       // expect(toolbar.querySelector('.background-color-picker').value).toBe('#51b6ca');
+    }));
+
+    it('should update the font color picker when selection moves between differently-formatted colors and back', fakeAsync(() => {
+      testComponent.value =
+        '<span id="first" style="color: rgb(193, 64, 64);">First</span>' +
+        '<span id="second" style="color: rgb(81, 182, 202);">Second</span>';
+      fixture.detectChanges();
+      tick();
+      fixture.detectChanges();
+
+      selectContent('#first');
+      SkyAppTestUtility.fireDomEvent(iframeDocument, 'selectionchange');
+      fixture.detectChanges();
+      tick();
+      fixture.detectChanges();
+
+      expect(getFontColorPicker().querySelector('input')?.value).toBe(
+        '#c14040',
+      );
+
+      selectContent('#second');
+      SkyAppTestUtility.fireDomEvent(iframeDocument, 'selectionchange');
+      fixture.detectChanges();
+      tick();
+      fixture.detectChanges();
+
+      expect(getFontColorPicker().querySelector('input')?.value).toBe(
+        '#51b6ca',
+      );
+
+      // Selecting back to the first color must still update the display,
+      // even though the picker previously rendered (and internally
+      // formatted) this exact color earlier in the test.
+      selectContent('#first');
+      SkyAppTestUtility.fireDomEvent(iframeDocument, 'selectionchange');
+      fixture.detectChanges();
+      tick();
+      fixture.detectChanges();
+
+      expect(getFontColorPicker().querySelector('input')?.value).toBe(
+        '#c14040',
+      );
     }));
 
     it('should set font family', fakeAsync(() => {
@@ -2115,5 +2158,94 @@ describe('Text editor', () => {
 
       fixture.detectChanges();
     });
+  });
+
+  describe('with signal-forms field', () => {
+    @Component({
+      standalone: true,
+      imports: [FormField, SkyTextEditorModule],
+      template: `<sky-text-editor
+        [formField]="textForm"
+        [labelText]="labelText"
+      />`,
+    })
+    class TextEditorWithSignalForm {
+      public readonly model = signal('');
+      public readonly textForm = form(this.model, (p) => {
+        required(p);
+      });
+      public labelText = 'Text editor';
+    }
+
+    let testComponent: TextEditorWithSignalForm;
+
+    beforeEach(() => {
+      id = 0;
+      TestBed.configureTestingModule({
+        imports: [TextEditorWithSignalForm],
+        providers: [
+          {
+            provide: SkyIdService,
+            useValue: {
+              generateId: () => ID_DEFAULT + (++id).toString(),
+            },
+          },
+        ],
+      });
+
+      fixture = TestBed.createComponent(TextEditorWithSignalForm);
+      fixture.detectChanges();
+
+      testComponent = (fixture as ComponentFixture<TextEditorWithSignalForm>)
+        .componentInstance;
+      editableElement = getIframeDocument().body;
+      textEditorDebugElement = fixture.debugElement.query(
+        By.directive(SkyTextEditorComponent),
+      );
+      textEditorComponent = textEditorDebugElement.componentInstance;
+      iframeElement = getIframeElement();
+    });
+
+    it('should render a sky-form-error when the field is required and has been touched', () => {
+      testComponent.textForm().markAsTouched();
+      fixture.detectChanges();
+
+      const error = fixture.nativeElement.querySelector('sky-form-error');
+      expect(error).toBeVisible();
+    });
+
+    it('sets the aria-invalid attribute to true when an error is present and the field is touched', fakeAsync(() => {
+      testComponent.textForm().markAsTouched();
+      fixture.detectChanges();
+      tick();
+      fixture.detectChanges();
+
+      validateIframeDocumentAttribute('aria-invalid', 'true');
+    }));
+
+    it('sets the aria-invalid attribute to false when no error is present', fakeAsync(() => {
+      testComponent.model.set('Testing');
+      fixture.detectChanges();
+      tick();
+      fixture.detectChanges();
+
+      validateIframeDocumentAttribute('aria-invalid', 'false');
+    }));
+
+    it('does not throw when the editor normalizes an empty value', () => {
+      expect(() => {
+        textEditorComponent.value = '<p><br></p>';
+        fixture.detectChanges();
+      }).not.toThrow();
+    });
+
+    it('propagates the normalized value back to the model', fakeAsync(() => {
+      testComponent.model.set('<p><br></p>');
+      fixture.detectChanges();
+      tick();
+      fixture.detectChanges();
+
+      expect(testComponent.model()).toBe('');
+    }));
   });
 });

--- a/libs/components/text-editor/src/lib/modules/text-editor/text-editor.component.spec.ts
+++ b/libs/components/text-editor/src/lib/modules/text-editor/text-editor.component.spec.ts
@@ -2247,5 +2247,15 @@ describe('Text editor', () => {
 
       expect(testComponent.model()).toBe('');
     }));
+
+    it('does not mark the field dirty when a programmatic write needs normalization', fakeAsync(() => {
+      testComponent.model.set('<p><br></p>');
+      fixture.detectChanges();
+      tick();
+      fixture.detectChanges();
+
+      expect(testComponent.model()).toBe('');
+      expect(testComponent.textForm().dirty()).toBeFalse();
+    }));
   });
 });

--- a/libs/components/text-editor/src/lib/modules/text-editor/text-editor.component.ts
+++ b/libs/components/text-editor/src/lib/modules/text-editor/text-editor.component.ts
@@ -15,20 +15,27 @@ import {
   booleanAttribute,
   inject,
 } from '@angular/core';
-import { ControlValueAccessor, NgControl } from '@angular/forms';
+import {
+  ControlValueAccessor,
+  NgControl,
+  TouchedChangeEvent,
+} from '@angular/forms';
+import { FormField } from '@angular/forms/signals';
 import { SkyCoreAdapterService, SkyIdModule, SkyIdService } from '@skyux/core';
 import {
   SKY_FORM_ERRORS_ENABLED,
   SkyFormErrorsModule,
   SkyInputBoxHostService,
   SkyRequiredStateDirective,
+  skyIsAbstractControl,
+  skyWatchFormFieldChanges,
 } from '@skyux/forms';
 import { SkyHelpInlineModule } from '@skyux/help-inline';
 import { SkyToolbarModule } from '@skyux/layout';
 import { SkyThemeModule } from '@skyux/theme';
 
 import { Subject } from 'rxjs';
-import { takeUntil } from 'rxjs/operators';
+import { filter, takeUntil } from 'rxjs/operators';
 
 import { SkyTextEditorResourcesModule } from '../shared/sky-text-editor-resources.module';
 
@@ -321,10 +328,11 @@ export class SkyTextEditorComponent
     if (this.#_value !== normalizedValue) {
       this.#_value = normalizedValue;
 
-      // Update angular form control if model has been normalized.
-      /* istanbul ignore else */
+      // Update angular form control if model has been normalized. Signal-forms controls
+      // (bound via `[formField]`) don't support imperative `setValue()` calls; they receive
+      // the normalized value through the registered `onChange` callback instead.
       if (
-        this.ngControl?.control &&
+        skyIsAbstractControl(this.ngControl?.control) &&
         normalizedValue !== this.ngControl.control.value
       ) {
         this.ngControl.control.setValue(normalizedValue, {
@@ -387,9 +395,24 @@ export class SkyTextEditorComponent
   protected readonly ngControl = inject(NgControl);
   protected readonly requiredState = inject(SkyRequiredStateDirective);
 
+  /**
+   * The signal-forms `FormField` directive bound to this editor, if any. `InteropNgControl`
+   * (the fake `NgControl` provided by `FormField`) doesn't expose `statusChanges`, so field
+   * state changes are observed here instead.
+   */
+  #formField = inject(FormField, { optional: true });
+
   constructor() {
     this.#id = this.#defaultId = this.#idSvc.generateId();
     this.ngControl.valueAccessor = this;
+
+    skyWatchFormFieldChanges(
+      () => this.#formField,
+      this.#changeDetector,
+      () => {
+        this.#updateA11yAttributes();
+      },
+    );
   }
 
   public ngAfterViewInit(): void {
@@ -414,6 +437,20 @@ export class SkyTextEditorComponent
    */
   public writeValue(value: string): void {
     this.value = value;
+
+    // Propagate the normalized value back to the form when normalization changed the
+    // incoming value. Signal-forms controls (bound via `[formField]`) don't support
+    // imperative `setValue()` calls, so this callback is the only way to keep the model
+    // in sync with the editor for those controls. Real `AbstractControl`s are already
+    // synced by the `value` setter above, so calling `onChange` again here would
+    // incorrectly mark them dirty.
+    if (
+      value &&
+      this.#_value !== value &&
+      !skyIsAbstractControl(this.ngControl?.control)
+    ) {
+      this.#_onChange(this.#_value);
+    }
 
     // Update HTML if necessary.
     if (this.#initialized) {
@@ -479,6 +516,21 @@ export class SkyTextEditorComponent
         // Trigger change detection when the field status is modified programmatically.
         this.#changeDetector.markForCheck();
       });
+
+    // `statusChanges` doesn't emit when only the touched state changes (e.g. a consumer
+    // calls `control.markAsTouched()` directly), so the touched-gated error message wouldn't
+    // otherwise be marked for check.
+    if (skyIsAbstractControl(this.ngControl.control)) {
+      this.ngControl.control.events
+        .pipe(
+          filter((event) => event instanceof TouchedChangeEvent),
+          takeUntil(this.#ngUnsubscribe),
+        )
+        .subscribe(() => {
+          this.#updateA11yAttributes();
+          this.#changeDetector.markForCheck();
+        });
+    }
 
     this.#editorService
       .inputListener()

--- a/libs/components/text-editor/src/lib/modules/text-editor/text-editor.component.ts
+++ b/libs/components/text-editor/src/lib/modules/text-editor/text-editor.component.ts
@@ -435,14 +435,17 @@ export class SkyTextEditorComponent
   public writeValue(value: string): void {
     this.value = value;
 
-    // Only signal-forms controls need normalized values propagated back via `onChange`;
-    // `AbstractControl`s already sync through the `value` setter above.
+    // Only signal-forms controls need normalized values propagated back; `AbstractControl`s
+    // already sync through the `value` setter above. Calling `onChange` here would mark the
+    // field dirty unconditionally (it always does, for every form flavor), so write directly
+    // to the field's `value` signal instead -- the same mechanism the field's own `reset()`
+    // uses to change its value without dirtying it.
     if (
       value &&
       this.#_value !== value &&
       !skyIsAbstractControl(this.ngControl?.control)
     ) {
-      this.#_onChange(this.#_value);
+      this.#formField?.state().value.set(this.#_value);
     }
 
     // Update HTML if necessary.

--- a/libs/components/text-editor/src/lib/modules/text-editor/text-editor.component.ts
+++ b/libs/components/text-editor/src/lib/modules/text-editor/text-editor.component.ts
@@ -328,9 +328,8 @@ export class SkyTextEditorComponent
     if (this.#_value !== normalizedValue) {
       this.#_value = normalizedValue;
 
-      // Update angular form control if model has been normalized. Signal-forms controls
-      // (bound via `[formField]`) don't support imperative `setValue()` calls; they receive
-      // the normalized value through the registered `onChange` callback instead.
+      // Only `AbstractControl`s get the normalized value set imperatively; signal-forms
+      // controls receive it through `onChange` in `writeValue` instead.
       if (
         skyIsAbstractControl(this.ngControl?.control) &&
         normalizedValue !== this.ngControl.control.value
@@ -395,11 +394,9 @@ export class SkyTextEditorComponent
   protected readonly ngControl = inject(NgControl);
   protected readonly requiredState = inject(SkyRequiredStateDirective);
 
-  /**
-   * The signal-forms `FormField` directive bound to this editor, if any. `InteropNgControl`
-   * (the fake `NgControl` provided by `FormField`) doesn't expose `statusChanges`, so field
-   * state changes are observed here instead.
-   */
+  // The signal-forms `FormField` directive bound to this editor, if any. `InteropNgControl`
+  // (the fake `NgControl` provided by `FormField`) doesn't expose `statusChanges`, so field
+  // state changes are observed here instead.
   #formField = inject(FormField, { optional: true });
 
   constructor() {
@@ -438,12 +435,8 @@ export class SkyTextEditorComponent
   public writeValue(value: string): void {
     this.value = value;
 
-    // Propagate the normalized value back to the form when normalization changed the
-    // incoming value. Signal-forms controls (bound via `[formField]`) don't support
-    // imperative `setValue()` calls, so this callback is the only way to keep the model
-    // in sync with the editor for those controls. Real `AbstractControl`s are already
-    // synced by the `value` setter above, so calling `onChange` again here would
-    // incorrectly mark them dirty.
+    // Only signal-forms controls need normalized values propagated back via `onChange`;
+    // `AbstractControl`s already sync through the `value` setter above.
     if (
       value &&
       this.#_value !== value &&


### PR DESCRIPTION
Part 7 of 7 in the signal-forms support stack. Split out of #4629 (closed).
Stack: #4685 <- #4686 <- #4687 <- #4688 <- #4689 <- #4690 <- #4691.

[AB#4008241](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/4008241)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
