### PR TITLE
fix(components/manifest): inline TypeScript helpers to remove undeclared tslib dependency

### DIFF
--- a/libs/components/manifest/tsconfig.json
+++ b/libs/components/manifest/tsconfig.json
@@ -1,6 +1,9 @@
 {
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
+    // Inline TypeScript's helpers; a `require("tslib")` in this CommonJS output
+    // breaks browser builds that consume the package through a tsconfig path.
+    "importHelpers": false,
     "isolatedModules": true,
     "module": "CommonJS",
     "moduleResolution": "node",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Build Improvements**
  * Updated manifest build output to inline required helpers, reducing reliance on an external runtime helper package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->