### PR TITLE
feat(components/theme): darken action links on hover/active in modern theme (#4738)

### DIFF
--- a/libs/components/popovers/src/lib/modules/dropdown/dropdown-item.component.scss
+++ b/libs/components/popovers/src/lib/modules/dropdown/dropdown-item.component.scss
@@ -174,5 +174,35 @@
     & > button {
       outline: none;
     }
+
+    // Explicit pin: without this, the global .sky-theme-modern
+    // a:hover/:active rule (specificity (0,3,1)) unconditionally beats this
+    // component's own (0,1,1) color rule, since ViewEncapsulation.None means
+    // no attribute-selector boost applies here. Nesting under this
+    // already-modern-scoped mixin raises this to (0,4,1), safely above it.
+    // :not([disabled]) excludes disabled anchors entirely rather than
+    // competing with the disabled-state color rule — that rule is pinned
+    // separately below instead of relying on stylesheet order.
+    & > a:hover:not([disabled]),
+    & > a:active:not([disabled]) {
+      color: var(
+        --sky-override-dropdown-item-color-text,
+        var(--sky-color-text-default)
+      );
+    }
+
+    // Same reasoning as above, but for the disabled color: the shared
+    // .sky-dropdown-item > a[disabled]:hover rule (0,3,1, unscoped to
+    // .sky-theme-modern) previously tied the global rule's specificity
+    // exactly, so which one won depended on stylesheet injection order.
+    // Nesting under this mixin raises it to (0,4,1), guaranteeing the
+    // disabled color wins regardless of order.
+    & > a[disabled]:hover,
+    & > a[disabled]:active {
+      color: var(
+        --sky-override-dropdown-item-disabled-color-text,
+        var(--sky-color-text-deemphasized)
+      );
+    }
   }
 }

--- a/libs/components/tabs/src/lib/modules/vertical-tabset/vertical-tab.component.scss
+++ b/libs/components/tabs/src/lib/modules/vertical-tabset/vertical-tab.component.scss
@@ -44,6 +44,7 @@
     font-weight: var(--sky-font-style-emphasized);
 
     &:hover {
+      color: var(--sky-color-text-selected);
       text-decoration-line: var(
         --sky-override-vertical-tab-active-text-decoration,
         var(
@@ -54,6 +55,7 @@
     }
 
     &:active {
+      color: var(--sky-color-text-selected);
       text-decoration-line: var(
         --sky-override-vertical-tab-active-text-decoration,
         var(

--- a/libs/components/theme/src/lib/styles/themes/modern/_buttons.scss
+++ b/libs/components/theme/src/lib/styles/themes/modern/_buttons.scss
@@ -554,7 +554,7 @@
 
     &:hover,
     &:active {
-      color: var(--sky-color-text-action);
+      color: var(--sky-color-text-action_contrast);
     }
 
     &.sky-btn-disabled,

--- a/libs/components/theme/src/lib/styles/themes/modern/_theme.scss
+++ b/libs/components/theme/src/lib/styles/themes/modern/_theme.scss
@@ -54,6 +54,18 @@ body.sky-theme-modern {
       );
     }
 
+    // Excludes anchors styled as buttons (.sky-btn-default/-primary/-danger/
+    // -borderless/-link/-link-inline, and anything else carrying the base
+    // .sky-btn marker class) — those already own their own color at every
+    // state via their own rules; this rule is only for genuine inline links.
+    &:hover:not(.sky-btn) {
+      color: var(--sky-color-text-action_contrast);
+    }
+
+    &:active:not(.sky-btn) {
+      color: var(--sky-color-text-action_contrast);
+    }
+
     &:focus-visible:not(:active) {
       outline: none;
       box-shadow: 0 0 0 var(--sky-border-width-action-focus)


### PR DESCRIPTION
:cherries: Cherry picked from #4738 [feat(components/theme): darken action links on hover/active in modern theme](https://github.com/blackbaud/skyux/pull/4738)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved hover and active text colors for dropdown links, including disabled states, in the modern theme.
  - Updated active vertical tabs to retain the correct selected text color during hover and interaction.
  - Adjusted inline link buttons and links to use improved contrast colors while preserving specialized button styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->