### PR TITLE
feat(components/packages): add `migrate-karma-to-vitest` generate schematic

### DIFF
--- a/libs/components/packages/collection.json
+++ b/libs/components/packages/collection.json
@@ -36,6 +36,10 @@
       "factory": "./src/schematics/ng-generate/convert-progress-indicator-wizard-to-tab-wizard/convert-progress-indicator-wizard-to-tab-wizard.schematic",
       "schema": "./src/schematics/ng-generate/convert-progress-indicator-wizard-to-tab-wizard/schema.json"
     },
+    "migrate-karma-to-vitest": {
+      "description": "Replace the @skyux-sdk/testing Jasmine matchers with the @skyux-sdk/vitest matchers.",
+      "factory": "./src/schematics/ng-generate/migrate-karma-to-vitest/migrate-karma-to-vitest.schematic"
+    },
     "remove-compat-stylesheets": {
       "description": "Remove SKY UX compatibility stylesheets.",
       "factory": "./src/schematics/ng-generate/remove-compat-stylesheets/remove-compat-stylesheets.schematic",

--- a/libs/components/packages/src/schematics/ng-generate/migrate-karma-to-vitest/migrate-karma-to-vitest.schematic.spec.ts
+++ b/libs/components/packages/src/schematics/ng-generate/migrate-karma-to-vitest/migrate-karma-to-vitest.schematic.spec.ts
@@ -1,0 +1,245 @@
+import { Tree } from '@angular-devkit/schematics';
+import { SchematicTestRunner } from '@angular-devkit/schematics/testing';
+
+import path from 'node:path';
+
+describe('Generate > Migrate karma to vitest', () => {
+  const runner = new SchematicTestRunner(
+    'schematics',
+    path.join(__dirname, '../../../../collection.json'),
+  );
+
+  function setupTree(
+    files: Record<string, string>,
+    devDependencies: Record<string, string> = {
+      '@skyux-sdk/testing': '^15.0.0',
+    },
+  ): Tree {
+    const tree = Tree.empty();
+
+    tree.create(
+      '/angular.json',
+      JSON.stringify({
+        version: 1,
+        projects: {
+          app: {
+            projectType: 'application',
+            root: '',
+            sourceRoot: 'src',
+            architect: {},
+          },
+        },
+      }),
+    );
+
+    tree.create(
+      '/package.json',
+      JSON.stringify({ name: 'test', devDependencies }),
+    );
+
+    for (const [filePath, content] of Object.entries(files)) {
+      tree.create(filePath, content);
+    }
+
+    return tree;
+  }
+
+  async function runSchematic(tree: Tree): Promise<string[]> {
+    const warnings: string[] = [];
+
+    const subscription = runner.logger.subscribe((entry) => {
+      if (entry.level === 'warn') {
+        warnings.push(entry.message);
+      }
+    });
+
+    try {
+      await runner.runSchematic('migrate-karma-to-vitest', {}, tree);
+    } finally {
+      subscription.unsubscribe();
+    }
+
+    return warnings;
+  }
+
+  function getDevDependencies(tree: Tree): Record<string, string> {
+    return JSON.parse(tree.readText('/package.json')).devDependencies;
+  }
+
+  it('should skip the migration if the deprecated package is not installed', async () => {
+    const tree = setupTree(
+      {
+        '/src/app/test.spec.ts': `import { expect } from '@skyux-sdk/testing';\n`,
+      },
+      {},
+    );
+
+    const warnings = await runSchematic(tree);
+
+    expect(warnings).toEqual([
+      "Dependency '@skyux-sdk/testing' not installed. Skipping migration.",
+    ]);
+    expect(tree.readText('/src/app/test.spec.ts')).toBe(
+      `import { expect } from '@skyux-sdk/testing';\n`,
+    );
+  });
+
+  it('should skip the migration if the supported package is already installed', async () => {
+    const tree = setupTree(
+      {
+        '/src/app/test.spec.ts': `import { expect } from '@skyux-sdk/testing';\n`,
+      },
+      {
+        '@skyux-sdk/testing': '^15.0.0',
+        '@skyux-sdk/vitest': '^15.0.0',
+      },
+    );
+
+    const warnings = await runSchematic(tree);
+
+    expect(warnings).toEqual([
+      "Dependency '@skyux-sdk/vitest' already installed. Skipping migration.",
+    ]);
+    expect(getDevDependencies(tree)).toEqual({
+      '@skyux-sdk/testing': '^15.0.0',
+      '@skyux-sdk/vitest': '^15.0.0',
+    });
+  });
+
+  it('should swap the deprecated package with the supported package', async () => {
+    const tree = setupTree({
+      '/src/app/test.spec.ts': `import { expect } from '@skyux-sdk/testing';
+import { SkyA11yAnalyzerConfig } from '@skyux-sdk/testing';
+
+describe('test', () => {
+  const config: SkyA11yAnalyzerConfig = {};
+  expect(config).toBeDefined();
+});
+`,
+    });
+
+    await runSchematic(tree);
+
+    expect(tree.readText('/src/app/test.spec.ts'))
+      .toBe(`import { SkyToBeAccessibleOptions } from '@skyux-sdk/vitest';
+
+describe('test', () => {
+  const config: SkyToBeAccessibleOptions = {};
+  expect(config).toBeDefined();
+});
+`);
+  });
+
+  it('should combine multiple imports of the supported package', async () => {
+    const tree = setupTree({
+      '/src/app/test.spec.ts': `import { SkyToBeVisibleOptions } from '@skyux-sdk/vitest';
+import { expectAsync, SkyA11yAnalyzerConfig } from '@skyux-sdk/testing';
+
+describe('test', () => {
+  const options: SkyToBeVisibleOptions = {};
+  const config: SkyA11yAnalyzerConfig = {};
+  expectAsync(options).toBeResolved();
+});
+`,
+    });
+
+    await runSchematic(tree);
+
+    expect(tree.readText('/src/app/test.spec.ts'))
+      .toBe(`import { SkyToBeVisibleOptions, SkyToBeAccessibleOptions } from '@skyux-sdk/vitest';
+
+describe('test', () => {
+  const options: SkyToBeVisibleOptions = {};
+  const config: SkyToBeAccessibleOptions = {};
+  expectAsync(options).toBeResolved();
+});
+`);
+  });
+
+  it('should retain imports that are not matchers', async () => {
+    const tree = setupTree({
+      '/src/app/test.spec.ts': `import { SkyAppTestModule, expect } from '@skyux-sdk/testing';
+
+describe('test', () => {
+  SkyAppTestModule;
+  expect(true).toBeTruthy();
+});
+`,
+    });
+
+    const warnings = await runSchematic(tree);
+
+    expect(tree.readText('/src/app/test.spec.ts'))
+      .toBe(`import { SkyAppTestModule } from '@skyux-sdk/testing';
+
+describe('test', () => {
+  SkyAppTestModule;
+  expect(true).toBeTruthy();
+});
+`);
+
+    expect(warnings).toEqual([
+      "Dependency '@skyux-sdk/testing' is still imported by the workspace and was not uninstalled.",
+    ]);
+
+    expect(getDevDependencies(tree)).toEqual({
+      '@skyux-sdk/testing': '^15.0.0',
+      '@skyux-sdk/vitest': '^0.0.0-PLACEHOLDER',
+    });
+  });
+
+  it('should ignore files that do not reference the deprecated package', async () => {
+    const tree = setupTree({
+      '/src/app/app.component.ts': `import { Component } from '@angular/core';\n`,
+      '/src/app/typings.d.ts': `import { expect } from '@skyux-sdk/testing';\n`,
+    });
+
+    await runSchematic(tree);
+
+    expect(tree.readText('/src/app/app.component.ts')).toBe(
+      `import { Component } from '@angular/core';\n`,
+    );
+    expect(tree.readText('/src/app/typings.d.ts')).toBe(
+      `import { expect } from '@skyux-sdk/testing';\n`,
+    );
+  });
+
+  it('should swap the package.json dependencies', async () => {
+    const tree = setupTree(
+      {
+        '/src/app/test.spec.ts': `import { expect } from '@skyux-sdk/testing';\n`,
+      },
+      {
+        '@skyux-sdk/testing': '^15.0.0',
+        typescript: '^5.0.0',
+      },
+    );
+
+    await runSchematic(tree);
+
+    expect(getDevDependencies(tree)).toEqual({
+      '@skyux-sdk/vitest': '^0.0.0-PLACEHOLDER',
+      typescript: '^5.0.0',
+    });
+  });
+
+  it('should install the supported package and run its ng-add schematic', async () => {
+    const tree = setupTree({
+      '/src/app/test.spec.ts': `import { expect } from '@skyux-sdk/testing';\n`,
+    });
+
+    await runSchematic(tree);
+
+    expect(runner.tasks.map((task) => task.name)).toEqual([
+      'node-package',
+      'run-schematic',
+    ]);
+
+    expect(runner.tasks[1].options).toEqual(
+      expect.objectContaining({
+        collection: '@skyux-sdk/vitest',
+        name: 'ng-add',
+      }),
+    );
+  });
+});

--- a/libs/components/packages/src/schematics/ng-generate/migrate-karma-to-vitest/migrate-karma-to-vitest.schematic.spec.ts
+++ b/libs/components/packages/src/schematics/ng-generate/migrate-karma-to-vitest/migrate-karma-to-vitest.schematic.spec.ts
@@ -156,6 +156,33 @@ describe('test', () => {
 `);
   });
 
+  it('should leave aliased imports for the consumer to migrate', async () => {
+    const tree = setupTree({
+      '/src/app/test.spec.ts': `import { expect as skyExpect, SkyA11yAnalyzerConfig as A11yConfig } from '@skyux-sdk/testing';
+
+describe('test', () => {
+  const config: A11yConfig = {};
+  skyExpect(config).toBeDefined();
+});
+`,
+    });
+
+    const warnings = await runSchematic(tree);
+
+    expect(tree.readText('/src/app/test.spec.ts'))
+      .toBe(`import { expect as skyExpect, SkyA11yAnalyzerConfig as A11yConfig } from '@skyux-sdk/testing';
+
+describe('test', () => {
+  const config: A11yConfig = {};
+  skyExpect(config).toBeDefined();
+});
+`);
+
+    expect(warnings).toEqual([
+      "Dependency '@skyux-sdk/testing' is still imported by the workspace and was not uninstalled.",
+    ]);
+  });
+
   it('should retain imports that are not matchers', async () => {
     const tree = setupTree({
       '/src/app/test.spec.ts': `import { SkyAppTestModule, expect } from '@skyux-sdk/testing';

--- a/libs/components/packages/src/schematics/ng-generate/migrate-karma-to-vitest/migrate-karma-to-vitest.schematic.spec.ts
+++ b/libs/components/packages/src/schematics/ng-generate/migrate-karma-to-vitest/migrate-karma-to-vitest.schematic.spec.ts
@@ -181,6 +181,11 @@ describe('test', () => {
     expect(warnings).toEqual([
       "Dependency '@skyux-sdk/testing' is still imported by the workspace and was not uninstalled.",
     ]);
+
+    expect(getDevDependencies(tree)).toEqual({
+      '@skyux-sdk/testing': '^15.0.0',
+      '@skyux-sdk/vitest': '^0.0.0-PLACEHOLDER',
+    });
   });
 
   it('should retain imports that are not matchers', async () => {

--- a/libs/components/packages/src/schematics/ng-generate/migrate-karma-to-vitest/migrate-karma-to-vitest.schematic.ts
+++ b/libs/components/packages/src/schematics/ng-generate/migrate-karma-to-vitest/migrate-karma-to-vitest.schematic.ts
@@ -1,0 +1,160 @@
+import { chain, Rule, Tree } from '@angular-devkit/schematics';
+import {
+  NodePackageInstallTask,
+  RunSchematicTask,
+} from '@angular-devkit/schematics/tasks';
+import {
+  addPackageJsonDependency,
+  getPackageJsonDependency,
+  NodeDependencyType,
+  removePackageJsonDependency,
+} from '@schematics/angular/utility/dependencies';
+import { getWorkspace } from '@schematics/angular/utility/workspace';
+import { VERSION as SKYUX_VERSION } from '../../../version';
+import { isPackageUsed } from '../../utility/dependencies';
+import { combineImports } from '../../utility/typescript/combine-imports';
+import { parseSourceFile } from '../../utility/typescript/ng-ast';
+import { removeImport } from '../../utility/typescript/remove-import';
+import { swapImportedClass } from '../../utility/typescript/swap-imported-class';
+import { visitProjectFiles } from '../../utility/visit-project-files';
+import { getSourceRoot } from '../../utility/workspace';
+
+const DEPRECATED_PACKAGE = '@skyux-sdk/testing';
+const SUPPORTED_PACKAGE = '@skyux-sdk/vitest';
+
+/**
+ * This schematic uninstalls our @skyux-sdk/testing jasmine matchers library and
+ * replaces it with the @skyux-sdk/vitest matchers library. This schematic assumes
+ * the `migrate-sdk-testing-imports` migration ran during the v15 update.
+ */
+export default function migrateKarmaToVitest(): Rule {
+  return (tree, context) => {
+    if (!getPackageJsonDependency(tree, DEPRECATED_PACKAGE)) {
+      context.logger.warn(
+        `Dependency '${DEPRECATED_PACKAGE}' not installed. Skipping migration.`,
+      );
+
+      return;
+    }
+
+    if (getPackageJsonDependency(tree, SUPPORTED_PACKAGE)) {
+      context.logger.warn(
+        `Dependency '${SUPPORTED_PACKAGE}' already installed. Skipping migration.`,
+      );
+
+      return;
+    }
+
+    return chain([
+      migrateSdkTestingImports(),
+      removeSdkTestingMatcherImports(),
+      uninstallSdkTesting(),
+      installSdkVitest(),
+    ]);
+  };
+}
+
+async function visitFilesImportingSdkTesting(
+  tree: Tree,
+  callback: (filePath: string) => void,
+): Promise<void> {
+  const workspace = await getWorkspace(tree);
+
+  for (const project of workspace.projects.values()) {
+    visitProjectFiles(tree, getSourceRoot(project), (filePath) => {
+      if (
+        filePath.endsWith('.ts') &&
+        !filePath.endsWith('.d.ts') &&
+        tree.readText(filePath).includes(DEPRECATED_PACKAGE)
+      ) {
+        callback(filePath);
+      }
+    });
+  }
+}
+
+function migrateSdkTestingImports(): Rule {
+  return (tree): Promise<void> => {
+    return visitFilesImportingSdkTesting(tree, (filePath) => {
+      const swapRecorder = tree.beginUpdate(filePath);
+
+      swapImportedClass(
+        swapRecorder,
+        filePath,
+        parseSourceFile(tree, filePath),
+        [
+          {
+            classNames: {
+              SkyA11yAnalyzerConfig: 'SkyToBeAccessibleOptions',
+              SkyToBeVisibleOptions: 'SkyToBeVisibleOptions',
+            },
+            moduleName: {
+              old: DEPRECATED_PACKAGE,
+              new: SUPPORTED_PACKAGE,
+            },
+          },
+        ],
+      );
+
+      tree.commitUpdate(swapRecorder);
+
+      const combineRecorder = tree.beginUpdate(filePath);
+
+      combineImports(
+        combineRecorder,
+        parseSourceFile(tree, filePath),
+        SUPPORTED_PACKAGE,
+      );
+
+      tree.commitUpdate(combineRecorder);
+    });
+  };
+}
+
+function uninstallSdkTesting(): Rule {
+  return async (tree, context) => {
+    if (await isPackageUsed(tree, DEPRECATED_PACKAGE)) {
+      context.logger.warn(
+        `Dependency '${DEPRECATED_PACKAGE}' is still imported by the workspace and was not uninstalled.`,
+      );
+
+      return;
+    }
+
+    removePackageJsonDependency(tree, DEPRECATED_PACKAGE);
+  };
+}
+
+function installSdkVitest(): Rule {
+  return (tree, context) => {
+    addPackageJsonDependency(tree, {
+      type: NodeDependencyType.Dev,
+      name: SUPPORTED_PACKAGE,
+      version: `^${SKYUX_VERSION.full}`,
+      overwrite: true,
+    });
+
+    // The package's `ng-add` can only run after the install task puts its
+    // collection on disk.
+    const installTaskId = context.addTask(new NodePackageInstallTask());
+
+    context.addTask(new RunSchematicTask(SUPPORTED_PACKAGE, 'ng-add', {}), [
+      installTaskId,
+    ]);
+  };
+}
+
+function removeSdkTestingMatcherImports(): Rule {
+  return (tree): Promise<void> => {
+    return visitFilesImportingSdkTesting(tree, (filePath) => {
+      const recorder = tree.beginUpdate(filePath);
+
+      removeImport(recorder, parseSourceFile(tree, filePath), {
+        classNames: ['expect', 'expectAsync'],
+        moduleName: DEPRECATED_PACKAGE,
+      });
+
+      tree.commitUpdate(recorder);
+    });
+  };
+}


### PR DESCRIPTION
[AB#3987231](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3987231)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a migration tool to transition projects from Karma-based testing to Vitest.
  - Automatically updates test imports and matcher usage.
  - Installs and configures Vitest, removing the legacy testing package when no longer needed.

- **Tests**
  - Added coverage for migration setup, dependency validation, import updates, package replacement, and preservation of unrelated project files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->