### PR TITLE
fix(components/ag-grid): date filter widgets use grid background and focus styles, inputs use text color (#4713)

### DIFF
--- a/libs/components/ag-grid/src/lib/modules/ag-grid/cell-editors/cell-editor-autocomplete/cell-editor-autocomplete.component.scss
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/cell-editors/cell-editor-autocomplete/cell-editor-autocomplete.component.scss
@@ -2,6 +2,7 @@ sky-autocomplete {
   input {
     background-color: transparent;
     border: none;
+    color: var(--ag-input-text-color);
     box-shadow: none;
   }
 }

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/cell-editors/cell-editor-currency/cell-editor-currency.component.scss
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/cell-editors/cell-editor-currency/cell-editor-currency.component.scss
@@ -12,6 +12,7 @@
 input {
   background-color: transparent;
   border: none;
+  color: var(--ag-input-text-color);
   height: 100%;
   width: 100%;
   padding-left: var(

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/cell-editors/cell-editor-number/cell-editor-number.component.scss
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/cell-editors/cell-editor-number/cell-editor-number.component.scss
@@ -1,5 +1,6 @@
 input {
   background-color: transparent;
   border: none;
+  color: var(--ag-input-text-color);
   text-align: right;
 }

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/cell-editors/cell-editor-text/cell-editor-text.component.scss
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/cell-editors/cell-editor-text/cell-editor-text.component.scss
@@ -13,6 +13,7 @@
 input {
   background-color: transparent;
   border: none;
+  color: var(--ag-input-text-color);
   height: 100%;
   width: 100%;
   padding-left: var(

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/column-filters/column-filter-datepicker/column-filter-datepicker.component.scss
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/column-filters/column-filter-datepicker/column-filter-datepicker.component.scss
@@ -7,6 +7,15 @@ sky-datepicker {
   width: calc(100% - var(--sky-margin-inline-xs));
 }
 
-input {
+input.sky-form-control {
   height: calc(var(--ag-header-height) - 2px);
+  background-color: var(--ag-input-background-color);
+  border: none;
+  box-shadow: inset 0 0 0 var(--ag-border-width) var(--ag-border-color);
+  color: var(--ag-input-text-color);
+
+  &:focus {
+    box-shadow: inset var(--ag-focus-shadow);
+    outline: none;
+  }
 }

--- a/libs/components/ag-grid/src/lib/styles/_base.scss
+++ b/libs/components/ag-grid/src/lib/styles/_base.scss
@@ -47,7 +47,46 @@
         appearance: none;
         border-radius: 0;
         height: calc(var(--ag-header-height) - 2px);
+
+        &:focus {
+          box-shadow: inset var(--ag-focus-shadow);
+        }
       }
+    }
+
+    .sky-input-group-datepicker-btn {
+      --sky-color-border-action-secondary-base: var(--ag-border-color);
+      border-start-start-radius: 0;
+      border-end-start-radius: 0;
+    }
+  }
+
+  .ag-filter-wrapper {
+    --ag-border-color: var(
+      --sky-override-ag-grid-filter-border-color,
+      var(--sky-color-border-input-base)
+    );
+    --ag-border-radius: var(
+      --sky-override-ag-grid-filter-border-radius,
+      var(--sky-border-radius-s)
+    );
+
+    .ag-picker-field-wrapper {
+      border-radius: var(--ag-border-radius);
+    }
+
+    .sky-datepicker .sky-input-group input.sky-form-control {
+      border-start-start-radius: var(--ag-border-radius);
+      border-end-start-radius: var(--ag-border-radius);
+    }
+
+    .sky-input-group-datepicker-btn {
+      --sky-color-background-action-secondary-base: var(
+        --ag-input-background-color
+      );
+      --sky-color-border-action-secondary-base: var(--ag-border-color);
+      border-start-start-radius: 0;
+      border-end-start-radius: 0;
     }
   }
 

--- a/libs/components/ag-grid/src/lib/styles/_overrides.scss
+++ b/libs/components/ag-grid/src/lib/styles/_overrides.scss
@@ -36,6 +36,10 @@
   );
   --sky-override-ag-grid-column-border: 1px solid
     var(--sky-border-color-neutral-medium);
+  --sky-override-ag-grid-filter-border-color: var(
+    --sky-border-color-neutral-medium
+  );
+  --sky-override-ag-grid-filter-border-radius: 3px;
   --sky-override-ag-grid-focus-border-color: var(--sky-highlight-color-info);
   --sky-override-ag-grid-focus-border-width: 2px;
   --sky-override-ag-grid-font-family:

--- a/libs/components/theme/src/lib/styles/themes/modern/_buttons.scss
+++ b/libs/components/theme/src/lib/styles/themes/modern/_buttons.scss
@@ -435,6 +435,7 @@
       background-color: var(
         --sky-color-background-action-tertiary-on_prominent-focus
       );
+      border: none;
       box-shadow:
         inset 0 0 0 var(--sky-border-width-action-focus)
           var(--sky-color-border-action-tertiary-on_prominent-focus),


### PR DESCRIPTION
:cherries: Cherry picked from #4713 [fix(components/ag-grid): date filter widgets use grid background and focus styles, inputs use text color](https://github.com/blackbaud/skyux/pull/4713)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved AG Grid cell editor text colors to follow the active theme.
  * Refined datepicker and floating-filter styling, including borders, focus states, sizing, spacing, and button alignment.
  * Added consistent filter border colors and rounded corners in the default theme.
  * Removed unwanted focus borders from prominent borderless icon buttons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->