### PR TITLE
chore: enable dark mode visual tests (#4695)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,6 @@ nx-cloud.env
 .claude/worktrees
 .cursor/rules/nx-rules.mdc
 .github/instructions/nx.instructions.md
+
+# Claude Code superpowers scratch workspace
+/.superpowers

--- a/apps/e2e/icon-storybook-e2e/src/e2e/icons-by-row.component.cy.ts
+++ b/apps/e2e/icon-storybook-e2e/src/e2e/icons-by-row.component.cy.ts
@@ -2,22 +2,31 @@ const PAGE_COUNT = 4 as const;
 const PAGES = Array.from({ length: PAGE_COUNT }, (_, i) => i + 1);
 
 describe('icons', () => {
-  const theme = 'modern-v2-light';
+  (['modern-v2-light', 'modern-v2-dark'] as const).forEach((theme) => {
+    // Light keeps its historical un-suffixed snapshot names so existing
+    // Percy baselines aren't orphaned; only the new dark run is suffixed.
+    const snapshotSuffix = theme === 'modern-v2-light' ? '' : `-${theme}`;
 
-  ['line', 'solid'].forEach((variant) => {
-    describe(variant, () => {
-      PAGES.forEach((page) => {
-        it(`should render ${variant} icons, page ${page}`, () => {
-          cy.viewport(1024, 4000);
-          cy.visit(
-            `/iframe.html?args=page:${page};pages:${PAGE_COUNT};variant:${variant}&globals=theme:${theme}&id=icons-by-rowcomponent--icons-by-row`,
-          );
-          cy.get('#ready').should('exist');
-          cy.get('app-icons-by-row')
-            .should('exist')
-            .should('be.visible')
-            .screenshot(`icons-${variant}-page-${page}`);
-          cy.percySnapshot(`icons-${variant}-page-${page}`, { widths: [1024] });
+    describe(`in ${theme} theme`, () => {
+      ['line', 'solid'].forEach((variant) => {
+        describe(variant, () => {
+          PAGES.forEach((page) => {
+            it(`should render ${variant} icons, page ${page}`, () => {
+              cy.viewport(1024, 4000);
+              cy.visit(
+                `/iframe.html?args=page:${page};pages:${PAGE_COUNT};variant:${variant}&globals=theme:${theme}&id=icons-by-rowcomponent--icons-by-row`,
+              );
+              cy.get('#ready').should('exist');
+              cy.get('app-icons-by-row')
+                .should('exist')
+                .should('be.visible')
+                .screenshot(`icons-${variant}-page-${page}${snapshotSuffix}`);
+              cy.percySnapshot(
+                `icons-${variant}-page-${page}${snapshotSuffix}`,
+                { widths: [1024] },
+              );
+            });
+          });
         });
       });
     });

--- a/apps/e2e/icon-storybook/src/app/icons-by-row/icons-by-row.component.scss
+++ b/apps/e2e/icon-storybook/src/app/icons-by-row/icons-by-row.component.scss
@@ -1,6 +1,4 @@
 :host {
-  /* Maximum contrast for visual tests */
-  background-color: white;
   display: grid;
   grid-template-columns: 1fr;
   grid-template-rows: repeat(auto-fill, 100px);

--- a/apps/e2e/tabs-storybook-e2e/src/e2e/sectioned-form.component.cy.ts
+++ b/apps/e2e/tabs-storybook-e2e/src/e2e/sectioned-form.component.cy.ts
@@ -46,7 +46,9 @@ describe('sectioned form', () => {
           .should('be.visible')
           .click();
 
-        cy.get('#inputName').should('exist').should('be.visible');
+        cy.get('[data-sky-id="inputName"]')
+          .should('exist')
+          .should('be.visible');
 
         cy.window().screenshot(`sectioned-form-${size}-${theme}`);
         cy.window().percySnapshot(`sectioned-form-${size}-${theme}`, {

--- a/apps/e2e/tabs-storybook/src/app/sectioned-form/sectioned-form-information-form-demo.component.html
+++ b/apps/e2e/tabs-storybook/src/app/sectioned-form/sectioned-form-information-form-demo.component.html
@@ -1,25 +1,20 @@
 <div style="display: flex">
   <div style="margin-right: 10px; flex: 1">
-    <label
-      for="inputName"
-      class="sky-control-label"
-      [ngClass]="{ 'sky-control-label-required': nameRequired }"
-    >
-      Name
-    </label>
-    <input
-      class="sky-form-control"
-      id="inputName"
-      type="text"
-      [ngModel]="name"
-      [required]="nameRequired"
-      (blur)="checkValidity()"
-      (ngModelChange)="nameChange($event)"
-    />
+    <sky-input-box labelText="Name">
+      <input
+        data-sky-id="inputName"
+        type="text"
+        [ngModel]="name"
+        [required]="nameRequired"
+        (blur)="checkValidity()"
+        (ngModelChange)="nameChange($event)"
+      />
+    </sky-input-box>
   </div>
   <div style="margin-right: 10px; flex: 1">
-    <label for="inputId" class="sky-control-label"> Id </label>
-    <input class="sky-form-control" id="inputId" type="text" [ngModel]="id" />
+    <sky-input-box labelText="Id">
+      <input data-sky-id="inputId" type="text" [ngModel]="id" />
+    </sky-input-box>
   </div>
 </div>
 

--- a/apps/e2e/tabs-storybook/src/app/sectioned-form/sectioned-form-information-form-demo.component.ts
+++ b/apps/e2e/tabs-storybook/src/app/sectioned-form/sectioned-form-information-form-demo.component.ts
@@ -1,13 +1,13 @@
 import { CommonModule } from '@angular/common';
 import { Component, inject } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { SkyCheckboxModule } from '@skyux/forms';
+import { SkyCheckboxModule, SkyInputBoxModule } from '@skyux/forms';
 import { SkySectionedFormService } from '@skyux/tabs';
 
 @Component({
   selector: 'app-sectioned-form-information-form-demo',
   templateUrl: './sectioned-form-information-form-demo.component.html',
-  imports: [CommonModule, FormsModule, SkyCheckboxModule],
+  imports: [CommonModule, FormsModule, SkyCheckboxModule, SkyInputBoxModule],
 })
 export class SectionedFormInformationFormDemoComponent {
   public name = '';

--- a/apps/integration-e2e/src/e2e/page-viewport-left-data-manager-split-view.cy.ts
+++ b/apps/integration-e2e/src/e2e/page-viewport-left-data-manager-split-view.cy.ts
@@ -20,7 +20,7 @@ describe('Page Viewport Left Data Manager Split View', () => {
 
       cy.get('sky-split-view').should('exist').should('be.visible');
 
-      cy.skyVisualTest(`page-viewport-left-data-manager-split-view`);
+      cy.skyVisualTest(`page-viewport-left-data-manager-split-view-${theme}`);
     });
   });
 });

--- a/libs/sdk/e2e-schematics/src/lib/e2e-variations/e2e-variations.spec.ts
+++ b/libs/sdk/e2e-schematics/src/lib/e2e-variations/e2e-variations.spec.ts
@@ -4,9 +4,11 @@ describe('e2e variations', function () {
   it('should run all variations', function () {
     const callback = jest.fn();
     E2eVariations.forEachTheme(callback);
-    expect(callback).toHaveBeenCalledTimes(2);
-    expect(callback).toHaveBeenCalledWith('default');
-    expect(callback).toHaveBeenCalledWith('modern-v2-light');
+    expect(callback.mock.calls).toEqual([
+      ['default'],
+      ['modern-v2-light'],
+      ['modern-v2-dark'],
+    ]);
     expect(callback).not.toHaveBeenCalledWith('modern-light');
     expect(callback).not.toHaveBeenCalledWith('modern-dark');
     callback.mockReset();

--- a/libs/sdk/e2e-schematics/src/lib/e2e-variations/e2e-variations.ts
+++ b/libs/sdk/e2e-schematics/src/lib/e2e-variations/e2e-variations.ts
@@ -1,4 +1,4 @@
-export type E2EVariationName = 'default' | 'modern-v2-light';
+export type E2EVariationName = 'default' | 'modern-v2-dark' | 'modern-v2-light';
 
 export const E2eVariations = {
   DISPLAY_WIDTHS: [1280],
@@ -8,5 +8,6 @@ export const E2eVariations = {
   forEachTheme: (callback: (theme: E2EVariationName) => void): void => {
     callback('default');
     callback('modern-v2-light');
+    callback('modern-v2-dark');
   },
 };


### PR DESCRIPTION
:cherries: Cherry picked from #4695 [chore: enable dark mode visual tests](https://github.com/blackbaud/skyux/pull/4695)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the modern dark theme across end-to-end and visual testing variations.
  * Updated form examples to use standardized input components for Name and ID fields.

* **Bug Fixes**
  * Improved visual test snapshot separation by including the active theme.
  * Updated automated test selectors for more reliable form interactions.

* **Tests**
  * Expanded icon and theme coverage to validate light and dark theme rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->