### PR TITLE
fix(components/forms): file drop link input uses input box background color in dark mode

### DIFF
--- a/libs/components/forms/src/lib/modules/file-attachment/file-drop/file-drop.component.scss
+++ b/libs/components/forms/src/lib/modules/file-attachment/file-drop/file-drop.component.scss
@@ -277,11 +277,11 @@ button.sky-file-drop {
   sky-input-box {
     --sky-comp-override-input-box-group-background-color: var(
       --sky-override-file-drop-link-input-background-color,
-      var(--bb-color-white)
+      var(--sky-color-background-input-base)
     );
     --sky-comp-override-input-box-group-background-color-focused: var(
       --sky-override-file-drop-link-input-background-color,
-      var(--bb-color-white)
+      var(--sky-color-background-input-base)
     );
 
     margin-bottom: var(


### PR DESCRIPTION
## Summary
- The "Link to a file" input in `file-attachment`/`file-drop` hardcoded its group background to `--bb-color-white` for non-default themes, so it rendered white instead of following the dark-mode-aware `--sky-color-background-input-base` token that `sky-input-box` normally uses for base and focused states.
- Swapped both fallbacks in `file-drop.component.scss` to `--sky-color-background-input-base`, matching `input-box.component.scss`'s own modern-theme rule. The legacy default theme is unaffected (still resolves to `transparent` via the existing compat override).

Fixes [AB#4102338](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/4102338).

## Test plan
- [x] `nx lint forms` — 0 errors
- [x] `nx test forms --configuration=ci` — 650/650 passing, 100% coverage
- [ ] `modern-v2-dark` Percy/Cypress baselines for the file-attachment stories with `allowLinks=true` will need re-approval since the input background visibly changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the file attachment link input background styling for normal and focused states.
  * Ensured the input uses the correct theme background color for improved visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->