### PR TITLE
fix(components/avatar): use correct background colors (#4727)

### DIFF
--- a/libs/components/avatar/src/lib/modules/avatar/avatar.inner.component.scss
+++ b/libs/components/avatar/src/lib/modules/avatar/avatar.inner.component.scss
@@ -2,6 +2,27 @@
 @use 'libs/components/theme/src/lib/styles/variables' as *;
 @use 'libs/components/theme/src/lib/styles/compat-tokens-mixins' as compatMixins;
 
+// modern theme avatar colors are out of chronological order to match the historical order
+$sky-avatar-colors: (
+  var(--sky-theme-color-classify-6-soft),
+  var(--sky-theme-color-classify-1-soft),
+  var(--sky-theme-color-classify-2-soft),
+  var(--sky-theme-color-classify-4-soft),
+  var(--sky-theme-color-classify-3-soft),
+  var(--sky-theme-color-classify-5-soft),
+  var(--sky-theme-color-classify-7-soft)
+);
+
+$sky-avatar-colors-default: (
+  var(--sky-category-color-green),
+  var(--sky-category-color-teal),
+  var(--sky-category-color-purple),
+  var(--sky-category-color-orange),
+  var(--sky-category-color-blue),
+  var(--sky-category-color-yellow),
+  var(--sky-category-color-red)
+);
+
 @include compatMixins.sky-default-overrides('.sky-avatar') {
   $avatar-border-width: 2px;
   $avatar-size-large: 100px;
@@ -48,18 +69,13 @@
     ($avatar-border-width * 2)};
   --sky-override-avatar-wrapper-width-sm: #{$avatar-size-small +
     ($avatar-border-width * 2)};
-}
 
-// begin avatar colors
-$sky-avatar-colors: (
-  var(--sky-category-color-green),
-  var(--sky-category-color-teal),
-  var(--sky-category-color-purple),
-  var(--sky-category-color-orange),
-  var(--sky-category-color-blue),
-  var(--sky-category-color-yellow),
-  var(--sky-category-color-red)
-);
+  @for $i from 1 through list.length($sky-avatar-colors-default) {
+    .sky-avatar-colors-#{$i} {
+      background-color: list.nth($sky-avatar-colors-default, $i);
+    }
+  }
+}
 
 @for $i from 1 through list.length($sky-avatar-colors) {
   .sky-avatar-colors-#{$i} {


### PR DESCRIPTION
:cherries: Cherry picked from #4727 [fix(components/avatar): use correct background colors](https://github.com/blackbaud/skyux/pull/4727)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated avatar color styling to distinguish modern theme colors from default-theme compatibility colors.
  * Preserved historical color ordering for modern avatar color classes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->