### PR TITLE
fix!: toolbar, filter bar, and list summary inherit container padding

### DIFF
--- a/apps/e2e/layout-storybook/src/app/toolbar/toolbar.component.html
+++ b/apps/e2e/layout-storybook/src/app/toolbar/toolbar.component.html
@@ -127,3 +127,23 @@
     </sky-toolbar-item>
   </sky-toolbar-section>
 </sky-toolbar>
+
+<sky-box headingText="Toolbar in a box">
+  <sky-box-content>
+    <p class="app-reference-text">
+      A toolbar in a container inherits the container's padding, so its buttons
+      line up with the text above and below it.
+    </p>
+    <sky-toolbar>
+      <sky-toolbar-item>
+        <button type="button" class="sky-btn sky-btn-primary">New</button>
+      </sky-toolbar-item>
+      <sky-toolbar-item>
+        <button type="button" class="sky-btn sky-btn-default">Edit</button>
+      </sky-toolbar-item>
+    </sky-toolbar>
+    <p class="app-reference-text">
+      This paragraph sits on the same left edge as the buttons above.
+    </p>
+  </sky-box-content>
+</sky-box>

--- a/apps/e2e/layout-storybook/src/app/toolbar/toolbar.component.scss
+++ b/apps/e2e/layout-storybook/src/app/toolbar/toolbar.component.scss
@@ -1,3 +1,12 @@
 :host {
   display: block;
 }
+
+.app-reference-text {
+  margin: 0;
+}
+
+sky-box {
+  display: block;
+  margin-top: 20px;
+}

--- a/apps/e2e/layout-storybook/src/app/toolbar/toolbar.module.ts
+++ b/apps/e2e/layout-storybook/src/app/toolbar/toolbar.module.ts
@@ -4,7 +4,7 @@ import { FormsModule } from '@angular/forms';
 import { RouterModule, Routes } from '@angular/router';
 import { SkyRadioModule } from '@skyux/forms';
 import { SkyIconModule } from '@skyux/icon';
-import { SkyToolbarModule } from '@skyux/layout';
+import { SkyBoxModule, SkyToolbarModule } from '@skyux/layout';
 import { SkyFilterModule } from '@skyux/lists';
 import { SkySearchModule } from '@skyux/lookup';
 import { SkyThemeModule } from '@skyux/theme';
@@ -18,6 +18,7 @@ const routes: Routes = [{ path: '', component: ToolbarComponent }];
     CommonModule,
     FormsModule,
     RouterModule.forChild(routes),
+    SkyBoxModule,
     SkyIconModule,
     SkyRadioModule,
     SkyFilterModule,

--- a/apps/e2e/lists-storybook/src/app/list-summary/list-summary.component.ts
+++ b/apps/e2e/lists-storybook/src/app/list-summary/list-summary.component.ts
@@ -46,5 +46,9 @@ export class ListSummaryComponent {
       value: 1999,
       labelText: 'Video games',
     },
+    {
+      value: 128,
+      labelText: 'Volunteer hours logged',
+    },
   ];
 }

--- a/apps/e2e/pages-storybook/src/app/page/layouts/tabs-page/tabs-page.component.html
+++ b/apps/e2e/pages-storybook/src/app/page/layouts/tabs-page/tabs-page.component.html
@@ -7,7 +7,7 @@
   </sky-page-header>
   <sky-page-content>
     <sky-tabset>
-      <sky-tab tabHeading="Tab 1" [layout]="showLinks() ? 'none' : 'fit'">
+      <sky-tab tabHeading="Tab 1" layout="list">
         <sky-toolbar>
           <sky-toolbar-item>
             <button type="button" class="sky-btn sky-btn-primary">

--- a/libs/components/filter-bar/src/lib/modules/filter-bar/filter-bar.component.scss
+++ b/libs/components/filter-bar/src/lib/modules/filter-bar/filter-bar.component.scss
@@ -1,15 +1,10 @@
 :host {
   display: block;
-}
 
-// Default theme sets this toolbar override in the toolbar component.
-:host-context(.sky-theme-modern) .sky-filter-bar-toolbar {
-  --sky-override-toolbar-container-padding: var(
-      --sky-comp-filter_bar-space-inset-top
-    )
-    var(--sky-comp-filter_bar-space-inset-right)
-    var(--sky-comp-filter_bar-space-inset-bottom)
-    var(--sky-comp-filter_bar-space-inset-left);
+  --sky-comp-override-toolbar-padding: var(
+    --sky-compat-filter-bar-toolbar-padding,
+    0 0 var(--sky-comp-filter_bar-space-inset-bottom)
+  );
 }
 
 // When filter bar is a child of data manager toolbar, add a top border as if it were a toolbar section.
@@ -19,4 +14,18 @@
     var(--sky-border-width-divider) var(--sky-border-style-divider)
       var(--sky-color-border-divider)
   );
+
+  --sky-comp-override-toolbar-padding: var(
+      --sky-comp-filter_bar-space-inset-top
+    )
+    0 var(--sky-comp-filter_bar-space-inset-bottom);
+}
+
+:host-context(.sky-layout-host-list) {
+  --sky-comp-override-toolbar-padding: var(
+      --sky-comp-filter_bar-space-inset-top
+    )
+    var(--sky-comp-filter_bar-space-inset-right)
+    var(--sky-comp-filter_bar-space-inset-bottom)
+    var(--sky-comp-filter_bar-space-inset-left);
 }

--- a/libs/components/layout/src/lib/modules/toolbar/toolbar-section.component.scss
+++ b/libs/components/layout/src/lib/modules/toolbar/toolbar-section.component.scss
@@ -11,15 +11,24 @@
   flex-wrap: nowrap;
   padding: var(
     --sky-override-toolbar-container-padding,
-    var(--sky-comp-toolbar-space-inset-top)
-      var(--sky-comp-toolbar-space-inset-right)
-      var(--sky-comp-toolbar-space-inset-bottom)
-      var(--sky-comp-toolbar-space-inset-left)
+    var(
+      --sky-compat-toolbar-container-padding,
+      var(--sky-comp-override-toolbar-section-space-inset-top, 0)
+        var(--sky-comp-override-toolbar-section-space-inset-right, 0)
+        var(--sky-comp-toolbar-space-inset-bottom)
+        var(--sky-comp-override-toolbar-section-space-inset-left, 0)
+    )
   );
   min-height: $sky-toolbar-min-height;
   align-items: center;
   position: relative;
   overflow-x: auto;
+}
+
+:host(:not(:first-child)) {
+  --sky-comp-override-toolbar-section-space-inset-top: var(
+    --sky-comp-toolbar-space-inset-top
+  );
 }
 
 .sky-toolbar-section-items {

--- a/libs/components/layout/src/lib/modules/toolbar/toolbar.component.scss
+++ b/libs/components/layout/src/lib/modules/toolbar/toolbar.component.scss
@@ -46,13 +46,18 @@ sky-toolbar + :host {
     --sky-comp-override-list-header-background-color,
     var(--sky-override-toolbar-background-color)
   );
-  // This padding override is used by the SkyFilterBar component in modern theme.
   padding: var(
     --sky-override-toolbar-container-padding,
-    var(--sky-comp-toolbar-space-inset-top)
-      var(--sky-comp-toolbar-space-inset-right)
-      var(--sky-comp-toolbar-space-inset-bottom)
-      var(--sky-comp-toolbar-space-inset-left)
+    var(
+      --sky-compat-toolbar-container-padding,
+      var(
+        --sky-comp-override-toolbar-padding,
+        var(--sky-comp-override-toolbar-space-inset-top, 0)
+          var(--sky-comp-override-toolbar-space-inset-right, 0)
+          var(--sky-comp-toolbar-space-inset-bottom)
+          var(--sky-comp-override-toolbar-space-inset-left, 0)
+      )
+    )
   );
   border-top: var(--sky-override-toolbar-border-top-bottom, none);
   border-bottom: var(--sky-override-toolbar-border-top-bottom, none);

--- a/libs/components/lists/src/lib/modules/list-summary/list-summary.component.scss
+++ b/libs/components/lists/src/lib/modules/list-summary/list-summary.component.scss
@@ -18,10 +18,13 @@
   align-items: baseline;
   padding: var(
     --sky-override-list-summary-padding,
-    var(--sky-comp-list_summary-space-inset-top)
-      var(--sky-comp-list_summary-space-inset-right)
-      var(--sky-comp-list_summary-space-inset-bottom)
-      var(--sky-comp-list_summary-space-inset-left)
+    var(
+      --sky-compat-list-summary-padding,
+      var(--sky-comp-list_summary-space-inset-top)
+        var(--sky-comp-override-list-summary-space-inset-right, 0)
+        var(--sky-comp-list_summary-space-inset-bottom)
+        var(--sky-comp-override-list-summary-space-inset-left, 0)
+    )
   );
   background-color: var(
     --sky-override-list-summary-background-color,

--- a/libs/components/packages/src/schematics/migrations/update-15/add-compat-stylesheets/add-compat-stylesheet.schematic.spec.ts
+++ b/libs/components/packages/src/schematics/migrations/update-15/add-compat-stylesheets/add-compat-stylesheet.schematic.spec.ts
@@ -85,10 +85,25 @@ describe('Migrations > Add compat stylesheets', () => {
 
     const compatStylesheetContents = updatedTree.readText(compatStylesheetPath);
 
+    expect(compatStylesheetContents).toContain('COMPONENT: BUTTON');
     expect(compatStylesheetContents).toContain(
       '--sky-compat-btn-disabled-pointer-events: none;',
     );
-    expect(compatStylesheetContents).toContain('COMPONENT: BUTTON');
+
+    expect(compatStylesheetContents).toContain('COMPONENT: TOOLBAR');
+    expect(compatStylesheetContents).toContain(
+      '--sky-compat-toolbar-container-padding:',
+    );
+
+    expect(compatStylesheetContents).toContain('COMPONENT: FILTER BAR');
+    expect(compatStylesheetContents).toContain(
+      '--sky-compat-filter-bar-toolbar-padding:',
+    );
+
+    expect(compatStylesheetContents).toContain('COMPONENT: LIST SUMMARY');
+    expect(compatStylesheetContents).toContain(
+      '--sky-compat-list-summary-padding:',
+    );
 
     const updatedAngularJson = updatedTree.readJson(
       '/angular.json',
@@ -130,6 +145,9 @@ describe('Migrations > Add compat stylesheets', () => {
     await validateCompatStylesheet(
       JSON.stringify({
         dependencies: {
+          '@skyux/filter-bar': 'CURRENT_VERSION.0.0',
+          '@skyux/layout': 'CURRENT_VERSION.0.0',
+          '@skyux/lists': 'CURRENT_VERSION.0.0',
           '@skyux/theme': 'CURRENT_VERSION.0.0',
         },
       }),
@@ -137,10 +155,34 @@ describe('Migrations > Add compat stylesheets', () => {
     );
   });
 
+  it('should only add compat styles for libraries that are installed', async () => {
+    const { runSchematic, tree } = await setupTest();
+
+    tree.overwrite(
+      '/package.json',
+      JSON.stringify({
+        dependencies: {
+          '@skyux/layout': 'CURRENT_VERSION.0.0',
+        },
+      }),
+    );
+
+    const updatedTree = await runSchematic();
+    const contents = updatedTree.readText(compatStylesheetPath);
+
+    expect(contents).toContain('--sky-compat-toolbar-container-padding:');
+    expect(contents).not.toContain('--sky-compat-filter-bar-toolbar-padding:');
+    expect(contents).not.toContain('--sky-compat-list-summary-padding:');
+    expect(contents).not.toContain('--sky-compat-btn-disabled-pointer-events:');
+  });
+
   it('should add a compat stylesheet for libraries in devDependencies', async () => {
     await validateCompatStylesheet(
       JSON.stringify({
         devDependencies: {
+          '@skyux/filter-bar': 'CURRENT_VERSION.0.0',
+          '@skyux/layout': 'CURRENT_VERSION.0.0',
+          '@skyux/lists': 'CURRENT_VERSION.0.0',
           '@skyux/theme': 'CURRENT_VERSION.0.0',
         },
       }),
@@ -152,6 +194,9 @@ describe('Migrations > Add compat stylesheets', () => {
     await validateCompatStylesheet(
       JSON.stringify({
         devDependencies: {
+          '@skyux/filter-bar': 'CURRENT_VERSION.0.0',
+          '@skyux/layout': 'CURRENT_VERSION.0.0',
+          '@skyux/lists': 'CURRENT_VERSION.0.0',
           '@skyux/theme': 'CURRENT_VERSION.0.0',
         },
       }),
@@ -164,6 +209,9 @@ describe('Migrations > Add compat stylesheets', () => {
     await validateCompatStylesheet(
       JSON.stringify({
         devDependencies: {
+          '@skyux/filter-bar': 'CURRENT_VERSION.0.0',
+          '@skyux/layout': 'CURRENT_VERSION.0.0',
+          '@skyux/lists': 'CURRENT_VERSION.0.0',
           '@skyux/theme': 'CURRENT_VERSION.0.0',
         },
       }),
@@ -181,6 +229,9 @@ describe('Migrations > Add compat stylesheets', () => {
       '/package.json',
       JSON.stringify({
         dependencies: {
+          '@skyux/filter-bar': 'CURRENT_VERSION.0.0',
+          '@skyux/layout': 'CURRENT_VERSION.0.0',
+          '@skyux/lists': 'CURRENT_VERSION.0.0',
           '@skyux/theme': 'CURRENT_VERSION.0.0',
         },
       }),
@@ -239,6 +290,9 @@ describe('Migrations > Add compat stylesheets', () => {
       '/package.json',
       JSON.stringify({
         dependencies: {
+          '@skyux/filter-bar': 'CURRENT_VERSION.0.0',
+          '@skyux/layout': 'CURRENT_VERSION.0.0',
+          '@skyux/lists': 'CURRENT_VERSION.0.0',
           '@skyux/theme': 'CURRENT_VERSION.0.0',
         },
       }),

--- a/libs/components/packages/src/schematics/migrations/update-15/add-compat-stylesheets/add-compat-stylesheet.schematic.ts
+++ b/libs/components/packages/src/schematics/migrations/update-15/add-compat-stylesheets/add-compat-stylesheet.schematic.ts
@@ -42,6 +42,72 @@ Pointer events are no longer disabled on elements with the "sky-btn-disabled" cl
         },
       ],
     },
+    {
+      name: '@skyux/layout',
+      components: [
+        {
+          name: 'toolbar',
+          styles: [
+            {
+              css: `
+:root {
+  --sky-compat-toolbar-container-padding: var(--sky-comp-toolbar-space-inset-top)
+    var(--sky-comp-toolbar-space-inset-right)
+    var(--sky-comp-toolbar-space-inset-bottom)
+    var(--sky-comp-toolbar-space-inset-left);
+}
+`,
+              instructions: `
+The toolbar no longer applies its own left, right, and top padding unless it is inside a page or tab with layout="list". Everywhere else it now inherits the padding of its container, so that its contents line up with the content above and below it. To address this change, remove this block of code, then remove any negative margins or spacing overrides your app applied to compensate for the toolbar's extra padding.`,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      name: '@skyux/filter-bar',
+      components: [
+        {
+          name: 'filter bar',
+          styles: [
+            {
+              css: `
+:root {
+  --sky-compat-filter-bar-toolbar-padding: var(--sky-comp-filter_bar-space-inset-top)
+    var(--sky-comp-filter_bar-space-inset-right)
+    var(--sky-comp-filter_bar-space-inset-bottom)
+    var(--sky-comp-filter_bar-space-inset-left);
+}
+`,
+              instructions: `
+The filter bar no longer applies its own left, right, and top padding unless it is inside a page or tab with layout="list". Everywhere else it now inherits the padding of its container, so that its filters line up with the content above and below it. To address this change, remove this block of code, then remove any negative margins or spacing overrides your app applied to compensate for the filter bar's extra padding.`,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      name: '@skyux/lists',
+      components: [
+        {
+          name: 'list summary',
+          styles: [
+            {
+              css: `
+:root {
+  --sky-compat-list-summary-padding: var(--sky-comp-list_summary-space-inset-top)
+    var(--sky-comp-list_summary-space-inset-right)
+    var(--sky-comp-list_summary-space-inset-bottom)
+    var(--sky-comp-list_summary-space-inset-left);
+}
+`,
+              instructions: `
+The list summary no longer applies its own left and right padding unless it is inside a page or tab with layout="list". Everywhere else it now inherits the padding of its container, so that its summary items line up with the content above and below it. Its top and bottom padding is unchanged. To address this change, remove this block of code, then remove any negative margins or spacing overrides your app applied to compensate for the list summary's extra padding.`,
+            },
+          ],
+        },
+      ],
+    },
   ],
 };
 

--- a/libs/components/theme/src/lib/styles/_layout-host.scss
+++ b/libs/components/theme/src/lib/styles/_layout-host.scss
@@ -164,6 +164,31 @@
         var(--sky-comp-layout-header-list-space-inset-xs-bottom)
         var(--sky-comp-layout-header-list-space-inset-xs-left)
     );
+
+    --sky-comp-override-toolbar-space-inset-top: var(
+      --sky-comp-toolbar-space-inset-top
+    );
+    --sky-comp-override-toolbar-space-inset-right: var(
+      --sky-comp-toolbar-space-inset-right
+    );
+    --sky-comp-override-toolbar-space-inset-left: var(
+      --sky-comp-toolbar-space-inset-left
+    );
+    --sky-comp-override-toolbar-section-space-inset-top: var(
+      --sky-comp-toolbar-space-inset-top
+    );
+    --sky-comp-override-toolbar-section-space-inset-right: var(
+      --sky-comp-toolbar-space-inset-right
+    );
+    --sky-comp-override-toolbar-section-space-inset-left: var(
+      --sky-comp-toolbar-space-inset-left
+    );
+    --sky-comp-override-list-summary-space-inset-right: var(
+      --sky-comp-list_summary-space-inset-right
+    );
+    --sky-comp-override-list-summary-space-inset-left: var(
+      --sky-comp-list_summary-space-inset-left
+    );
   }
 
   &-tabs {


### PR DESCRIPTION
Resolves [AB#3647955](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3647955).

## Problem

The toolbar, filter bar, and list summary each applied their own inset padding on every side. That padding is only correct where the component sits flush and has nothing above it to inherit from.

In any container that already provides padding — a box, a modal, or directly beneath a heading — the two stacked, and the component's contents ended up indented past the content above and below them. `sky-toolbar-section` made it worse by repeating the same inset inside the toolbar container, so a sectioned toolbar was indented twice.

## Change

The horizontal and top insets now apply only inside a page or tab with `layout="list"`, which is the one context that supplies no padding of its own.

| Component | Default | Inside `layout="list"` |
|---|---|---|
| `sky-toolbar` | bottom inset only | all four sides |
| `sky-toolbar-section` | bottom inset only* | all four sides |
| `sky-filter-bar` | bottom inset only | all four sides |
| `sky-list-summary` | top + bottom inset | all four sides |

Two insets are deliberately unconditional, because no parent supplies them:

- **Bottom**, on all four components — it separates the component from the content beneath it.
- **Top on a section after the first** (\*) — that is the gap between stacked rows, not an edge inset. Without it the rows collide with the divider that `sky-toolbar-section:not(:first-child)` draws between them.

The list summary also keeps its top and bottom inset everywhere, since that is its own vertical rhythm rather than something a parent provides.

### Implementation note

The `layout="list"` restore feeds **custom properties** into the existing `padding` shorthand rather than redeclaring `padding` under `:host-context(...)`. A redeclaration compiles to a higher specificity than the deliberate `padding-top: 0` that `SkyListToolbarComponent` sets on its search section, and a shorthand would reset it. Feeding properties leaves that longhand to win.

**Default theme is unchanged.** Its `sky-default-overrides` blocks still set `--sky-override-toolbar-container-padding` and `--sky-override-list-summary-padding`, which take precedence over every token path.

## Breaking change

Apps that added negative margins or spacing overrides to compensate for the extra padding should remove them.

The SKY UX 15 compatibility stylesheet reintroduces the previous padding in the meantime — three entries added to `add-compat-stylesheet.schematic.ts` for `@skyux/layout`, `@skyux/filter-bar`, and `@skyux/lists`, each with a `--sky-compat-*` hook in the component and TODO instructions for removing it.

## Expected visual test failures

**The ag-grid and data-manager snapshots are expected to fail.** Those fixtures render a data manager outside a list layout, so their toolbars now inherit their container's padding instead of supplying their own. Those data managers belong on a page with `layout="list"`; the failures are the change working, not a regression. Please do not treat red Percy on those as a blocker.

Diffs are also expected on the toolbar, filter bar, and list summary snapshots.

## Testing

Visual coverage was added to the **existing** toolbar story rather than as a new story, so it rides along on the Percy snapshots already captured across `default`, `modern-v2-light`, and `modern-v2-dark`. It renders a toolbar inside a `sky-box` with reference text above and below, which is the case this change fixes and the only place in any storybook that puts a toolbar in a padded container.

Restore-branch coverage comes from the existing `data-manager-with-list-toolbars` story, which renders a real filter bar and list summary inside a `sky-data-manager-toolbar`.

Unit tests were deliberately not used: Karma runs without a theme applied, so the compat overrides win and this change is a no-op in that environment.

## Verified locally

- `nx build playground`
- `nx lint` and `nx build-storybook` on the affected storybook apps
- Compiled CSS inspected to confirm the restore no longer overrides `padding-top`

Not verified locally: `nx test packages` (needs Node 24.9+ for Jest's ESM path), and Percy, which only renders in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

