### PR TITLE
fix: report the underlying axe error when accessibility checks fail

### DIFF
--- a/libs/sdk/testing/private/src/a11y/a11y-analyzer.spec.ts
+++ b/libs/sdk/testing/private/src/a11y/a11y-analyzer.spec.ts
@@ -9,7 +9,7 @@ describe('A11y analyzer', () => {
       options: axe.RunOptions,
       callback: axe.RunCallback,
     ): void {
-      callback(new Error('some error'), {} as axe.AxeResults);
+      callback(new Error('some error'), undefined as unknown as axe.AxeResults);
     }
 
     vi.spyOn(
@@ -20,42 +20,67 @@ describe('A11y analyzer', () => {
     await expect(_SkyA11yAnalyzer.run('element')).rejects.toThrow('some error');
   });
 
+  it('should handle axe errors reported as a string', async () => {
+    function mockRun(
+      context: axe.ElementContext,
+      options: axe.RunOptions,
+      callback: axe.RunCallback,
+    ): void {
+      callback(
+        'Axe is already running.' as unknown as Error,
+        undefined as unknown as axe.AxeResults,
+      );
+    }
+
+    vi.spyOn(
+      (_SkyA11yAnalyzer as unknown as { analyzer: typeof axe }).analyzer,
+      'run',
+    ).mockImplementation(mockRun as unknown as typeof axe.run);
+
+    await expect(_SkyA11yAnalyzer.run('element')).rejects.toThrow(
+      'Axe is already running.',
+    );
+  });
+
   it('should filter known ag-grid axe errors', async () => {
     function mockRun(
       context: axe.ElementContext,
       options: axe.RunOptions,
       callback: axe.RunCallback,
     ): void {
-      callback(new Error(), {
-        violations: [
-          {
-            id: 'aria-required-children',
-            tags: ['wcag2a', 'wcag412'],
-            nodes: [
-              {
-                target: ['div.ag-root'],
-                html: '<div class="ag-root" role="grid"></div>',
-                any: [],
-                all: [
-                  {
-                    id: 'aria-required-children',
-                    data: null,
-                    relatedNodes: [
-                      {
-                        target: ['div.ag-header'],
-                        html: '<div class="ag-header" role="presentation"></div>',
-                      },
-                    ],
-                  },
-                ] as axe.CheckResult[],
-                none: [],
-                impact: 'critical',
-                failureSummary: 'some failure summary',
-              } as axe.NodeResult,
-            ],
-          },
-        ],
-      } as axe.AxeResults);
+      callback(
+        null as unknown as Error,
+        {
+          violations: [
+            {
+              id: 'aria-required-children',
+              tags: ['wcag2a', 'wcag412'],
+              nodes: [
+                {
+                  target: ['div.ag-root'],
+                  html: '<div class="ag-root" role="grid"></div>',
+                  any: [],
+                  all: [
+                    {
+                      id: 'aria-required-children',
+                      data: null,
+                      relatedNodes: [
+                        {
+                          target: ['div.ag-header'],
+                          html: '<div class="ag-header" role="presentation"></div>',
+                        },
+                      ],
+                    },
+                  ] as axe.CheckResult[],
+                  none: [],
+                  impact: 'critical',
+                  failureSummary: 'some failure summary',
+                } as axe.NodeResult,
+              ],
+            },
+          ],
+        } as axe.AxeResults,
+      );
     }
 
     vi.spyOn(
@@ -72,25 +97,28 @@ describe('A11y analyzer', () => {
       options: axe.RunOptions,
       callback: axe.RunCallback,
     ): void {
-      callback(new Error(), {
-        violations: [
-          {
-            id: 'aria-allowed-role',
-            tags: ['wcag2a', 'wcag412'],
-            nodes: [
-              {
-                target: ['fieldset'],
-                html: '<fieldset role="radiogroup" class="sky-radio-group">',
-                any: [],
-                all: [],
-                none: [],
-                impact: 'minor',
-                failureSummary: 'some failure summary',
-              } as axe.NodeResult,
-            ],
-          },
-        ],
-      } as axe.AxeResults);
+      callback(
+        null as unknown as Error,
+        {
+          violations: [
+            {
+              id: 'aria-allowed-role',
+              tags: ['wcag2a', 'wcag412'],
+              nodes: [
+                {
+                  target: ['fieldset'],
+                  html: '<fieldset role="radiogroup" class="sky-radio-group">',
+                  any: [],
+                  all: [],
+                  none: [],
+                  impact: 'minor',
+                  failureSummary: 'some failure summary',
+                } as axe.NodeResult,
+              ],
+            },
+          ],
+        } as axe.AxeResults,
+      );
     }
 
     vi.spyOn(
@@ -107,25 +135,28 @@ describe('A11y analyzer', () => {
       options: axe.RunOptions,
       callback: axe.RunCallback,
     ): void {
-      callback(new Error(), {
-        violations: [
-          {
-            id: 'aria-allowed-role',
-            tags: ['wcag2a', 'wcag412'],
-            nodes: [
-              {
-                target: ['p'],
-                html: '<p role="radiogroup">',
-                any: [],
-                all: [],
-                none: [],
-                impact: 'minor',
-                failureSummary: 'some failure summary',
-              } as axe.NodeResult,
-            ],
-          },
-        ],
-      } as axe.AxeResults);
+      callback(
+        null as unknown as Error,
+        {
+          violations: [
+            {
+              id: 'aria-allowed-role',
+              tags: ['wcag2a', 'wcag412'],
+              nodes: [
+                {
+                  target: ['p'],
+                  html: '<p role="radiogroup">',
+                  any: [],
+                  all: [],
+                  none: [],
+                  impact: 'minor',
+                  failureSummary: 'some failure summary',
+                } as axe.NodeResult,
+              ],
+            },
+          ],
+        } as axe.AxeResults,
+      );
     }
 
     vi.spyOn(
@@ -144,25 +175,28 @@ describe('A11y analyzer', () => {
       options: axe.RunOptions,
       callback: axe.RunCallback,
     ): void {
-      callback(new Error(), {
-        violations: [
-          {
-            id: 'aria-allowed-role',
-            tags: ['wcag2a', 'wcag412'],
-            nodes: [
-              {
-                target: ['p'],
-                html: '<fieldset role="alert">',
-                any: [],
-                all: [],
-                none: [],
-                impact: 'minor',
-                failureSummary: 'some failure summary',
-              } as axe.NodeResult,
-            ],
-          },
-        ],
-      } as axe.AxeResults);
+      callback(
+        null as unknown as Error,
+        {
+          violations: [
+            {
+              id: 'aria-allowed-role',
+              tags: ['wcag2a', 'wcag412'],
+              nodes: [
+                {
+                  target: ['p'],
+                  html: '<fieldset role="alert">',
+                  any: [],
+                  all: [],
+                  none: [],
+                  impact: 'minor',
+                  failureSummary: 'some failure summary',
+                } as axe.NodeResult,
+              ],
+            },
+          ],
+        } as axe.AxeResults,
+      );
     }
 
     vi.spyOn(
@@ -181,37 +215,40 @@ describe('A11y analyzer', () => {
       options: axe.RunOptions,
       callback: axe.RunCallback,
     ): void {
-      callback(new Error(), {
-        violations: [
-          {
-            id: 'aria-valid-attr',
-            tags: ['wcag2a', 'wcag412'],
-            nodes: [
-              {
-                ancestry: ['original-header'],
-                target: [],
-                html: '<div class="other-header" aria-description="test"></div>',
-                any: [],
-                all: [
-                  {
-                    id: 'aria-valid-attr',
-                    data: null,
-                  },
-                ] as axe.CheckResult[],
-                none: [],
-              } as axe.NodeResult,
-              {
-                ancestry: [],
-                target: [],
-                html: '',
-                any: [],
-                all: [],
-                none: [],
-              } as axe.NodeResult,
-            ],
-          },
-        ],
-      } as axe.AxeResults);
+      callback(
+        null as unknown as Error,
+        {
+          violations: [
+            {
+              id: 'aria-valid-attr',
+              tags: ['wcag2a', 'wcag412'],
+              nodes: [
+                {
+                  ancestry: ['original-header'],
+                  target: [],
+                  html: '<div class="other-header" aria-description="test"></div>',
+                  any: [],
+                  all: [
+                    {
+                      id: 'aria-valid-attr',
+                      data: null,
+                    },
+                  ] as axe.CheckResult[],
+                  none: [],
+                } as axe.NodeResult,
+                {
+                  ancestry: [],
+                  target: [],
+                  html: '',
+                  any: [],
+                  all: [],
+                  none: [],
+                } as axe.NodeResult,
+              ],
+            },
+          ],
+        } as axe.AxeResults,
+      );
     }
 
     vi.spyOn(
@@ -230,40 +267,44 @@ describe('A11y analyzer', () => {
       options: axe.RunOptions,
       callback: axe.RunCallback,
     ): void {
-      callback(new Error(), {
-        violations: [
-          {
-            id: 'color-contrast',
-            help: 'Elements must have sufficient color contrast',
-            helpUrl: 'https://dequeuniversity.com/rules/axe/4.0/color-contrast',
-            tags: ['wcag2aa', 'wcag143', 'best-practice'],
-            nodes: [
-              {
-                target: ['span.low-contrast'],
-                html: '<span class="low-contrast">Hello</span>',
-                ancestry: ['body > span.low-contrast'],
-                any: [
-                  {
-                    id: 'color-contrast',
-                    message: 'Element has insufficient color contrast',
-                    relatedNodes: [
-                      {
-                        target: ['body'],
-                        html: '<body>\n  <span class="low-contrast">Hello</span>\n</body>',
-                      },
-                    ],
-                  } as unknown as axe.CheckResult,
-                ],
-                all: [],
-                none: [],
-                impact: 'serious',
-                failureSummary:
-                  'Fix any of the following:\n  Element has insufficient color contrast',
-              } as axe.NodeResult,
-            ],
-          },
-        ],
-      } as axe.AxeResults);
+      callback(
+        null as unknown as Error,
+        {
+          violations: [
+            {
+              id: 'color-contrast',
+              help: 'Elements must have sufficient color contrast',
+              helpUrl:
+                'https://dequeuniversity.com/rules/axe/4.0/color-contrast',
+              tags: ['wcag2aa', 'wcag143', 'best-practice'],
+              nodes: [
+                {
+                  target: ['span.low-contrast'],
+                  html: '<span class="low-contrast">Hello</span>',
+                  ancestry: ['body > span.low-contrast'],
+                  any: [
+                    {
+                      id: 'color-contrast',
+                      message: 'Element has insufficient color contrast',
+                      relatedNodes: [
+                        {
+                          target: ['body'],
+                          html: '<body>\n  <span class="low-contrast">Hello</span>\n</body>',
+                        },
+                      ],
+                    } as unknown as axe.CheckResult,
+                  ],
+                  all: [],
+                  none: [],
+                  impact: 'serious',
+                  failureSummary:
+                    'Fix any of the following:\n  Element has insufficient color contrast',
+                } as axe.NodeResult,
+              ],
+            },
+          ],
+        } as axe.AxeResults,
+      );
     }
 
     vi.spyOn(
@@ -288,28 +329,31 @@ describe('A11y analyzer', () => {
       options: axe.RunOptions,
       callback: axe.RunCallback,
     ): void {
-      callback(new Error(), {
-        violations: [
-          {
-            id: 'button-name',
-            help: 'Buttons must have discernible text',
-            helpUrl: 'https://dequeuniversity.com/rules/axe/4.0/button-name',
-            tags: ['wcag2a', 'wcag412'],
-            nodes: [
-              {
-                target: ['button'],
-                html: '<button></button>',
-                any: [],
-                all: [],
-                none: [],
-                impact: 'critical',
-                failureSummary:
-                  'Fix any of the following:\n  Button has no text',
-              } as axe.NodeResult,
-            ],
-          },
-        ],
-      } as axe.AxeResults);
+      callback(
+        null as unknown as Error,
+        {
+          violations: [
+            {
+              id: 'button-name',
+              help: 'Buttons must have discernible text',
+              helpUrl: 'https://dequeuniversity.com/rules/axe/4.0/button-name',
+              tags: ['wcag2a', 'wcag412'],
+              nodes: [
+                {
+                  target: ['button'],
+                  html: '<button></button>',
+                  any: [],
+                  all: [],
+                  none: [],
+                  impact: 'critical',
+                  failureSummary:
+                    'Fix any of the following:\n  Button has no text',
+                } as axe.NodeResult,
+              ],
+            },
+          ],
+        } as axe.AxeResults,
+      );
     }
 
     vi.spyOn(

--- a/libs/sdk/testing/private/src/a11y/a11y-analyzer.ts
+++ b/libs/sdk/testing/private/src/a11y/a11y-analyzer.ts
@@ -108,8 +108,9 @@ export abstract class _SkyA11yAnalyzer {
 
     return new Promise((resolve, reject) => {
       const callback: axe.RunCallback = (error, results) => {
-        if (error?.message) {
-          reject(error);
+        // axe reports some failures as a bare string rather than an Error.
+        if (error) {
+          reject(error instanceof Error ? error : new Error(String(error)));
           return;
         }
 

--- a/libs/sdk/vitest/src/lib/utility/a11y-analyzer.spec.ts
+++ b/libs/sdk/vitest/src/lib/utility/a11y-analyzer.spec.ts
@@ -9,7 +9,7 @@ describe('A11y analyzer', () => {
       options: axe.RunOptions,
       callback: axe.RunCallback,
     ): void {
-      callback(new Error('some error'), {} as axe.AxeResults);
+      callback(new Error('some error'), undefined as unknown as axe.AxeResults);
     }
 
     vi.spyOn(
@@ -20,42 +20,67 @@ describe('A11y analyzer', () => {
     await expect(SkyA11yAnalyzer.run('element')).rejects.toThrow('some error');
   });
 
+  it('should handle axe errors reported as a string', async () => {
+    function mockRun(
+      context: axe.ElementContext,
+      options: axe.RunOptions,
+      callback: axe.RunCallback,
+    ): void {
+      callback(
+        'Axe is already running.' as unknown as Error,
+        undefined as unknown as axe.AxeResults,
+      );
+    }
+
+    vi.spyOn(
+      (SkyA11yAnalyzer as unknown as { analyzer: typeof axe }).analyzer,
+      'run',
+    ).mockImplementation(mockRun as unknown as typeof axe.run);
+
+    await expect(SkyA11yAnalyzer.run('element')).rejects.toThrow(
+      'Axe is already running.',
+    );
+  });
+
   it('should filter known ag-grid axe errors', async () => {
     function mockRun(
       context: axe.ElementContext,
       options: axe.RunOptions,
       callback: axe.RunCallback,
     ): void {
-      callback(new Error(), {
-        violations: [
-          {
-            id: 'aria-required-children',
-            tags: ['wcag2a', 'wcag412'],
-            nodes: [
-              {
-                target: ['div.ag-root'],
-                html: '<div class="ag-root" role="grid"></div>',
-                any: [],
-                all: [
-                  {
-                    id: 'aria-required-children',
-                    data: null,
-                    relatedNodes: [
-                      {
-                        target: ['div.ag-header'],
-                        html: '<div class="ag-header" role="presentation"></div>',
-                      },
-                    ],
-                  },
-                ] as axe.CheckResult[],
-                none: [],
-                impact: 'critical',
-                failureSummary: 'some failure summary',
-              } as axe.NodeResult,
-            ],
-          },
-        ],
-      } as axe.AxeResults);
+      callback(
+        null as unknown as Error,
+        {
+          violations: [
+            {
+              id: 'aria-required-children',
+              tags: ['wcag2a', 'wcag412'],
+              nodes: [
+                {
+                  target: ['div.ag-root'],
+                  html: '<div class="ag-root" role="grid"></div>',
+                  any: [],
+                  all: [
+                    {
+                      id: 'aria-required-children',
+                      data: null,
+                      relatedNodes: [
+                        {
+                          target: ['div.ag-header'],
+                          html: '<div class="ag-header" role="presentation"></div>',
+                        },
+                      ],
+                    },
+                  ] as axe.CheckResult[],
+                  none: [],
+                  impact: 'critical',
+                  failureSummary: 'some failure summary',
+                } as axe.NodeResult,
+              ],
+            },
+          ],
+        } as axe.AxeResults,
+      );
     }
 
     vi.spyOn(
@@ -72,25 +97,28 @@ describe('A11y analyzer', () => {
       options: axe.RunOptions,
       callback: axe.RunCallback,
     ): void {
-      callback(new Error(), {
-        violations: [
-          {
-            id: 'aria-allowed-role',
-            tags: ['wcag2a', 'wcag412'],
-            nodes: [
-              {
-                target: ['fieldset'],
-                html: '<fieldset role="radiogroup" class="sky-radio-group">',
-                any: [],
-                all: [],
-                none: [],
-                impact: 'minor',
-                failureSummary: 'some failure summary',
-              } as axe.NodeResult,
-            ],
-          },
-        ],
-      } as axe.AxeResults);
+      callback(
+        null as unknown as Error,
+        {
+          violations: [
+            {
+              id: 'aria-allowed-role',
+              tags: ['wcag2a', 'wcag412'],
+              nodes: [
+                {
+                  target: ['fieldset'],
+                  html: '<fieldset role="radiogroup" class="sky-radio-group">',
+                  any: [],
+                  all: [],
+                  none: [],
+                  impact: 'minor',
+                  failureSummary: 'some failure summary',
+                } as axe.NodeResult,
+              ],
+            },
+          ],
+        } as axe.AxeResults,
+      );
     }
 
     vi.spyOn(
@@ -107,25 +135,28 @@ describe('A11y analyzer', () => {
       options: axe.RunOptions,
       callback: axe.RunCallback,
     ): void {
-      callback(new Error(), {
-        violations: [
-          {
-            id: 'aria-allowed-role',
-            tags: ['wcag2a', 'wcag412'],
-            nodes: [
-              {
-                target: ['p'],
-                html: '<p role="radiogroup">',
-                any: [],
-                all: [],
-                none: [],
-                impact: 'minor',
-                failureSummary: 'some failure summary',
-              } as axe.NodeResult,
-            ],
-          },
-        ],
-      } as axe.AxeResults);
+      callback(
+        null as unknown as Error,
+        {
+          violations: [
+            {
+              id: 'aria-allowed-role',
+              tags: ['wcag2a', 'wcag412'],
+              nodes: [
+                {
+                  target: ['p'],
+                  html: '<p role="radiogroup">',
+                  any: [],
+                  all: [],
+                  none: [],
+                  impact: 'minor',
+                  failureSummary: 'some failure summary',
+                } as axe.NodeResult,
+              ],
+            },
+          ],
+        } as axe.AxeResults,
+      );
     }
 
     vi.spyOn(
@@ -144,25 +175,28 @@ describe('A11y analyzer', () => {
       options: axe.RunOptions,
       callback: axe.RunCallback,
     ): void {
-      callback(new Error(), {
-        violations: [
-          {
-            id: 'aria-allowed-role',
-            tags: ['wcag2a', 'wcag412'],
-            nodes: [
-              {
-                target: ['p'],
-                html: '<fieldset role="alert">',
-                any: [],
-                all: [],
-                none: [],
-                impact: 'minor',
-                failureSummary: 'some failure summary',
-              } as axe.NodeResult,
-            ],
-          },
-        ],
-      } as axe.AxeResults);
+      callback(
+        null as unknown as Error,
+        {
+          violations: [
+            {
+              id: 'aria-allowed-role',
+              tags: ['wcag2a', 'wcag412'],
+              nodes: [
+                {
+                  target: ['p'],
+                  html: '<fieldset role="alert">',
+                  any: [],
+                  all: [],
+                  none: [],
+                  impact: 'minor',
+                  failureSummary: 'some failure summary',
+                } as axe.NodeResult,
+              ],
+            },
+          ],
+        } as axe.AxeResults,
+      );
     }
 
     vi.spyOn(
@@ -181,37 +215,40 @@ describe('A11y analyzer', () => {
       options: axe.RunOptions,
       callback: axe.RunCallback,
     ): void {
-      callback(new Error(), {
-        violations: [
-          {
-            id: 'aria-valid-attr',
-            tags: ['wcag2a', 'wcag412'],
-            nodes: [
-              {
-                ancestry: ['original-header'],
-                target: [],
-                html: '<div class="other-header" aria-description="test"></div>',
-                any: [],
-                all: [
-                  {
-                    id: 'aria-valid-attr',
-                    data: null,
-                  },
-                ] as axe.CheckResult[],
-                none: [],
-              } as axe.NodeResult,
-              {
-                ancestry: [],
-                target: [],
-                html: '',
-                any: [],
-                all: [],
-                none: [],
-              } as axe.NodeResult,
-            ],
-          },
-        ],
-      } as axe.AxeResults);
+      callback(
+        null as unknown as Error,
+        {
+          violations: [
+            {
+              id: 'aria-valid-attr',
+              tags: ['wcag2a', 'wcag412'],
+              nodes: [
+                {
+                  ancestry: ['original-header'],
+                  target: [],
+                  html: '<div class="other-header" aria-description="test"></div>',
+                  any: [],
+                  all: [
+                    {
+                      id: 'aria-valid-attr',
+                      data: null,
+                    },
+                  ] as axe.CheckResult[],
+                  none: [],
+                } as axe.NodeResult,
+                {
+                  ancestry: [],
+                  target: [],
+                  html: '',
+                  any: [],
+                  all: [],
+                  none: [],
+                } as axe.NodeResult,
+              ],
+            },
+          ],
+        } as axe.AxeResults,
+      );
     }
 
     vi.spyOn(
@@ -230,40 +267,44 @@ describe('A11y analyzer', () => {
       options: axe.RunOptions,
       callback: axe.RunCallback,
     ): void {
-      callback(new Error(), {
-        violations: [
-          {
-            id: 'color-contrast',
-            help: 'Elements must have sufficient color contrast',
-            helpUrl: 'https://dequeuniversity.com/rules/axe/4.0/color-contrast',
-            tags: ['wcag2aa', 'wcag143', 'best-practice'],
-            nodes: [
-              {
-                target: ['span.low-contrast'],
-                html: '<span class="low-contrast">Hello</span>',
-                ancestry: ['body > span.low-contrast'],
-                any: [
-                  {
-                    id: 'color-contrast',
-                    message: 'Element has insufficient color contrast',
-                    relatedNodes: [
-                      {
-                        target: ['body'],
-                        html: '<body>\n  <span class="low-contrast">Hello</span>\n</body>',
-                      },
-                    ],
-                  } as unknown as axe.CheckResult,
-                ],
-                all: [],
-                none: [],
-                impact: 'serious',
-                failureSummary:
-                  'Fix any of the following:\n  Element has insufficient color contrast',
-              } as axe.NodeResult,
-            ],
-          },
-        ],
-      } as axe.AxeResults);
+      callback(
+        null as unknown as Error,
+        {
+          violations: [
+            {
+              id: 'color-contrast',
+              help: 'Elements must have sufficient color contrast',
+              helpUrl:
+                'https://dequeuniversity.com/rules/axe/4.0/color-contrast',
+              tags: ['wcag2aa', 'wcag143', 'best-practice'],
+              nodes: [
+                {
+                  target: ['span.low-contrast'],
+                  html: '<span class="low-contrast">Hello</span>',
+                  ancestry: ['body > span.low-contrast'],
+                  any: [
+                    {
+                      id: 'color-contrast',
+                      message: 'Element has insufficient color contrast',
+                      relatedNodes: [
+                        {
+                          target: ['body'],
+                          html: '<body>\n  <span class="low-contrast">Hello</span>\n</body>',
+                        },
+                      ],
+                    } as unknown as axe.CheckResult,
+                  ],
+                  all: [],
+                  none: [],
+                  impact: 'serious',
+                  failureSummary:
+                    'Fix any of the following:\n  Element has insufficient color contrast',
+                } as axe.NodeResult,
+              ],
+            },
+          ],
+        } as axe.AxeResults,
+      );
     }
 
     vi.spyOn(
@@ -288,28 +329,31 @@ describe('A11y analyzer', () => {
       options: axe.RunOptions,
       callback: axe.RunCallback,
     ): void {
-      callback(new Error(), {
-        violations: [
-          {
-            id: 'button-name',
-            help: 'Buttons must have discernible text',
-            helpUrl: 'https://dequeuniversity.com/rules/axe/4.0/button-name',
-            tags: ['wcag2a', 'wcag412'],
-            nodes: [
-              {
-                target: ['button'],
-                html: '<button></button>',
-                any: [],
-                all: [],
-                none: [],
-                impact: 'critical',
-                failureSummary:
-                  'Fix any of the following:\n  Button has no text',
-              } as axe.NodeResult,
-            ],
-          },
-        ],
-      } as axe.AxeResults);
+      callback(
+        null as unknown as Error,
+        {
+          violations: [
+            {
+              id: 'button-name',
+              help: 'Buttons must have discernible text',
+              helpUrl: 'https://dequeuniversity.com/rules/axe/4.0/button-name',
+              tags: ['wcag2a', 'wcag412'],
+              nodes: [
+                {
+                  target: ['button'],
+                  html: '<button></button>',
+                  any: [],
+                  all: [],
+                  none: [],
+                  impact: 'critical',
+                  failureSummary:
+                    'Fix any of the following:\n  Button has no text',
+                } as axe.NodeResult,
+              ],
+            },
+          ],
+        } as axe.AxeResults,
+      );
     }
 
     vi.spyOn(

--- a/libs/sdk/vitest/src/lib/utility/a11y-analyzer.ts
+++ b/libs/sdk/vitest/src/lib/utility/a11y-analyzer.ts
@@ -111,8 +111,9 @@ export abstract class SkyA11yAnalyzer {
 
     return new Promise((resolve, reject) => {
       const callback: axe.RunCallback = (error, results) => {
-        if (error?.message) {
-          reject(error);
+        // axe reports some failures as a bare string rather than an Error.
+        if (error) {
+          reject(error instanceof Error ? error : new Error(String(error)));
           return;
         }
 


### PR DESCRIPTION
[AB#4097065](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/4097065)

When accessibility checks fail before axe can run (most commonly because two `toBeAccessible()` assertions overlapped, so axe raised "Axe is already running") `axe-core` reports the failure by calling the run callback with a bare string and no results object. The old guard, `if (error?.message)`, missed that case because a string has no `.message` property, so it fell through and dereferenced `results.violations` on `undefined`. The test still failed, but with `TypeError: Cannot read properties of undefined (reading 'violations')`, which points at our library's internals and hides the actual cause. 

Changing the guard to `if (error)` and normalizing non-Error values surfaces the real axe message instead, so a developer who forgot an `await` sees exactly that rather than a confusing crash inside `@skyux-sdk/testing`/`@skyux-sdk/vitest`. The accompanying specs needed updating too: seven of them passed `new Error()` to mean "no error," which only worked because of the buggy guard and effectively locked the bug in as the expected contract; they now pass `null`, matching what axe actually does on success.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Accessibility analysis now correctly reports all axe errors, including errors returned as plain text.
  * Error messages are consistently surfaced as standard errors.
* **Tests**
  * Expanded coverage for successful analyses, filtered and unfiltered violations, related nodes, detailed output, and rule overrides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->