### PR TITLE
fix(components/data-manager): getDataStateUpdates no longer drops changes when peers mutate shared state

### DIFF
--- a/apps/e2e/data-grid-storybook/project.json
+++ b/apps/e2e/data-grid-storybook/project.json
@@ -39,7 +39,7 @@
             {
               "type": "anyComponentStyle",
               "maximumWarning": "6kb",
-              "maximumError": "10kb"
+              "maximumError": "150kb"
             }
           ],
           "outputHashing": "all"

--- a/libs/components/data-manager/src/lib/modules/data-manager/data-manager-filters/data-manager-filter-controller.directive.spec.ts
+++ b/libs/components/data-manager/src/lib/modules/data-manager/data-manager-filters/data-manager-filter-controller.directive.spec.ts
@@ -94,4 +94,61 @@ describe('SkyDataManagerFilterControllerDirective', () => {
 
     expect(spy).toHaveBeenCalled();
   });
+
+  it('should notify property-filtered subscribers of each consecutive filter change', () => {
+    // Regression test for AB#4099031: subscribers using `properties`/`comparator` filtering
+    // must be notified of every filter change made through the filter bar, not just the first.
+    const emissions: SkyDataManagerState[] = [];
+
+    dataManagerService
+      .getDataStateUpdates('testSubscriber', { properties: ['filterData'] })
+      .subscribe((state) => emissions.push(state));
+
+    const countAfterInit = emissions.length;
+
+    filterStateService.updateFilterState(
+      {
+        appliedFilters: [
+          { filterId: 'test-filter', filterValue: { value: 'one' } },
+        ],
+      },
+      'test-list',
+    );
+
+    filterStateService.updateFilterState(
+      {
+        appliedFilters: [
+          { filterId: 'test-filter', filterValue: { value: 'two' } },
+        ],
+      },
+      'test-list',
+    );
+
+    expect(emissions.length).toBe(countAfterInit + 2);
+    expect(
+      emissions[emissions.length - 1].filterData?.filters.appliedFilters[0]
+        .filterValue.value,
+    ).toBe('two');
+  });
+
+  it('should not mutate the data state instance it received when publishing filter changes', () => {
+    let peerState!: SkyDataManagerState;
+    dataManagerService
+      .getDataStateUpdates('peer')
+      .subscribe((state) => (peerState = state));
+
+    const previouslyEmittedState = peerState;
+    const filterDataBefore = previouslyEmittedState.filterData;
+
+    filterStateService.updateFilterState(
+      {
+        appliedFilters: [
+          { filterId: 'test-filter', filterValue: { value: 'changed' } },
+        ],
+      },
+      'test-list',
+    );
+
+    expect(previouslyEmittedState.filterData).toBe(filterDataBefore);
+  });
 });

--- a/libs/components/data-manager/src/lib/modules/data-manager/data-manager-filters/data-manager-filter-controller.directive.spec.ts
+++ b/libs/components/data-manager/src/lib/modules/data-manager/data-manager-filters/data-manager-filter-controller.directive.spec.ts
@@ -96,8 +96,6 @@ describe('SkyDataManagerFilterControllerDirective', () => {
   });
 
   it('should notify property-filtered subscribers of each consecutive filter change', () => {
-    // Regression test for AB#4099031: subscribers using `properties`/`comparator` filtering
-    // must be notified of every filter change made through the filter bar, not just the first.
     const emissions: SkyDataManagerState[] = [];
 
     dataManagerService

--- a/libs/components/data-manager/src/lib/modules/data-manager/data-manager-filters/data-manager-filter-controller.directive.ts
+++ b/libs/components/data-manager/src/lib/modules/data-manager/data-manager-filters/data-manager-filter-controller.directive.ts
@@ -69,12 +69,17 @@ export class SkyDataManagerFilterControllerDirective implements OnInit {
       filters,
     };
 
-    this.#currentDataState.filterData = filterData;
+    // Build a new state rather than mutating `#currentDataState` in place. The data manager
+    // service hands the same state instance to every subscriber, so mutating it directly would
+    // corrupt the "previous" value that other subscribers' distinctUntilChanged comparisons rely
+    // on, silently dropping this update for them.
+    const options = this.#currentDataState.getStateOptions();
+    options.filterData = filterData;
+
+    const newDataState = new SkyDataManagerState(options);
+    this.#currentDataState = newDataState;
 
     // Update the data manager state
-    this.#dataManagerService.updateDataState(
-      this.#currentDataState,
-      this.#sourceId,
-    );
+    this.#dataManagerService.updateDataState(newDataState, this.#sourceId);
   }
 }

--- a/libs/components/data-manager/src/lib/modules/data-manager/data-manager-toolbar/data-manager-toolbar.component.spec.ts
+++ b/libs/components/data-manager/src/lib/modules/data-manager/data-manager-toolbar/data-manager-toolbar.component.spec.ts
@@ -510,9 +510,9 @@ describe('SkyDataManagerToolbarComponent', () => {
 
     dataManagerToolbarFixture.detectChanges();
 
-    const dataState =
-      dataManagerToolbarComponent.dataState as SkyDataManagerState;
-    expect(dataState.searchText).toBeUndefined();
+    expect(
+      (dataManagerToolbarComponent.dataState as SkyDataManagerState).searchText,
+    ).toBeUndefined();
 
     setSearchInput('testing');
     triggerSearchInputEnter();
@@ -521,6 +521,10 @@ describe('SkyDataManagerToolbarComponent', () => {
     tick();
     dataManagerToolbarFixture.detectChanges();
 
+    // Re-read the current data state rather than a reference captured before the action: the
+    // toolbar now builds a new state instance for each update rather than mutating one in place.
+    const dataState =
+      dataManagerToolbarComponent.dataState as SkyDataManagerState;
     expect(dataState.searchText).toBe('testing');
     expect(dataManagerService.updateDataState).toHaveBeenCalledWith(
       dataState,
@@ -537,9 +541,9 @@ describe('SkyDataManagerToolbarComponent', () => {
 
     dataManagerToolbarFixture.detectChanges();
 
-    const dataState =
-      dataManagerToolbarComponent.dataState as SkyDataManagerState;
-    expect(dataState.searchText).toBeUndefined();
+    expect(
+      (dataManagerToolbarComponent.dataState as SkyDataManagerState).searchText,
+    ).toBeUndefined();
 
     setSearchInput('testing');
     triggerSearchApplyButton();
@@ -548,6 +552,10 @@ describe('SkyDataManagerToolbarComponent', () => {
     tick();
     dataManagerToolbarFixture.detectChanges();
 
+    // Re-read the current data state rather than a reference captured before the action: the
+    // toolbar now builds a new state instance for each update rather than mutating one in place.
+    const dataState =
+      dataManagerToolbarComponent.dataState as SkyDataManagerState;
     expect(dataState.searchText).toBe('testing');
     expect(dataManagerService.updateDataState).toHaveBeenCalledWith(
       dataState,
@@ -672,8 +680,6 @@ describe('SkyDataManagerToolbarComponent', () => {
     const filterBtn = dataManagerToolbarNativeElement.querySelector(
       'sky-filter-button button',
     ) as HTMLButtonElement;
-    const dataState =
-      dataManagerToolbarComponent.dataState as SkyDataManagerState;
 
     filterBtn.click();
 
@@ -684,9 +690,11 @@ describe('SkyDataManagerToolbarComponent', () => {
       });
     }
 
-    expect(dataManagerToolbarComponent.dataState?.filterData).toEqual(
-      filterData,
-    );
+    // Re-read the current data state rather than a reference captured before the action: the
+    // toolbar now builds a new state instance for each update rather than mutating one in place.
+    const dataState =
+      dataManagerToolbarComponent.dataState as SkyDataManagerState;
+    expect(dataState.filterData).toEqual(filterData);
     expect(dataManagerService.updateDataState).toHaveBeenCalledWith(
       dataState,
       'toolbar',

--- a/libs/components/data-manager/src/lib/modules/data-manager/data-manager-toolbar/data-manager-toolbar.component.spec.ts
+++ b/libs/components/data-manager/src/lib/modules/data-manager/data-manager-toolbar/data-manager-toolbar.component.spec.ts
@@ -521,8 +521,6 @@ describe('SkyDataManagerToolbarComponent', () => {
     tick();
     dataManagerToolbarFixture.detectChanges();
 
-    // Re-read the current data state rather than a reference captured before the action: the
-    // toolbar now builds a new state instance for each update rather than mutating one in place.
     const dataState =
       dataManagerToolbarComponent.dataState as SkyDataManagerState;
     expect(dataState.searchText).toBe('testing');
@@ -552,8 +550,6 @@ describe('SkyDataManagerToolbarComponent', () => {
     tick();
     dataManagerToolbarFixture.detectChanges();
 
-    // Re-read the current data state rather than a reference captured before the action: the
-    // toolbar now builds a new state instance for each update rather than mutating one in place.
     const dataState =
       dataManagerToolbarComponent.dataState as SkyDataManagerState;
     expect(dataState.searchText).toBe('testing');
@@ -690,8 +686,6 @@ describe('SkyDataManagerToolbarComponent', () => {
       });
     }
 
-    // Re-read the current data state rather than a reference captured before the action: the
-    // toolbar now builds a new state instance for each update rather than mutating one in place.
     const dataState =
       dataManagerToolbarComponent.dataState as SkyDataManagerState;
     expect(dataState.filterData).toEqual(filterData);

--- a/libs/components/data-manager/src/lib/modules/data-manager/data-manager-toolbar/data-manager-toolbar.component.ts
+++ b/libs/components/data-manager/src/lib/modules/data-manager/data-manager-toolbar/data-manager-toolbar.component.ts
@@ -40,6 +40,7 @@ import { SkyDataManagerConfig } from '../models/data-manager-config';
 import { SkyDataManagerSortOption } from '../models/data-manager-sort-option';
 import { SkyDataManagerState } from '../models/data-manager-state';
 import { SkyDataViewConfig } from '../models/data-view-config';
+import { SkyDataViewState } from '../models/data-view-state';
 
 import { SkyDataManagerToolbarLeftItemComponent } from './data-manager-toolbar-left-item.component';
 import { SkyDataManagerToolbarPrimaryItemComponent } from './data-manager-toolbar-primary-item.component';
@@ -206,8 +207,13 @@ export class SkyDataManagerToolbarComponent implements OnDestroy, OnInit {
 
   public sortSelected(sortOption: SkyDataManagerSortOption): void {
     if (this.dataState) {
-      this.dataState.activeSortOption = sortOption;
-      this.#dataManagerService.updateDataState(this.dataState, this.#_source);
+      // Build a new state rather than mutating the current one in place. The data manager
+      // service hands the same state instance to every subscriber, so mutating it directly could
+      // corrupt another subscriber's distinctUntilChanged comparison and silently drop this
+      // update for them.
+      const options = this.dataState.getStateOptions();
+      options.activeSortOption = sortOption;
+      this.dataState = new SkyDataManagerState(options);
     }
   }
 
@@ -217,8 +223,10 @@ export class SkyDataManagerToolbarComponent implements OnDestroy, OnInit {
 
   public searchApplied(text: string): void {
     if (this.dataState) {
-      this.dataState.searchText = text;
-      this.#dataManagerService.updateDataState(this.dataState, this.#_source);
+      // See the comment in `sortSelected` on why a new state is built rather than mutated.
+      const options = this.dataState.getStateOptions();
+      options.searchText = text;
+      this.dataState = new SkyDataManagerState(options);
     }
   }
 
@@ -253,11 +261,10 @@ export class SkyDataManagerToolbarComponent implements OnDestroy, OnInit {
 
       modalInstance.closed.subscribe((result: SkyModalCloseArgs) => {
         if (this.dataState && result.reason === 'save') {
-          this.dataState.filterData = result.data;
-          this.#dataManagerService.updateDataState(
-            this.dataState,
-            this.#_source,
-          );
+          // See the comment in `sortSelected` on why a new state is built rather than mutated.
+          const options = this.dataState.getStateOptions();
+          options.filterData = result.data;
+          this.dataState = new SkyDataManagerState(options);
         }
       });
     }
@@ -298,11 +305,17 @@ export class SkyDataManagerToolbarComponent implements OnDestroy, OnInit {
               (col: SkyDataManagerColumnPickerOption) => col.id,
             );
 
-            viewState.displayedColumnIds = displayedColumnIds;
+            // See the comment in `sortSelected` on why a copy is mutated rather than `viewState`,
+            // which is shared with every subscriber of the current data manager state.
+            const updatedViewState = new SkyDataViewState(
+              viewState.getViewStateOptions(),
+            );
+            updatedViewState.displayedColumnIds = displayedColumnIds;
+
             if (this.dataState && this.activeView) {
               this.dataState = this.dataState.addOrUpdateView(
                 this.activeView.id,
-                viewState,
+                updatedViewState,
               );
             }
           }
@@ -327,8 +340,10 @@ export class SkyDataManagerToolbarComponent implements OnDestroy, OnInit {
 
   public onOnlyShowSelected(event: SkyCheckboxChange): void {
     if (this.dataState) {
-      this.dataState.onlyShowSelected = !!event.checked;
-      this.#dataManagerService.updateDataState(this.dataState, this.#_source);
+      // See the comment in `sortSelected` on why a new state is built rather than mutated.
+      const options = this.dataState.getStateOptions();
+      options.onlyShowSelected = !!event.checked;
+      this.dataState = new SkyDataManagerState(options);
     }
   }
 }

--- a/libs/components/data-manager/src/lib/modules/data-manager/data-manager-toolbar/data-manager-toolbar.component.ts
+++ b/libs/components/data-manager/src/lib/modules/data-manager/data-manager-toolbar/data-manager-toolbar.component.ts
@@ -207,10 +207,6 @@ export class SkyDataManagerToolbarComponent implements OnDestroy, OnInit {
 
   public sortSelected(sortOption: SkyDataManagerSortOption): void {
     if (this.dataState) {
-      // Build a new state rather than mutating the current one in place. The data manager
-      // service hands the same state instance to every subscriber, so mutating it directly could
-      // corrupt another subscriber's distinctUntilChanged comparison and silently drop this
-      // update for them.
       const options = this.dataState.getStateOptions();
       options.activeSortOption = sortOption;
       this.dataState = new SkyDataManagerState(options);
@@ -223,7 +219,6 @@ export class SkyDataManagerToolbarComponent implements OnDestroy, OnInit {
 
   public searchApplied(text: string): void {
     if (this.dataState) {
-      // See the comment in `sortSelected` on why a new state is built rather than mutated.
       const options = this.dataState.getStateOptions();
       options.searchText = text;
       this.dataState = new SkyDataManagerState(options);
@@ -261,7 +256,6 @@ export class SkyDataManagerToolbarComponent implements OnDestroy, OnInit {
 
       modalInstance.closed.subscribe((result: SkyModalCloseArgs) => {
         if (this.dataState && result.reason === 'save') {
-          // See the comment in `sortSelected` on why a new state is built rather than mutated.
           const options = this.dataState.getStateOptions();
           options.filterData = result.data;
           this.dataState = new SkyDataManagerState(options);
@@ -305,8 +299,6 @@ export class SkyDataManagerToolbarComponent implements OnDestroy, OnInit {
               (col: SkyDataManagerColumnPickerOption) => col.id,
             );
 
-            // See the comment in `sortSelected` on why a copy is mutated rather than `viewState`,
-            // which is shared with every subscriber of the current data manager state.
             const updatedViewState = new SkyDataViewState(
               viewState.getViewStateOptions(),
             );
@@ -340,7 +332,6 @@ export class SkyDataManagerToolbarComponent implements OnDestroy, OnInit {
 
   public onOnlyShowSelected(event: SkyCheckboxChange): void {
     if (this.dataState) {
-      // See the comment in `sortSelected` on why a new state is built rather than mutated.
       const options = this.dataState.getStateOptions();
       options.onlyShowSelected = !!event.checked;
       this.dataState = new SkyDataManagerState(options);

--- a/libs/components/data-manager/src/lib/modules/data-manager/data-manager.service.spec.ts
+++ b/libs/components/data-manager/src/lib/modules/data-manager/data-manager.service.spec.ts
@@ -335,6 +335,107 @@ describe('SkyDataManagerService', () => {
           expect(dataState).toEqual(startingDataState);
         });
       });
+
+      describe('with a comparator that throws', () => {
+        // Regression test for AB#4099031: a comparator that assumes properties present on
+        // every state (rather than guarding every access) throws on a state that lacks them.
+        // The subscription must keep emitting rather than silently dying.
+        const throwingComparator = (
+          state1: SkyDataManagerState,
+          state2: SkyDataManagerState,
+        ): boolean =>
+          state1.filterData?.filters?.appliedFilters[0].filterValue.value ===
+          state2.filterData?.filters?.appliedFilters[0].filterValue.value;
+
+        it('should keep emitting instead of erroring the subscription', () => {
+          const emissions: SkyDataManagerState[] = [];
+          let errored = false;
+
+          subscription.add(
+            dataManagerService
+              .getDataStateUpdates(sourceId, {
+                comparator: throwingComparator,
+              })
+              .subscribe({
+                next: (state) => emissions.push(state),
+                error: () => (errored = true),
+              }),
+          );
+
+          const countAfterInit = emissions.length;
+          const baseOptions = currentDataState.getStateOptions();
+
+          dataManagerService.updateDataState(
+            new SkyDataManagerState({
+              ...baseOptions,
+              filterData: {
+                filtersApplied: true,
+                filters: {
+                  appliedFilters: [
+                    { filterId: 'a', filterValue: { value: 'one' } },
+                  ],
+                },
+              },
+            }),
+            otherSourceId,
+          );
+
+          dataManagerService.updateDataState(
+            new SkyDataManagerState({
+              ...baseOptions,
+              filterData: {
+                filtersApplied: true,
+                filters: {
+                  appliedFilters: [
+                    { filterId: 'a', filterValue: { value: 'two' } },
+                  ],
+                },
+              },
+            }),
+            otherSourceId,
+          );
+
+          expect(errored).toBeFalse();
+          expect(emissions.length).toBe(countAfterInit + 2);
+        });
+      });
+
+      describe('with filters and an unserializable state property', () => {
+        it('should keep emitting instead of erroring the subscription', () => {
+          const cyclic: Record<string, unknown> = { value: 1 };
+          cyclic['self'] = cyclic;
+
+          const emissions: SkyDataManagerState[] = [];
+          let errored = false;
+
+          subscription.add(
+            dataManagerService
+              .getDataStateUpdates(sourceId, {
+                properties: ['additionalData'],
+              })
+              .subscribe({
+                next: (state) => emissions.push(state),
+                error: () => (errored = true),
+              }),
+          );
+
+          const countAfterInit = emissions.length;
+          const baseOptions = currentDataState.getStateOptions();
+
+          dataManagerService.updateDataState(
+            new SkyDataManagerState({ ...baseOptions, additionalData: cyclic }),
+            otherSourceId,
+          );
+
+          dataManagerService.updateDataState(
+            new SkyDataManagerState({ ...baseOptions, additionalData: cyclic }),
+            otherSourceId,
+          );
+
+          expect(errored).toBeFalse();
+          expect(emissions.length).toBe(countAfterInit + 2);
+        });
+      });
     });
   });
 
@@ -1066,6 +1167,72 @@ describe('SkyDataManagerService', () => {
 
       // Original state should not be mutated
       expect(state.views.length).toBe(1);
+    });
+
+    it('should emit via getDataStateUpdates with a property filter when a peer mutates a previously emitted state instance in place and republishes it', () => {
+      const emissions: SkyDataManagerState[] = [];
+
+      subscription.add(
+        dataManagerService
+          .getDataStateUpdates('subscriber', { properties: ['filterData'] })
+          .subscribe((state) => emissions.push(state)),
+      );
+
+      let peerState!: SkyDataManagerState;
+      subscription.add(
+        dataManagerService
+          .getDataStateUpdates('peer')
+          .subscribe((state) => (peerState = state)),
+      );
+
+      const countAfterInit = emissions.length;
+
+      // Simulate a peer (e.g. SkyDataManagerFilterControllerDirective, prior to its fix)
+      // mutating the state instance it was handed in place before republishing it. The
+      // subscriber's retained "previous" comparison value must not be corrupted by this.
+      peerState.filterData = {
+        filtersApplied: true,
+        filters: { appliedFilters: [{ filterId: 'a' }] },
+      };
+      dataManagerService.updateDataState(peerState, 'peer');
+
+      expect(emissions.length).toBe(countAfterInit + 1);
+      expect(
+        emissions[emissions.length - 1].filterData?.filtersApplied,
+      ).toBeTrue();
+    });
+
+    it('should emit via getDataStateUpdates with a custom comparator when a peer mutates a previously emitted state instance in place and republishes it', () => {
+      const emissions: SkyDataManagerState[] = [];
+
+      subscription.add(
+        dataManagerService
+          .getDataStateUpdates('subscriber', {
+            comparator: (state1, state2) =>
+              state1.filterData?.filtersApplied ===
+              state2.filterData?.filtersApplied,
+          })
+          .subscribe((state) => emissions.push(state)),
+      );
+
+      let peerState!: SkyDataManagerState;
+      subscription.add(
+        dataManagerService
+          .getDataStateUpdates('peer')
+          .subscribe((state) => (peerState = state)),
+      );
+
+      const countAfterInit = emissions.length;
+
+      // The fixture's default state already has filtersApplied set to true, so flip it to
+      // false to produce a value the comparator can actually detect as changed.
+      peerState.filterData = { filtersApplied: false, filters: undefined };
+      dataManagerService.updateDataState(peerState, 'peer');
+
+      expect(emissions.length).toBe(countAfterInit + 1);
+      expect(
+        emissions[emissions.length - 1].filterData?.filtersApplied,
+      ).toBeFalse();
     });
   });
 

--- a/libs/components/data-manager/src/lib/modules/data-manager/data-manager.service.ts
+++ b/libs/components/data-manager/src/lib/modules/data-manager/data-manager.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, OnDestroy } from '@angular/core';
-import { SkyUIConfigService } from '@skyux/core';
+import { SkyLogService, SkyUIConfigService } from '@skyux/core';
 
 import {
   BehaviorSubject,
@@ -53,10 +53,13 @@ export class SkyDataManagerService implements OnDestroy {
   #ngUnsubscribe = new Subject<void>();
   #initSource = 'dataManagerServiceInit';
   #uiConfigService: SkyUIConfigService;
+  #logger: SkyLogService | undefined;
+  #incomparableStateCount = 0;
 
   // eslint-disable-next-line @angular-eslint/prefer-inject -- constructor injection is required to maintain the public API for consumers who may instantiate this service directly (e.g. `new SkyDataManagerService(...)`).
-  constructor(uiConfigService: SkyUIConfigService) {
+  constructor(uiConfigService: SkyUIConfigService, logger?: SkyLogService) {
     this.#uiConfigService = uiConfigService;
+    this.#logger = logger;
   }
 
   public ngOnDestroy(): void {
@@ -235,24 +238,40 @@ export class SkyDataManagerService implements OnDestroy {
     updateFilter?: SkyDataManagerStateUpdateFilterArgs,
   ): Observable<SkyDataManagerState> {
     // filter out events from the provided source and emit just the dataState
-    if (updateFilter) {
-      return this.#dataStateChange.pipe(
-        filter((stateChange) => sourceId !== stateChange.source),
-        map((stateChange) => stateChange.dataState),
-        updateFilter.comparator
-          ? distinctUntilChanged(updateFilter.comparator)
-          : distinctUntilChanged(
-              this.#getDefaultStateComparator(
-                updateFilter.properties as (keyof SkyDataManagerStateOptions)[],
-              ),
-            ),
-      );
-    } else {
-      return this.#dataStateChange.pipe(
-        filter((stateChange) => sourceId !== stateChange.source),
-        map((stateChange) => stateChange.dataState),
+    const dataStateUpdates = this.#dataStateChange.pipe(
+      filter((stateChange) => sourceId !== stateChange.source),
+      map((stateChange) => stateChange.dataState),
+    );
+
+    if (!updateFilter) {
+      return dataStateUpdates;
+    }
+
+    if (updateFilter.comparator) {
+      const comparator = updateFilter.comparator;
+
+      // Compare independent clones of the emitted state rather than the state instance itself.
+      // Other data manager participants may mutate the state instance they were handed in place
+      // before republishing it, which would otherwise make distinctUntilChanged's retained
+      // "previous" value silently match the new one, dropping a real change.
+      return dataStateUpdates.pipe(
+        map((state) => new SkyDataManagerState(state.getStateOptions())),
+        distinctUntilChanged((state1, state2) =>
+          this.#compareStatesSafely(comparator, state1, state2),
+        ),
       );
     }
+
+    const properties = updateFilter.properties as
+      | (keyof SkyDataManagerStateOptions)[]
+      | undefined;
+
+    return dataStateUpdates.pipe(
+      distinctUntilChanged(
+        (key1, key2) => key1 === key2,
+        (state) => this.#getStateComparisonKey(state, properties),
+      ),
+    );
   }
 
   /**
@@ -404,22 +423,47 @@ export class SkyDataManagerService implements OnDestroy {
     return filteredStateProperties;
   }
 
-  #getDefaultStateComparator(
+  /**
+   * Returns a string key representing the given state's filtered properties, for use as a
+   * `distinctUntilChanged` key selector. If the filtered properties cannot be serialized (for
+   * example, a circular reference), a unique key is returned so the state is treated as changed
+   * rather than allowing the comparison to throw and end the subscription.
+   */
+  #getStateComparisonKey(
+    state: SkyDataManagerState,
     properties: (keyof SkyDataManagerStateOptions)[] | undefined,
-  ): (state1: SkyDataManagerState, state2: SkyDataManagerState) => boolean {
-    return (
+  ): string {
+    try {
+      return JSON.stringify(this.#filterDataStateProperties(state, properties));
+    } catch (err) {
+      this.#logger?.warn(
+        'The data manager state could not be serialized for comparison in getDataStateUpdates and will be treated as a change.',
+        [err],
+      );
+      return `__skyDataManagerIncomparableState${++this.#incomparableStateCount}`;
+    }
+  }
+
+  /**
+   * Calls the given comparator and returns its result. If the comparator throws, the states are
+   * treated as changed rather than allowing the error to end the subscription.
+   */
+  #compareStatesSafely(
+    comparator: (
       state1: SkyDataManagerState,
       state2: SkyDataManagerState,
-    ): boolean => {
-      const filteredState1 = this.#filterDataStateProperties(
-        state1,
-        properties,
+    ) => boolean,
+    state1: SkyDataManagerState,
+    state2: SkyDataManagerState,
+  ): boolean {
+    try {
+      return comparator(state1, state2);
+    } catch (err) {
+      this.#logger?.warn(
+        'The comparator provided to getDataStateUpdates threw an error while comparing data manager state and will be treated as a change.',
+        [err],
       );
-      const filteredState2 = this.#filterDataStateProperties(
-        state2,
-        properties,
-      );
-      return JSON.stringify(filteredState1) === JSON.stringify(filteredState2);
-    };
+      return false;
+    }
   }
 }


### PR DESCRIPTION
[AB#4099031](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/4099031)

`distinctUntilChanged` retained a live reference to the previously emitted
`SkyDataManagerState`. Several participants (the filter controller directive
and four toolbar actions) mutated that shared instance in place before
republishing, corrupting the retained "previous" value and silently
dropping real changes for properties/comparator subscribers. Also guard
against a throwing comparator or unserializable state, which previously
killed the subscription permanently and silently.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved data grid filtering, searching, sorting, and selection updates so subscribers consistently receive the latest state.
  * Prevented previously emitted data states from being modified unexpectedly.
  * Improved resilience when state comparisons encounter invalid or unsupported data.

* **Tests**
  * Added regression coverage for consecutive filter changes, state immutability, subscriber updates, and comparison edge cases.

* **Chores**
  * Increased the production style-size budget to support larger component styles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->