### PR TITLE
chore: update design-tokens to 7.0.0-alpha.10

### DIFF
--- a/libs/components/packages/package.json
+++ b/libs/components/packages/package.json
@@ -105,7 +105,7 @@
     "typescript": "^6.0.3"
   },
   "dependencies": {
-    "@blackbaud/skyux-design-tokens": "7.0.0-alpha.9",
+    "@blackbaud/skyux-design-tokens": "7.0.0-alpha.10",
     "fs-extra": "11.3.6",
     "jsonc-parser": "3.3.1",
     "parse5": "7.3.0",

--- a/libs/components/theme/package.json
+++ b/libs/components/theme/package.json
@@ -20,7 +20,7 @@
     "@angular/core": "^22.1.2"
   },
   "dependencies": {
-    "@blackbaud/skyux-design-tokens": "7.0.0-alpha.9",
+    "@blackbaud/skyux-design-tokens": "7.0.0-alpha.10",
     "fontfaceobserver": "2.3.0",
     "tslib": "^2.8.1"
   },

--- a/libs/sdk/skyux-eslint/package.json
+++ b/libs/sdk/skyux-eslint/package.json
@@ -33,7 +33,7 @@
     "@typescript-eslint/utils": "^8.67.0"
   },
   "dependencies": {
-    "@blackbaud/skyux-design-tokens": "7.0.0-alpha.9",
+    "@blackbaud/skyux-design-tokens": "7.0.0-alpha.10",
     "@skyux-sdk/eslint-schematics": "0.0.0-PLACEHOLDER",
     "@skyux/manifest": "0.0.0-PLACEHOLDER",
     "tslib": "^2.8.1"

--- a/libs/sdk/skyux-stylelint/package.json
+++ b/libs/sdk/skyux-stylelint/package.json
@@ -23,7 +23,7 @@
     "stylelint": "^17.14.1"
   },
   "dependencies": {
-    "@blackbaud/skyux-design-tokens": "7.0.0-alpha.9",
+    "@blackbaud/skyux-design-tokens": "7.0.0-alpha.10",
     "tslib": "^2.8.1"
   },
   "type": "module",

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@angular/platform-browser-dynamic": "22.1.2",
         "@angular/router": "22.1.2",
         "@blackbaud/angular-tree-component": "1.0.0",
-        "@blackbaud/skyux-design-tokens": "7.0.0-alpha.9",
+        "@blackbaud/skyux-design-tokens": "7.0.0-alpha.10",
         "@eslint/js": "9.39.5",
         "@nx/angular": "23.1.1",
         "@skyux/icons": "11.4.0",
@@ -6030,9 +6030,9 @@
       }
     },
     "node_modules/@blackbaud/skyux-design-tokens": {
-      "version": "7.0.0-alpha.9",
-      "resolved": "https://registry.npmjs.org/@blackbaud/skyux-design-tokens/-/skyux-design-tokens-7.0.0-alpha.9.tgz",
-      "integrity": "sha512-aEWdEjQJYEHLryGzs7UcqpuGn9kJ7gZIylxpa/rOzTyyLOGwL08M9OAYCE4sOe3UlBH7S2q48GPf48M8piZE/w==",
+      "version": "7.0.0-alpha.10",
+      "resolved": "https://registry.npmjs.org/@blackbaud/skyux-design-tokens/-/skyux-design-tokens-7.0.0-alpha.10.tgz",
+      "integrity": "sha512-Be7MJnbEGiiytSIn5//YAKshDN9zQ76+7RTNP8r/+FgAFnL6CxL39AEvmNeAuRu6xGWsrnwgXhNNJ4Kup0EiIw==",
       "license": "MIT",
       "engines": {
         "node": ">= 4.2.1",

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "@angular/platform-browser-dynamic": "22.1.2",
     "@angular/router": "22.1.2",
     "@blackbaud/angular-tree-component": "1.0.0",
-    "@blackbaud/skyux-design-tokens": "7.0.0-alpha.9",
+    "@blackbaud/skyux-design-tokens": "7.0.0-alpha.10",
     "@eslint/js": "9.39.5",
     "@nx/angular": "23.1.1",
     "@skyux/icons": "11.4.0",


### PR DESCRIPTION
## Summary
- Manual cherry-pick of #4739 (`chore: update design-tokens to 6.10.0`) onto `main`, whose auto-cherry-pick failed due to conflicts with main's `7.0.0-alpha.9` design-tokens line
- Conflicts resolved by bumping `@blackbaud/skyux-design-tokens` to `7.0.0-alpha.10` (instead of `6.10.0`) across all workspace `package.json` files and `package-lock.json`, keeping all other main-only dependency versions untouched

## Test plan
- CI build checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the SKY UX design tokens package to version `7.0.0-alpha.10` across the project.
  - Keeps shared component styling, themes, and linting integrations aligned with the latest design token release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->