### PR TITLE
chore: enable dark mode visual tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ nx-cloud.env
 
 .cursor/rules/nx-rules.mdc
 .github/instructions/nx.instructions.md
+
+# Claude Code superpowers scratch workspace
+/.superpowers

--- a/apps/e2e/icon-storybook-e2e/src/e2e/icons-by-row.component.cy.ts
+++ b/apps/e2e/icon-storybook-e2e/src/e2e/icons-by-row.component.cy.ts
@@ -3,6 +3,8 @@ const PAGES = Array.from({ length: PAGE_COUNT }, (_, i) => i + 1);
 
 describe('icons', () => {
   (['modern-v2-light', 'modern-v2-dark'] as const).forEach((theme) => {
+    // Light keeps its historical un-suffixed snapshot names so existing
+    // Percy baselines aren't orphaned; only the new dark run is suffixed.
     const snapshotSuffix = theme === 'modern-v2-light' ? '' : `-${theme}`;
 
     describe(`in ${theme} theme`, () => {

--- a/apps/e2e/icon-storybook-e2e/src/e2e/icons-by-row.component.cy.ts
+++ b/apps/e2e/icon-storybook-e2e/src/e2e/icons-by-row.component.cy.ts
@@ -2,22 +2,29 @@ const PAGE_COUNT = 4 as const;
 const PAGES = Array.from({ length: PAGE_COUNT }, (_, i) => i + 1);
 
 describe('icons', () => {
-  const theme = 'modern-v2-light';
+  (['modern-v2-light', 'modern-v2-dark'] as const).forEach((theme) => {
+    const snapshotSuffix = theme === 'modern-v2-light' ? '' : `-${theme}`;
 
-  ['line', 'solid'].forEach((variant) => {
-    describe(variant, () => {
-      PAGES.forEach((page) => {
-        it(`should render ${variant} icons, page ${page}`, () => {
-          cy.viewport(1024, 4000);
-          cy.visit(
-            `/iframe.html?args=page:${page};pages:${PAGE_COUNT};variant:${variant}&globals=theme:${theme}&id=icons-by-rowcomponent--icons-by-row`,
-          );
-          cy.get('#ready').should('exist');
-          cy.get('app-icons-by-row')
-            .should('exist')
-            .should('be.visible')
-            .screenshot(`icons-${variant}-page-${page}`);
-          cy.percySnapshot(`icons-${variant}-page-${page}`, { widths: [1024] });
+    describe(`in ${theme} theme`, () => {
+      ['line', 'solid'].forEach((variant) => {
+        describe(variant, () => {
+          PAGES.forEach((page) => {
+            it(`should render ${variant} icons, page ${page}`, () => {
+              cy.viewport(1024, 4000);
+              cy.visit(
+                `/iframe.html?args=page:${page};pages:${PAGE_COUNT};variant:${variant}&globals=theme:${theme}&id=icons-by-rowcomponent--icons-by-row`,
+              );
+              cy.get('#ready').should('exist');
+              cy.get('app-icons-by-row')
+                .should('exist')
+                .should('be.visible')
+                .screenshot(`icons-${variant}-page-${page}${snapshotSuffix}`);
+              cy.percySnapshot(
+                `icons-${variant}-page-${page}${snapshotSuffix}`,
+                { widths: [1024] },
+              );
+            });
+          });
         });
       });
     });

--- a/apps/e2e/icon-storybook/src/app/icons-by-row/icons-by-row.component.scss
+++ b/apps/e2e/icon-storybook/src/app/icons-by-row/icons-by-row.component.scss
@@ -1,6 +1,4 @@
 :host {
-  /* Maximum contrast for visual tests */
-  background-color: white;
   display: grid;
   grid-template-columns: 1fr;
   grid-template-rows: repeat(auto-fill, 100px);

--- a/apps/e2e/tabs-storybook-e2e/src/e2e/sectioned-form.component.cy.ts
+++ b/apps/e2e/tabs-storybook-e2e/src/e2e/sectioned-form.component.cy.ts
@@ -46,7 +46,9 @@ describe('sectioned form', () => {
           .should('be.visible')
           .click();
 
-        cy.get('#inputName').should('exist').should('be.visible');
+        cy.get('[data-sky-id="inputName"]')
+          .should('exist')
+          .should('be.visible');
 
         cy.window().screenshot(`sectioned-form-${size}-${theme}`);
         cy.window().percySnapshot(`sectioned-form-${size}-${theme}`, {

--- a/apps/e2e/tabs-storybook/src/app/sectioned-form/sectioned-form-information-form-demo.component.html
+++ b/apps/e2e/tabs-storybook/src/app/sectioned-form/sectioned-form-information-form-demo.component.html
@@ -2,7 +2,7 @@
   <div style="margin-right: 10px; flex: 1">
     <sky-input-box labelText="Name">
       <input
-        id="inputName"
+        data-sky-id="inputName"
         type="text"
         [ngModel]="name"
         [required]="nameRequired"
@@ -13,7 +13,7 @@
   </div>
   <div style="margin-right: 10px; flex: 1">
     <sky-input-box labelText="Id">
-      <input id="inputId" type="text" [ngModel]="id" />
+      <input data-sky-id="inputId" type="text" [ngModel]="id" />
     </sky-input-box>
   </div>
 </div>

--- a/apps/e2e/tabs-storybook/src/app/sectioned-form/sectioned-form-information-form-demo.component.html
+++ b/apps/e2e/tabs-storybook/src/app/sectioned-form/sectioned-form-information-form-demo.component.html
@@ -1,25 +1,20 @@
 <div style="display: flex">
   <div style="margin-right: 10px; flex: 1">
-    <label
-      for="inputName"
-      class="sky-control-label"
-      [ngClass]="{ 'sky-control-label-required': nameRequired }"
-    >
-      Name
-    </label>
-    <input
-      class="sky-form-control"
-      id="inputName"
-      type="text"
-      [ngModel]="name"
-      [required]="nameRequired"
-      (blur)="checkValidity()"
-      (ngModelChange)="nameChange($event)"
-    />
+    <sky-input-box labelText="Name">
+      <input
+        id="inputName"
+        type="text"
+        [ngModel]="name"
+        [required]="nameRequired"
+        (blur)="checkValidity()"
+        (ngModelChange)="nameChange($event)"
+      />
+    </sky-input-box>
   </div>
   <div style="margin-right: 10px; flex: 1">
-    <label for="inputId" class="sky-control-label"> Id </label>
-    <input class="sky-form-control" id="inputId" type="text" [ngModel]="id" />
+    <sky-input-box labelText="Id">
+      <input id="inputId" type="text" [ngModel]="id" />
+    </sky-input-box>
   </div>
 </div>
 

--- a/apps/e2e/tabs-storybook/src/app/sectioned-form/sectioned-form-information-form-demo.component.ts
+++ b/apps/e2e/tabs-storybook/src/app/sectioned-form/sectioned-form-information-form-demo.component.ts
@@ -1,13 +1,13 @@
 import { CommonModule } from '@angular/common';
 import { Component, inject } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { SkyCheckboxModule } from '@skyux/forms';
+import { SkyCheckboxModule, SkyInputBoxModule } from '@skyux/forms';
 import { SkySectionedFormService } from '@skyux/tabs';
 
 @Component({
   selector: 'app-sectioned-form-information-form-demo',
   templateUrl: './sectioned-form-information-form-demo.component.html',
-  imports: [CommonModule, FormsModule, SkyCheckboxModule],
+  imports: [CommonModule, FormsModule, SkyCheckboxModule, SkyInputBoxModule],
 })
 export class SectionedFormInformationFormDemoComponent {
   public name = '';

--- a/apps/integration-e2e/src/e2e/page-viewport-left-data-manager-split-view.cy.ts
+++ b/apps/integration-e2e/src/e2e/page-viewport-left-data-manager-split-view.cy.ts
@@ -20,7 +20,7 @@ describe('Page Viewport Left Data Manager Split View', () => {
 
       cy.get('sky-split-view').should('exist').should('be.visible');
 
-      cy.skyVisualTest(`page-viewport-left-data-manager-split-view`);
+      cy.skyVisualTest(`page-viewport-left-data-manager-split-view-${theme}`);
     });
   });
 });

--- a/libs/sdk/e2e-schematics/src/lib/e2e-variations/e2e-variations.spec.ts
+++ b/libs/sdk/e2e-schematics/src/lib/e2e-variations/e2e-variations.spec.ts
@@ -4,10 +4,11 @@ describe('e2e variations', function () {
   it('should run all variations', function () {
     const callback = jest.fn();
     E2eVariations.forEachTheme(callback);
-    expect(callback).toHaveBeenCalledTimes(3);
-    expect(callback).toHaveBeenCalledWith('default');
-    expect(callback).toHaveBeenCalledWith('modern-v2-light');
-    expect(callback).toHaveBeenCalledWith('modern-v2-dark');
+    expect(callback.mock.calls).toEqual([
+      ['default'],
+      ['modern-v2-light'],
+      ['modern-v2-dark'],
+    ]);
     expect(callback).not.toHaveBeenCalledWith('modern-light');
     expect(callback).not.toHaveBeenCalledWith('modern-dark');
     callback.mockReset();

--- a/libs/sdk/e2e-schematics/src/lib/e2e-variations/e2e-variations.spec.ts
+++ b/libs/sdk/e2e-schematics/src/lib/e2e-variations/e2e-variations.spec.ts
@@ -4,9 +4,10 @@ describe('e2e variations', function () {
   it('should run all variations', function () {
     const callback = jest.fn();
     E2eVariations.forEachTheme(callback);
-    expect(callback).toHaveBeenCalledTimes(2);
+    expect(callback).toHaveBeenCalledTimes(3);
     expect(callback).toHaveBeenCalledWith('default');
     expect(callback).toHaveBeenCalledWith('modern-v2-light');
+    expect(callback).toHaveBeenCalledWith('modern-v2-dark');
     expect(callback).not.toHaveBeenCalledWith('modern-light');
     expect(callback).not.toHaveBeenCalledWith('modern-dark');
     callback.mockReset();

--- a/libs/sdk/e2e-schematics/src/lib/e2e-variations/e2e-variations.ts
+++ b/libs/sdk/e2e-schematics/src/lib/e2e-variations/e2e-variations.ts
@@ -1,4 +1,4 @@
-export type E2EVariationName = 'default' | 'modern-v2-light';
+export type E2EVariationName = 'default' | 'modern-v2-dark' | 'modern-v2-light';
 
 export const E2eVariations = {
   DISPLAY_WIDTHS: [1280],
@@ -8,5 +8,6 @@ export const E2eVariations = {
   forEachTheme: (callback: (theme: E2EVariationName) => void): void => {
     callback('default');
     callback('modern-v2-light');
+    callback('modern-v2-dark');
   },
 };


### PR DESCRIPTION
## Summary
- Widen `E2eVariations.forEachTheme` (`libs/sdk/e2e-schematics`) to also emit `modern-v2-dark`, alongside the existing `default` and `modern-v2-light` — this is the single shared helper ~94 Cypress visual-test spec files already loop over, so they all gain a dark-mode Percy snapshot with no further edits.
- Fix the one exception file, `apps/e2e/icon-storybook-e2e/src/e2e/icons-by-row.component.cy.ts`, which hardcoded a single theme instead of using that helper, so it also gets dark-mode coverage without renaming/orphaning its existing light-theme Percy baselines.
- Ignore this session's local `.superpowers/` scratch workspace.

Design rationale and rollout considerations are written up in `docs/dark-mode-visual-testing/README.md` (kept local/untracked, not part of this PR).

## Test plan
- [x] `npx nx test e2e-schematics` — 109/109 passing, including a strengthened assertion pinning theme call order
- [x] `npx nx lint e2e-schematics` / `npx nx lint icon-storybook-e2e` — clean
- [x] Static verification that both the legacy `percySnapshot` pipeline and the newer `skyVisualTest` pipeline render/name the new `modern-v2-dark` snapshots correctly, and that `SkyThemeService`'s mode-validation exception is structurally unreachable via Storybook's `PreviewWrapperComponent` — full reasoning traced against source, see commit history
- [ ] CI's `e2e`/Percy job (this repo's sandboxed local dev environment reliably hangs at Cypress/Electron startup, so live Cypress execution was not run locally — CI runs in a normal Linux container and should not hit this)
- [ ] Review and approve the new `modern-v2-dark` Percy baselines once CI generates them across all affected `-storybook-e2e` projects — first automated dark-mode coverage for most components, worth a deliberate look rather than a bulk-approve

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the modern-v2-dark theme across visual and end-to-end testing.
  * Updated the sectioned form demo with consistent input box styling for Name and Id fields.

* **Tests**
  * Enhanced theme-specific snapshots and validation for light and dark experiences.
  * Updated visual test identifiers and form input targeting for more reliable coverage.

* **Chores**
  * Excluded the Claude Code scratch workspace from version control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->