### PR TITLE
fix(components/i18n): add detailed deprecation documentation for legacy i18n services

### DIFF
--- a/libs/components/i18n/src/lib/modules/i18n/lib-resources-legacy.service.ts
+++ b/libs/components/i18n/src/lib/modules/i18n/lib-resources-legacy.service.ts
@@ -30,8 +30,9 @@ type ResourceDictionary = Record<string, ResourceKey | TemplatedResource>;
  * @deprecated This service preserves the behavior `SkyLibResourcesService` had before
  * SKY UX 15, when its observables emitted a single value and completed. It exists only
  * as a temporary landing spot for code that relied on that completion, and the SKY UX 15
- * `ng update` migration pointed existing code here automatically. Because it resolves
- * the locale only once, the strings it returns go stale when the user's locale changes.
+ * `ng update` migration pointed existing code here automatically. Because `getString()`
+ * and `getStrings()` resolve the locale only once, the strings they emit go stale when
+ * the user's locale changes.
  * Move back to `SkyLibResourcesService` — removing any dependency on the observables
  * completing, such as `forkJoin`, `lastValueFrom`, or `toPromise` — so displayed strings
  * stay in sync with the active locale. This service will be removed in a future major

--- a/libs/components/i18n/src/lib/modules/i18n/lib-resources-legacy.service.ts
+++ b/libs/components/i18n/src/lib/modules/i18n/lib-resources-legacy.service.ts
@@ -27,7 +27,15 @@ type ResourceDictionary = Record<string, ResourceKey | TemplatedResource>;
 /**
  * An Angular service for interacting with library resource strings.
  *
- * @deprecated This service is deprecated. Use `SkyLibResourcesService` instead.
+ * @deprecated This service preserves the behavior `SkyLibResourcesService` had before
+ * SKY UX 15, when its observables emitted a single value and completed. It exists only
+ * as a temporary landing spot for code that relied on that completion, and the SKY UX 15
+ * `ng update` migration pointed existing code here automatically. Because it resolves
+ * the locale only once, the strings it returns go stale when the user's locale changes.
+ * Move back to `SkyLibResourcesService` — removing any dependency on the observables
+ * completing, such as `forkJoin`, `lastValueFrom`, or `toPromise` — so displayed strings
+ * stay in sync with the active locale. This service will be removed in a future major
+ * version.
  */
 @Injectable({
   providedIn: 'root',
@@ -54,7 +62,9 @@ export class SkyLibResourcesLegacyService {
   /**
    * Adds locale resources to be used by library components.
    *
-   * @deprecated This method is deprecated. Use `SkyLibResourcesService.addResources()` instead.
+   * @deprecated Use `SkyLibResourcesService.addResources()` instead. It behaves identically
+   * and shares the same underlying resource registry, so migrating requires no other changes
+   * and lets you drop this service entirely.
    */
   public static addResources(
     localeResources: Record<string, SkyLibResources>,
@@ -66,7 +76,10 @@ export class SkyLibResourcesLegacyService {
    * Gets a resource string based on its name. Emits once and completes.
    * @param name The name of the resource string.
    * @param args Any templated args.
-   * @deprecated This method is deprecated. Use `SkyLibResourcesService.getString()` instead.
+   * @deprecated This method reads the locale once and completes, so the string it emits
+   * is not updated when the user's locale changes. Use `SkyLibResourcesService.getString()`
+   * instead, which re-emits the translated string on every locale change. Subscribers must
+   * no longer rely on the observable completing.
    */
   public getString(name: string, ...args: any[]): Observable<string> {
     const mappedNameObs = this.#resourceNameProvider
@@ -101,7 +114,10 @@ export class SkyLibResourcesLegacyService {
    * }
    * ```
    *
-   * @deprecated This method is deprecated. Use `SkyLibResourcesService.getStrings()` instead.
+   * @deprecated This method reads the locale once and completes, so the dictionary it emits
+   * is not updated when the user's locale changes. Use `SkyLibResourcesService.getStrings()`
+   * instead, which re-emits the translated dictionary on every locale change. Subscribers
+   * must no longer rely on the observable completing.
    */
   public getStrings<T extends ResourceDictionary>(
     dictionary: T,
@@ -127,7 +143,9 @@ export class SkyLibResourcesLegacyService {
    * @param info The locale to use.
    * @param name The name of the resource string.
    * @param args Any templated args.
-   * @deprecated This method is deprecated. Use `SkyLibResourcesService.getStringForLocale()` instead.
+   * @deprecated Use `SkyLibResourcesService.getStringForLocale()` instead. Because the locale
+   * is passed in explicitly, that method behaves the same as this one, so migrating requires
+   * no other changes and lets you drop this service entirely.
    */
   public getStringForLocale(
     info: SkyAppLocaleInfo,

--- a/libs/components/i18n/src/lib/modules/i18n/resources-legacy.service.ts
+++ b/libs/components/i18n/src/lib/modules/i18n/resources-legacy.service.ts
@@ -31,7 +31,15 @@ function getDefaultObs(): Observable<SkyResourceType> {
 /**
  * An Angular service for interacting with resource strings.
  *
- * @deprecated This service is deprecated. Use `SkyAppResourcesService` instead.
+ * @deprecated This service preserves the behavior `SkyAppResourcesService` had before
+ * SKY UX 15, when its observables emitted a single value and completed. It exists only
+ * as a temporary landing spot for code that relied on that completion, and the SKY UX 15
+ * `ng update` migration pointed existing code here automatically. Because it resolves
+ * the locale only once, the strings it returns go stale when the user's locale changes.
+ * Move back to `SkyAppResourcesService` — removing any dependency on the observables
+ * completing, such as `forkJoin`, `lastValueFrom`, or `toPromise` — so displayed strings
+ * stay in sync with the active locale. This service will be removed in a future major
+ * version.
  */
 @Injectable({
   providedIn: 'root',
@@ -67,7 +75,10 @@ export class SkyAppResourcesLegacyService {
    * Gets a resource string based on its name. Emits once and completes.
    * @param name The name of the resource string.
    * @param args Any templated args.
-   * @deprecated This method is deprecated. Use `SkyAppResourcesService.getString()` instead.
+   * @deprecated This method reads the locale once and completes, so the string it emits
+   * is not updated when the user's locale changes. Use `SkyAppResourcesService.getString()`
+   * instead, which re-emits the translated string on every locale change. Subscribers must
+   * no longer rely on the observable completing.
    */
   public getString(name: string, ...args: any[]): Observable<string> {
     const localeObs: Observable<SkyAppLocaleInfo> =
@@ -94,7 +105,10 @@ export class SkyAppResourcesLegacyService {
    * }
    * ```
    *
-   * @deprecated This method is deprecated. Use `SkyAppResourcesService.getStrings()` instead.
+   * @deprecated This method reads the locale once and completes, so the dictionary it emits
+   * is not updated when the user's locale changes. Use `SkyAppResourcesService.getStrings()`
+   * instead, which re-emits the translated dictionary on every locale change. Subscribers
+   * must no longer rely on the observable completing.
    */
   public getStrings<T extends ResourceDictionary>(
     dictionary: T,
@@ -120,7 +134,9 @@ export class SkyAppResourcesLegacyService {
    * @param localeInfo The locale to use.
    * @param name The name of the resource string.
    * @param args Any templated args.
-   * @deprecated This method is deprecated. Use `SkyAppResourcesService.getStringForLocale()` instead.
+   * @deprecated Use `SkyAppResourcesService.getStringForLocale()` instead. Because the locale
+   * is passed in explicitly, that method behaves the same as this one, so migrating requires
+   * no other changes and lets you drop this service entirely.
    */
   public getStringForLocale(
     localeInfo: SkyAppLocaleInfo,

--- a/libs/components/i18n/src/lib/modules/i18n/resources-legacy.service.ts
+++ b/libs/components/i18n/src/lib/modules/i18n/resources-legacy.service.ts
@@ -34,8 +34,9 @@ function getDefaultObs(): Observable<SkyResourceType> {
  * @deprecated This service preserves the behavior `SkyAppResourcesService` had before
  * SKY UX 15, when its observables emitted a single value and completed. It exists only
  * as a temporary landing spot for code that relied on that completion, and the SKY UX 15
- * `ng update` migration pointed existing code here automatically. Because it resolves
- * the locale only once, the strings it returns go stale when the user's locale changes.
+ * `ng update` migration pointed existing code here automatically. Because `getString()`
+ * and `getStrings()` resolve the locale only once, the strings they emit go stale when
+ * the user's locale changes.
  * Move back to `SkyAppResourcesService` — removing any dependency on the observables
  * completing, such as `forkJoin`, `lastValueFrom`, or `toPromise` — so displayed strings
  * stay in sync with the active locale. This service will be removed in a future major


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified deprecation guidance for legacy resource services and lookup methods.
  - Documented legacy observable behavior, including single-emission completion and stale results after locale changes.
  - Added migration guidance pointing to the current APIs and noting that completion should not be relied upon.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->