### PR TITLE
fix(components/packages): update `migrate-sdk-testing-imports` schematic to migrate `SkyA11yAnalyzerConfig` and `SkyToBeVisibleOptions` types to @skyux-sdk/vitest

### DIFF
--- a/libs/components/packages/src/schematics/migrations/update-15/migrate-sdk-testing-imports/migrate-sdk-testing-imports.schematic.spec.ts
+++ b/libs/components/packages/src/schematics/migrations/update-15/migrate-sdk-testing-imports/migrate-sdk-testing-imports.schematic.spec.ts
@@ -166,6 +166,99 @@ const options: SkyAppTestUtilityDomEventOptions = { bubbles: true };
 `);
   });
 
+  it('should rename `SkyA11yAnalyzerConfig` and move it to the vitest package', async () => {
+    const tree = setupTree({
+      '/src/app/test.spec.ts': `import { SkyA11yAnalyzerConfig } from '@skyux-sdk/testing';
+
+const config: SkyA11yAnalyzerConfig = { rules: {} };
+`,
+    });
+
+    await runSchematic(tree);
+
+    expect(tree.readText('/src/app/test.spec.ts'))
+      .toBe(`import { SkyToBeAccessibleOptions } from '@skyux-sdk/vitest';
+
+const config: SkyToBeAccessibleOptions = { rules: {} };
+`);
+  });
+
+  it('should move `SkyToBeVisibleOptions` to the vitest package', async () => {
+    const tree = setupTree({
+      '/src/app/test.spec.ts': `import { SkyToBeVisibleOptions } from '@skyux-sdk/testing';
+
+const options: SkyToBeVisibleOptions = {};
+`,
+    });
+
+    await runSchematic(tree);
+
+    expect(tree.readText('/src/app/test.spec.ts'))
+      .toBe(`import { SkyToBeVisibleOptions } from '@skyux-sdk/vitest';
+
+const options: SkyToBeVisibleOptions = {};
+`);
+  });
+
+  it('should move imports to both the core and vitest packages', async () => {
+    const tree = setupTree({
+      '/src/app/test.spec.ts': `import { SkyA11yAnalyzerConfig, SkyBy } from '@skyux-sdk/testing';
+
+const config: SkyA11yAnalyzerConfig = { rules: {} };
+
+describe('test', () => {
+  SkyBy.dataSkyId('a');
+});
+`,
+    });
+
+    await runSchematic(tree);
+
+    expect(tree.readText('/src/app/test.spec.ts'))
+      .toBe(`import { SkyBy } from '@skyux/core/testing';
+import { SkyToBeAccessibleOptions } from '@skyux-sdk/vitest';
+
+const config: SkyToBeAccessibleOptions = { rules: {} };
+
+describe('test', () => {
+  SkyBy.dataSkyId('a');
+});
+`);
+  });
+
+  it('should merge into an existing vitest import statement', async () => {
+    const tree = setupTree({
+      '/src/app/test.spec.ts': `import { SkyToBeAccessibleOptions } from '@skyux-sdk/vitest';
+import { SkyToBeVisibleOptions } from '@skyux-sdk/testing';
+
+const accessible: SkyToBeAccessibleOptions = { rules: {} };
+const visible: SkyToBeVisibleOptions = {};
+`,
+    });
+
+    await runSchematic(tree);
+
+    expect(tree.readText('/src/app/test.spec.ts'))
+      .toBe(`import { SkyToBeAccessibleOptions, SkyToBeVisibleOptions } from '@skyux-sdk/vitest';
+
+const accessible: SkyToBeAccessibleOptions = { rules: {} };
+const visible: SkyToBeVisibleOptions = {};
+`);
+  });
+
+  it('should remove the deprecated dependency when only vitest types were used', async () => {
+    const tree = setupTree({
+      '/src/app/test.spec.ts': `import { SkyA11yAnalyzerConfig } from '@skyux-sdk/testing';
+
+const config: SkyA11yAnalyzerConfig = { rules: {} };
+`,
+    });
+
+    await runSchematic(tree);
+
+    expect(getDevDependencies(tree)).toEqual({ typescript: '^5.0.0' });
+  });
+
   it('should ignore files without moved imports', async () => {
     const source = `import { SkyAppTestModule } from '@skyux-sdk/testing';
 import { SkyBy } from './sky-by';

--- a/libs/components/packages/src/schematics/migrations/update-15/migrate-sdk-testing-imports/migrate-sdk-testing-imports.schematic.ts
+++ b/libs/components/packages/src/schematics/migrations/update-15/migrate-sdk-testing-imports/migrate-sdk-testing-imports.schematic.ts
@@ -24,6 +24,16 @@ const SWAP_OPTIONS: SwapImportedClassOptions[] = [
     },
     moduleName: { old: DEPRECATED_PACKAGE, new: SUPPORTED_PACKAGE },
   },
+  {
+    classNames: {
+      SkyA11yAnalyzerConfig: 'SkyToBeAccessibleOptions',
+      SkyToBeVisibleOptions: 'SkyToBeVisibleOptions',
+    },
+    moduleName: {
+      old: DEPRECATED_PACKAGE,
+      new: '@skyux-sdk/vitest',
+    },
+  },
 ];
 
 function migrateFile(tree: Tree, filePath: string): void {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an automated migration for accessibility testing imports.
  * Migrates accessibility types to the Vitest package, including renaming `SkyA11yAnalyzerConfig` to `SkyToBeAccessibleOptions`.
  * Updates and consolidates imports while removing the deprecated testing dependency when no longer needed.

* **Tests**
  * Added coverage for migrated imports, renamed types, and dependency cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->