### PR TITLE
chore: update library resources (#4709)

### DIFF
--- a/libs/components/ag-grid/src/assets/locales/resources_fr_CA.json
+++ b/libs/components/ag-grid/src/assets/locales/resources_fr_CA.json
@@ -37,7 +37,7 @@
   },
   "skyux_lookup_tokens_summary": {
     "_description": "Texte affiché lorsque l’utilisateur a plus que le nombre maximal d’éléments sélectionné",
-    "message": "{0} articles sélectionnés"
+    "message": "{0} éléments sélectionnés"
   },
   "sky_ag_grid_cell_editor_currency_aria_label": {
     "_description": "étiquette aria pour un éditeur de cellule de devise",
@@ -65,7 +65,7 @@
   },
   "sky_ag_grid_locale_no_rows_to_show": {
     "_description": "Remplacement du texte localisé localeText d’ag-Grid pour le message de superposition noRowsToShow affiché lorsque la grille est vide",
-    "message": "Aucune donnée disponible."
+    "message": "Aucune donnée disponible"
   },
   "sky_ag_grid_locale_no_matching_rows": {
     "_description": "Remplacement du texte localisé localeText d’ag-Grid pour le message de superposition noMatchingRows affiché lorsqu’aucune ligne ne correspond aux filtres",

--- a/libs/components/ag-grid/src/lib/modules/shared/sky-ag-grid-resources.module.ts
+++ b/libs/components/ag-grid/src/lib/modules/shared/sky-ag-grid-resources.module.ts
@@ -90,7 +90,7 @@ const RESOURCES: Record<string, SkyLibResources> = {
     sky_ag_grid_cell_renderer_currency_validator_message: {
       message: 'Entrez une devise valide.',
     },
-    skyux_lookup_tokens_summary: { message: '{0} articles sélectionnés' },
+    skyux_lookup_tokens_summary: { message: '{0} éléments sélectionnés' },
     sky_ag_grid_cell_editor_currency_aria_label: {
       message: 'Devise modifiable {0} pour la ligne {1}',
     },
@@ -109,9 +109,7 @@ const RESOURCES: Record<string, SkyLibResources> = {
     sky_ag_grid_column_group_header_collapse_aria_label: {
       message: 'Réduire le groupe de colonnes {0}',
     },
-    sky_ag_grid_locale_no_rows_to_show: {
-      message: 'Aucune donnée disponible.',
-    },
+    sky_ag_grid_locale_no_rows_to_show: { message: 'Aucune donnée disponible' },
     sky_ag_grid_locale_no_matching_rows: {
       message: 'Aucune ligne correspondante',
     },

--- a/libs/components/charts/src/assets/locales/resources_fr_CA.json
+++ b/libs/components/charts/src/assets/locales/resources_fr_CA.json
@@ -1,7 +1,7 @@
 {
   "skyux_charts.chart.bar.accessible_summary": {
     "_description": "Le résumé accessible annoncé pour une figure de graphique à barres, décrivant sa forme et indiquant qu’un tableau de données est disponible comme solution de rechange",
-    "message": "Graphique à barres Nombre de séries : {0}. Nombre de catégories : {1}. Un tableau de données est disponible dans le menu du contexte du graphique.",
+    "message": "Graphique à barres. Nombre de séries : {0}. Nombre de catégories : {1}. Un tableau de données est disponible dans le menu du contexte du graphique.",
     "_0": "Le nombre de séries",
     "_1": "Le nombre de catégories"
   },

--- a/libs/components/charts/src/lib/shared/sky-charts-resources.module.ts
+++ b/libs/components/charts/src/lib/shared/sky-charts-resources.module.ts
@@ -33,7 +33,7 @@ const RESOURCES: Record<string, SkyLibResources> = {
   'FR-CA': {
     'skyux_charts.chart.bar.accessible_summary': {
       message:
-        'Graphique à barres Nombre de séries : {0}. Nombre de catégories : {1}. Un tableau de données est disponible dans le menu du contexte du graphique.',
+        'Graphique à barres. Nombre de séries : {0}. Nombre de catégories : {1}. Un tableau de données est disponible dans le menu du contexte du graphique.',
     },
     'skyux_charts.chart.controls.context_menu.accessible_name': {
       message: 'Menu du contexte pour {0}',

--- a/libs/components/datetime/src/assets/locales/resources_fr_CA.json
+++ b/libs/components/datetime/src/assets/locales/resources_fr_CA.json
@@ -149,7 +149,7 @@
   },
   "skyux_date_range_picker_end_date_label": {
     "_description": "L’étiquette pour le type de format Plage spécifique du sélectionneur de la seconde date.",
-    "message": "À ce jour"
+    "message": "Jusqu'à la date du"
   },
   "skyux_date_range_picker_before_date_label": {
     "_description": "L’étiquette pour le type de format du champ Avant du sélecteur de plage de dates.",

--- a/libs/components/datetime/src/lib/modules/shared/sky-datetime-resources.module.ts
+++ b/libs/components/datetime/src/lib/modules/shared/sky-datetime-resources.module.ts
@@ -202,7 +202,7 @@ const RESOURCES: Record<string, SkyLibResources> = {
     skyux_date_range_picker_start_date_label: {
       message: 'À partir de la date du',
     },
-    skyux_date_range_picker_end_date_label: { message: 'À ce jour' },
+    skyux_date_range_picker_end_date_label: { message: "Jusqu'à la date du" },
     skyux_date_range_picker_before_date_label: { message: 'Date avant' },
     skyux_date_range_picker_after_date_label: { message: 'Date après' },
     skyux_date_range_picker_default_aria_label: { message: '{0} pour {1}' },

--- a/libs/components/lookup/src/assets/locales/resources_fr_CA.json
+++ b/libs/components/lookup/src/assets/locales/resources_fr_CA.json
@@ -93,7 +93,7 @@
   },
   "skyux_lookup_tokens_summary": {
     "_description": "Texte affiché lorsque l’utilisateur a plus que le nombre maximal d’éléments sélectionné",
-    "message": "{0} articles sélectionnés"
+    "message": "{0} éléments sélectionnés"
   },
   "skyux_search_aria_label_descriptor": {
     "_description": "Étiquette aria par défaut pour une recherche lorsqu’un descripteur est donné",

--- a/libs/components/lookup/src/lib/modules/shared/sky-lookup-resources.module.ts
+++ b/libs/components/lookup/src/lib/modules/shared/sky-lookup-resources.module.ts
@@ -101,7 +101,7 @@ const RESOURCES: Record<string, SkyLibResources> = {
     },
     skyux_lookup_show_more_select: { message: 'Sélectionner' },
     skyux_lookup_show_more_select_context: { message: 'Sélectionner {0}' },
-    skyux_lookup_tokens_summary: { message: '{0} articles sélectionnés' },
+    skyux_lookup_tokens_summary: { message: '{0} éléments sélectionnés' },
     skyux_search_aria_label_descriptor: { message: 'Rechercher {0}' },
     skyux_search_dismiss: { message: 'Omettre la recherche' },
     skyux_search_label: { message: 'Rechercher des articles' },

--- a/libs/components/modals/src/assets/locales/resources_fr_CA.json
+++ b/libs/components/modals/src/assets/locales/resources_fr_CA.json
@@ -16,8 +16,8 @@
     "message": "Annuler"
   },
   "skyux_modal_close": {
-    "_description": "Texte du bouton modal de fermeture",
-    "message": "Fermer la fenêtre"
+    "_description": "Texte du bouton de fermeture de la boîte de dialogue",
+    "message": "Fermer la boîte de dialogue"
   },
   "skyux_modal_open_help": {
     "_description": "Texte du bouton de l’en-tête modal Ouvrir l’aide",
@@ -33,14 +33,14 @@
   },
   "skyux_modal_dirty_default_message": {
     "_description": "Message d’invite par défaut lors de la fermeture d’un élément modal marqué comme étant souillé.",
-    "message": "Êtes-vous certain de vouloir supprimer ces changements?"
+    "message": "Êtes-vous certain de vouloir abandonner ces modifications?"
   },
   "skyux_modal_dirty_default_discard_changes_text": {
-    "_description": "Texte par défaut pour le bouton « Supprimer les changements » lors de la fermeture d’un élément modal marqué comme étant souillé.",
-    "message": "Supprimer les changements"
+    "_description": "Texte par défaut pour le bouton « Abandonner les modifications » lors de la fermeture d’un élément modal marqué comme étant souillé.",
+    "message": "Abandonner les modifications"
   },
   "skyux_modal_dirty_default_keep_working_text": {
-    "_description": "Texte par défaut pour le bouton « Continuer à travailler » lors de la fermeture d’un élément modal marqué comme étant souillé.",
-    "message": "Continuer à travailler"
+    "_description": "Texte par défaut pour le bouton « Continuer la modification » lors de la fermeture d’un élément modal marqué comme étant souillé.",
+    "message": "Continuer la modification"
   }
 }

--- a/libs/components/modals/src/lib/modules/shared/sky-modals-resources.module.ts
+++ b/libs/components/modals/src/lib/modules/shared/sky-modals-resources.module.ts
@@ -36,18 +36,18 @@ const RESOURCES: Record<string, SkyLibResources> = {
     skyux_confirm_dialog_default_yes_text: { message: 'Oui' },
     skyux_confirm_dialog_default_no_text: { message: 'Non' },
     skyux_confirm_dialog_default_cancel_text: { message: 'Annuler' },
-    skyux_modal_close: { message: 'Fermer la fenêtre' },
+    skyux_modal_close: { message: 'Fermer la boîte de dialogue' },
     skyux_modal_open_help: { message: 'Ouvrir l’aide' },
     skyux_modal_footer_cancel_button: { message: 'Annuler' },
     skyux_modal_footer_primary_button: { message: 'Sauvegarder' },
     skyux_modal_dirty_default_message: {
-      message: 'Êtes-vous certain de vouloir supprimer ces changements?',
+      message: 'Êtes-vous certain de vouloir abandonner ces modifications?',
     },
     skyux_modal_dirty_default_discard_changes_text: {
-      message: 'Supprimer les changements',
+      message: 'Abandonner les modifications',
     },
     skyux_modal_dirty_default_keep_working_text: {
-      message: 'Continuer à travailler',
+      message: 'Continuer la modification',
     },
   },
 };

--- a/libs/components/text-editor/src/assets/locales/resources_fr_CA.json
+++ b/libs/components/text-editor/src/assets/locales/resources_fr_CA.json
@@ -117,7 +117,7 @@
   },
   "skyux_text_editor_url_modal_open_in_new_window_label": {
     "_description": "Texte pour le texte en retrait sous la zone de saisie de l’URL dans l’élément modal de l’URL",
-    "message": "Ce lien s’ouvrira dans une nouvelle fenêtre"
+    "message": "Ce lien s’ouvrira dans une nouvelle fenêtre."
   },
   "skyux_text_editor_url_modal_new_option_label": {
     "_description": "Texte pour l’étiquette optionnelle « Nouvelle fenêtre » dans l’élément modal de l’URL",

--- a/libs/components/text-editor/src/lib/modules/shared/sky-text-editor-resources.module.ts
+++ b/libs/components/text-editor/src/lib/modules/shared/sky-text-editor-resources.module.ts
@@ -148,7 +148,7 @@ const RESOURCES: Record<string, SkyLibResources> = {
       message: 'Fenêtre actuelle',
     },
     skyux_text_editor_url_modal_open_in_new_window_label: {
-      message: 'Ce lien s’ouvrira dans une nouvelle fenêtre',
+      message: 'Ce lien s’ouvrira dans une nouvelle fenêtre.',
     },
     skyux_text_editor_url_modal_new_option_label: {
       message: 'Nouvelle fenêtre',

--- a/libs/components/toast/src/assets/locales/resources_fr_CA.json
+++ b/libs/components/toast/src/assets/locales/resources_fr_CA.json
@@ -1,7 +1,7 @@
 {
   "skyux_toast_close_button_aria_label": {
     "_description": "Texte du lecteur d’écran du bouton fermer sur des messages transitoires",
-    "message": "Message de fermeture :"
+    "message": "Fermer le message"
   },
   "skyux_toast_close_button_title": {
     "_description": "Texte de l’infobulle du bouton fermer sur des messages transitoires",

--- a/libs/components/toast/src/lib/modules/shared/sky-toast-resources.module.ts
+++ b/libs/components/toast/src/lib/modules/shared/sky-toast-resources.module.ts
@@ -19,7 +19,7 @@ const RESOURCES: Record<string, SkyLibResources> = {
     skyux_toast_close_button_title: { message: 'Close the message' },
   },
   'FR-CA': {
-    skyux_toast_close_button_aria_label: { message: 'Message de fermeture :' },
+    skyux_toast_close_button_aria_label: { message: 'Fermer le message' },
     skyux_toast_close_button_title: { message: 'Fermer le message' },
   },
 };


### PR DESCRIPTION
:cherries: Cherry picked from #4709 [chore: update library resources](https://github.com/blackbaud/skyux/pull/4709)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization**
  * Updated Canadian French translations across grids, lookups, date pickers, modals, text editors, and notifications.
  * Improved terminology for selected items, date-range labels, modal actions, and toast close controls.
  * Standardized punctuation and wording in empty-state, chart, and link-opening messages.
* **Accessibility**
  * Refined French Canadian screen-reader labels and accessible chart summaries for clearer announcements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->