### PR TITLE
chore: re-check e2e visual review when the screenshot removed label changes

### DIFF
--- a/.github/workflows/e2e-screenshot-removed-check.yml
+++ b/.github/workflows/e2e-screenshot-removed-check.yml
@@ -1,0 +1,62 @@
+name: E2E Screenshot Removed Check
+
+on:
+  pull_request_target:
+    types:
+      - labeled
+      - unlabeled
+
+jobs:
+  e2e-screenshot-removed-recheck:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.label.name == 'screenshot removed' }}
+    steps:
+      - uses: actions/github-script@v8
+        with:
+          github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+          script: |
+            const sha = context.payload.pull_request.head.sha;
+
+            console.log(`Finding e2e workflow run for commit ${sha}.`);
+            const {data} = await github.rest.actions.listWorkflowRuns({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'e2e.yml',
+              head_sha: sha,
+              status: 'completed',
+              per_page: 1
+            });
+
+            const run = data.workflow_runs[0];
+
+            if (!run) {
+              console.log(`No completed e2e workflow run found for commit ${sha}. Nothing to re-check.`);
+              return;
+            }
+
+            console.log(`Found e2e workflow run ${run.id} (conclusion: ${run.conclusion}). Looking for the E2E Visual Review job.`);
+            const {data: jobsData} = await github.rest.actions.listJobsForWorkflowRun({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: run.id,
+              per_page: 100,
+              filter: 'latest'
+            });
+            const e2eReviewJob = (jobsData.jobs || []).find(job => job.name === 'E2E Visual Review');
+
+            if (!e2eReviewJob) {
+              console.log(`No "E2E Visual Review" job found for workflow run ${run.id}.`);
+              return;
+            }
+
+            if (e2eReviewJob.status !== 'completed') {
+              console.log(`E2E Visual Review job ${e2eReviewJob.id} for workflow run ${run.id} is still ${e2eReviewJob.status}. It will pick up the current "screenshot removed" label state on its own once it runs, so no re-run is needed.`);
+              return;
+            }
+
+            console.log(`Re-running E2E Visual Review job ${e2eReviewJob.id} for workflow run ${run.id} (the "screenshot removed" label was ${context.payload.action}).`);
+            await github.rest.actions.reRunJobForWorkflowRun({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              job_id: e2eReviewJob.id
+            });

--- a/.github/workflows/e2e-screenshot-removed-check.yml
+++ b/.github/workflows/e2e-screenshot-removed-check.yml
@@ -6,6 +6,8 @@ on:
       - labeled
       - unlabeled
 
+permissions: {}
+
 jobs:
   e2e-screenshot-removed-recheck:
     runs-on: ubuntu-latest
@@ -27,12 +29,18 @@ jobs:
               per_page: 100
             });
 
-            const run = workflowRuns.find((workflowRun) =>
-              workflowRun.pull_requests.some((pullRequest) => pullRequest.number === prNumber)
-            );
+            const rerunWindowStart = Date.now() - (30 * 24 * 60 * 60 * 1000);
+            const run = workflowRuns.find((workflowRun) => {
+              const createdAt = Date.parse(workflowRun.created_at);
+              return (
+                !Number.isNaN(createdAt) &&
+                createdAt >= rerunWindowStart &&
+                workflowRun.pull_requests.some((pullRequest) => pullRequest.number === prNumber)
+              );
+            });
 
             if (!run) {
-              console.log(`No completed e2e workflow run found for PR #${prNumber}. Nothing to re-check.`);
+              console.log(`No completed e2e workflow run from the last 30 days found for PR #${prNumber}. Nothing to re-check.`);
               return;
             }
 

--- a/.github/workflows/e2e-screenshot-removed-check.yml
+++ b/.github/workflows/e2e-screenshot-removed-check.yml
@@ -17,6 +17,7 @@ jobs:
         with:
           github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
           script: |
+            const RERUN_WINDOW_DAYS = 30;
             const prNumber = context.payload.pull_request.number;
 
             console.log(`Finding latest completed e2e workflow run for PR #${prNumber}.`);
@@ -29,7 +30,8 @@ jobs:
               per_page: 100
             });
 
-            const rerunWindowStart = Date.now() - (30 * 24 * 60 * 60 * 1000);
+            const rerunWindowStart =
+              Date.now() - (RERUN_WINDOW_DAYS * 24 * 60 * 60 * 1000);
             const run = workflowRuns.find((workflowRun) => {
               const createdAt = Date.parse(workflowRun.created_at);
               return (
@@ -40,7 +42,7 @@ jobs:
             });
 
             if (!run) {
-              console.log(`No completed e2e workflow run from the last 30 days found for PR #${prNumber}. Nothing to re-check.`);
+              console.log(`No completed e2e workflow run from the last ${RERUN_WINDOW_DAYS} days found for PR #${prNumber}. Nothing to re-check.`);
               return;
             }
 

--- a/.github/workflows/e2e-screenshot-removed-check.yml
+++ b/.github/workflows/e2e-screenshot-removed-check.yml
@@ -19,6 +19,9 @@ jobs:
           script: |
             const RERUN_WINDOW_DAYS = 30;
             const prNumber = context.payload.pull_request.number;
+            const rerunWindowStart =
+              Date.now() - (RERUN_WINDOW_DAYS * 24 * 60 * 60 * 1000);
+            const rerunWindowStartIso = new Date(rerunWindowStart).toISOString();
 
             console.log(`Finding latest completed e2e workflow run for PR #${prNumber}.`);
             const workflowRuns = await github.paginate(github.rest.actions.listWorkflowRuns, {
@@ -27,11 +30,10 @@ jobs:
               workflow_id: 'e2e.yml',
               event: 'pull_request_target',
               status: 'completed',
+              created: `>=${rerunWindowStartIso}`,
               per_page: 100
             });
 
-            const rerunWindowStart =
-              Date.now() - (RERUN_WINDOW_DAYS * 24 * 60 * 60 * 1000);
             const run = workflowRuns.find((workflowRun) => {
               const createdAt = Date.parse(workflowRun.created_at);
               return (
@@ -47,14 +49,18 @@ jobs:
             }
 
             console.log(`Found e2e workflow run ${run.id} (conclusion: ${run.conclusion}). Looking for the E2E Visual Review job.`);
-            const {data: jobsData} = await github.rest.actions.listJobsForWorkflowRun({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              run_id: run.id,
-              per_page: 100,
-              filter: 'latest'
-            });
-            const e2eReviewJob = (jobsData.jobs || []).find(job => job.name === 'E2E Visual Review');
+            const jobs = await github.paginate(
+              github.rest.actions.listJobsForWorkflowRun,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                run_id: run.id,
+                per_page: 100,
+                filter: 'latest'
+              },
+              (response) => response.data.jobs
+            );
+            const e2eReviewJob = jobs.find(job => job.name === 'E2E Visual Review');
 
             if (!e2eReviewJob) {
               console.log(`No "E2E Visual Review" job found for workflow run ${run.id}.`);

--- a/.github/workflows/e2e-screenshot-removed-check.yml
+++ b/.github/workflows/e2e-screenshot-removed-check.yml
@@ -15,26 +15,24 @@ jobs:
         with:
           github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
           script: |
-            const sha = context.payload.pull_request.head.sha;
-
-            console.log(`Finding e2e workflow run for commit ${sha}.`);
             const prNumber = context.payload.pull_request.number;
-            const {data} = await github.rest.actions.listWorkflowRuns({
+
+            console.log(`Finding latest completed e2e workflow run for PR #${prNumber}.`);
+            const workflowRuns = await github.paginate(github.rest.actions.listWorkflowRuns, {
               owner: context.repo.owner,
               repo: context.repo.repo,
               workflow_id: 'e2e.yml',
-              head_sha: sha,
               event: 'pull_request_target',
               status: 'completed',
               per_page: 100
             });
 
-            const run = data.workflow_runs.find((workflowRun) =>
+            const run = workflowRuns.find((workflowRun) =>
               workflowRun.pull_requests.some((pullRequest) => pullRequest.number === prNumber)
             );
 
             if (!run) {
-              console.log(`No completed e2e workflow run found for commit ${sha}. Nothing to re-check.`);
+              console.log(`No completed e2e workflow run found for PR #${prNumber}. Nothing to re-check.`);
               return;
             }
 

--- a/.github/workflows/e2e-screenshot-removed-check.yml
+++ b/.github/workflows/e2e-screenshot-removed-check.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
           script: |
-            const RERUN_WINDOW_DAYS = 30;
+            const RERUN_WINDOW_DAYS = 1;
             const prNumber = context.payload.pull_request.number;
             const rerunWindowStart =
               Date.now() - (RERUN_WINDOW_DAYS * 24 * 60 * 60 * 1000);

--- a/.github/workflows/e2e-screenshot-removed-check.yml
+++ b/.github/workflows/e2e-screenshot-removed-check.yml
@@ -18,16 +18,20 @@ jobs:
             const sha = context.payload.pull_request.head.sha;
 
             console.log(`Finding e2e workflow run for commit ${sha}.`);
+            const prNumber = context.payload.pull_request.number;
             const {data} = await github.rest.actions.listWorkflowRuns({
               owner: context.repo.owner,
               repo: context.repo.repo,
               workflow_id: 'e2e.yml',
               head_sha: sha,
+              event: 'pull_request_target',
               status: 'completed',
-              per_page: 1
+              per_page: 100
             });
 
-            const run = data.workflow_runs[0];
+            const run = data.workflow_runs.find((workflowRun) =>
+              workflowRun.pull_requests.some((pullRequest) => pullRequest.number === prNumber)
+            );
 
             if (!run) {
               console.log(`No completed e2e workflow run found for commit ${sha}. Nothing to re-check.`);

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -550,6 +550,7 @@ jobs:
               // after the "screenshot removed" label is added or removed)
               // reflect the PR's current labels instead of stale ones.
               const isPush = ${{ github.event_name == 'push' }};
+              const prNumber = ${{ toJSON(needs.install-deps.outputs.pr-number) }};
               const currentLabels = isPush
                 ? []
                 : await github.paginate(
@@ -557,7 +558,7 @@ jobs:
                     {
                       owner: context.repo.owner,
                       repo: context.repo.repo,
-                      issue_number: ${{ needs.install-deps.outputs.pr-number }},
+                      issue_number: Number(prNumber),
                     },
                     (response) => response.data.map((label) => label.name)
                   );

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -543,12 +543,31 @@ jobs:
               const globPattern = await glob.create('${{ runner.temp }}/percy-builds/percy-build-*.txt');
               const buildIdFiles = await globPattern.glob()
 
+              // Fetch the PR's labels live rather than trusting
+              // needs.install-deps.outputs.pr-labels, which is frozen from
+              // when this workflow run started. This lets a re-run of just
+              // this job (e.g. triggered by e2e-screenshot-removed-check.yml
+              // after the "screenshot removed" label is added or removed)
+              // reflect the PR's current labels instead of stale ones.
+              const isPush = ${{ github.event_name == 'push' }};
+              const currentLabels = isPush
+                ? []
+                : await github.rest.issues
+                    .listLabelsOnIssue({
+                      owner: context.repo.owner,
+                      repo: context.repo.repo,
+                      issue_number: ${{ needs.install-deps.outputs.pr-number }},
+                    })
+                    .then(({ data }) => data.map((label) => label.name));
+              const allowMissingScreenshots =
+                isPush || currentLabels.includes('screenshot removed');
+
               await verifyE2e(
                 e2eProjects,
                 buildIdFiles,
                 core,
                 { listJobsForWorkflowRun, downloadJobLogs },
-                ${{ github.event_name == 'push' || contains( fromJSON( needs.install-deps.outputs.pr-labels ), 'screenshot removed' ) }},
+                allowMissingScreenshots,
                 (url) => fetch(url, options),
                 (number) => process.exit(number)
               );

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -552,13 +552,15 @@ jobs:
               const isPush = ${{ github.event_name == 'push' }};
               const currentLabels = isPush
                 ? []
-                : await github.rest.issues
-                    .listLabelsOnIssue({
+                : await github.paginate(
+                    github.rest.issues.listLabelsOnIssue,
+                    {
                       owner: context.repo.owner,
                       repo: context.repo.repo,
                       issue_number: ${{ needs.install-deps.outputs.pr-number }},
-                    })
-                    .then(({ data }) => data.map((label) => label.name));
+                    },
+                    (response) => response.data.map((label) => label.name)
+                  );
               const allowMissingScreenshots =
                 isPush || currentLabels.includes('screenshot removed');
 


### PR DESCRIPTION
## Summary
- Add `e2e-screenshot-removed-check.yml`, a standalone workflow mirroring the existing `e2e-check.yml` pattern: triggered on `pull_request_target: [labeled, unlabeled]`, filtered to the `screenshot removed` label, it finds the latest completed `e2e.yml` run for the PR's head SHA and re-runs only its `E2E Visual Review` job — `install-deps`, `build-storybook`, `build-apps`, and `e2e` are never touched.
- Fix the `verify` job in `e2e.yml` so that job's `allowMissingScreenshots` check fetches the PR's labels live via the API instead of trusting `needs.install-deps.outputs.pr-labels`, which is frozen from whenever the original workflow run started. Without this, even the new targeted re-run would still see stale labels and fail identically.

### Why
Adding the `screenshot removed` label today doesn't trigger any workflow run (label events aren't in `e2e.yml`'s trigger types), and manually re-running the failed `E2E Visual Review` job doesn't help either, because that job's label check reads a value computed once by `install-deps` at the start of the original run — a job-level re-run never re-executes `install-deps` to refresh it. Both fixes together make "add the label" actually work, cheaply (one small job, no builds or Cypress runs) — without re-triggering the rest of the `e2e.yml` pipeline.

## Test plan
- [x] Both workflow files parse as valid YAML.
- [ ] Add the `screenshot removed` label to a PR with a completed, failed-on-missing-screenshots `e2e.yml` run and confirm `e2e-screenshot-removed-check.yml` finds and re-runs its `E2E Visual Review` job, and that the re-run now passes.
- [ ] Remove the label from the same PR and confirm the job re-runs again and correctly fails.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Visual checks now use the pull request’s latest labels, ensuring screenshot-removal approvals are recognized correctly.
  * Completed visual review checks automatically rerun when the screenshot-removal label changes.
  * Improved reliability when locating relevant pull request checks and visual review results.
  * Added clearer handling when required checks are unavailable or still in progress, reducing confusion during visual validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->