### PR TITLE
chore: release 15.0.0-alpha.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
 
+## [15.0.0-alpha.11](https://github.com/blackbaud/skyux/compare/15.0.0-alpha.10...15.0.0-alpha.11) (2026-09-03)
+
+
+### Bug Fixes
+
+* **components/layout:** inline delete cancel button is not transparent in dark modet in dark mode ([#4744](https://github.com/blackbaud/skyux/issues/4744)) ([#4747](https://github.com/blackbaud/skyux/issues/4747)) ([ee762e0](https://github.com/blackbaud/skyux/commit/ee762e0638c2211fd558b707d0ade37083963e9f))
+
 ## [15.0.0-alpha.10](https://github.com/blackbaud/skyux/compare/15.0.0-alpha.9...15.0.0-alpha.10) (2026-09-02)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 ## [15.0.0-alpha.11](https://github.com/blackbaud/skyux/compare/15.0.0-alpha.10...15.0.0-alpha.11) (2026-09-03)
 
 
+### Features
+
+* **components/indicators:** use status color tokens for status text, links, icons ([#4736](https://github.com/blackbaud/skyux/issues/4736)) ([#4746](https://github.com/blackbaud/skyux/issues/4746)) ([d4f638d](https://github.com/blackbaud/skyux/commit/d4f638d5e5f463893ce1b4c51874b395790c8a07))
+
+
 ### Bug Fixes
 
 * **components/layout:** inline delete cancel button is not transparent in dark modet in dark mode ([#4744](https://github.com/blackbaud/skyux/issues/4744)) ([#4747](https://github.com/blackbaud/skyux/issues/4747)) ([ee762e0](https://github.com/blackbaud/skyux/commit/ee762e0638c2211fd558b707d0ade37083963e9f))

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "skyux",
-  "version": "15.0.0-alpha.10",
+  "version": "15.0.0-alpha.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "skyux",
-      "version": "15.0.0-alpha.10",
+      "version": "15.0.0-alpha.11",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skyux",
-  "version": "15.0.0-alpha.10",
+  "version": "15.0.0-alpha.11",
   "license": "MIT",
   "scripts": {
     "ng": "nx",


### PR DESCRIPTION
## [15.0.0-alpha.11](https://github.com/blackbaud/skyux/compare/15.0.0-alpha.10...15.0.0-alpha.11) (2026-09-03)


### Features

* **components/indicators:** use status color tokens for status text, links, icons ([#4736](https://github.com/blackbaud/skyux/issues/4736)) ([#4746](https://github.com/blackbaud/skyux/issues/4746)) ([d4f638d](https://github.com/blackbaud/skyux/commit/d4f638d5e5f463893ce1b4c51874b395790c8a07))


### Bug Fixes

* **components/layout:** inline delete cancel button is not transparent in dark modet in dark mode ([#4744](https://github.com/blackbaud/skyux/issues/4744)) ([#4747](https://github.com/blackbaud/skyux/issues/4747)) ([ee762e0](https://github.com/blackbaud/skyux/commit/ee762e0638c2211fd558b707d0ade37083963e9f))

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added indicators to provide additional visual status information.

* **Bug Fixes**
  * Fixed an issue where layouts did not display correctly in dark mode.

* **Release**
  * Updated the application to version 15.0.0-alpha.11.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->