### PR TITLE
feat(components/theme): darken action links on hover/active in modern theme

### DIFF
--- a/libs/components/popovers/src/lib/modules/dropdown/dropdown-item.component.scss
+++ b/libs/components/popovers/src/lib/modules/dropdown/dropdown-item.component.scss
@@ -180,8 +180,10 @@
     // component's own (0,1,1) color rule, since ViewEncapsulation.None means
     // no attribute-selector boost applies here. Nesting under this
     // already-modern-scoped mixin raises this to (0,3,1), safely above it.
-    & > a:hover,
-    & > a:active {
+    // :not([disabled]) keeps this from also outranking the disabled-state
+    // color rule below, which must keep winning for disabled items.
+    & > a:hover:not([disabled]),
+    & > a:active:not([disabled]) {
       color: var(
         --sky-override-dropdown-item-color-text,
         var(--sky-color-text-default)

--- a/libs/components/popovers/src/lib/modules/dropdown/dropdown-item.component.scss
+++ b/libs/components/popovers/src/lib/modules/dropdown/dropdown-item.component.scss
@@ -175,13 +175,16 @@
       outline: none;
     }
 
-    // Explicit pin, not a tie: without this, the global .sky-theme-modern
-    // a:hover/:active rule (specificity (0,2,1)) unconditionally beats this
+    // Explicit pin: without this, the global .sky-theme-modern
+    // a:hover/:active rule (specificity (0,3,1)) unconditionally beats this
     // component's own (0,1,1) color rule, since ViewEncapsulation.None means
     // no attribute-selector boost applies here. Nesting under this
-    // already-modern-scoped mixin raises this to (0,3,1), safely above it.
-    // :not([disabled]) keeps this from also outranking the disabled-state
-    // color rule below, which must keep winning for disabled items.
+    // already-modern-scoped mixin raises this to (0,4,1), safely above it.
+    // :not([disabled]) excludes disabled anchors entirely rather than
+    // competing with the disabled-state color rule below — on a disabled
+    // anchor, that rule (0,3,1) and the global rule (0,3,1, since disabled
+    // dropdown items aren't .sky-btn-styled) are an exact tie resolved by
+    // stylesheet injection order, which today resolves correctly.
     & > a:hover:not([disabled]),
     & > a:active:not([disabled]) {
       color: var(

--- a/libs/components/popovers/src/lib/modules/dropdown/dropdown-item.component.scss
+++ b/libs/components/popovers/src/lib/modules/dropdown/dropdown-item.component.scss
@@ -174,5 +174,18 @@
     & > button {
       outline: none;
     }
+
+    // Explicit pin, not a tie: without this, the global .sky-theme-modern
+    // a:hover/:active rule (specificity (0,2,1)) unconditionally beats this
+    // component's own (0,1,1) color rule, since ViewEncapsulation.None means
+    // no attribute-selector boost applies here. Nesting under this
+    // already-modern-scoped mixin raises this to (0,3,1), safely above it.
+    & > a:hover,
+    & > a:active {
+      color: var(
+        --sky-override-dropdown-item-color-text,
+        var(--sky-color-text-default)
+      );
+    }
   }
 }

--- a/libs/components/popovers/src/lib/modules/dropdown/dropdown-item.component.scss
+++ b/libs/components/popovers/src/lib/modules/dropdown/dropdown-item.component.scss
@@ -181,15 +181,27 @@
     // no attribute-selector boost applies here. Nesting under this
     // already-modern-scoped mixin raises this to (0,4,1), safely above it.
     // :not([disabled]) excludes disabled anchors entirely rather than
-    // competing with the disabled-state color rule below — on a disabled
-    // anchor, that rule (0,3,1) and the global rule (0,3,1, since disabled
-    // dropdown items aren't .sky-btn-styled) are an exact tie resolved by
-    // stylesheet injection order, which today resolves correctly.
+    // competing with the disabled-state color rule — that rule is pinned
+    // separately below instead of relying on stylesheet order.
     & > a:hover:not([disabled]),
     & > a:active:not([disabled]) {
       color: var(
         --sky-override-dropdown-item-color-text,
         var(--sky-color-text-default)
+      );
+    }
+
+    // Same reasoning as above, but for the disabled color: the shared
+    // .sky-dropdown-item > a[disabled]:hover rule (0,3,1, unscoped to
+    // .sky-theme-modern) previously tied the global rule's specificity
+    // exactly, so which one won depended on stylesheet injection order.
+    // Nesting under this mixin raises it to (0,4,1), guaranteeing the
+    // disabled color wins regardless of order.
+    & > a[disabled]:hover,
+    & > a[disabled]:active {
+      color: var(
+        --sky-override-dropdown-item-disabled-color-text,
+        var(--sky-color-text-deemphasized)
       );
     }
   }

--- a/libs/components/tabs/src/lib/modules/vertical-tabset/vertical-tab.component.scss
+++ b/libs/components/tabs/src/lib/modules/vertical-tabset/vertical-tab.component.scss
@@ -44,6 +44,7 @@
     font-weight: var(--sky-font-style-emphasized);
 
     &:hover {
+      color: var(--sky-color-text-selected);
       text-decoration-line: var(
         --sky-override-vertical-tab-active-text-decoration,
         var(
@@ -54,6 +55,7 @@
     }
 
     &:active {
+      color: var(--sky-color-text-selected);
       text-decoration-line: var(
         --sky-override-vertical-tab-active-text-decoration,
         var(

--- a/libs/components/theme/src/lib/styles/themes/modern/_buttons.scss
+++ b/libs/components/theme/src/lib/styles/themes/modern/_buttons.scss
@@ -554,7 +554,7 @@
 
     &:hover,
     &:active {
-      color: var(--sky-color-text-action);
+      color: var(--sky-color-text-action_contrast);
     }
 
     &.sky-btn-disabled,

--- a/libs/components/theme/src/lib/styles/themes/modern/_theme.scss
+++ b/libs/components/theme/src/lib/styles/themes/modern/_theme.scss
@@ -41,7 +41,6 @@ body.sky-theme-modern {
     text-decoration-thickness: var(--sky-size-text_underline-thickness);
 
     &:hover {
-      color: var(--sky-color-text-action_contrast);
       text-decoration-line: var(
         --sky-comp-override-inline-link-text-decoration-line-hover,
         var(--sky-font-text_decoration-inline_link-hover)
@@ -49,11 +48,22 @@ body.sky-theme-modern {
     }
 
     &:active {
-      color: var(--sky-color-text-action_contrast);
       text-decoration-line: var(
         --sky-comp-override-inline-link-text-decoration-line-active,
         var(--sky-font-text_decoration-inline_link-active)
       );
+    }
+
+    // Excludes anchors styled as buttons (.sky-btn-default/-primary/-danger/
+    // -borderless/-link/-link-inline, and anything else carrying the base
+    // .sky-btn marker class) — those already own their own color at every
+    // state via their own rules; this rule is only for genuine inline links.
+    &:hover:not(.sky-btn) {
+      color: var(--sky-color-text-action_contrast);
+    }
+
+    &:active:not(.sky-btn) {
+      color: var(--sky-color-text-action_contrast);
     }
 
     &:focus-visible:not(:active) {

--- a/libs/components/theme/src/lib/styles/themes/modern/_theme.scss
+++ b/libs/components/theme/src/lib/styles/themes/modern/_theme.scss
@@ -41,6 +41,7 @@ body.sky-theme-modern {
     text-decoration-thickness: var(--sky-size-text_underline-thickness);
 
     &:hover {
+      color: var(--sky-color-text-action_contrast);
       text-decoration-line: var(
         --sky-comp-override-inline-link-text-decoration-line-hover,
         var(--sky-font-text_decoration-inline_link-hover)
@@ -48,6 +49,7 @@ body.sky-theme-modern {
     }
 
     &:active {
+      color: var(--sky-color-text-action_contrast);
       text-decoration-line: var(
         --sky-comp-override-inline-link-text-decoration-line-active,
         var(--sky-font-text_decoration-inline_link-active)


### PR DESCRIPTION
## Summary

In modern theme, plain `<a>` tags and `.sky-btn-link-inline` elements now change text color to `--sky-color-text-action_contrast` on `:hover` and `:active`, previously unchanged from the base `--sky-color-text-action` color. Base state and `:focus` state colors are untouched. Default theme is untouched. `.sky-btn-link` is explicitly excluded — its color never changes as part of this work.

Built on top of #4729 (dark mode underline scope) — this branch was staged on `claude/ado-4059378` until that PR merged, then rebased onto post-merge `14.x.x`.

Key points:
- **Global rule changes**: `.sky-theme-modern a` gets a new `:hover`/`:active` color declaration; `.sky-btn-link-inline`'s existing (previously no-op) `:hover`/`:active` color declaration is updated to the new token.
- **`.sky-btn` exclusion**: the global `a` color rule explicitly excludes any anchor also carrying the `.sky-btn` class (`:not(.sky-btn)`), so anchor-rendered buttons (`.sky-btn-default`, `.sky-btn-primary`, `.sky-btn-danger`, `.sky-btn-borderless`, `action-button`, and `.sky-btn-link`) keep their own color at every state, unaffected by this change — this was a real regression caught during final review, not an incidental side effect.
- **Two component-level regression fixes**, both following the same pattern (an explicit color pin at sufficient specificity to survive the new global rule): the selected vertical tab (`vertical-tab.component.scss`) and dropdown-item links (`dropdown-item.component.scss`, also guarded against overreaching into the disabled state).
- A full-codebase audit (run twice, independently) found no other component needs a similar fix — everything else either already uses the target token, never displayed the action-blue color to begin with, or survives via specificity/encapsulation margins that were independently re-verified.
- Manually verified in a live Storybook (modern, dark theme): anchor-rendered `.sky-btn-primary` stays fixed on hover; `.sky-btn-link-inline` correctly darkens; `.sky-btn-link` stays fixed, confirming the exclusion.

## Test plan

- [x] All 4 plan tasks implemented, tested, and reviewed (task-scoped code review after each).
- [x] Final whole-branch review found 1 Critical + 2 Important findings (the `.sky-btn` exclusion gap, a disabled-state overreach, and stale report documentation) — all fixed in one wave and independently re-reviewed clean.
- [x] Per-project unit tests (`theme`, `tabs`, `popovers`) passed before and after rebasing onto `14.x.x`.
- [x] Manual browser verification of the three highest-risk hover-color behaviors (button-styled anchor unaffected, `.sky-btn-link-inline` changes, `.sky-btn-link` unaffected) in modern/dark theme.
- [ ] Recommend confirming a green CI run, given the local environment's known Nx-affected aggregate-run flakiness (unrelated to this branch's changes — documented in prior work on this same theme area).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Improved modern-theme color consistency for dropdown links, vertical tabs, and inline links during hover and active states.
  - Disabled dropdown links now retain their configured disabled text color across stylesheet ordering.
  - Selected vertical tabs preserve their selected text color during hover and active states.
  - Inline links and inline link buttons use higher-contrast action text colors for improved readability.
  - Preserved distinct styling for specially marked button elements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->