### PR TITLE
fix: support dark mode in fluid grid code example and visual test (#4718)

### DIFF
--- a/apps/e2e/layout-storybook/src/app/fluid-grid/fluid-grid.component.html
+++ b/apps/e2e/layout-storybook/src/app/fluid-grid/fluid-grid.component.html
@@ -1,12 +1,27 @@
 <div class="sky-padding-even-md">
   <sky-row>
-    <sky-column [screenSmall]="4" [screenMedium]="3" [screenLarge]="2">
+    <sky-column
+      class="sky-theme-color-classify-1-soft"
+      [screenSmall]="4"
+      [screenMedium]="3"
+      [screenLarge]="2"
+    >
       small 4 medium 3 large 2
     </sky-column>
-    <sky-column [screenSmall]="4" [screenMedium]="9" [screenLarge]="8">
+    <sky-column
+      class="sky-theme-color-classify-1-soft"
+      [screenSmall]="4"
+      [screenMedium]="9"
+      [screenLarge]="8"
+    >
       small 4 medium 9 large 8
     </sky-column>
-    <sky-column [screenSmall]="4" [screenMedium]="12" [screenLarge]="2">
+    <sky-column
+      class="sky-theme-color-classify-1-soft"
+      [screenSmall]="4"
+      [screenMedium]="12"
+      [screenLarge]="2"
+    >
       small 4 medium 12 large 2
     </sky-column>
   </sky-row>
@@ -14,8 +29,12 @@
 
 <div class="sky-padding-even-md">
   <sky-row>
-    <sky-column [screenXSmall]="6"> xsmall 6 </sky-column>
-    <sky-column [screenXSmall]="6"> xsmall 6 </sky-column>
+    <sky-column class="sky-theme-color-classify-1-soft" [screenXSmall]="6">
+      xsmall 6
+    </sky-column>
+    <sky-column class="sky-theme-color-classify-1-soft" [screenXSmall]="6">
+      xsmall 6
+    </sky-column>
   </sky-row>
 </div>
 
@@ -24,13 +43,28 @@
 <div class="sky-padding-even-md">
   <sky-fluid-grid>
     <sky-row>
-      <sky-column [screenSmall]="4" [screenMedium]="3" [screenLarge]="2">
+      <sky-column
+        class="sky-theme-color-classify-1-soft"
+        [screenSmall]="4"
+        [screenMedium]="3"
+        [screenLarge]="2"
+      >
         small 4 medium 3 large 2
       </sky-column>
-      <sky-column [screenSmall]="4" [screenMedium]="9" [screenLarge]="8">
+      <sky-column
+        class="sky-theme-color-classify-1-soft"
+        [screenSmall]="4"
+        [screenMedium]="9"
+        [screenLarge]="8"
+      >
         small 4 medium 9 large 8
       </sky-column>
-      <sky-column [screenSmall]="4" [screenMedium]="12" [screenLarge]="2">
+      <sky-column
+        class="sky-theme-color-classify-1-soft"
+        [screenSmall]="4"
+        [screenMedium]="12"
+        [screenLarge]="2"
+      >
         small 4 medium 12 large 2
       </sky-column>
     </sky-row>
@@ -40,8 +74,12 @@
 <div class="sky-padding-even-md">
   <sky-fluid-grid>
     <sky-row>
-      <sky-column [screenXSmall]="6"> xsmall 6 </sky-column>
-      <sky-column [screenXSmall]="6"> xsmall 6 </sky-column>
+      <sky-column class="sky-theme-color-classify-1-soft" [screenXSmall]="6">
+        xsmall 6
+      </sky-column>
+      <sky-column class="sky-theme-color-classify-1-soft" [screenXSmall]="6">
+        xsmall 6
+      </sky-column>
     </sky-row>
   </sky-fluid-grid>
 </div>
@@ -49,13 +87,28 @@
 <div class="sky-padding-even-md">
   <sky-fluid-grid [disableMargin]="true">
     <sky-row>
-      <sky-column [screenSmall]="4" [screenMedium]="3" [screenLarge]="2">
+      <sky-column
+        class="sky-theme-color-classify-1-soft"
+        [screenSmall]="4"
+        [screenMedium]="3"
+        [screenLarge]="2"
+      >
         small 4 medium 3 large 2 (fluid grid margin disabled)
       </sky-column>
-      <sky-column [screenSmall]="4" [screenMedium]="9" [screenLarge]="8">
+      <sky-column
+        class="sky-theme-color-classify-1-soft"
+        [screenSmall]="4"
+        [screenMedium]="9"
+        [screenLarge]="8"
+      >
         small 4 medium 9 large 8 (fluid grid margin disabled)
       </sky-column>
-      <sky-column [screenSmall]="4" [screenMedium]="12" [screenLarge]="2">
+      <sky-column
+        class="sky-theme-color-classify-1-soft"
+        [screenSmall]="4"
+        [screenMedium]="12"
+        [screenLarge]="2"
+      >
         small 4 medium 12 large 2 (fluid grid margin disabled)
       </sky-column>
     </sky-row>

--- a/apps/e2e/layout-storybook/src/app/fluid-grid/fluid-grid.component.scss
+++ b/apps/e2e/layout-storybook/src/app/fluid-grid/fluid-grid.component.scss
@@ -3,6 +3,5 @@
 }
 
 .sky-column {
-  background-color: #97eced;
-  border: 1px solid #56e0e1;
+  border: 1px solid var(--sky-theme-color-classify-1-heavy);
 }

--- a/libs/components/code-examples/src/lib/modules/layout/fluid-grid/example.component.html
+++ b/libs/components/code-examples/src/lib/modules/layout/fluid-grid/example.component.html
@@ -1,4 +1,4 @@
-<div class="highlight-columns">
+<div class="highlight-columns sky-theme-color-classify-1-soft">
   <sky-fluid-grid
     data-sky-id="fluid-grid"
     [disableMargin]="disableMargin"

--- a/libs/components/code-examples/src/lib/modules/layout/fluid-grid/example.component.ts
+++ b/libs/components/code-examples/src/lib/modules/layout/fluid-grid/example.component.ts
@@ -10,8 +10,7 @@ import { SkyFluidGridGutterSizeType, SkyFluidGridModule } from '@skyux/layout';
   styles: [
     `
       .highlight-columns .sky-column {
-        background-color: #97eced;
-        border: 1px solid #56e0e1;
+        border: 1px solid var(--sky-theme-color-classify-1-heavy);
         overflow-wrap: break-word;
       }
     `,


### PR DESCRIPTION
:cherries: Cherry picked from #4718 [fix: support dark mode in fluid grid code example and visual test](https://github.com/blackbaud/skyux/pull/4718)

[AB#4100565](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/4100565) 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated fluid-grid examples with theme-based classification colors.
  * Improved column border styling and removed background colors for clearer visual presentation.
  * Applied consistent styling across standard, wrapping, extra-small, and margin-disabled grid examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->