### PR TITLE
fix(components/ag-grid): date filter widgets use grid background and focus styles, inputs use text color

### DIFF
--- a/libs/components/ag-grid/src/lib/modules/ag-grid/cell-editors/cell-editor-autocomplete/cell-editor-autocomplete.component.scss
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/cell-editors/cell-editor-autocomplete/cell-editor-autocomplete.component.scss
@@ -2,6 +2,7 @@ sky-autocomplete {
   input {
     background-color: transparent;
     border: none;
+    color: var(--ag-input-text-color);
     box-shadow: none;
   }
 }

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/cell-editors/cell-editor-currency/cell-editor-currency.component.scss
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/cell-editors/cell-editor-currency/cell-editor-currency.component.scss
@@ -12,6 +12,7 @@
 input {
   background-color: transparent;
   border: none;
+  color: var(--ag-input-text-color);
   height: 100%;
   width: 100%;
   padding-left: var(

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/cell-editors/cell-editor-number/cell-editor-number.component.scss
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/cell-editors/cell-editor-number/cell-editor-number.component.scss
@@ -1,5 +1,6 @@
 input {
   background-color: transparent;
   border: none;
+  color: var(--ag-input-text-color);
   text-align: right;
 }

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/cell-editors/cell-editor-text/cell-editor-text.component.scss
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/cell-editors/cell-editor-text/cell-editor-text.component.scss
@@ -13,6 +13,7 @@
 input {
   background-color: transparent;
   border: none;
+  color: var(--ag-input-text-color);
   height: 100%;
   width: 100%;
   padding-left: var(

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/column-filters/column-filter-datepicker/column-filter-datepicker.component.scss
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/column-filters/column-filter-datepicker/column-filter-datepicker.component.scss
@@ -7,6 +7,15 @@ sky-datepicker {
   width: calc(100% - var(--sky-margin-inline-xs));
 }
 
-input {
+input.sky-form-control {
   height: calc(var(--ag-header-height) - 2px);
+  background-color: var(--ag-input-background-color);
+  border: none;
+  box-shadow: inset 0 0 0 var(--ag-border-width) var(--ag-border-color);
+  color: var(--ag-input-text-color);
+
+  &:focus {
+    box-shadow: inset var(--ag-focus-shadow);
+    outline: none;
+  }
 }

--- a/libs/components/ag-grid/src/lib/styles/_base.scss
+++ b/libs/components/ag-grid/src/lib/styles/_base.scss
@@ -52,13 +52,30 @@
     }
   }
 
-  .ag-filter-body {
+  .ag-filter-wrapper {
+    --ag-border-color: var(
+      --sky-override-ag-grid-filter-border-color,
+      var(--sky-color-border-input-base)
+    );
+    --ag-border-radius: var(
+      --sky-override-ag-grid-filter-border-radius,
+      var(--sky-border-radius-s)
+    );
+
+    .ag-picker-field-wrapper {
+      border-radius: var(--ag-border-radius);
+    }
+
     .sky-datepicker .sky-input-group input.sky-form-control {
       border-start-start-radius: var(--ag-border-radius);
       border-end-start-radius: var(--ag-border-radius);
     }
 
     .sky-input-group-datepicker-btn {
+      --sky-color-background-action-secondary-base: var(
+        --ag-input-background-color
+      );
+      --sky-color-border-action-secondary-base: var(--ag-border-color);
       border-start-start-radius: 0;
       border-end-start-radius: 0;
     }

--- a/libs/components/ag-grid/src/lib/styles/_base.scss
+++ b/libs/components/ag-grid/src/lib/styles/_base.scss
@@ -38,7 +38,29 @@
         appearance: none;
         border-radius: 0;
         height: calc(var(--ag-header-height) - 2px);
+
+        &:focus {
+          box-shadow: inset var(--ag-focus-shadow);
+        }
       }
+    }
+
+    .sky-input-group-datepicker-btn {
+      --sky-color-border-action-secondary-base: var(--ag-border-color);
+      border-start-start-radius: 0;
+      border-end-start-radius: 0;
+    }
+  }
+
+  .ag-filter-body {
+    .sky-datepicker .sky-input-group input.sky-form-control {
+      border-start-start-radius: var(--ag-border-radius);
+      border-end-start-radius: var(--ag-border-radius);
+    }
+
+    .sky-input-group-datepicker-btn {
+      border-start-start-radius: 0;
+      border-end-start-radius: 0;
     }
   }
 

--- a/libs/components/ag-grid/src/lib/styles/_overrides.scss
+++ b/libs/components/ag-grid/src/lib/styles/_overrides.scss
@@ -36,6 +36,10 @@
   );
   --sky-override-ag-grid-column-border: 1px solid
     var(--sky-border-color-neutral-medium);
+  --sky-override-ag-grid-filter-border-color: var(
+    --sky-border-color-neutral-medium
+  );
+  --sky-override-ag-grid-filter-border-radius: 3px;
   --sky-override-ag-grid-focus-border-color: var(--sky-highlight-color-info);
   --sky-override-ag-grid-focus-border-width: 2px;
   --sky-override-ag-grid-font-family:

--- a/libs/components/theme/src/lib/styles/themes/modern/_buttons.scss
+++ b/libs/components/theme/src/lib/styles/themes/modern/_buttons.scss
@@ -435,6 +435,7 @@
       background-color: var(
         --sky-color-background-action-tertiary-on_prominent-focus
       );
+      border: none;
       box-shadow:
         inset 0 0 0 var(--sky-border-width-action-focus)
           var(--sky-color-border-action-tertiary-on_prominent-focus),


### PR DESCRIPTION
## Problem

The date filter widgets in AG Grid did not pick up the grid's background color, so in dark mode the floating filter input rendered white.

The floating filter is SKY's own `sky-datepicker`, registered as `dateComponent` on `defaultColDef` — not an AG Grid input. A bare `.sky-form-control` outside `sky-input-box` sets no background at all, so it fell through to the browser default and never participated in dark mode. AG Grid's own inputs were unaffected because they get `inputBackgroundColor: { ref: 'backgroundColor' }` from `inputStyleBordered`.

Nothing in the AG Grid theming API can reach a `.sky-form-control`, and there was no `--sky-override-*` hook for it either.

## Changes

**`column-filter-datepicker.component.scss`** — the filter input now takes its background, text color, and border from the AG Grid input params so it tracks the grid in both light and dark modes. Both the resting and focused edges are drawn as inset shadows rather than a real border, so the edge is always flush and the two never stack. This also displaces `sky-field-status(active)`'s 8px glow, which was the previous focus treatment.

**`_base.scss`**

- Added `inset` to `.ag-input-field-input:focus`. AG Grid uses `inset` for its `div`/`span`/`label` focus rings but not for its inputs, so the text and number floating filters were drawing their ring outside the box and clipping. **This changes those filters too, not just the datepicker.**
- Floating filter datepicker button: squared the left corners, and repointed `--sky-color-border-action-secondary-base` at `--ag-border-color` so its edge matches the input. Overriding that token rather than the whole `box-shadow` keeps the button's elevation and its `:hover`/`:active` shadows intact.
- Filter menu popup (`.ag-filter-body`): the input gets rounded left corners and the button gets squared left corners, so the two read as one joined group.

These live in the global stylesheet rather than the component because the filter component uses emulated encapsulation, so its `_ngcontent` attribute never reaches the button inside `sky-datepicker`'s view.

## Testing

- `nx lint ag-grid` — passed
- `nx build ag-grid` — succeeded
- `nx test ag-grid` — 426 passing

## Notes for reviewers

- **E2E baselines will move.** `ag-grid-widgets.component.cy.ts` screenshots this grid across every theme, and its story enables `floatingFilter` with `agDateColumnFilter`.
- The selector chain on the filter menu input (`.sky-datepicker .sky-input-group input.sky-form-control`) is load-order insurance: `_forms.scss` forces `border-radius: 0` at specificity (0,4,1), and a shorter selector would silently lose.
- Out of scope: the broader gap where any bare non-`input-box` `.sky-form-control` has no dark mode background. Fixing that in `theme/_forms.scss` would cover every legacy input but has a much wider blast radius.
- Unrelated flakes: `SkyAgGridWrapperComponent` header-cell focus and the three `SkyAgGridCellEditorLookupComponent` `select()` specs fail whenever the browser window loses focus, on a clean tree as well.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated date picker and filter input styling to better match the AG Grid visual theme.
  * Improved focus indicators with consistent shadows and removed conflicting outlines.
  * Standardized borders, colors, backgrounds, and corner rounding across filter controls.
  * Improved text color consistency across autocomplete, currency, number, and text cell editors.
  * Removed the border from prominent borderless buttons when focused.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->