### PR TITLE
fix(components/forms): remove reference to character counter component in the input box `characterLimit` docs

### DIFF
--- a/libs/components/forms/src/lib/modules/input-box/input-box.component.ts
+++ b/libs/components/forms/src/lib/modules/input-box/input-box.component.ts
@@ -101,14 +101,9 @@ export class SkyInputBoxComponent
   public labelText: string | undefined;
 
   /**
-   * The number of characters a value may contain before the input box's form control becomes
-   * invalid. This property displays a character count beside the input box label and adds
-   * [`Validators.maxLength`](https://angular.dev/api/forms/Validators) to the input's form
-   * control; it does not stop users from typing past the limit. Don't use it with inputs where
-   * users are unlikely to exceed character limits. Instead, use `Validators.maxLength` directly
-   * along with a `maxlength` attribute on the input element to handle maximum length validation.
-   * The validation error message and the screen reader announcement of the count require
-   * `labelText`.
+   * This property displays a character count indicator in the top right of the input field to
+   * indicate the number of characters that users enter, the character limit, and a danger
+   * icon if users exceed the limit.
    */
   @Input()
   public set characterLimit(value: NumberInput) {

--- a/libs/components/forms/src/lib/modules/input-box/input-box.component.ts
+++ b/libs/components/forms/src/lib/modules/input-box/input-box.component.ts
@@ -101,13 +101,14 @@ export class SkyInputBoxComponent
   public labelText: string | undefined;
 
   /**
-   * The maximum number of characters to allow in the input box. This property displays a
-   * character count beside the input box label and adds
-   * [Angular's max length validator](https://angular.io/api/forms/MaxLengthValidator) to the
-   * input's form control, so don't use it with inputs where users are unlikely to exceed
-   * character limits. Instead, use the max length validator directly along with a `maxLength`
-   * attribute on the input element to handle maximum length validation. The validation error
-   * message and the screen reader announcement of the count require `labelText`.
+   * The number of characters a value may contain before the input box's form control becomes
+   * invalid. This property displays a character count beside the input box label and adds
+   * [`Validators.maxLength`](https://angular.dev/api/forms/Validators) to the input's form
+   * control; it does not stop users from typing past the limit. Don't use it with inputs where
+   * users are unlikely to exceed character limits. Instead, use `Validators.maxLength` directly
+   * along with a `maxlength` attribute on the input element to handle maximum length validation.
+   * The validation error message and the screen reader announcement of the count require
+   * `labelText`.
    */
   @Input()
   public set characterLimit(value: NumberInput) {

--- a/libs/components/forms/src/lib/modules/input-box/input-box.component.ts
+++ b/libs/components/forms/src/lib/modules/input-box/input-box.component.ts
@@ -101,9 +101,13 @@ export class SkyInputBoxComponent
   public labelText: string | undefined;
 
   /**
-   * This property displays a character count indicator in the top right of the input field to
-   * indicate the number of characters that users enter, the character limit, and a danger
-   * icon if users exceed the limit.
+   * The character limit for the input box. If users exceed the limit, the input box's form control
+   * becomes invalid and the property adds [Validators.maxLength](https://angular.dev/api/forms/Validators).
+   * The validation error message and screen reader announcement use `labelText`. This property also
+   * displays a character count indicator in the top right with the number of characters that users enter,
+   * the character limit, and a danger icon if users exceed the limit. If users are unlikely to exceed a
+   * character limit, use `Validators.maxLength` directly instead with a `maxLength` attribute on the
+   * input element.
    */
   @Input()
   public set characterLimit(value: NumberInput) {

--- a/libs/components/forms/src/lib/modules/input-box/input-box.component.ts
+++ b/libs/components/forms/src/lib/modules/input-box/input-box.component.ts
@@ -101,13 +101,13 @@ export class SkyInputBoxComponent
   public labelText: string | undefined;
 
   /**
-   * The maximum number of characters to allow in the input box. This property places a
-   * [SKY UX character count](https://developer.blackbaud.com/skyux/components/character-count)
-   * on the input element with the appropriate validator, so don't use it with inputs where
-   * users are unlikely to exceed character limits. Instead, use
-   * [Angular's max length validator](https://angular.io/api/forms/MaxLengthValidator) and a
-   * `maxLength` attribute on the input element to handle maximum length validation.
-   *
+   * The maximum number of characters to allow in the input box. This property displays a
+   * character count beside the input box label and adds
+   * [Angular's max length validator](https://angular.io/api/forms/MaxLengthValidator) to the
+   * input's form control, so don't use it with inputs where users are unlikely to exceed
+   * character limits. Instead, use the max length validator directly along with a `maxLength`
+   * attribute on the input element to handle maximum length validation. The validation error
+   * message and the screen reader announcement of the count require `labelText`.
    */
   @Input()
   public set characterLimit(value: NumberInput) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that `characterLimit` uses Angular maximum-length validation and displays a character count beside the label.
  * Documented count-indicator placement and behavior when the limit is exceeded.
  * Explained that users may type beyond the limit unless the separate `maxlength` attribute is applied.
  * Noted that validation messages and screen-reader announcements use the label text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->