### PR TITLE
feat: dark mode uses new `steel-grey` color scheme

### DIFF
--- a/libs/components/packages/package.json
+++ b/libs/components/packages/package.json
@@ -105,7 +105,7 @@
     "typescript": "^6.0.3"
   },
   "dependencies": {
-    "@blackbaud/skyux-design-tokens": "7.0.0-alpha.3",
+    "@blackbaud/skyux-design-tokens": "7.0.0-alpha.8",
     "fs-extra": "11.3.6",
     "jsonc-parser": "3.3.1",
     "parse5": "7.3.0",

--- a/libs/components/theme/package.json
+++ b/libs/components/theme/package.json
@@ -20,7 +20,7 @@
     "@angular/core": "^22.1.2"
   },
   "dependencies": {
-    "@blackbaud/skyux-design-tokens": "7.0.0-alpha.3",
+    "@blackbaud/skyux-design-tokens": "7.0.0-alpha.8",
     "fontfaceobserver": "2.3.0",
     "tslib": "^2.8.1"
   },

--- a/libs/sdk/skyux-eslint/package.json
+++ b/libs/sdk/skyux-eslint/package.json
@@ -33,7 +33,7 @@
     "@typescript-eslint/utils": "^8.67.0"
   },
   "dependencies": {
-    "@blackbaud/skyux-design-tokens": "7.0.0-alpha.3",
+    "@blackbaud/skyux-design-tokens": "7.0.0-alpha.8",
     "@skyux-sdk/eslint-schematics": "0.0.0-PLACEHOLDER",
     "@skyux/manifest": "0.0.0-PLACEHOLDER",
     "tslib": "^2.8.1"

--- a/libs/sdk/skyux-stylelint/package.json
+++ b/libs/sdk/skyux-stylelint/package.json
@@ -23,7 +23,7 @@
     "stylelint": "^17.14.1"
   },
   "dependencies": {
-    "@blackbaud/skyux-design-tokens": "7.0.0-alpha.3",
+    "@blackbaud/skyux-design-tokens": "7.0.0-alpha.8",
     "tslib": "^2.8.1"
   },
   "type": "module",

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@angular/platform-browser-dynamic": "22.1.2",
         "@angular/router": "22.1.2",
         "@blackbaud/angular-tree-component": "1.0.0",
-        "@blackbaud/skyux-design-tokens": "7.0.0-alpha.3",
+        "@blackbaud/skyux-design-tokens": "7.0.0-alpha.8",
         "@eslint/js": "9.39.5",
         "@nx/angular": "23.1.1",
         "@skyux/icons": "11.4.0",
@@ -6030,9 +6030,9 @@
       }
     },
     "node_modules/@blackbaud/skyux-design-tokens": {
-      "version": "7.0.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/@blackbaud/skyux-design-tokens/-/skyux-design-tokens-7.0.0-alpha.3.tgz",
-      "integrity": "sha512-1b0iDhafZ5eXpDKKaYgX7MLl3OSfDms+PWlTXrfUK8nFzIv8DNbThGPlsfOa0M3CGz9iQspgsQSpIDvco2E8SQ==",
+      "version": "7.0.0-alpha.8",
+      "resolved": "https://registry.npmjs.org/@blackbaud/skyux-design-tokens/-/skyux-design-tokens-7.0.0-alpha.8.tgz",
+      "integrity": "sha512-/yE/JX7opnRHC0L9ZwXaxlakm9HTA8lnp+7ON2n+czXRkDC8BhlkTIAJGGxyTtlLk7ow9OnAI4dcY69OeYywZw==",
       "license": "MIT",
       "engines": {
         "node": ">= 4.2.1",

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "@angular/platform-browser-dynamic": "22.1.2",
     "@angular/router": "22.1.2",
     "@blackbaud/angular-tree-component": "1.0.0",
-    "@blackbaud/skyux-design-tokens": "7.0.0-alpha.3",
+    "@blackbaud/skyux-design-tokens": "7.0.0-alpha.8",
     "@eslint/js": "9.39.5",
     "@nx/angular": "23.1.1",
     "@skyux/icons": "11.4.0",


### PR DESCRIPTION
## Summary
Forward-ports PR #4706 (merged to `14.x.x`) onto `main`. That commit bumped `@blackbaud/skyux-design-tokens` from `6.5.1` to `6.8.0` for the `steel-grey` dark-mode color scheme; cherry-picking it directly onto `main` conflicted because `main` had already moved to the `7.0.0-alpha.x` pre-release line (`7.0.0-alpha.3`) independently.

Conflicts resolved by setting `@blackbaud/skyux-design-tokens` to `7.0.0-alpha.8` (the alpha line's latest at time of this PR) across all 5 affected `package.json` files, keeping every other unrelated dependency at `main`'s current version. `7.0.0-alpha.8`'s own changelog already includes the same "steel-gray" dark-mode color update (from `7.0.0-alpha.7`) plus a light-mode color-shift revert fix on top — no breaking changes listed.

`package-lock.json` was regenerated via a clean `npm install` rather than hand-edited; the resulting diff is limited to the two `@blackbaud/skyux-design-tokens` entries.

## Test plan
- [x] `npx nx build theme` — builds successfully against `@blackbaud/skyux-design-tokens@7.0.0-alpha.8`.
- [x] Reviewed `@blackbaud/skyux-design-tokens`'s CHANGELOG between `alpha.3` and `alpha.8` — only Features/Fixes, no breaking changes.
- [ ] `npx nx test theme` (Karma/Chrome) — could not be run in this sandboxed environment (Chrome-based test runners hang at startup here); needs to run in CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the design tokens package to the latest 7.0.0 alpha release across the project.
  * Ensured components, themes, linting tools, and related packages use the same design token version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->