### PR TITLE
fix(components/text-editor): ensure editor area is always white

### DIFF
--- a/libs/components/text-editor/src/lib/modules/text-editor/text-editor.component.scss
+++ b/libs/components/text-editor/src/lib/modules/text-editor/text-editor.component.scss
@@ -3,7 +3,6 @@
 @use 'libs/components/theme/src/lib/styles/compat-tokens-mixins' as compatMixins;
 
 @include compatMixins.sky-default-overrides('.sky-text-editor') {
-  --sky-override-text-editor-background-color: white;
   --sky-override-text-editor-toolbar-background-color: white;
   --sky-override-text-editor-label-background-color: transparent;
   --sky-override-text-editor-border-error: 1px solid
@@ -108,7 +107,7 @@ sky-text-editor.sky-form-field-stacked {
   .sky-text-editor-wrapper {
     display: flex;
     flex-wrap: wrap;
-    background-color: var(--sky-override-text-editor-background-color);
+    background-color: #fff;
     width: 100%;
     height: 300px;
     padding: var(
@@ -141,7 +140,7 @@ sky-text-editor.sky-form-field-stacked {
     &.sky-text-editor-wrapper-disabled {
       background-color: var(
         --sky-override-text-editor-wrapper-background-color-disabled,
-        var(--sky-color-background-input-disabled)
+        #eeeeef
       );
       box-shadow: var(
         --sky-override-text-editor-box-shadow,

--- a/libs/components/text-editor/src/lib/modules/text-editor/text-editor.component.scss
+++ b/libs/components/text-editor/src/lib/modules/text-editor/text-editor.component.scss
@@ -108,10 +108,7 @@ sky-text-editor.sky-form-field-stacked {
   .sky-text-editor-wrapper {
     display: flex;
     flex-wrap: wrap;
-    background-color: var(
-      --sky-override-text-editor-background-color,
-      #fcfdfd
-    );
+    background-color: var(--sky-override-text-editor-background-color, #fcfdfd);
     width: 100%;
     height: 300px;
     padding: var(

--- a/libs/components/text-editor/src/lib/modules/text-editor/text-editor.component.scss
+++ b/libs/components/text-editor/src/lib/modules/text-editor/text-editor.component.scss
@@ -110,7 +110,7 @@ sky-text-editor.sky-form-field-stacked {
     flex-wrap: wrap;
     background-color: var(
       --sky-override-text-editor-background-color,
-      #FCFDFD
+      #fcfdfd
     );
     width: 100%;
     height: 300px;

--- a/libs/components/text-editor/src/lib/modules/text-editor/text-editor.component.scss
+++ b/libs/components/text-editor/src/lib/modules/text-editor/text-editor.component.scss
@@ -3,6 +3,7 @@
 @use 'libs/components/theme/src/lib/styles/compat-tokens-mixins' as compatMixins;
 
 @include compatMixins.sky-default-overrides('.sky-text-editor') {
+  --sky-override-text-editor-background-color: white;
   --sky-override-text-editor-toolbar-background-color: white;
   --sky-override-text-editor-label-background-color: transparent;
   --sky-override-text-editor-border-error: 1px solid
@@ -107,7 +108,10 @@ sky-text-editor.sky-form-field-stacked {
   .sky-text-editor-wrapper {
     display: flex;
     flex-wrap: wrap;
-    background-color: #fff;
+    background-color: var(
+      --sky-override-text-editor-background-color,
+      #FCFDFD
+    );
     width: 100%;
     height: 300px;
     padding: var(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated the text editor’s default background to a near-white shade.
  * Updated the disabled editor background to a light gray shade.
  * Refined background colors across active and disabled states for a more consistent visual appearance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->