### PR TITLE
fix: support dark mode in fluid grid code example and visual test

### DIFF
--- a/apps/e2e/layout-storybook/src/app/fluid-grid/fluid-grid.component.html
+++ b/apps/e2e/layout-storybook/src/app/fluid-grid/fluid-grid.component.html
@@ -1,61 +1,114 @@
-<div class="sky-padding-even-md sky-theme-color-classify-1-soft">
+<div class="sky-padding-even-md">
   <sky-row>
-    <sky-column [screenSmall]="4" [screenMedium]="3" [screenLarge]="2">
+    <sky-column
+      class="sky-theme-color-classify-1-soft"
+      [screenSmall]="4"
+      [screenMedium]="3"
+      [screenLarge]="2"
+    >
       small 4 medium 3 large 2
     </sky-column>
-    <sky-column [screenSmall]="4" [screenMedium]="9" [screenLarge]="8">
+    <sky-column
+      class="sky-theme-color-classify-1-soft"
+      [screenSmall]="4"
+      [screenMedium]="9"
+      [screenLarge]="8"
+    >
       small 4 medium 9 large 8
     </sky-column>
-    <sky-column [screenSmall]="4" [screenMedium]="12" [screenLarge]="2">
+    <sky-column
+      class="sky-theme-color-classify-1-soft"
+      [screenSmall]="4"
+      [screenMedium]="12"
+      [screenLarge]="2"
+    >
       small 4 medium 12 large 2
     </sky-column>
   </sky-row>
 </div>
 
-<div class="sky-padding-even-md sky-theme-color-classify-1-soft">
+<div class="sky-padding-even-md">
   <sky-row>
-    <sky-column [screenXSmall]="6"> xsmall 6 </sky-column>
-    <sky-column [screenXSmall]="6"> xsmall 6 </sky-column>
+    <sky-column class="sky-theme-color-classify-1-soft" [screenXSmall]="6">
+      xsmall 6
+    </sky-column>
+    <sky-column class="sky-theme-color-classify-1-soft" [screenXSmall]="6">
+      xsmall 6
+    </sky-column>
   </sky-row>
 </div>
 
 <h2>Fluid grid using wrapping fluid-grid component</h2>
 
-<div class="sky-padding-even-md sky-theme-color-classify-1-soft">
+<div class="sky-padding-even-md">
   <sky-fluid-grid>
     <sky-row>
-      <sky-column [screenSmall]="4" [screenMedium]="3" [screenLarge]="2">
+      <sky-column
+        class="sky-theme-color-classify-1-soft"
+        [screenSmall]="4"
+        [screenMedium]="3"
+        [screenLarge]="2"
+      >
         small 4 medium 3 large 2
       </sky-column>
-      <sky-column [screenSmall]="4" [screenMedium]="9" [screenLarge]="8">
+      <sky-column
+        class="sky-theme-color-classify-1-soft"
+        [screenSmall]="4"
+        [screenMedium]="9"
+        [screenLarge]="8"
+      >
         small 4 medium 9 large 8
       </sky-column>
-      <sky-column [screenSmall]="4" [screenMedium]="12" [screenLarge]="2">
+      <sky-column
+        class="sky-theme-color-classify-1-soft"
+        [screenSmall]="4"
+        [screenMedium]="12"
+        [screenLarge]="2"
+      >
         small 4 medium 12 large 2
       </sky-column>
     </sky-row>
   </sky-fluid-grid>
 </div>
 
-<div class="sky-padding-even-md sky-theme-color-classify-1-soft">
+<div class="sky-padding-even-md">
   <sky-fluid-grid>
     <sky-row>
-      <sky-column [screenXSmall]="6"> xsmall 6 </sky-column>
-      <sky-column [screenXSmall]="6"> xsmall 6 </sky-column>
+      <sky-column class="sky-theme-color-classify-1-soft" [screenXSmall]="6">
+        xsmall 6
+      </sky-column>
+      <sky-column class="sky-theme-color-classify-1-soft" [screenXSmall]="6">
+        xsmall 6
+      </sky-column>
     </sky-row>
   </sky-fluid-grid>
 </div>
 
-<div class="sky-padding-even-md sky-theme-color-classify-1-soft">
+<div class="sky-padding-even-md">
   <sky-fluid-grid [disableMargin]="true">
     <sky-row>
-      <sky-column [screenSmall]="4" [screenMedium]="3" [screenLarge]="2">
+      <sky-column
+        class="sky-theme-color-classify-1-soft"
+        [screenSmall]="4"
+        [screenMedium]="3"
+        [screenLarge]="2"
+      >
         small 4 medium 3 large 2 (fluid grid margin disabled)
       </sky-column>
-      <sky-column [screenSmall]="4" [screenMedium]="9" [screenLarge]="8">
+      <sky-column
+        class="sky-theme-color-classify-1-soft"
+        [screenSmall]="4"
+        [screenMedium]="9"
+        [screenLarge]="8"
+      >
         small 4 medium 9 large 8 (fluid grid margin disabled)
       </sky-column>
-      <sky-column [screenSmall]="4" [screenMedium]="12" [screenLarge]="2">
+      <sky-column
+        class="sky-theme-color-classify-1-soft"
+        [screenSmall]="4"
+        [screenMedium]="12"
+        [screenLarge]="2"
+      >
         small 4 medium 12 large 2 (fluid grid margin disabled)
       </sky-column>
     </sky-row>

--- a/apps/e2e/layout-storybook/src/app/fluid-grid/fluid-grid.component.html
+++ b/apps/e2e/layout-storybook/src/app/fluid-grid/fluid-grid.component.html
@@ -1,4 +1,4 @@
-<div class="sky-padding-even-md">
+<div class="sky-padding-even-md sky-theme-color-classify-1-soft">
   <sky-row>
     <sky-column [screenSmall]="4" [screenMedium]="3" [screenLarge]="2">
       small 4 medium 3 large 2
@@ -12,7 +12,7 @@
   </sky-row>
 </div>
 
-<div class="sky-padding-even-md">
+<div class="sky-padding-even-md sky-theme-color-classify-1-soft">
   <sky-row>
     <sky-column [screenXSmall]="6"> xsmall 6 </sky-column>
     <sky-column [screenXSmall]="6"> xsmall 6 </sky-column>
@@ -21,7 +21,7 @@
 
 <h2>Fluid grid using wrapping fluid-grid component</h2>
 
-<div class="sky-padding-even-md">
+<div class="sky-padding-even-md sky-theme-color-classify-1-soft">
   <sky-fluid-grid>
     <sky-row>
       <sky-column [screenSmall]="4" [screenMedium]="3" [screenLarge]="2">
@@ -37,7 +37,7 @@
   </sky-fluid-grid>
 </div>
 
-<div class="sky-padding-even-md">
+<div class="sky-padding-even-md sky-theme-color-classify-1-soft">
   <sky-fluid-grid>
     <sky-row>
       <sky-column [screenXSmall]="6"> xsmall 6 </sky-column>
@@ -46,7 +46,7 @@
   </sky-fluid-grid>
 </div>
 
-<div class="sky-padding-even-md">
+<div class="sky-padding-even-md sky-theme-color-classify-1-soft">
   <sky-fluid-grid [disableMargin]="true">
     <sky-row>
       <sky-column [screenSmall]="4" [screenMedium]="3" [screenLarge]="2">

--- a/apps/e2e/layout-storybook/src/app/fluid-grid/fluid-grid.component.scss
+++ b/apps/e2e/layout-storybook/src/app/fluid-grid/fluid-grid.component.scss
@@ -3,6 +3,5 @@
 }
 
 .sky-column {
-  background-color: #97eced;
-  border: 1px solid #56e0e1;
+  border: 1px solid var(--sky-theme-color-classify-1-heavy);
 }

--- a/libs/components/code-examples/src/lib/modules/layout/fluid-grid/example.component.html
+++ b/libs/components/code-examples/src/lib/modules/layout/fluid-grid/example.component.html
@@ -1,4 +1,4 @@
-<div class="highlight-columns">
+<div class="highlight-columns sky-theme-color-classify-1-soft">
   <sky-fluid-grid
     data-sky-id="fluid-grid"
     [disableMargin]="disableMargin"

--- a/libs/components/code-examples/src/lib/modules/layout/fluid-grid/example.component.ts
+++ b/libs/components/code-examples/src/lib/modules/layout/fluid-grid/example.component.ts
@@ -10,8 +10,7 @@ import { SkyFluidGridGutterSizeType, SkyFluidGridModule } from '@skyux/layout';
   styles: [
     `
       .highlight-columns .sky-column {
-        background-color: #97eced;
-        border: 1px solid #56e0e1;
+        border: 1px solid var(--sky-theme-color-classify-1-heavy);
         overflow-wrap: break-word;
       }
     `,


### PR DESCRIPTION
## Summary

- Replaces hard-coded highlight colors (`#97eced` background, `#56e0e1` border) with themed classification color tokens (`sky-theme-color-classify-1-soft` background class, `var(--sky-theme-color-classify-1-heavy)` border) so the fluid grid highlighted columns render correctly in dark mode.
- Applied to the `@skyux/code-examples` fluid grid example (rendered in docs and the `code-examples-playground` app) and the `layout-storybook` Percy visual test.
- Mirrors the fix already applied to the docs demo app in [engineeringsystem/skyux-spa-skyux-v14#79](https://github.com/engineeringsystem/skyux-spa-skyux-v14/pull/79), which explicitly called out that the code example itself still needed this separate update.

Fixes [AB#4100565](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/4100565)

## Test plan

- [x] `npx nx lint code-examples` — passes
- [x] `npx nx lint layout-storybook` — passes
- [x] `npx nx build code-examples` — passes
- [x] `npx nx build layout-storybook` — passes
- [x] `npx nx test code-examples --configuration=ci --include="**/fluid-grid/example.component.spec.ts"` — 7/7 passing, 100% coverage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated fluid-grid examples and demos with themed soft backgrounds.
  * Updated column highlights to use the theme’s heavy accent color.
  * Removed hard-coded colors and unnecessary background styling for more consistent theming.
  * Improved theme consistency across responsive and margin-disabled fluid-grid layouts.
  * Ensured column borders and highlighting adapt appropriately to the selected visual theme.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->