### PR TITLE
chore: update design-tokens to 6.10.0

### DIFF
--- a/libs/components/packages/package.json
+++ b/libs/components/packages/package.json
@@ -107,7 +107,7 @@
     "@angular/core": "^21.2.0"
   },
   "dependencies": {
-    "@blackbaud/skyux-design-tokens": "6.9.0",
+    "@blackbaud/skyux-design-tokens": "6.10.0",
     "fs-extra": "11.3.4",
     "jsonc-parser": "3.3.1",
     "parse5": "7.3.0",

--- a/libs/components/theme/package.json
+++ b/libs/components/theme/package.json
@@ -20,7 +20,7 @@
     "@angular/core": "^21.2.0"
   },
   "dependencies": {
-    "@blackbaud/skyux-design-tokens": "6.9.0",
+    "@blackbaud/skyux-design-tokens": "6.10.0",
     "fontfaceobserver": "2.3.0",
     "tslib": "^2.8.1"
   },

--- a/libs/sdk/skyux-eslint/package.json
+++ b/libs/sdk/skyux-eslint/package.json
@@ -33,7 +33,7 @@
     "@typescript-eslint/utils": "^8.56.1"
   },
   "dependencies": {
-    "@blackbaud/skyux-design-tokens": "6.9.0",
+    "@blackbaud/skyux-design-tokens": "6.10.0",
     "@skyux-sdk/eslint-schematics": "0.0.0-PLACEHOLDER",
     "@skyux/manifest": "0.0.0-PLACEHOLDER",
     "tslib": "^2.8.1"

--- a/libs/sdk/skyux-stylelint/package.json
+++ b/libs/sdk/skyux-stylelint/package.json
@@ -23,7 +23,7 @@
     "stylelint": "^17.14.1"
   },
   "dependencies": {
-    "@blackbaud/skyux-design-tokens": "6.9.0",
+    "@blackbaud/skyux-design-tokens": "6.10.0",
     "tslib": "^2.8.1"
   },
   "type": "module",

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@angular/platform-browser-dynamic": "21.2.0",
         "@angular/router": "21.2.0",
         "@blackbaud/angular-tree-component": "1.0.0",
-        "@blackbaud/skyux-design-tokens": "6.9.0",
+        "@blackbaud/skyux-design-tokens": "6.10.0",
         "@eslint/js": "9.39.3",
         "@nx/angular": "22.5.3",
         "@skyux/icons": "10.4.0",
@@ -3287,9 +3287,9 @@
       }
     },
     "node_modules/@blackbaud/skyux-design-tokens": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/@blackbaud/skyux-design-tokens/-/skyux-design-tokens-6.9.0.tgz",
-      "integrity": "sha512-ScfnJx18Y7eMfw6t2mlfftBZdfVo6ryieOY8uuPH/2+VpLL9a4TjCh+WpZjZg46sGEjXEhCxpreWEztnqz6zIA==",
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@blackbaud/skyux-design-tokens/-/skyux-design-tokens-6.10.0.tgz",
+      "integrity": "sha512-WJXYOzLW7qiugQYTcV/jHIhNZ1yxh3YFZb0G+3V5RysoISHCJ+tH0GPWYpYOIEiS92aZgzeKmb7sSKCKMS2fCw==",
       "license": "MIT",
       "engines": {
         "node": ">= 4.2.1",

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "@angular/platform-browser-dynamic": "21.2.0",
     "@angular/router": "21.2.0",
     "@blackbaud/angular-tree-component": "1.0.0",
-    "@blackbaud/skyux-design-tokens": "6.9.0",
+    "@blackbaud/skyux-design-tokens": "6.10.0",
     "@eslint/js": "9.39.3",
     "@nx/angular": "22.5.3",
     "@skyux/icons": "10.4.0",


### PR DESCRIPTION
## Summary
- Bumps `@blackbaud/skyux-design-tokens` from `6.9.0` to `6.10.0` across all workspace `package.json` files and `package-lock.json`

## Test plan
- CI build checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the design token resources to the latest available release across shared components, themes, and development tooling.
  * Maintains consistent styling foundations and compatibility across the broader design system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->