### PR TITLE
fix(sdk/vitest): add './package.json' to exports

### DIFF
--- a/libs/sdk/vitest/package.json
+++ b/libs/sdk/vitest/package.json
@@ -27,7 +27,9 @@
       "types": "./matchers-setup.d.mts",
       "default": "./matchers-setup.mjs"
     },
-    "./package.json": "./package.json"
+    "./package.json": {
+      "default": "./package.json"
+    }
   },
   "schematics": "@skyux-sdk/testing-schematics/collection.json",
   "ng-add": {

--- a/libs/sdk/vitest/package.json
+++ b/libs/sdk/vitest/package.json
@@ -27,9 +27,7 @@
       "types": "./matchers-setup.d.mts",
       "default": "./matchers-setup.mjs"
     },
-    "./package.json": {
-      "default": "./package.json"
-    }
+    "./package.json": "./package.json"
   },
   "schematics": "@skyux-sdk/testing-schematics/collection.json",
   "ng-add": {

--- a/libs/sdk/vitest/package.json
+++ b/libs/sdk/vitest/package.json
@@ -26,6 +26,9 @@
     "./matchers-setup.mjs": {
       "types": "./matchers-setup.d.mts",
       "default": "./matchers-setup.mjs"
+    },
+    "./package.json": {
+      "default": "./package.json"
     }
   },
   "schematics": "@skyux-sdk/testing-schematics/collection.json",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved package compatibility by making package metadata consistently accessible through the SDK package exports.
  * Updated metadata access to work more reliably across supported tooling and environments, reducing potential issues when inspecting or consuming package information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->