### PR TITLE
fix: input components native controls match color scheme

### DIFF
--- a/apps/e2e/forms-storybook-e2e/src/e2e/input-box.component.cy.ts
+++ b/apps/e2e/forms-storybook-e2e/src/e2e/input-box.component.cy.ts
@@ -72,15 +72,12 @@ describe('forms-storybook - input box', () => {
         cy.skyReady('app-input-box', [], ['#input-box-number'])
           .get('#input-box-number input')
           .click();
-        cy.get('#input-box-number').screenshot(
-          `inputboxcomponent-inputbox--input-box-${theme}-number-focus`,
-        );
-        cy.get('#input-box-number').percySnapshot(
+        cy.skyVisualTest(
           `inputboxcomponent-inputbox--input-box-${theme}-number-focus`,
           {
-            widths: E2eVariations.DISPLAY_WIDTHS,
-            scope: '#input-box-number',
+            overwrite: true,
           },
+          '#input-box-number',
         );
       });
 

--- a/apps/e2e/forms-storybook-e2e/src/e2e/input-box.component.cy.ts
+++ b/apps/e2e/forms-storybook-e2e/src/e2e/input-box.component.cy.ts
@@ -68,6 +68,22 @@ describe('forms-storybook - input box', () => {
         );
       });
 
+      it('should properly focus a number input box', () => {
+        cy.skyReady('app-input-box', [], ['#input-box-number'])
+          .get('#input-box-number input')
+          .click();
+        cy.get('#input-box-number').screenshot(
+          `inputboxcomponent-inputbox--input-box-${theme}-number-focus`,
+        );
+        cy.get('#input-box-number').percySnapshot(
+          `inputboxcomponent-inputbox--input-box-${theme}-number-focus`,
+          {
+            widths: E2eVariations.DISPLAY_WIDTHS,
+            scope: '#input-box-number',
+          },
+        );
+      });
+
       it('should properly focus a input box with buttons', () => {
         cy.skyReady('app-input-box', [], ['#input-box-button-multiple'])
           .get('#input-box-button-multiple input')

--- a/apps/e2e/forms-storybook/src/app/input-box/input-box.component.html
+++ b/apps/e2e/forms-storybook/src/app/input-box/input-box.component.html
@@ -259,49 +259,49 @@ Value</textarea
 
 <div class="sky-padding-even-md" id="input-box-number">
   <sky-input-box stacked="true" labelText="Number">
-    <input type="number" value="8675309"/>
+    <input type="number" value="8675309" />
   </sky-input-box>
 </div>
 
 <div class="sky-padding-even-md" id="input-box-number-disabled">
   <sky-input-box stacked="true" labelText="Number" [disabled]="true">
-    <input type="number" value="8675309" disabled/>
+    <input type="number" value="8675309" disabled />
   </sky-input-box>
 </div>
 
 <div class="sky-padding-even-md" id="input-box-email">
   <sky-input-box stacked="true" labelText="Email">
-    <input type="email" value="no-reply@blackbaud.com"/>
+    <input type="email" value="no-reply@blackbaud.com" />
   </sky-input-box>
 </div>
 
 <div class="sky-padding-even-md" id="input-box-email-disabled">
   <sky-input-box stacked="true" labelText="Email" [disabled]="true">
-    <input type="email"value="no-reply@blackbaud.com" disabled/>
+    <input type="email" value="no-reply@blackbaud.com" disabled />
   </sky-input-box>
 </div>
 
 <div class="sky-padding-even-md" id="input-box-password">
   <sky-input-box stacked="true" labelText="Password">
-    <input type="password" value="testpass"/>
+    <input type="password" value="testpass" />
   </sky-input-box>
 </div>
 
 <div class="sky-padding-even-md" id="input-box-password-disabled">
   <sky-input-box stacked="true" labelText="Password" [disabled]="true">
-    <input type="password" value="testpass" disabled/>
+    <input type="password" value="testpass" disabled />
   </sky-input-box>
 </div>
 
 <div class="sky-padding-even-md" id="input-box-tel">
   <sky-input-box stacked="true" labelText="Telephone">
-    <input type="tel" value="8675309"/>
+    <input type="tel" value="8675309" />
   </sky-input-box>
 </div>
 
 <div class="sky-padding-even-md" id="input-box-tel-disabled">
   <sky-input-box stacked="true" labelText="Telephone" [disabled]="true">
-    <input type="tel" value="8675309" disabled/>
+    <input type="tel" value="8675309" disabled />
   </sky-input-box>
 </div>
 

--- a/apps/e2e/forms-storybook/src/app/input-box/input-box.component.html
+++ b/apps/e2e/forms-storybook/src/app/input-box/input-box.component.html
@@ -257,6 +257,54 @@ Value</textarea
   </sky-input-box>
 </div>
 
+<div class="sky-padding-even-md" id="input-box-number">
+  <sky-input-box stacked="true" labelText="Number">
+    <input type="number" value="8675309"/>
+  </sky-input-box>
+</div>
+
+<div class="sky-padding-even-md" id="input-box-number-disabled">
+  <sky-input-box stacked="true" labelText="Number" [disabled]="true">
+    <input type="number" value="8675309" disabled/>
+  </sky-input-box>
+</div>
+
+<div class="sky-padding-even-md" id="input-box-email">
+  <sky-input-box stacked="true" labelText="Email">
+    <input type="email" value="no-reply@blackbaud.com"/>
+  </sky-input-box>
+</div>
+
+<div class="sky-padding-even-md" id="input-box-email-disabled">
+  <sky-input-box stacked="true" labelText="Email" [disabled]="true">
+    <input type="email"value="no-reply@blackbaud.com" disabled/>
+  </sky-input-box>
+</div>
+
+<div class="sky-padding-even-md" id="input-box-password">
+  <sky-input-box stacked="true" labelText="Password">
+    <input type="password" value="testpass"/>
+  </sky-input-box>
+</div>
+
+<div class="sky-padding-even-md" id="input-box-password-disabled">
+  <sky-input-box stacked="true" labelText="Password" [disabled]="true">
+    <input type="password" value="testpass" disabled/>
+  </sky-input-box>
+</div>
+
+<div class="sky-padding-even-md" id="input-box-tel">
+  <sky-input-box stacked="true" labelText="Telephone">
+    <input type="tel" value="8675309"/>
+  </sky-input-box>
+</div>
+
+<div class="sky-padding-even-md" id="input-box-tel-disabled">
+  <sky-input-box stacked="true" labelText="Telephone" [disabled]="true">
+    <input type="tel" value="8675309" disabled/>
+  </sky-input-box>
+</div>
+
 <div class="sky-padding-even-md" id="input-box-select">
   <sky-input-box stacked="true">
     <label class="sky-control-label" [for]="inputBoxSelect.id"> Select </label>

--- a/libs/components/packages/package.json
+++ b/libs/components/packages/package.json
@@ -107,7 +107,7 @@
     "@angular/core": "^21.2.0"
   },
   "dependencies": {
-    "@blackbaud/skyux-design-tokens": "6.10.0",
+    "@blackbaud/skyux-design-tokens": "6.11.0",
     "fs-extra": "11.3.4",
     "jsonc-parser": "3.3.1",
     "parse5": "7.3.0",

--- a/libs/components/theme/package.json
+++ b/libs/components/theme/package.json
@@ -20,7 +20,7 @@
     "@angular/core": "^21.2.0"
   },
   "dependencies": {
-    "@blackbaud/skyux-design-tokens": "6.10.0",
+    "@blackbaud/skyux-design-tokens": "6.11.0",
     "fontfaceobserver": "2.3.0",
     "tslib": "^2.8.1"
   },

--- a/libs/components/theme/src/lib/styles/themes/modern/_forms.scss
+++ b/libs/components/theme/src/lib/styles/themes/modern/_forms.scss
@@ -4,7 +4,7 @@
 .sky-theme-modern {
   .sky-form-control {
     font-size: var(--sky-font-size-body-m);
-    color-scheme: light;
+    color-scheme: var(--sky-color_scheme);
   }
 
   .sky-error-label {
@@ -22,11 +22,5 @@
     color: var(--sky-color-text-deemphasized);
     font-style: var(--sky-font-style-deemphasized-style);
     opacity: 1;
-  }
-}
-
-.sky-theme-modern.sky-theme-mode-dark {
-  .sky-form-control {
-    color-scheme: dark;
   }
 }

--- a/libs/components/theme/src/lib/styles/themes/modern/_forms.scss
+++ b/libs/components/theme/src/lib/styles/themes/modern/_forms.scss
@@ -4,6 +4,7 @@
 .sky-theme-modern {
   .sky-form-control {
     font-size: var(--sky-font-size-body-m);
+    color-scheme: light;
   }
 
   .sky-error-label {
@@ -21,5 +22,11 @@
     color: var(--sky-color-text-deemphasized);
     font-style: var(--sky-font-style-deemphasized-style);
     opacity: 1;
+  }
+}
+
+.sky-theme-modern.sky-theme-mode-dark {
+  .sky-form-control {
+    color-scheme: dark;
   }
 }

--- a/libs/sdk/skyux-eslint/package.json
+++ b/libs/sdk/skyux-eslint/package.json
@@ -33,7 +33,7 @@
     "@typescript-eslint/utils": "^8.56.1"
   },
   "dependencies": {
-    "@blackbaud/skyux-design-tokens": "6.10.0",
+    "@blackbaud/skyux-design-tokens": "6.11.0",
     "@skyux-sdk/eslint-schematics": "0.0.0-PLACEHOLDER",
     "@skyux/manifest": "0.0.0-PLACEHOLDER",
     "tslib": "^2.8.1"

--- a/libs/sdk/skyux-stylelint/package.json
+++ b/libs/sdk/skyux-stylelint/package.json
@@ -23,7 +23,7 @@
     "stylelint": "^17.14.1"
   },
   "dependencies": {
-    "@blackbaud/skyux-design-tokens": "6.10.0",
+    "@blackbaud/skyux-design-tokens": "6.11.0",
     "tslib": "^2.8.1"
   },
   "type": "module",

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@angular/platform-browser-dynamic": "21.2.0",
         "@angular/router": "21.2.0",
         "@blackbaud/angular-tree-component": "1.0.0",
-        "@blackbaud/skyux-design-tokens": "6.10.0",
+        "@blackbaud/skyux-design-tokens": "6.11.0",
         "@eslint/js": "9.39.3",
         "@nx/angular": "22.5.3",
         "@skyux/icons": "10.4.0",
@@ -3287,9 +3287,9 @@
       }
     },
     "node_modules/@blackbaud/skyux-design-tokens": {
-      "version": "6.10.0",
-      "resolved": "https://registry.npmjs.org/@blackbaud/skyux-design-tokens/-/skyux-design-tokens-6.10.0.tgz",
-      "integrity": "sha512-WJXYOzLW7qiugQYTcV/jHIhNZ1yxh3YFZb0G+3V5RysoISHCJ+tH0GPWYpYOIEiS92aZgzeKmb7sSKCKMS2fCw==",
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/@blackbaud/skyux-design-tokens/-/skyux-design-tokens-6.11.0.tgz",
+      "integrity": "sha512-J4nl4KA2SPxEHUrgz6mWM/YVUkN11g1p8SBQCHinGQ+V72bfakAvt3Awu4Z0i8KUgaDRdhp7jZSUjtQZv8Pzmw==",
       "license": "MIT",
       "engines": {
         "node": ">= 4.2.1",

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "@angular/platform-browser-dynamic": "21.2.0",
     "@angular/router": "21.2.0",
     "@blackbaud/angular-tree-component": "1.0.0",
-    "@blackbaud/skyux-design-tokens": "6.10.0",
+    "@blackbaud/skyux-design-tokens": "6.11.0",
     "@eslint/js": "9.39.3",
     "@nx/angular": "22.5.3",
     "@skyux/icons": "10.4.0",


### PR DESCRIPTION
[AB#4111910](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/4111910)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added examples showcasing number, email, password, and telephone input fields.
  - Added enabled and disabled variants for each input type.

- **Style**
  - Updated modern theme form controls to follow the active light or dark color scheme.

- **Tests**
  - Added visual coverage for focused number input fields using the number-input examples.
  - Improved visual test scoping for more reliable focused-input comparisons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->