### PR TITLE
feat(components/docs-tools): add dark mode theme for code snippet (#4765)

### DIFF
--- a/libs/components/docs-tools/src/lib/modules/code-snippet/code-snippet-wrapper.component.ts
+++ b/libs/components/docs-tools/src/lib/modules/code-snippet/code-snippet-wrapper.component.ts
@@ -26,6 +26,7 @@ import { SkyDocsCodeSnippetToolbarComponent } from './code-snippet-toolbar.compo
   styleUrls: [
     './code-snippet.component.scss',
     './themes/vscode-modern-light.scss',
+    './themes/vscode-modern-dark.scss',
   ],
   template: `
     @if (!hideToolbar()) {

--- a/libs/components/docs-tools/src/lib/modules/code-snippet/code-snippet.component.ts
+++ b/libs/components/docs-tools/src/lib/modules/code-snippet/code-snippet.component.ts
@@ -32,6 +32,7 @@ import { SkyDocsCodeSnippetToolbarComponent } from './code-snippet-toolbar.compo
   styleUrls: [
     './code-snippet.component.scss',
     './themes/vscode-modern-light.scss',
+    './themes/vscode-modern-dark.scss',
   ],
   template: `
     @if (!hideToolbar()) {

--- a/libs/components/docs-tools/src/lib/modules/code-snippet/themes/vscode-modern-dark.scss
+++ b/libs/components/docs-tools/src/lib/modules/code-snippet/themes/vscode-modern-dark.scss
@@ -1,0 +1,57 @@
+.sky-theme-modern.sky-theme-mode-dark {
+  sky-docs-code-snippet {
+    .hljs-keyword,
+    .hljs-doctag,
+    .hljs-variable.language_,
+    .hljs-literal,
+    .hljs-function {
+      color: #569cd6;
+    }
+
+    .hljs-meta,
+    .hljs-title.class_,
+    .hljs-built_in,
+    .hljs-params {
+      color: #4ec9b0;
+    }
+
+    .hljs-attribute,
+    .hljs-title.function_ {
+      color: #dcdcaa;
+    }
+
+    .hljs-attr {
+      color: #9cdcfe;
+    }
+
+    .hljs-string {
+      color: #ce9178;
+    }
+
+    .hljs-comment {
+      color: #6a9955;
+    }
+
+    .hljs-attr,
+    .hljs-property,
+    .hljs-variable.constant_ {
+      color: #4fc1ff;
+    }
+
+    .hljs-number {
+      color: #b5cea8;
+    }
+
+    .hljs-tag {
+      .hljs-name {
+        color: #569cd6;
+      }
+      .hljs-attr {
+        color: #9cdcfe;
+      }
+      .hljs-string {
+        color: #ce9178;
+      }
+    }
+  }
+}

--- a/libs/components/manifest/tsconfig.json
+++ b/libs/components/manifest/tsconfig.json
@@ -1,6 +1,9 @@
 {
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
+    // Inline TypeScript's helpers; a `require("tslib")` in this CommonJS output
+    // breaks browser builds that consume the package through a tsconfig path.
+    "importHelpers": false,
     "isolatedModules": true,
     "module": "CommonJS",
     "moduleResolution": "node",


### PR DESCRIPTION
:cherries: Cherry picked from #4765 [feat(components/docs-tools): add dark mode theme for code snippet](https://github.com/blackbaud/skyux/pull/4765)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Added a modern dark VS Code theme for syntax highlighting in documentation code snippets.
  - Improved readability for keywords, functions, strings, comments, properties, numbers, and other code elements.

- **Bug Fixes**
  - Updated browser builds to avoid requiring a separate runtime helper package when using the package through a TypeScript path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->