### PR TITLE
fix(components/ag-grid): apply data manager sort options to the grid (#4745)

### DIFF
--- a/apps/playground/src/app/components/ag-grid/data-manager/data-view-grid.component.ts
+++ b/apps/playground/src/app/components/ag-grid/data-manager/data-view-grid.component.ts
@@ -82,6 +82,7 @@ export class DataViewGridComponent implements OnInit {
     searchHighlightEnabled: true,
     multiselectToolbarEnabled: true,
     columnPickerEnabled: true,
+    sortEnabled: true,
     columnOptions: [
       {
         id: 'selected',

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/ag-grid-data-manager-adapter.directive.spec.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/ag-grid-data-manager-adapter.directive.spec.ts
@@ -1,6 +1,6 @@
 import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
-import { DebugElement } from '@angular/core';
+import { DebugElement, Signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { expect, expectAsync } from '@skyux-sdk/testing';
@@ -912,7 +912,7 @@ it('should move the horizontal scroll based on enableTopScroll check', async () 
 describe('sorting via the data manager toolbar', () => {
   let sortFixture: ComponentFixture<SkyAgGridDataManagerFixtureComponent>;
   let sortFixtureComponent: SkyAgGridDataManagerFixtureComponent;
-  let sortGrid: AgGridAngular;
+  let sortGrid: Signal<AgGridAngular>;
   let sortDataManagerService: SkyDataManagerService;
   let sortDataManagerHarness: SkyDataManagerHarness;
 
@@ -943,7 +943,7 @@ describe('sorting via the data manager toolbar', () => {
     sortFixture.detectChanges();
     await sortFixture.whenStable();
 
-    sortGrid = sortFixtureComponent.agGrid as AgGridAngular;
+    sortGrid = sortFixtureComponent.agGrid as Signal<AgGridAngular>;
     sortDataManagerService = TestBed.inject(SkyDataManagerService);
 
     const loader: HarnessLoader = TestbedHarnessEnvironment.loader(sortFixture);
@@ -958,13 +958,13 @@ describe('sorting via the data manager toolbar', () => {
     sortFixture.detectChanges();
     await sortFixture.whenStable();
 
-    expect(sortGrid.api.getColumnState()).toEqual([
+    expect(sortGrid().api.getColumnState()).toEqual([
       jasmine.objectContaining({ colId: 'selected', sort: null }),
       jasmine.objectContaining({ colId: 'name', sort: 'asc' }),
       jasmine.objectContaining({ colId: 'target', sort: null }),
       jasmine.objectContaining({ colId: 'noHeader', sort: null }),
     ]);
-    expect(sortGrid.api.getDisplayedRowAtIndex(0)?.data?.name).toBe('Jill');
+    expect(sortGrid().api.getDisplayedRowAtIndex(0)?.data?.name).toBe('Jill');
   });
 
   it('should sort the grid descending when a sort option is selected', async () => {
@@ -975,13 +975,13 @@ describe('sorting via the data manager toolbar', () => {
     sortFixture.detectChanges();
     await sortFixture.whenStable();
 
-    expect(sortGrid.api.getColumnState()).toEqual([
+    expect(sortGrid().api.getColumnState()).toEqual([
       jasmine.objectContaining({ colId: 'selected', sort: null }),
       jasmine.objectContaining({ colId: 'name', sort: 'desc' }),
       jasmine.objectContaining({ colId: 'target', sort: null }),
       jasmine.objectContaining({ colId: 'noHeader', sort: null }),
     ]);
-    expect(sortGrid.api.getDisplayedRowAtIndex(0)?.data?.name).toBe('Mary');
+    expect(sortGrid().api.getDisplayedRowAtIndex(0)?.data?.name).toBe('Mary');
   });
 
   it('should sort the grid using a sort option whose property name matches a colId', async () => {
@@ -992,7 +992,7 @@ describe('sorting via the data manager toolbar', () => {
     sortFixture.detectChanges();
     await sortFixture.whenStable();
 
-    expect(sortGrid.api.getColumnState()).toEqual([
+    expect(sortGrid().api.getColumnState()).toEqual([
       jasmine.objectContaining({ colId: 'selected', sort: null }),
       jasmine.objectContaining({ colId: 'name', sort: null }),
       jasmine.objectContaining({ colId: 'target', sort: null }),
@@ -1022,7 +1022,7 @@ describe('sorting via the data manager toolbar', () => {
   });
 
   it('should keep the matching sort option active when the column header is sorted directly', async () => {
-    sortGrid.api.applyColumnState({
+    sortGrid().api.applyColumnState({
       state: [{ colId: 'name', sort: 'asc' }],
       defaultState: { sort: null },
     });
@@ -1036,7 +1036,7 @@ describe('sorting via the data manager toolbar', () => {
   });
 
   it('should report a column-derived sort option when the sorted column has no matching sort option', async () => {
-    sortGrid.api.applyColumnState({
+    sortGrid().api.applyColumnState({
       state: [{ colId: 'target', sort: 'asc' }],
       defaultState: { sort: null },
     });
@@ -1046,7 +1046,7 @@ describe('sorting via the data manager toolbar', () => {
       'updateDataState',
     ).and.callThrough();
 
-    sortGrid.sortChanged.emit();
+    sortGrid().sortChanged.emit();
     sortFixture.detectChanges();
     await sortFixture.whenStable();
 

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/ag-grid-data-manager-adapter.directive.spec.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/ag-grid-data-manager-adapter.directive.spec.ts
@@ -1,7 +1,9 @@
+import { HarnessLoader } from '@angular/cdk/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { DebugElement } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { expect } from '@skyux-sdk/testing';
+import { expect, expectAsync } from '@skyux-sdk/testing';
 import {
   SkyMediaQueryTestingController,
   provideSkyMediaQueryTesting,
@@ -10,6 +12,7 @@ import {
   SkyDataManagerService,
   SkyDataManagerState,
 } from '@skyux/data-manager';
+import { SkyDataManagerHarness } from '@skyux/data-manager/testing';
 
 import { AgGridAngular } from 'ag-grid-angular';
 import {
@@ -567,7 +570,7 @@ describe('SkyAgGridDataManagerAdapterDirective', () => {
     );
   });
 
-  it('should update the data state when the sort changes and use empty strings for header/field when not present', async () => {
+  it('should update the data state when the sort changes and fall back to colId/empty string for propertyName/header when not present', async () => {
     await agGridDataManagerFixture.whenStable();
 
     agGridComponent.api.applyColumnState({
@@ -593,7 +596,7 @@ describe('SkyAgGridDataManagerAdapterDirective', () => {
     dataState.activeSortOption = {
       id: 'noHeader',
       descending: true,
-      propertyName: '',
+      propertyName: 'noHeader',
       label: '',
     };
 
@@ -605,7 +608,7 @@ describe('SkyAgGridDataManagerAdapterDirective', () => {
     );
   });
 
-  it('should update the data state when the sort changes and use empty strings for header/field when not present', async () => {
+  it('should update the data state when the sort changes and fall back to colId/empty string for propertyName/header when not present', async () => {
     await agGridDataManagerFixture.whenStable();
 
     agGridComponent.api.applyColumnState({
@@ -632,7 +635,7 @@ describe('SkyAgGridDataManagerAdapterDirective', () => {
     dataState.activeSortOption = {
       id: 'noHeader',
       descending: true,
-      propertyName: '',
+      propertyName: 'noHeader',
       label: '',
     };
 
@@ -774,6 +777,75 @@ describe('SkyAgGridDataManagerAdapterDirective', () => {
       }),
     ]);
   });
+
+  it('should apply sort by matching propertyName to a column field when the sort option id is not a colId', async () => {
+    const newDataState = new SkyDataManagerState({ ...dataState });
+    newDataState.activeSortOption = {
+      id: 'az',
+      propertyName: 'name',
+      descending: false,
+      label: 'First Name (A - Z)',
+    };
+    dataManagerService.updateDataState(newDataState, 'unitTest');
+    agGridDataManagerFixture.detectChanges();
+    await agGridDataManagerFixture.whenStable();
+
+    expect(agGridComponent.api.getColumnState()).toEqual([
+      jasmine.objectContaining({ colId: 'selected', sort: null }),
+      jasmine.objectContaining({ colId: 'name', sort: 'asc' }),
+      jasmine.objectContaining({ colId: 'target', sort: null }),
+      jasmine.objectContaining({ colId: 'noHeader', sort: null }),
+    ]);
+  });
+
+  it('should apply sort by matching propertyName to a colId when no column field matches', async () => {
+    const newDataState = new SkyDataManagerState({ ...dataState });
+    newDataState.activeSortOption = {
+      id: 'byBlank',
+      propertyName: 'noHeader',
+      descending: false,
+      label: 'Blank column',
+    };
+    dataManagerService.updateDataState(newDataState, 'unitTest');
+    agGridDataManagerFixture.detectChanges();
+    await agGridDataManagerFixture.whenStable();
+
+    expect(agGridComponent.api.getColumnState()).toEqual([
+      jasmine.objectContaining({ colId: 'selected', sort: null }),
+      jasmine.objectContaining({ colId: 'name', sort: null }),
+      jasmine.objectContaining({ colId: 'target', sort: null }),
+      jasmine.objectContaining({ colId: 'noHeader', sort: 'asc' }),
+    ]);
+  });
+
+  it('should leave the existing sort untouched when no column matches the sort option', async () => {
+    await agGridDataManagerFixture.whenStable();
+
+    agGridComponent.api.applyColumnState({
+      state: [{ colId: 'name', sort: 'asc' }],
+      defaultState: { sort: null },
+    });
+    agGridDataManagerFixture.detectChanges();
+    await agGridDataManagerFixture.whenStable();
+
+    const newDataState = new SkyDataManagerState({ ...dataState });
+    newDataState.activeSortOption = {
+      id: 'nope',
+      propertyName: 'nope',
+      descending: true,
+      label: 'Nope',
+    };
+    dataManagerService.updateDataState(newDataState, 'unitTest');
+    agGridDataManagerFixture.detectChanges();
+    await agGridDataManagerFixture.whenStable();
+
+    expect(agGridComponent.api.getColumnState()).toEqual([
+      jasmine.objectContaining({ colId: 'selected', sort: null }),
+      jasmine.objectContaining({ colId: 'name', sort: 'asc' }),
+      jasmine.objectContaining({ colId: 'target', sort: null }),
+      jasmine.objectContaining({ colId: 'noHeader', sort: null }),
+    ]);
+  });
 });
 
 it('should move the horizontal scroll based on enableTopScroll check', async () => {
@@ -835,6 +907,160 @@ it('should move the horizontal scroll based on enableTopScroll check', async () 
     '.ag-header',
     '.ag-body-horizontal-scroll',
   ]);
+});
+
+describe('sorting via the data manager toolbar', () => {
+  let sortFixture: ComponentFixture<SkyAgGridDataManagerFixtureComponent>;
+  let sortFixtureComponent: SkyAgGridDataManagerFixtureComponent;
+  let sortGrid: AgGridAngular;
+  let sortDataManagerService: SkyDataManagerService;
+  let sortDataManagerHarness: SkyDataManagerHarness;
+
+  // No explicit return type: the harness type comes from
+  // `SkyDataManagerToolbarHarness`, and `@skyux/lists` (which owns
+  // `SkySortHarness`) is not a direct peer dependency of this library.
+  async function getSortButton() {
+    const toolbarHarness = await sortDataManagerHarness.getToolbar();
+    const sortButtonHarness = await toolbarHarness.getSortButton();
+
+    if (!sortButtonHarness) {
+      throw new Error('Expected the data manager sort button to render.');
+    }
+
+    return sortButtonHarness;
+  }
+
+  beforeEach(async () => {
+    TestBed.configureTestingModule({
+      imports: [SkyAgGridDataManagerFixtureComponent],
+      providers: [SkyDataManagerService, provideSkyMediaQueryTesting()],
+    });
+
+    sortFixture = TestBed.createComponent(SkyAgGridDataManagerFixtureComponent);
+    sortFixtureComponent = sortFixture.componentInstance;
+    sortFixtureComponent.enableSort = true;
+
+    sortFixture.detectChanges();
+    await sortFixture.whenStable();
+
+    sortGrid = sortFixtureComponent.agGrid as AgGridAngular;
+    sortDataManagerService = TestBed.inject(SkyDataManagerService);
+
+    const loader: HarnessLoader = TestbedHarnessEnvironment.loader(sortFixture);
+    sortDataManagerHarness = await loader.getHarness(SkyDataManagerHarness);
+  });
+
+  it('should sort the grid ascending when a sort option is selected', async () => {
+    const sortButton = await getSortButton();
+    await sortButton.click();
+    const item = await sortButton.getItem({ text: 'First Name (A - Z)' });
+    await item.click();
+    sortFixture.detectChanges();
+    await sortFixture.whenStable();
+
+    expect(sortGrid.api.getColumnState()).toEqual([
+      jasmine.objectContaining({ colId: 'selected', sort: null }),
+      jasmine.objectContaining({ colId: 'name', sort: 'asc' }),
+      jasmine.objectContaining({ colId: 'target', sort: null }),
+      jasmine.objectContaining({ colId: 'noHeader', sort: null }),
+    ]);
+    expect(sortGrid.api.getDisplayedRowAtIndex(0)?.data?.name).toBe('Jill');
+  });
+
+  it('should sort the grid descending when a sort option is selected', async () => {
+    const sortButton = await getSortButton();
+    await sortButton.click();
+    const item = await sortButton.getItem({ text: 'First Name (Z - A)' });
+    await item.click();
+    sortFixture.detectChanges();
+    await sortFixture.whenStable();
+
+    expect(sortGrid.api.getColumnState()).toEqual([
+      jasmine.objectContaining({ colId: 'selected', sort: null }),
+      jasmine.objectContaining({ colId: 'name', sort: 'desc' }),
+      jasmine.objectContaining({ colId: 'target', sort: null }),
+      jasmine.objectContaining({ colId: 'noHeader', sort: null }),
+    ]);
+    expect(sortGrid.api.getDisplayedRowAtIndex(0)?.data?.name).toBe('Mary');
+  });
+
+  it('should sort the grid using a sort option whose property name matches a colId', async () => {
+    const sortButton = await getSortButton();
+    await sortButton.click();
+    const item = await sortButton.getItem({ text: 'Blank column' });
+    await item.click();
+    sortFixture.detectChanges();
+    await sortFixture.whenStable();
+
+    expect(sortGrid.api.getColumnState()).toEqual([
+      jasmine.objectContaining({ colId: 'selected', sort: null }),
+      jasmine.objectContaining({ colId: 'name', sort: null }),
+      jasmine.objectContaining({ colId: 'target', sort: null }),
+      jasmine.objectContaining({ colId: 'noHeader', sort: 'asc' }),
+    ]);
+  });
+
+  it('should keep the matching sort option active after switching between sort options', async () => {
+    let sortButton = await getSortButton();
+    await sortButton.click();
+    let item = await sortButton.getItem({ text: 'First Name (A - Z)' });
+    await item.click();
+    sortFixture.detectChanges();
+    await sortFixture.whenStable();
+
+    sortButton = await getSortButton();
+    await sortButton.click();
+    item = await sortButton.getItem({ text: 'First Name (Z - A)' });
+    await item.click();
+    sortFixture.detectChanges();
+    await sortFixture.whenStable();
+
+    sortButton = await getSortButton();
+    await sortButton.click();
+    item = await sortButton.getItem({ text: 'First Name (Z - A)' });
+    await expectAsync(item.isActive()).toBeResolvedTo(true);
+  });
+
+  it('should keep the matching sort option active when the column header is sorted directly', async () => {
+    sortGrid.api.applyColumnState({
+      state: [{ colId: 'name', sort: 'asc' }],
+      defaultState: { sort: null },
+    });
+    sortFixture.detectChanges();
+    await sortFixture.whenStable();
+
+    const sortButton = await getSortButton();
+    await sortButton.click();
+    const item = await sortButton.getItem({ text: 'First Name (A - Z)' });
+    await expectAsync(item.isActive()).toBeResolvedTo(true);
+  });
+
+  it('should report a column-derived sort option when the sorted column has no matching sort option', async () => {
+    sortGrid.api.applyColumnState({
+      state: [{ colId: 'target', sort: 'asc' }],
+      defaultState: { sort: null },
+    });
+
+    const updateDataState = spyOn(
+      sortDataManagerService,
+      'updateDataState',
+    ).and.callThrough();
+
+    sortGrid.sortChanged.emit();
+    sortFixture.detectChanges();
+    await sortFixture.whenStable();
+
+    expect(updateDataState).toHaveBeenCalledWith(
+      jasmine.objectContaining({
+        activeSortOption: jasmine.objectContaining({
+          id: 'target',
+          propertyName: 'target',
+          descending: false,
+        }),
+      }),
+      sortFixtureComponent.viewConfig.id,
+    );
+  });
 });
 
 describe('Read columnOptions from grid API', () => {

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/ag-grid-data-manager-adapter.directive.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/ag-grid-data-manager-adapter.directive.ts
@@ -16,6 +16,7 @@ import { SkyBreakpoint, SkyMediaQueryService } from '@skyux/core';
 import {
   SkyDataManagerColumnPickerOption,
   SkyDataManagerService,
+  SkyDataManagerSortOption,
   SkyDataManagerState,
   SkyDataViewColumnWidths,
   SkyDataViewState,
@@ -337,19 +338,9 @@ export class SkyAgGridDataManagerAdapterDirective implements OnDestroy {
           const newState = new SkyDataManagerState(
             this.#currentDataState.getStateOptions(),
           );
-          if (activeSortColumnState) {
-            const activeSortColumnDef = agGrid.api.getColumnDef(
-              activeSortColumnState.colId,
-            );
-            newState.activeSortOption = {
-              descending: activeSortColumnState.sort === 'desc',
-              id: activeSortColumnState.colId,
-              propertyName: activeSortColumnDef?.field || '',
-              label: activeSortColumnDef?.headerName || '',
-            };
-          } else {
-            newState.activeSortOption = undefined;
-          }
+          newState.activeSortOption = activeSortColumnState
+            ? this.#resolveActiveSortOption(agGrid.api, activeSortColumnState)
+            : undefined;
           this.#currentDataState = newState;
           this.#dataManagerSvc.updateDataState(newState, viewConfig.id);
 
@@ -357,6 +348,36 @@ export class SkyAgGridDataManagerAdapterDirective implements OnDestroy {
         }
       });
     }
+  }
+
+  #resolveActiveSortOption(
+    api: GridApi,
+    activeSortColumnState: ColumnState,
+  ): SkyDataManagerSortOption {
+    const activeSortColumnDef = api.getColumnDef(activeSortColumnState.colId);
+    const descending = activeSortColumnState.sort === 'desc';
+    const propertyName =
+      activeSortColumnDef?.field || activeSortColumnState.colId;
+
+    // Prefer the configured sort option matching this column and direction
+    // so the sort menu's selected item stays in sync; columns without a
+    // matching option fall back to a column-derived sort option.
+    const matchingSortOption = this.#dataManagerSvc
+      .getCurrentDataManagerConfig()
+      .sortOptions?.find(
+        (option) =>
+          option.propertyName === propertyName &&
+          !!option.descending === descending,
+      );
+
+    return (
+      matchingSortOption ?? {
+        descending,
+        id: activeSortColumnState.colId,
+        propertyName,
+        label: activeSortColumnDef?.headerName || '',
+      }
+    );
   }
 
   #updateColumnsInCurrentDataState(api: GridApi): void {
@@ -436,16 +457,42 @@ export class SkyAgGridDataManagerAdapterDirective implements OnDestroy {
     const activeSort = dataState.activeSortOption;
 
     if (agGridApi && activeSort) {
-      agGridApi.applyColumnState({
-        state: [
-          {
-            colId: activeSort.id,
-            sort: activeSort.descending ? 'desc' : 'asc',
-          },
-        ],
-        defaultState: { sort: null },
-      });
+      const colId = this.#resolveSortColumnId(agGridApi, activeSort);
+
+      if (colId) {
+        agGridApi.applyColumnState({
+          state: [
+            {
+              colId,
+              sort: activeSort.descending ? 'desc' : 'asc',
+            },
+          ],
+          defaultState: { sort: null },
+        });
+      }
     }
+  }
+
+  #resolveSortColumnId(
+    api: GridApi,
+    activeSort: SkyDataManagerSortOption,
+  ): string | undefined {
+    const columnStates = api.getColumnState();
+    const findColId = (
+      predicate: (state: ColumnState) => boolean,
+    ): string | undefined => columnStates.find(predicate)?.colId;
+
+    // Match on the option's data property first, since a sort option's ID is
+    // arbitrary and could otherwise select an unrelated column. Only fall
+    // back to the legacy ID match for options predating the property lookup.
+    return (
+      findColId(
+        (state) =>
+          api.getColumnDef(state.colId)?.field === activeSort.propertyName,
+      ) ??
+      findColId((state) => state.colId === activeSort.propertyName) ??
+      findColId((state) => state.colId === activeSort.id)
+    );
   }
 
   #updateColumnWidth(

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/fixtures/ag-grid-data-manager.component.fixture.html
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/fixtures/ag-grid-data-manager.component.fixture.html
@@ -1,4 +1,5 @@
 <sky-data-manager>
+  <sky-data-manager-toolbar />
   <sky-data-view skyAgGridDataManagerAdapter [viewId]="viewConfig.id">
     @if (displayFirstGrid()) {
       <sky-ag-grid-wrapper>

--- a/libs/components/ag-grid/src/lib/modules/ag-grid/fixtures/ag-grid-data-manager.component.fixture.ts
+++ b/libs/components/ag-grid/src/lib/modules/ag-grid/fixtures/ag-grid-data-manager.component.fixture.ts
@@ -9,6 +9,7 @@ import {
 import {
   SkyDataManagerModule,
   SkyDataManagerService,
+  SkyDataManagerSortOption,
   SkyDataManagerState,
   SkyDataViewConfig,
 } from '@skyux/data-manager';
@@ -75,6 +76,28 @@ export class SkyAgGridDataManagerFixtureComponent implements OnInit {
   public displaySecondGrid = input(false);
   public displayOtherView = input(false);
   public enableTopScroll = input(false);
+  public enableSort = false;
+
+  public sortOptions: SkyDataManagerSortOption[] = [
+    {
+      id: 'az',
+      label: 'First Name (A - Z)',
+      descending: false,
+      propertyName: 'name',
+    },
+    {
+      id: 'za',
+      label: 'First Name (Z - A)',
+      descending: true,
+      propertyName: 'name',
+    },
+    {
+      id: 'byBlank',
+      label: 'Blank column',
+      descending: false,
+      propertyName: 'noHeader',
+    },
+  ];
 
   public gridData = SKY_AG_GRID_DATA;
 
@@ -117,13 +140,18 @@ export class SkyAgGridDataManagerFixtureComponent implements OnInit {
       gridOptions: this.gridOptions,
     });
     this.#dataManagerService.initDataManager({
-      dataManagerConfig: {},
+      dataManagerConfig: this.enableSort
+        ? { sortOptions: this.sortOptions }
+        : {},
       defaultDataState: this.initialDataState,
       activeViewId: this.displayOtherView() ? 'otherView' : this.viewConfig.id,
       settingsKey: 'test',
     });
 
-    this.#dataManagerService.initDataView(this.viewConfig);
+    this.#dataManagerService.initDataView({
+      ...this.viewConfig,
+      sortEnabled: this.enableSort,
+    });
 
     if (this.displayOtherView()) {
       this.#dataManagerService.initDataView({

--- a/libs/components/code-examples/src/lib/modules/data-manager/data-manager/basic/view-grid.component.ts
+++ b/libs/components/code-examples/src/lib/modules/data-manager/data-manager/basic/view-grid.component.ts
@@ -114,6 +114,7 @@ export class ViewGridComponent {
       iconName: 'table',
       searchEnabled: true,
       columnPickerEnabled: true,
+      sortEnabled: true,
       columnOptions: this.#columnDefs.map(
         (colDef): SkyDataManagerColumnPickerOption => ({
           id: colDef.colId!,


### PR DESCRIPTION
The data manager sort button treated a sort option's arbitrary `id` as
an AG Grid `colId`, so selecting a menu item silently sorted nothing
and cleared any existing column sort. Resolve the target column via
`propertyName` (falling back to `id` for back-compat), and reuse the
matching sort option on grid-driven sort changes so the menu's
selection stays in sync.

[AB#4104863](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/4104863)

<!-- This is an auto-generated comment: release notes by coderabbit.ai
-->

* **New Features**
  * Enabled sorting in data manager grid views.
  * Added toolbar controls for ascending and descending sorting.
  * Sort selections now stay synchronized with the active grid sort.
  * Saved sort options can match columns by ID, field, or property name.
  * Added configured sort options with column-based fallback behavior.

* **Tests**
* Added coverage for sort matching, state synchronization,
toolbar-driven sorting, and columns without headers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---------

Co-authored-by: Claude Sonnet 5 <noreply@anthropic.com>
Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled sorting in data manager grid views.
  * Added support for sorting by configured field names or column IDs.
  * Added toolbar controls for ascending and descending sort orders.
  * Expanded data manager configuration to enable sorting and define sort options.

* **Bug Fixes**
  * Improved preservation and synchronization of active sort selections when applying saved grid state.
  * Improved handling of sort settings when columns use identifiers instead of field names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->