### PR TITLE
chore: release 15.0.0-alpha.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,17 @@
 
 ### ⚠ BREAKING CHANGES
 
+* **sdk/testing:** retain default rules when custom overrides are assigned to `toBeAccessible` matcher (#4682)
 * report unlabeled components in `prefer-label-text` rule (#4652)
 
 ### Features
 
 * report unlabeled components in `prefer-label-text` rule ([#4652](https://github.com/blackbaud/skyux/issues/4652)) ([7830ee9](https://github.com/blackbaud/skyux/commit/7830ee967cab9fa5b15659a000d282b5befe544c))
+
+
+### Bug Fixes
+
+* **sdk/testing:** retain default rules when custom overrides are assigned to `toBeAccessible` matcher ([#4682](https://github.com/blackbaud/skyux/issues/4682)) ([649ec93](https://github.com/blackbaud/skyux/commit/649ec93623e5313ea197bc62c59d767d552cf7f0))
 
 ## [15.0.0-alpha.6](https://github.com/blackbaud/skyux/compare/15.0.0-alpha.5...15.0.0-alpha.6) (2026-08-24)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,17 @@
 
 ### ⚠ BREAKING CHANGES
 
+* the recommended ESLint and Stylelint configs now enable
+`no-invalid-sky-classnames` (TS and template),
+`no-invalid-sky-custom-properties`,
+and `no-deprecated-sky-scss-variables`.
 * **components/tiles:** tile dashboard remains multi-column at the sm breakpoint (#4694)
 * **sdk/testing:** retain default rules when custom overrides are assigned to `toBeAccessible` matcher (#4682)
 * report unlabeled components in `prefer-label-text` rule (#4652)
 
 ### Features
 
+* add style public API rules to recommended ESLint and Stylelint rulesets ([#4684](https://github.com/blackbaud/skyux/issues/4684)) ([ac2c696](https://github.com/blackbaud/skyux/commit/ac2c696d765efc67011be746db52281d54ff73fc)), closes [AB#3958896](https://dev.azure.com/blackbaud/Products/_workitems/edit/3958896)
 * **components/tiles:** tile dashboard remains multi-column at the sm breakpoint ([#4694](https://github.com/blackbaud/skyux/issues/4694)) ([0189da9](https://github.com/blackbaud/skyux/commit/0189da9017883a5a10a016c9b9f4ff8cb0477749))
 * report unlabeled components in `prefer-label-text` rule ([#4652](https://github.com/blackbaud/skyux/issues/4652)) ([7830ee9](https://github.com/blackbaud/skyux/commit/7830ee967cab9fa5b15659a000d282b5befe544c))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,13 @@
 
 ### ⚠ BREAKING CHANGES
 
+* **components/tiles:** tile dashboard remains multi-column at the sm breakpoint (#4694)
 * **sdk/testing:** retain default rules when custom overrides are assigned to `toBeAccessible` matcher (#4682)
 * report unlabeled components in `prefer-label-text` rule (#4652)
 
 ### Features
 
+* **components/tiles:** tile dashboard remains multi-column at the sm breakpoint ([#4694](https://github.com/blackbaud/skyux/issues/4694)) ([0189da9](https://github.com/blackbaud/skyux/commit/0189da9017883a5a10a016c9b9f4ff8cb0477749))
 * report unlabeled components in `prefer-label-text` rule ([#4652](https://github.com/blackbaud/skyux/issues/4652)) ([7830ee9](https://github.com/blackbaud/skyux/commit/7830ee967cab9fa5b15659a000d282b5befe544c))
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 # Changelog
 
 
+## [15.0.0-alpha.7](https://github.com/blackbaud/skyux/compare/15.0.0-alpha.6...15.0.0-alpha.7) (2026-08-25)
+
+
+### ⚠ BREAKING CHANGES
+
+* report unlabeled components in `prefer-label-text` rule (#4652)
+
+### Features
+
+* report unlabeled components in `prefer-label-text` rule ([#4652](https://github.com/blackbaud/skyux/issues/4652)) ([7830ee9](https://github.com/blackbaud/skyux/commit/7830ee967cab9fa5b15659a000d282b5befe544c))
+
 ## [15.0.0-alpha.6](https://github.com/blackbaud/skyux/compare/15.0.0-alpha.5...15.0.0-alpha.6) (2026-08-24)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "skyux",
-  "version": "15.0.0-alpha.6",
+  "version": "15.0.0-alpha.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "skyux",
-      "version": "15.0.0-alpha.6",
+      "version": "15.0.0-alpha.7",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skyux",
-  "version": "15.0.0-alpha.6",
+  "version": "15.0.0-alpha.7",
   "license": "MIT",
   "scripts": {
     "ng": "nx",


### PR DESCRIPTION
## [15.0.0-alpha.7](https://github.com/blackbaud/skyux/compare/15.0.0-alpha.6...15.0.0-alpha.7) (2026-08-25)


### ⚠ BREAKING CHANGES

* the recommended ESLint and Stylelint configs now enable
`no-invalid-sky-classnames` (TS and template),
`no-invalid-sky-custom-properties`,
and `no-deprecated-sky-scss-variables`.
* **components/tiles:** tile dashboard remains multi-column at the sm breakpoint (#4694)
* **sdk/testing:** retain default rules when custom overrides are assigned to `toBeAccessible` matcher (#4682)
* report unlabeled components in `prefer-label-text` rule (#4652)

### Features

* add style public API rules to recommended ESLint and Stylelint rulesets ([#4684](https://github.com/blackbaud/skyux/issues/4684)) ([ac2c696](https://github.com/blackbaud/skyux/commit/ac2c696d765efc67011be746db52281d54ff73fc)), closes [AB#3958896](https://dev.azure.com/blackbaud/Products/_workitems/edit/3958896)
* **components/tiles:** tile dashboard remains multi-column at the sm breakpoint ([#4694](https://github.com/blackbaud/skyux/issues/4694)) ([0189da9](https://github.com/blackbaud/skyux/commit/0189da9017883a5a10a016c9b9f4ff8cb0477749))
* report unlabeled components in `prefer-label-text` rule ([#4652](https://github.com/blackbaud/skyux/issues/4652)) ([7830ee9](https://github.com/blackbaud/skyux/commit/7830ee967cab9fa5b15659a000d282b5befe544c))


### Bug Fixes

* **sdk/testing:** retain default rules when custom overrides are assigned to `toBeAccessible` matcher ([#4682](https://github.com/blackbaud/skyux/issues/4682)) ([649ec93](https://github.com/blackbaud/skyux/commit/649ec93623e5313ea197bc62c59d767d552cf7f0))

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added release notes for version 15.0.0-alpha.7.
  * Documented recommended ESLint and Stylelint rules, style API guidance, tile dashboard behavior, unlabeled component reporting, and accessibility test overrides.

* **Chores**
  * Updated the package version to 15.0.0-alpha.7.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->