### PR TITLE
chore: re-check e2e visual review when the screenshot removed label changes (#4699)

### DIFF
--- a/.github/workflows/e2e-screenshot-removed-check.yml
+++ b/.github/workflows/e2e-screenshot-removed-check.yml
@@ -1,0 +1,80 @@
+name: E2E Screenshot Removed Check
+
+on:
+  pull_request_target:
+    types:
+      - labeled
+      - unlabeled
+
+permissions: {}
+
+jobs:
+  e2e-screenshot-removed-recheck:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.label.name == 'screenshot removed' }}
+    steps:
+      - uses: actions/github-script@v8
+        with:
+          github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+          script: |
+            const RERUN_WINDOW_DAYS = 1;
+            const prNumber = context.payload.pull_request.number;
+            const rerunWindowStart =
+              Date.now() - (RERUN_WINDOW_DAYS * 24 * 60 * 60 * 1000);
+            const rerunWindowStartIso = new Date(rerunWindowStart).toISOString();
+
+            console.log(`Finding latest completed e2e workflow run for PR #${prNumber}.`);
+            const workflowRuns = await github.paginate(github.rest.actions.listWorkflowRuns, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'e2e.yml',
+              event: 'pull_request_target',
+              status: 'completed',
+              created: `>=${rerunWindowStartIso}`,
+              per_page: 100
+            });
+
+            const run = workflowRuns.find((workflowRun) => {
+              const createdAt = Date.parse(workflowRun.created_at);
+              return (
+                !Number.isNaN(createdAt) &&
+                createdAt >= rerunWindowStart &&
+                workflowRun.pull_requests.some((pullRequest) => pullRequest.number === prNumber)
+              );
+            });
+
+            if (!run) {
+              console.log(`No completed e2e workflow run from the last ${RERUN_WINDOW_DAYS} days found for PR #${prNumber}. Nothing to re-check.`);
+              return;
+            }
+
+            console.log(`Found e2e workflow run ${run.id} (conclusion: ${run.conclusion}). Looking for the E2E Visual Review job.`);
+            const jobs = await github.paginate(
+              github.rest.actions.listJobsForWorkflowRun,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                run_id: run.id,
+                per_page: 100,
+                filter: 'latest'
+              },
+              (response) => response.data.jobs
+            );
+            const e2eReviewJob = jobs.find(job => job.name === 'E2E Visual Review');
+
+            if (!e2eReviewJob) {
+              console.log(`No "E2E Visual Review" job found for workflow run ${run.id}.`);
+              return;
+            }
+
+            if (e2eReviewJob.status !== 'completed') {
+              console.log(`E2E Visual Review job ${e2eReviewJob.id} for workflow run ${run.id} is still ${e2eReviewJob.status}. It will pick up the current "screenshot removed" label state on its own once it runs, so no re-run is needed.`);
+              return;
+            }
+
+            console.log(`Re-running E2E Visual Review job ${e2eReviewJob.id} for workflow run ${run.id} (the "screenshot removed" label was ${context.payload.action}).`);
+            await github.rest.actions.reRunJobForWorkflowRun({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              job_id: e2eReviewJob.id
+            });

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -543,12 +543,34 @@ jobs:
               const globPattern = await glob.create('${{ runner.temp }}/percy-builds/percy-build-*.txt');
               const buildIdFiles = await globPattern.glob()
 
+              // Fetch the PR's labels live rather than trusting
+              // needs.install-deps.outputs.pr-labels, which is frozen from
+              // when this workflow run started. This lets a re-run of just
+              // this job (e.g. triggered by e2e-screenshot-removed-check.yml
+              // after the "screenshot removed" label is added or removed)
+              // reflect the PR's current labels instead of stale ones.
+              const isPush = ${{ github.event_name == 'push' }};
+              const prNumber = ${{ toJSON(needs.install-deps.outputs.pr-number) }};
+              const currentLabels = isPush
+                ? []
+                : await github.paginate(
+                    github.rest.issues.listLabelsOnIssue,
+                    {
+                      owner: context.repo.owner,
+                      repo: context.repo.repo,
+                      issue_number: Number(prNumber),
+                    },
+                    (response) => response.data.map((label) => label.name)
+                  );
+              const allowMissingScreenshots =
+                isPush || currentLabels.includes('screenshot removed');
+
               await verifyE2e(
                 e2eProjects,
                 buildIdFiles,
                 core,
                 { listJobsForWorkflowRun, downloadJobLogs },
-                ${{ github.event_name == 'push' || contains( fromJSON( needs.install-deps.outputs.pr-labels ), 'screenshot removed' ) }},
+                allowMissingScreenshots,
                 (url) => fetch(url, options),
                 (number) => process.exit(number)
               );


### PR DESCRIPTION
:cherries: Cherry picked from #4699 [chore: re-check e2e visual review when the screenshot removed label changes](https://github.com/blackbaud/skyux/pull/4699)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated handling for visual review checks when the “screenshot removed” label changes.
  * Visual review checks can now be rerun automatically when a completed test run is available.
* **Bug Fixes**
  * Updated end-to-end verification to use current pull request labels, ensuring screenshot-removal exceptions are applied accurately.
  * Push-based checks now correctly allow missing screenshots.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->