### PR TITLE
fix(components/packages): legacy resource service migrations should handle utf bom

### DIFF
--- a/libs/components/packages/src/schematics/migrations/update-15/legacy-i18n-services/legacy-i18n-services.schematic.spec.ts
+++ b/libs/components/packages/src/schematics/migrations/update-15/legacy-i18n-services/legacy-i18n-services.schematic.spec.ts
@@ -282,6 +282,40 @@ export const svc = SkyAppResourcesService;`;
     expect(tree.readText('/src/app/test.ts')).toBe(content);
   });
 
+  it('should swap the service in a file with a UTF-8 BOM', async () => {
+    const bom = '\uFEFF';
+    const tree = setupTree({
+      '/src/app/test.component.ts': `${bom}import { Component, inject } from '@angular/core';
+import { SkyAppResourcesService, SkyI18nModule } from '@skyux/i18n';
+
+@Component({ selector: 'app-test', template: '' })
+export class TestComponent {
+  readonly #resources = inject(SkyAppResourcesService);
+}`,
+    });
+
+    await runSchematic(tree);
+
+    // `Tree#readText` decodes and strips the BOM, so assert against the
+    // BOM-less text here...
+    expect(tree.readText('/src/app/test.component.ts'))
+      .toBe(`import { Component, inject } from '@angular/core';
+import { SkyAppResourcesLegacyService, SkyI18nModule } from '@skyux/i18n';
+
+@Component({ selector: 'app-test', template: '' })
+export class TestComponent {
+  readonly #resources = inject(SkyAppResourcesLegacyService);
+}`);
+
+    // ...and separately confirm the BOM byte sequence is still present (and
+    // the edits weren't shifted) in the raw file content.
+    const rawContent = tree
+      .read('/src/app/test.component.ts')
+      ?.toString('utf-8');
+    expect(rawContent?.startsWith(bom)).toBe(true);
+    expect(rawContent).toContain('SkyAppResourcesLegacyService, SkyI18nModule');
+  });
+
   it('should not change unrelated files', async () => {
     const content = `import { SkyAppLocaleProvider } from '@skyux/i18n';
 

--- a/libs/components/packages/src/schematics/utility/typescript/ng-ast.spec.ts
+++ b/libs/components/packages/src/schematics/utility/typescript/ng-ast.spec.ts
@@ -9,6 +9,7 @@ import {
   getInlineTemplates,
   getTemplateUrls,
   isSymbolInClassMetadataFieldArray,
+  parseSourceFile,
 } from './ng-ast';
 
 function getTsSource(path: string, content: string): ts.SourceFile {
@@ -34,6 +35,31 @@ function applyChanges(
 }
 
 describe('ng-ast', () => {
+  describe('parseSourceFile', () => {
+    it('should parse an existing file', () => {
+      const tree = new HostTree();
+      tree.create(
+        '/test.component.ts',
+        `import { Component } from '@angular/core';`,
+      );
+
+      const sourceFile = parseSourceFile(tree, '/test.component.ts');
+
+      expect(sourceFile.fileName).toBe('/test.component.ts');
+      expect(sourceFile.text).toBe(
+        `import { Component } from '@angular/core';`,
+      );
+    });
+
+    it('should throw when the file does not exist', () => {
+      const tree = new HostTree();
+
+      expect(() => parseSourceFile(tree, '/missing.component.ts')).toThrow(
+        'Could not read file: /missing.component.ts',
+      );
+    });
+  });
+
   describe('getInlineTemplates', () => {
     it('should get inline templates', () => {
       const sourceText = stripIndents`

--- a/libs/components/packages/src/schematics/utility/typescript/ng-ast.ts
+++ b/libs/components/packages/src/schematics/utility/typescript/ng-ast.ts
@@ -13,14 +13,18 @@ import ts from 'typescript';
  * Parse a TypeScript source file from tree
  */
 export function parseSourceFile(tree: Tree, filePath: string): ts.SourceFile {
-  const content = tree.read(filePath);
-  if (!content) {
+  if (tree.read(filePath) === null) {
     throw new Error(`Could not read file: ${filePath}`);
   }
 
+  // `Tree#readText` strips a leading UTF-8 BOM (via `TextDecoder`), matching
+  // the coordinate space `UpdateRecorder` uses internally. Reading raw bytes
+  // and calling `Buffer#toString()` instead keeps the BOM as a `\uFEFF`
+  // character, shifting every AST position by one relative to the recorder
+  // and corrupting edits in BOM-prefixed files.
   return ts.createSourceFile(
     filePath,
-    content.toString(),
+    tree.readText(filePath),
     ts.ScriptTarget.Latest,
     true,
   );


### PR DESCRIPTION
[AB#4113537](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/4113537)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved migration handling for files containing UTF-8 byte-order marks, preserving file encoding while applying updates at the correct positions.
  - Improved source-file parsing reliability by ensuring unreadable or missing files produce a clear error.
  - Updated parsing behavior to keep file coordinates aligned when processing encoded files.

- **Tests**
  - Added coverage for UTF-8 byte-order marks, existing files, and missing-file errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->