### PR TITLE
fix(components/layout): inline delete cancel button is not transparent in dark modet in dark mode (#4744)

### DIFF
--- a/libs/components/layout/src/lib/modules/inline-delete/inline-delete.component.html
+++ b/libs/components/layout/src/lib/modules/inline-delete/inline-delete.component.html
@@ -28,7 +28,7 @@
         {{ 'skyux_inline_delete_delete' | skyLibResources }}
       </button>
       <button
-        class="sky-btn sky-btn-default"
+        class="sky-btn sky-btn-default sky-inline-delete-cancel-button"
         type="button"
         (click)="onCancelClick()"
       >

--- a/libs/components/layout/src/lib/modules/inline-delete/inline-delete.component.scss
+++ b/libs/components/layout/src/lib/modules/inline-delete/inline-delete.component.scss
@@ -5,6 +5,9 @@
   --sky-override-inline-delete-background-color: rgba(0, 0, 0, 0.5);
   --sky-override-inline-delete-border: 2px solid #{$sky-highlight-color-danger};
   --sky-override-inline-delete-button-margin-right: #{$sky-margin};
+  --sky-override-inline-delete-cancel-button-background-color-active-hover: #{$sky-background-color-neutral-light};
+  --sky-override-inline-delete-cancel-button-background-color-base-disabled-focus: #{$sky-color-white};
+  --sky-override-inline-delete-cancel-button-opacity-disabled: 0.65;
   --sky-override-inline-delete-content-left: #{$sky-padding-double};
   --sky-override-inline-delete-content-padding: 0;
 }
@@ -33,6 +36,54 @@
     --sky-override-inline-delete-button-margin-right,
     var(--sky-space-gap-action_group-m)
   );
+}
+
+.sky-inline-delete-cancel-button {
+  background-color: var(
+    --sky-override-inline-delete-cancel-button-background-color-base-disabled-focus,
+    var(--sky-color-background-action-secondary-on_scrim-base)
+  );
+
+  &:active {
+    background-color: var(
+      --sky-override-inline-delete-cancel-button-background-color-active-hover,
+      var(--sky-color-background-action-secondary-on_scrim-active)
+    );
+  }
+
+  &:hover {
+    background-color: var(
+      --sky-override-inline-delete-cancel-button-background-color-active-hover,
+      var(--sky-color-background-action-secondary-on_scrim-hover)
+    );
+  }
+
+  &:focus-visible {
+    background-color: var(
+      --sky-override-inline-delete-cancel-button-background-color-base-disabled-focus,
+      var(--sky-color-background-action-secondary-on_scrim-focus)
+    );
+  }
+
+  &.sky-btn-disabled,
+  &[disabled] {
+    &,
+    &:hover,
+    &:focus-visible,
+    &.sky-btn-focus,
+    &:active,
+    &.sky-btn-active {
+      background-color: var(
+        --sky-override-inline-delete-cancel-button-background-color-base-disabled-focus,
+        var(--sky-color-background-action-secondary-on_scrim-disabled)
+      );
+      // Remove when default theme support is removed
+      opacity: var(
+        --sky-override-inline-delete-cancel-button-opacity-disabled,
+        1
+      );
+    }
+  }
 }
 
 // NOTE: Not tokenized - should be done with card if we tokenize the deprecated components


### PR DESCRIPTION
:cherries: Cherry picked from #4744 [fix(components/layout): inline delete cancel button is not transparent in dark modet in dark mode](https://github.com/blackbaud/skyux/pull/4744)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved the inline delete cancel button’s visual styling across default, hover, active, focus, and disabled states.
  - Added theme customization options for cancel-button colors, backgrounds, and disabled opacity.
  - Applied a dedicated CSS class to support consistent cancel-button styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->