### PR TITLE
feat(components/indicators): use status color tokens for status text, links, icons (#4736)

### DIFF
--- a/apps/e2e/indicators-storybook/src/app/alert/alert.component.html
+++ b/apps/e2e/indicators-storybook/src/app/alert/alert.component.html
@@ -10,6 +10,12 @@
         data-sky-id="my-href-unlinked"
         >skyHref unlinked link</a
       >
+      and a
+      <button class="sky-btn sky-btn-link-inline" type="button">
+        Button link (inline)
+      </button>
+      and a
+      <button class="sky-btn sky-btn-link" type="button">Button link</button>
     </sky-alert>
   }
 }

--- a/libs/components/indicators/src/lib/modules/alert/alert.modern.component.scss
+++ b/libs/components/indicators/src/lib/modules/alert/alert.modern.component.scss
@@ -6,26 +6,95 @@
 }
 
 @include mixins.sky-component('modern', '.sky-alert') {
+  --sky-icon-svg-path-2-color-input: var(--sky-color-icon-on_status);
+
   padding: var(--sky-comp-alert-space-inset-top)
     var(--sky-comp-alert-space-inset-right)
     var(--sky-comp-alert-space-inset-bottom)
     var(--sky-comp-alert-space-inset-left);
   border-left: solid var(--sky-border-width-accent);
-  color: var(--sky-color-text-default);
+  color: var(--sky-color-text-on_status);
   display: flex;
   flex-direction: row;
   align-items: center;
 
   .sky-alert-content {
+    --sky-comp-override-link-text-decoration-line: var(
+      --sky-font-text_decoration-action-tertiary-on_status-base
+    );
+    --sky-comp-override-link-text-decoration-line-hover: var(
+      --sky-font-text_decoration-action-tertiary-on_status-hover
+    );
+    --sky-comp-override-link-text-decoration-line-active: var(
+      --sky-font-text_decoration-action-tertiary-on_status-active
+    );
+    --sky-comp-override-link-text-decoration-line-focus: var(
+      --sky-font-text_decoration-action-tertiary-on_status-focus
+    );
+    --sky-comp-override-link-text-decoration-line-disabled: var(
+      --sky-font-text_decoration-action-tertiary-on_status-disabled
+    );
+    --sky-comp-override-inline-link-text-decoration-line: var(
+      --sky-font-text_decoration-action-tertiary-on_status-base
+    );
+    --sky-comp-override-inline-link-text-decoration-line-hover: var(
+      --sky-font-text_decoration-action-tertiary-on_status-hover
+    );
+    --sky-comp-override-inline-link-text-decoration-line-active: var(
+      --sky-font-text_decoration-action-tertiary-on_status-active
+    );
+    --sky-comp-override-inline-link-text-decoration-line-focus: var(
+      --sky-font-text_decoration-action-tertiary-on_status-focus
+    );
+    --sky-comp-override-inline-link-text-decoration-line-disabled: var(
+      --sky-font-text_decoration-action-tertiary-on_status-disabled
+    );
+
     padding: 0 var(--sky-space-gap-text_action-m) 0 var(--sky-space-gap-icon-l);
     width: 100%;
 
-    ::ng-deep a {
-      color: var(--sky-color-text-action_contrast);
-      text-decoration: var(--sky-font-text_decoration-visible_link);
+    ::ng-deep {
+      a,
+      .sky-btn-link,
+      .sky-btn-link-inline {
+        color: var(--sky-color-text-action_on_status);
 
-      &:hover {
-        color: var(--sky-color-text-action_contrast);
+        &:hover,
+        &:active {
+          color: var(--sky-color-text-action_on_status);
+        }
+      }
+
+      a,
+      .sky-btn-link-inline {
+        &:focus-visible:not(:active) {
+          box-shadow: 0 0 0 var(--sky-border-width-action-focus)
+            var(--sky-color-border-action-on_status-focus);
+        }
+      }
+
+      .sky-btn-link {
+        &:hover {
+          box-shadow:
+            inset 0 0 0 var(--sky-border-width-action-hover)
+              var(--sky-color-border-action-on_status-hover),
+            var(--sky-elevation-action-tertiary-hover);
+        }
+
+        &:active,
+        &.sky-btn-active {
+          box-shadow:
+            inset 0 0 0 var(--sky-border-width-action-active)
+              var(--sky-color-border-action-on_status-active),
+            var(--sky-elevation-action-tertiary-active);
+        }
+
+        &:focus-visible:not(:active) {
+          box-shadow:
+            inset 0 0 0 var(--sky-border-width-action-focus)
+              var(--sky-color-border-action-on_status-focus),
+            var(--sky-elevation-action-tertiary-focus);
+        }
       }
     }
   }
@@ -37,19 +106,16 @@
   &.sky-alert-info {
     background-color: var(--sky-color-background-container-info);
     border-color: var(--sky-color-border-info);
-    --sky-icon-svg-path-2-color-input: var(--sky-color-icon-inverse);
   }
 
   &.sky-alert-success {
     background-color: var(--sky-color-background-container-success);
     border-color: var(--sky-color-border-success);
-    --sky-icon-svg-path-2-color-input: var(--sky-color-icon-inverse);
   }
 
   &.sky-alert-warning {
     background-color: var(--sky-color-background-container-warning);
     border-color: var(--sky-color-border-warning);
-    --sky-icon-svg-path-2-color-input: var(--sky-color-icon-default);
   }
 
   &.sky-alert-danger {
@@ -64,9 +130,9 @@
       var(--sky-comp-button-borderless-space-inset-right)
       var(--sky-comp-button-borderless-space-inset-bottom)
       var(--sky-comp-button-borderless-space-inset-left);
-    color: var(--sky-color-icon-default);
+    color: var(--sky-color-text-on_status);
     border-style: solid;
-    border-color: var(--sky-color-border-action-tertiary-base);
+    border-color: var(--sky-color-border-action-on_status-base);
     border-radius: var(--sky-border-radius-s);
     border-width: var(--sky-border-width-action-base);
     background-color: var(--sky-color-background-action-tertiary-base);
@@ -75,19 +141,19 @@
 
     &:hover {
       opacity: 1;
-      border-color: var(--sky-color-border-action-tertiary-hover);
+      border-color: var(--sky-color-border-action-on_status-hover);
       border-width: var(--sky-border-width-action-hover);
     }
 
     &:focus-visible {
       outline: none;
-      border-color: var(--sky-color-border-action-tertiary-focus);
+      border-color: var(--sky-color-border-action-on_status-focus);
       border-width: var(--sky-border-width-action-focus);
     }
 
     &:active {
-      border-color: var(--sky-color-border-action-tertiary-focus);
-      border-width: var(--sky-border-width-action-focus);
+      border-color: var(--sky-color-border-action-on_status-active);
+      border-width: var(--sky-border-width-action-active);
     }
 
     &:focus-visible:not(:active) {

--- a/libs/components/indicators/src/lib/modules/label/label.component.scss
+++ b/libs/components/indicators/src/lib/modules/label/label.component.scss
@@ -40,6 +40,7 @@
   );
   --sky-override-label-margin: 0 3px;
   --sky-override-label-padding: 0.3em 0.6em 0.3em 0.6em;
+  --sky-override-label-text-color: #{$sky-text-color-default};
   --sky-override-label-text-padding-left: var(--sky-padding-half);
 }
 
@@ -63,10 +64,33 @@
   .sky-label-danger .sky-label-icon {
     color: var(--sky-color-background-icon_matte-danger);
   }
+
+  .sky-label ::ng-deep a {
+    &:focus-visible:not(:active) {
+      box-shadow: 0 0 0 var(--sky-border-width-action-focus)
+        var(--sky-color-border-action-on_status-focus);
+    }
+  }
 }
 
 .sky-label {
-  color: var(--sky-text-color-default);
+  --sky-comp-override-inline-link-text-decoration-line: var(
+    --sky-font-text_decoration-action-tertiary-on_status-base
+  );
+  --sky-comp-override-inline-link-text-decoration-line-hover: var(
+    --sky-font-text_decoration-action-tertiary-on_status-hover
+  );
+  --sky-comp-override-inline-link-text-decoration-line-active: var(
+    --sky-font-text_decoration-action-tertiary-on_status-active
+  );
+  --sky-comp-override-inline-link-text-decoration-line-focus: var(
+    --sky-font-text_decoration-action-tertiary-on_status-focus
+  );
+  --sky-comp-override-inline-link-text-decoration-line-disabled: var(
+    --sky-font-text_decoration-action-tertiary-on_status-disabled
+  );
+
+  color: var(--sky-override-label-text-color, var(--sky-color-text-on_status));
   display: var(--sky-override-label-display, inline-block);
   align-items: var(--sky-override-label-align-items, center);
   border-radius: var(
@@ -90,18 +114,18 @@
   ::ng-deep a {
     color: var(
       --sky-override-label-link-text-color,
-      var(--sky-color-text-action_contrast)
+      var(--sky-color-text-action_on_status)
     );
-    text-decoration: var(
+    text-decoration-line: var(
       --sky-override-label-link-text-decoration,
-      var(--sky-font-text_decoration-visible_link)
+      var(--sky-font-text_decoration-action-tertiary-on_status-base)
     );
 
     // In modern all states of a link display as "blue", so remove this hover state when default support is dropped
     &:hover {
       color: var(
         --sky-override-label-link-hover-color,
-        var(--sky-color-text-action_contrast)
+        var(--sky-color-text-action_on_status)
       );
     }
   }
@@ -114,7 +138,7 @@
   );
   --sky-icon-svg-path-2-color-input: var(
     --sky-override-label-inner-icon-path-color-success,
-    var(--sky-color-icon-inverse)
+    var(--sky-color-icon-on_status)
   );
 }
 
@@ -125,7 +149,7 @@
   );
   --sky-icon-svg-path-2-color-input: var(
     --sky-override-label-inner-icon-path-color-info,
-    var(--sky-color-icon-inverse)
+    var(--sky-color-icon-on_status)
   );
 }
 
@@ -136,7 +160,7 @@
   );
   --sky-icon-svg-path-2-color-input: var(
     --sky-override-label-inner-icon-path-color-warning,
-    var(--sky-color-icon-default)
+    var(--sky-color-icon-on_status)
   );
 }
 
@@ -147,7 +171,7 @@
   );
   --sky-icon-svg-path-2-color-input: var(
     --sky-override-label-inner-icon-path-color-danger,
-    var(--sky-color-icon-inverse)
+    var(--sky-color-icon-on_status)
   );
 }
 

--- a/libs/components/indicators/src/lib/modules/status-indicator/status-indicator.component.scss
+++ b/libs/components/indicators/src/lib/modules/status-indicator/status-indicator.component.scss
@@ -8,6 +8,7 @@
   --sky-override-status-indicator-icon-color-success: #{$sky-highlight-color-success};
   --sky-override-status-indicator-icon-color-warning: #{$sky-highlight-color-warning};
   --sky-override-status-indicator-icon-padding-right: #{$sky-space-xs};
+  --sky-override-status-indicator-inner-icon-color: #fff;
 }
 
 .sky-status-indicator {
@@ -16,6 +17,10 @@
 }
 
 .sky-status-indicator-icon {
+  --sky-icon-svg-path-2-color-input: var(
+    --sky-override-status-indicator-inner-icon-color,
+    var(--sky-color-icon-on_status)
+  );
   flex-shrink: 1;
   padding-right: var(
     --sky-staus-indicator-padding-right,
@@ -52,22 +57,4 @@
     --sky-override-status-indicator-icon-color-danger,
     var(--sky-color-background-icon_matte-danger)
   );
-}
-
-.sky-status-indicator-icon {
-  &.sky-status-indicator-icon-warning,
-  &.sky-status-indicator-icon-success {
-    --sky-icon-svg-path-2-color-input: var(--sky-color-icon-default);
-  }
-  &.sky-status-indicator-icon-danger {
-    --sky-icon-svg-path-2-color-input: var(--sky-color-icon-inverse);
-  }
-
-  &.sky-status-indicator-icon-info {
-    --sky-icon-svg-path-2-color-input: var(--sky-color-icon-inverse);
-  }
-
-  &.sky-status-indicator-icon-success {
-    --sky-icon-svg-path-2-color-input: var(--sky-color-icon-inverse);
-  }
 }

--- a/libs/components/toast/src/lib/modules/toast/toast.component.scss
+++ b/libs/components/toast/src/lib/modules/toast/toast.component.scss
@@ -30,9 +30,9 @@
   --sky-override-toast-content-link-color: #212327cc;
   --sky-override-toast-content-link-decoration: underline;
   --sky-override-toast-content-padding: #{$sky-padding} 0;
-  --sky-override-toast-info-success-exclamation-path-color: #{$sky-highlight-color-info};
   --sky-override-toast-margin-bottom: #{$sky-margin-double};
   --sky-override-toast-padding: 0 #{$sky-padding};
+  --sky-override-toast-text-color: #{$sky-text-color-default};
 }
 
 @mixin sky-toast-variant(
@@ -54,6 +54,10 @@ sky-toast {
   display: block;
 
   .sky-toast {
+    color: var(
+      --sky-override-toast-text-color,
+      var(--sky-color-text-on_status)
+    );
     padding: var(
       --sky-override-toast-padding,
       var(--sky-comp-toast-space-inset-top)
@@ -82,7 +86,7 @@ sky-toast {
       border: var(
         --sky-override-toast-close-button-border,
         solid var(--sky-border-width-action-base)
-          var(--sky-color-border-action-tertiary-base)
+          var(--sky-color-border-action-on_status-base)
       );
       border-radius: var(
         --sky-override-toast-close-button-border-radius,
@@ -90,7 +94,7 @@ sky-toast {
       );
       color: var(
         --sky-override-toast-close-button-color-icon,
-        var(--sky-color-icon-default)
+        var(--sky-color-text-on_status)
       );
       cursor: pointer;
       flex-shrink: var(--sky-override-toast-close-button-flex-shrink, 0);
@@ -135,6 +139,37 @@ sky-toast {
   }
 
   .sky-toast-content {
+    --sky-comp-override-link-text-decoration-line: var(
+      --sky-font-text_decoration-action-tertiary-on_status-base
+    );
+    --sky-comp-override-link-text-decoration-line-hover: var(
+      --sky-font-text_decoration-action-tertiary-on_status-hover
+    );
+    --sky-comp-override-link-text-decoration-line-active: var(
+      --sky-font-text_decoration-action-tertiary-on_status-active
+    );
+    --sky-comp-override-link-text-decoration-line-focus: var(
+      --sky-font-text_decoration-action-tertiary-on_status-focus
+    );
+    --sky-comp-override-link-text-decoration-line-disabled: var(
+      --sky-font-text_decoration-action-tertiary-on_status-disabled
+    );
+    --sky-comp-override-inline-link-text-decoration-line: var(
+      --sky-font-text_decoration-action-tertiary-on_status-base
+    );
+    --sky-comp-override-inline-link-text-decoration-line-hover: var(
+      --sky-font-text_decoration-action-tertiary-on_status-hover
+    );
+    --sky-comp-override-inline-link-text-decoration-line-active: var(
+      --sky-font-text_decoration-action-tertiary-on_status-active
+    );
+    --sky-comp-override-inline-link-text-decoration-line-focus: var(
+      --sky-font-text_decoration-action-tertiary-on_status-focus
+    );
+    --sky-comp-override-inline-link-text-decoration-line-disabled: var(
+      --sky-font-text_decoration-action-tertiary-on_status-disabled
+    );
+
     padding: var(
       --sky-override-toast-content-padding,
       0 var(--sky-space-gap-text_action-m) 0 var(--sky-space-gap-icon-l)
@@ -148,15 +183,16 @@ sky-toast {
     .sky-btn-link-inline {
       color: var(
         --sky-override-toast-content-link-color,
-        var(--sky-color-text-action_contrast)
+        var(--sky-color-text-action_on_status)
       );
-      text-decoration: var(
+      text-decoration-line: var(
         --sky-override-toast-content-link-decoration,
-        var(--sky-font-text_decoration-visible_link)
+        var(--sky-font-text_decoration-action-tertiary-on_status-base)
       );
 
-      &:hover {
-        color: var(--sky-color-text-action_contrast);
+      &:hover,
+      &:active {
+        color: var(--sky-color-text-action_on_status);
       }
     }
   }
@@ -177,8 +213,8 @@ sky-toast {
           var(--sky-color-background-icon_matte-info)
         ),
         var(
-          --sky-override-toast-info-success-exclamation-path-color,
-          var(--sky-color-icon-inverse)
+          --sky-override-toast-color-border-info,
+          var(--sky-color-icon-on_status)
         )
       );
     }
@@ -199,10 +235,7 @@ sky-toast {
         ),
         var(
           --sky-override-toast-color-border-success,
-          var(
-            --sky-override-toast-info-success-exclamation-path-color,
-            var(--sky-color-icon-inverse)
-          )
+          var(--sky-color-icon-on_status)
         )
       );
     }
@@ -223,7 +256,7 @@ sky-toast {
         ),
         var(
           --sky-override-toast-color-border-warning,
-          var(--sky-color-icon-default)
+          var(--sky-color-icon-on_status)
         )
       );
     }
@@ -244,7 +277,7 @@ sky-toast {
         ),
         var(
           --sky-override-toast-color-border-danger,
-          var(--sky-color-icon-inverse)
+          var(--sky-color-icon-on_status)
         )
       );
     }
@@ -265,18 +298,56 @@ sky-toast {
         box-shadow var(--sky-global-duration-short);
 
       &:hover {
-        border-color: var(--sky-color-border-action-tertiary-hover);
+        border-color: var(--sky-color-border-action-on_status-hover);
         border-width: var(--sky-border-width-action-hover);
       }
 
-      &:active,
       &:focus-visible {
-        border-color: var(--sky-color-border-action-tertiary-focus);
+        border-color: var(--sky-color-border-action-on_status-focus);
         border-width: var(--sky-border-width-action-focus);
+      }
+
+      &:active {
+        border-color: var(--sky-color-border-action-on_status-active);
+        border-width: var(--sky-border-width-action-active);
       }
 
       &:focus-visible:not(:active) {
         box-shadow: var(--sky-elevation-raised-100);
+      }
+    }
+
+    .sky-toast-content {
+      a,
+      .sky-btn-link-inline {
+        &:focus-visible:not(:active) {
+          box-shadow: 0 0 0 var(--sky-border-width-action-focus)
+            var(--sky-color-border-action-on_status-focus);
+        }
+      }
+
+      .sky-btn-link {
+        &:hover {
+          box-shadow:
+            inset 0 0 0 var(--sky-border-width-action-hover)
+              var(--sky-color-border-action-on_status-hover),
+            var(--sky-elevation-action-tertiary-hover);
+        }
+
+        &:active,
+        &.sky-btn-active {
+          box-shadow:
+            inset 0 0 0 var(--sky-border-width-action-active)
+              var(--sky-color-border-action-on_status-active),
+            var(--sky-elevation-action-tertiary-active);
+        }
+
+        &:focus-visible:not(:active) {
+          box-shadow:
+            inset 0 0 0 var(--sky-border-width-action-focus)
+              var(--sky-color-border-action-on_status-focus),
+            var(--sky-elevation-action-tertiary-focus);
+        }
       }
     }
 


### PR DESCRIPTION
:cherries: Cherry picked from #4736 [feat(components/indicators): use status color tokens for status text, links, icons](https://github.com/blackbaud/skyux/pull/4736)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added inline and standard button link examples to alert demonstrations.

* **Style**
  * Improved modern theme styling for alerts, labels, status indicators, and toasts.
  * Updated status-specific colors, link states, focus indicators, borders, icons, and close-button interactions for greater visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->