### PR TITLE
chore: release 14.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
 
+## [14.17.0](https://github.com/blackbaud/skyux/compare/14.16.0...14.17.0) (2026-08-27)
+
+
+### Features
+
+* dark mode uses new `steel-grey` color scheme ([#4706](https://github.com/blackbaud/skyux/issues/4706)) ([a0e9b74](https://github.com/blackbaud/skyux/commit/a0e9b742b4a0c861ec022715428e19cb9bd6fc30))
+
 ## [14.16.0](https://github.com/blackbaud/skyux/compare/14.15.1...14.16.0) (2026-08-26)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 
-## [14.17.0](https://github.com/blackbaud/skyux/compare/14.16.0...14.17.0) (2026-08-27)
+## [14.17.0](https://github.com/blackbaud/skyux/compare/14.16.0...14.17.0) (2026-08-28)
 
 
 ### Features
@@ -12,6 +12,7 @@
 ### Bug Fixes
 
 * **components/ag-grid:** date filter widgets use grid background and focus styles, inputs use text color ([#4713](https://github.com/blackbaud/skyux/issues/4713)) ([8464e4d](https://github.com/blackbaud/skyux/commit/8464e4d4b585d0619a417758c7de7ce53dda8e72))
+* support dark mode in fluid grid code example and visual test ([#4718](https://github.com/blackbaud/skyux/issues/4718)) ([ff67f1d](https://github.com/blackbaud/skyux/commit/ff67f1dba83cea896f5babe8437850c752d3e8bd))
 
 ## [14.16.0](https://github.com/blackbaud/skyux/compare/14.15.1...14.16.0) (2026-08-26)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@
 
 * dark mode uses new `steel-grey` color scheme ([#4706](https://github.com/blackbaud/skyux/issues/4706)) ([a0e9b74](https://github.com/blackbaud/skyux/commit/a0e9b742b4a0c861ec022715428e19cb9bd6fc30))
 
+
+### Bug Fixes
+
+* **components/ag-grid:** date filter widgets use grid background and focus styles, inputs use text color ([#4713](https://github.com/blackbaud/skyux/issues/4713)) ([8464e4d](https://github.com/blackbaud/skyux/commit/8464e4d4b585d0619a417758c7de7ce53dda8e72))
+
 ## [14.16.0](https://github.com/blackbaud/skyux/compare/14.15.1...14.16.0) (2026-08-26)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Bug Fixes
 
 * **components/ag-grid:** date filter widgets use grid background and focus styles, inputs use text color ([#4713](https://github.com/blackbaud/skyux/issues/4713)) ([8464e4d](https://github.com/blackbaud/skyux/commit/8464e4d4b585d0619a417758c7de7ce53dda8e72))
+* **components/forms:** file drop link input uses input box background color in dark mode ([#4720](https://github.com/blackbaud/skyux/issues/4720)) ([608ee91](https://github.com/blackbaud/skyux/commit/608ee911ce12109d5d29b5ff7faa5833f0c105bf))
 * support dark mode in fluid grid code example and visual test ([#4718](https://github.com/blackbaud/skyux/issues/4718)) ([ff67f1d](https://github.com/blackbaud/skyux/commit/ff67f1dba83cea896f5babe8437850c752d3e8bd))
 
 ## [14.16.0](https://github.com/blackbaud/skyux/compare/14.15.1...14.16.0) (2026-08-26)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "skyux",
-  "version": "14.16.0",
+  "version": "14.17.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "skyux",
-      "version": "14.16.0",
+      "version": "14.17.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skyux",
-  "version": "14.16.0",
+  "version": "14.17.0",
   "license": "MIT",
   "scripts": {
     "ng": "nx",


### PR DESCRIPTION
## [14.17.0](https://github.com/blackbaud/skyux/compare/14.16.0...14.17.0) (2026-08-28)


### Features

* dark mode uses new `steel-grey` color scheme ([#4706](https://github.com/blackbaud/skyux/issues/4706)) ([a0e9b74](https://github.com/blackbaud/skyux/commit/a0e9b742b4a0c861ec022715428e19cb9bd6fc30))


### Bug Fixes

* **components/ag-grid:** date filter widgets use grid background and focus styles, inputs use text color ([#4713](https://github.com/blackbaud/skyux/issues/4713)) ([8464e4d](https://github.com/blackbaud/skyux/commit/8464e4d4b585d0619a417758c7de7ce53dda8e72))
* **components/forms:** file drop link input uses input box background color in dark mode ([#4720](https://github.com/blackbaud/skyux/issues/4720)) ([608ee91](https://github.com/blackbaud/skyux/commit/608ee911ce12109d5d29b5ff7faa5833f0c105bf))
* support dark mode in fluid grid code example and visual test ([#4718](https://github.com/blackbaud/skyux/issues/4718)) ([ff67f1d](https://github.com/blackbaud/skyux/commit/ff67f1dba83cea896f5babe8437850c752d3e8bd))

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new steel-grey color scheme for dark mode.
  - Expanded dark mode support for the fluid grid example and visual testing.
- **Style**
  - Improved date filter styling in data grids.
  - Updated file drop inputs with appropriate background styling for dark mode.
- **Documentation**
  - Added release documentation for version 14.17.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->