### PR TITLE
feat(components/tiles)!: tile dashboard remains multi-column at the sm breakpoint

### DIFF
--- a/apps/e2e/tiles-storybook-e2e/src/e2e/tile-dashboard.component.cy.ts
+++ b/apps/e2e/tiles-storybook-e2e/src/e2e/tile-dashboard.component.cy.ts
@@ -3,41 +3,30 @@ import { E2eVariations } from '@skyux-sdk/e2e-schematics';
 describe('tiles-storybook', () => {
   E2eVariations.forEachTheme((theme) => {
     describe(`in ${theme} theme`, () => {
-      beforeEach(() =>
-        cy.visit(
-          `/iframe.html?globals=theme:${theme}&id=tiledashboardcomponent-tiledashboard--tile-dashboard`,
-        ),
-      );
+      E2eVariations.RESPONSIVE_WIDTHS.forEach((width) => {
+        describe(`at ${width}px`, () => {
+          beforeEach(() => {
+            cy.viewport(width, 960);
+            cy.visit(
+              `/iframe.html?globals=theme:${theme}&id=tiledashboardcomponent-tiledashboard--tile-dashboard`,
+            );
+          });
 
-      it('should render the component', () => {
-        cy.skyReady('app-tile-dashboard', ['.ready']).screenshot(
-          `tile-dashboard-${theme}-desktop`,
-          {
-            overwrite: true,
-          },
-        );
-        cy.get('app-tile-dashboard').percySnapshot(
-          `tile dashboard ${theme} desktop`,
-          {
-            widths: E2eVariations.DISPLAY_WIDTHS,
-          },
-        );
-      });
-
-      it('should render the component in mobile', () => {
-        cy.viewport('iphone-x', 'portrait');
-        cy.skyReady('app-tile-dashboard', ['.ready']).screenshot(
-          `tile-dashboard-${theme}-mobile`,
-          {
-            overwrite: true,
-          },
-        );
-        cy.get('app-tile-dashboard').percySnapshot(
-          `tile dashboard ${theme} mobile`,
-          {
-            widths: E2eVariations.MOBILE_WIDTHS,
-          },
-        );
+          it('should render the component', () => {
+            cy.skyReady('app-tile-dashboard', ['.ready']).screenshot(
+              `tile-dashboard-${theme}-${width}px`,
+              {
+                overwrite: true,
+              },
+            );
+            cy.get('app-tile-dashboard').percySnapshot(
+              `tile dashboard ${theme} ${width}px`,
+              {
+                widths: [width],
+              },
+            );
+          });
+        });
       });
     });
   });

--- a/libs/components/tiles/src/lib/modules/tiles/tile-dashboard-config/tile-dashboard-config-layout.ts
+++ b/libs/components/tiles/src/lib/modules/tiles/tile-dashboard-config/tile-dashboard-config-layout.ts
@@ -3,7 +3,7 @@ import { SkyTileDashboardConfigLayoutColumn } from './tile-dashboard-config-layo
 export interface SkyTileDashboardConfigLayout {
   /**
    * A `SkyTileDashboardConfigLayoutColumn` object that describes how to
-   * display tiles in a single column on small screens.
+   * display tiles in a single column on extra-small screens.
    */
   singleColumn: SkyTileDashboardConfigLayoutColumn;
   /**

--- a/libs/components/tiles/src/lib/modules/tiles/tile-dashboard/tile-dashboard.component.spec.ts
+++ b/libs/components/tiles/src/lib/modules/tiles/tile-dashboard/tile-dashboard.component.spec.ts
@@ -1,8 +1,17 @@
 import { QueryList } from '@angular/core';
-import { TestBed, fakeAsync, tick } from '@angular/core/testing';
+import {
+  ComponentFixture,
+  TestBed,
+  fakeAsync,
+  tick,
+} from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { expect, expectAsync } from '@skyux-sdk/testing';
 import { SkyUIConfigService } from '@skyux/core';
+import {
+  SkyMediaQueryTestingController,
+  provideSkyMediaQueryTesting,
+} from '@skyux/core/testing';
 import {
   SkyTheme,
   SkyThemeMode,
@@ -62,6 +71,7 @@ describe('Tile dashboard component', () => {
           provide: SkyThemeService,
           useValue: mockThemeSvc,
         },
+        provideSkyMediaQueryTesting(),
       ],
       imports: [SkyTileDashboardFixturesModule],
     });
@@ -130,6 +140,84 @@ describe('Tile dashboard component', () => {
 
     expect(fixture.componentInstance.dashboardConfig()).toEqual(newConfig);
   }));
+
+  describe('moved tile assistive text', () => {
+    function emitMovedTile(breakpoint: 'xs' | 'sm'): {
+      fixture: ComponentFixture<TileDashboardTestComponent>;
+    } {
+      const fixture = TestBed.overrideComponent(SkyTileDashboardComponent, {
+        add: {
+          providers: [
+            {
+              provide: SkyTileDashboardService,
+              useValue: mockTileDashboardService,
+            },
+          ],
+        },
+      }).createComponent(TileDashboardTestComponent);
+
+      TestBed.inject(SkyMediaQueryTestingController).setBreakpoint(breakpoint);
+
+      fixture.detectChanges();
+      tick();
+
+      mockTileDashboardService.configChange.emit({
+        tiles: [
+          { id: 'tile-1', componentType: Tile1TestComponent },
+          { id: 'tile-2', componentType: Tile2TestComponent },
+        ],
+        layout: {
+          multiColumn: [
+            { tiles: [{ id: 'tile-1', isCollapsed: false }] },
+            { tiles: [{ id: 'tile-2', isCollapsed: false }] },
+          ],
+          singleColumn: {
+            tiles: [
+              { id: 'tile-1', isCollapsed: false },
+              { id: 'tile-2', isCollapsed: false },
+            ],
+          },
+        },
+        movedTile: {
+          tileDescription: 'Tile 2',
+          column: 2,
+          position: 1,
+        },
+      });
+
+      fixture.detectChanges();
+      tick();
+      fixture.detectChanges();
+
+      return { fixture };
+    }
+
+    function getAssistiveText(
+      fixture: ComponentFixture<TileDashboardTestComponent>,
+    ): string {
+      return (
+        fixture.nativeElement
+          .querySelector('.sky-assistive-text')
+          ?.textContent?.trim() ?? ''
+      );
+    }
+
+    it('should report the multi-column position at the `sm` breakpoint', fakeAsync(() => {
+      const { fixture } = emitMovedTile('sm');
+
+      expect(getAssistiveText(fixture)).toBe(
+        'Tile 2 moved. Current column: 2 of 2. Current position in column: 1 of 1',
+      );
+    }));
+
+    it('should report the single-column position at the `xs` breakpoint', fakeAsync(() => {
+      const { fixture } = emitMovedTile('xs');
+
+      expect(getAssistiveText(fixture)).toBe(
+        'Tile 2 moved. Current column: 1 of 1. Current position in column: 1 of 2',
+      );
+    }));
+  });
 
   it('should not allow a new config to be set by the parent once initialized', fakeAsync(() => {
     const fixture = TestBed.overrideComponent(SkyTileDashboardComponent, {

--- a/libs/components/tiles/src/lib/modules/tiles/tile-dashboard/tile-dashboard.component.ts
+++ b/libs/components/tiles/src/lib/modules/tiles/tile-dashboard/tile-dashboard.component.ts
@@ -102,25 +102,11 @@ export class SkyTileDashboardComponent implements AfterViewInit, OnDestroy {
 
   public moveInstructionsId: string;
 
-  protected layoutClassName = computed(() => {
-    const breakpoint = this.#breakpoint();
-
-    let layoutClassName = '';
-
-    if (breakpoint === 'xs' || breakpoint === 'sm') {
-      layoutClassName = 'sky-tile-dashboard-single-column';
-    } else {
-      layoutClassName = 'sky-tile-dashboard-multi-column';
-    }
-
-    if (breakpoint === 'xs') {
-      layoutClassName += ' sky-tile-dashboard-xs';
-    } else {
-      layoutClassName += ' sky-tile-dashboard-gt-xs';
-    }
-
-    return layoutClassName;
-  });
+  protected layoutClassName = computed(() =>
+    this.#breakpoint() === 'xs'
+      ? 'sky-tile-dashboard-single-column sky-tile-dashboard-xs'
+      : 'sky-tile-dashboard-multi-column sky-tile-dashboard-gt-xs',
+  );
 
   #configSet = false;
   readonly #dashboardService = inject(SkyTileDashboardService);
@@ -144,7 +130,7 @@ export class SkyTileDashboardComponent implements AfterViewInit, OnDestroy {
         if (config.movedTile && this.#resourcesService) {
           let messageObservable: Observable<string>;
 
-          if (this.#breakpoint() === 'xs' || this.#breakpoint() === 'sm') {
+          if (this.#breakpoint() === 'xs') {
             messageObservable = this.#resourcesService.getString(
               'skyux_tile_moved_assistive_text',
               config.movedTile.tileDescription,

--- a/libs/components/tiles/src/lib/modules/tiles/tile-dashboard/tile-dashboard.service.spec.ts
+++ b/libs/components/tiles/src/lib/modules/tiles/tile-dashboard/tile-dashboard.service.spec.ts
@@ -656,7 +656,7 @@ describe('Tile dashboard service', () => {
 
   it('should allow tiles to be moved within a column in single column mode', fakeAsync(() => {
     const fixture = createDashboardTestComponent();
-    mediaQueryController.setBreakpoint('sm');
+    mediaQueryController.setBreakpoint('xs');
     fixture.detectChanges();
     tick();
     fixture.detectChanges();
@@ -756,7 +756,7 @@ describe('Tile dashboard service', () => {
     const fixture = createDashboardTestComponent();
     const el = fixture.nativeElement;
 
-    mediaQueryController.setBreakpoint('sm');
+    mediaQueryController.setBreakpoint('xs');
     fixture.detectChanges();
     tick();
     fixture.detectChanges();
@@ -803,6 +803,14 @@ describe('Tile dashboard service', () => {
     expect(getTileCount(multiColumnEls[0])).toBe(0);
     expect(getTileCount(multiColumnEls[1])).toBe(0);
     expect(getTileCount(singleColumnEl)).toBe(4);
+
+    mediaQueryController.setBreakpoint('sm');
+
+    fixture.detectChanges();
+
+    expect(getTileCount(multiColumnEls[0])).toBe(3);
+    expect(getTileCount(multiColumnEls[1])).toBe(1);
+    expect(getTileCount(singleColumnEl)).toBe(0);
 
     mediaQueryController.setBreakpoint('md');
 

--- a/libs/components/tiles/src/lib/modules/tiles/tile-dashboard/tile-dashboard.service.ts
+++ b/libs/components/tiles/src/lib/modules/tiles/tile-dashboard/tile-dashboard.service.ts
@@ -79,9 +79,7 @@ export class SkyTileDashboardService {
   readonly #uiConfigService = inject(SkyUIConfigService);
 
   readonly #mode = computed<SkyTileDashboardColumnMode>(() => {
-    const breakpoint = this.#breakpoint();
-
-    return breakpoint === 'xs' || breakpoint === 'sm' ? 'single' : 'multi';
+    return this.#breakpoint() === 'xs' ? 'single' : 'multi';
   });
 
   constructor() {

--- a/libs/components/tiles/testing/src/modules/tiles/tile-dashboard-harness.spec.ts
+++ b/libs/components/tiles/testing/src/modules/tiles/tile-dashboard-harness.spec.ts
@@ -88,6 +88,11 @@ describe('Tile dashboard test harness', () => {
       false,
     );
 
+    mediaQueryController.setBreakpoint('sm');
+    await expectAsync(tileDashboardHarness.isMultiColumn()).toBeResolvedTo(
+      true,
+    );
+
     mediaQueryController.setBreakpoint('lg');
     await expectAsync(tileDashboardHarness.isMultiColumn()).toBeResolvedTo(
       true,


### PR DESCRIPTION
## What changed

The tile dashboard collapsed to its single-column layout at both `xs` and `sm`. It now collapses only at `xs` (≤767px), so dashboards render multi-column from 768px up.

Three predicates gated on `sm`, all now keyed on `xs` alone:

- `tile-dashboard.service.ts` — the `#mode` computed. This is the one that actually moves tiles between the single- and multi-column layouts; drag/drop targets, keyboard navigation, and config persistence all read from it.
- `tile-dashboard.component.ts` — the layout class. Both branches ended up on the same condition, so the two `if`/`else` blocks collapse into one expression.
- `tile-dashboard.component.ts` — the "tile moved" assistive text, which reports column *N* of *M*. Without this it would announce "column 1 of 1" at `sm` while showing two columns.

**No SCSS changes were needed.** The styles key off `sky-tile-dashboard-xs`/`-gt-xs` and the `sky-host-responsive-container-sm-min` mixin (≥768px), both of which already treated `sm` as the larger-screen case, so the multi-column paddings and tile border radii were already correct there.

Also updated the doc comment on `SkyTileDashboardConfigLayout.singleColumn` from "small screens" to "extra-small screens".

## Breaking change

Consumers relying on a single-column layout between 768px and 991px will now see tiles laid out per `SkyTileDashboardConfigLayout.multiColumn` instead of `singleColumn`.

Note this applies to **any** column count, not just two. The multi-column layout renders whatever `multiColumn` contains at `flex-basis: 100/N%`, so a three-column dashboard now shows three columns at ~250px each in that range. Collapsing 3→2 isn't possible without a new layout tier in `SkyTileDashboardConfigLayout`, which currently models only `singleColumn` and `multiColumn`.

## Tests

- **Service spec** — two tests that used `sm` as a stand-in for single-column mode now use `xs`; the screen-size-change test asserts `sm` renders 3/1/0 tiles across the two multi columns and the single column.
- **Harness spec** — `isMultiColumn()` previously asserted only `xs` → false and `lg` → true, both unaffected by this change. Added `sm` → true.
- **Component spec** — two new tests for the moved-tile announcement at `sm` and `xs`. This branch had no assertions anywhere in the repo before; branch coverage was 100% only because drag/drop tests execute the line without checking its output. Required adding `provideSkyMediaQueryTesting()` to a spec that had no breakpoint control.
- **Visual** — the tiles spec now iterates `E2eVariations.RESPONSIVE_WIDTHS` (`[375, 800, 1000, 1280]`) with a real `cy.viewport()` per width, matching the pattern the `pages-storybook-e2e` tile dashboard specs already use. It previously covered only a default desktop viewport and `iphone-x`, so the entire changed range had no visual coverage.

The widths need a real `cy.viewport()` rather than a multi-width `widths` array: column mode is decided in JavaScript and the service physically relocates tiles between DOM containers, so Percy's re-render of a captured DOM at a different width would not switch layouts.

## Percy baselines

Two sources of expected diffs, both needing approval:

- The tiles snapshots are renamed and re-scoped (`desktop`/`mobile` → `375px`/`800px`/`1000px`/`1280px`), so this adds coverage at two breakpoints that were not previously captured.
- `blocks-tile-dashboard-page` and `tabs-tile-dashboard-page` in `pages-storybook-e2e` already iterate `RESPONSIVE_WIDTHS`, so their **800px baselines will diff.**

## Verification

`nx test tiles` 67/67 and `nx test tiles-testing` 19/19 pass, 100% statements and branches on both. Lint clean (warnings pre-existing). Cypress/Percy not run locally — needs a Percy token and a Storybook build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated responsive tile dashboards to use a single-column layout only on extra-small screens.
  * Small-screen layouts now correctly use multiple columns.
  * Updated accessibility messaging for moved tiles based on the active layout.

* **Tests**
  * Added breakpoint coverage for small-screen and tablet layouts across themes.
  * Expanded responsive behavior and accessibility test coverage.
  * Added visual checks for configured responsive widths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->