### PR TITLE
ci: disable animations for charts screenshots (#4755)

### DIFF
--- a/libs/components/charts/src/lib/chart-js/chart-js-config-utils.spec.ts
+++ b/libs/components/charts/src/lib/chart-js/chart-js-config-utils.spec.ts
@@ -62,6 +62,27 @@ describe('extendBaseChartJsConfig', () => {
     );
   });
 
+  it('should animate for the theme motion duration', () => {
+    const config = extend();
+
+    expect(config.options.animation).toEqual(
+      jasmine.objectContaining({ duration: 150, easing: 'easeInOutQuart' }),
+    );
+  });
+
+  it('should not animate when the theme suppresses motion', () => {
+    const config = extendBaseChartJsConfig<'bar'>(
+      createThemeStylesFixture({ motion: { duration: 0 } }),
+      {
+        type: 'bar',
+        data: { labels: ['a'], datasets: [{ data: [1] }] },
+        options: {},
+      },
+    );
+
+    expect(config.options.animation).toBe(false);
+  });
+
   it('should merge the base tooltip styling with the chart-specific callbacks', () => {
     const tooltip = getTooltip(extend());
 

--- a/libs/components/charts/src/lib/chart-js/chart-js-config-utils.ts
+++ b/libs/components/charts/src/lib/chart-js/chart-js-config-utils.ts
@@ -10,7 +10,7 @@ import { type SkyChartJsConfig } from './chart-js';
 function buildBaseChartJsOptions(
   themeStyles: SkyChartThemeStyles,
 ): ChartOptions {
-  const { font, text, tooltip } = themeStyles;
+  const { font, motion, text, tooltip } = themeStyles;
 
   const bodyFont = {
     family: font.family,
@@ -28,7 +28,14 @@ function buildBaseChartJsOptions(
     // Interaction: hovering and tooltips target the nearest point precisely.
     interaction: { mode: 'nearest', intersect: true },
     hover: { mode: 'nearest', intersect: true },
-    animation: { duration: 400, easing: 'easeInOutQuart' },
+
+    // Motion: the canvas cannot inherit CSS transitions, so the theme's
+    // duration drives the animation. `false` skips the animation frames
+    // entirely when motion is suppressed, so the chart paints its final state
+    // on the first frame.
+    animation: motion.duration
+      ? { duration: motion.duration, easing: 'easeInOutQuart' }
+      : false,
 
     plugins: {
       legend: {

--- a/libs/components/charts/src/lib/shared/chart-theme-styles.spec.ts
+++ b/libs/components/charts/src/lib/shared/chart-theme-styles.spec.ts
@@ -99,6 +99,28 @@ describe('resolveChartThemeStyles', () => {
     expect(themeStyles.text.lineHeight).toBe(1.25);
   });
 
+  it('should resolve the motion duration in milliseconds', () => {
+    // The three values `@skyux/theme` authors: the default, the
+    // `prefers-reduced-motion` value, and the motion-suppressed value.
+    expect(
+      resolve({ '--sky-global-duration-short': '150ms' }).motion.duration,
+    ).toBe(150);
+
+    expect(
+      resolve({ '--sky-global-duration-short': '1ms' }).motion.duration,
+    ).toBe(1);
+
+    expect(
+      resolve({ '--sky-global-duration-short': '0s' }).motion.duration,
+    ).toBe(0);
+  });
+
+  it('should resolve an unresolved motion duration to zero', () => {
+    expect(
+      resolve({ '--sky-global-duration-short': 'auto' }).motion.duration,
+    ).toBe(0);
+  });
+
   it('should resolve the eight categorical palette colors in order', () => {
     const themeStyles = resolve({
       '--sky-color-viz-category-1': '#first',

--- a/libs/components/charts/src/lib/shared/chart-theme-styles.ts
+++ b/libs/components/charts/src/lib/shared/chart-theme-styles.ts
@@ -23,6 +23,15 @@ export interface SkyChartThemeStyles {
     deemphasizedColor: string;
     lineHeight: number;
   };
+  motion: {
+    /**
+     * How long a chart animates for, in milliseconds. Resolves to `0` when
+     * motion is suppressed — by `sky-animations-disabled` or a
+     * `prefers-reduced-motion` preference — so the canvas honors the same
+     * motion preferences as CSS.
+     */
+    duration: number;
+  };
   height: {
     /** The minimum chart height, in pixels. */
     min: number;
@@ -162,6 +171,9 @@ export function resolveChartThemeStyles(
         color: readString(styles, '--sky-color-text-default'),
         deemphasizedColor: readString(styles, '--sky-color-text-deemphasized'),
         lineHeight: readLineHeight(styles, probe),
+      },
+      motion: {
+        duration: readDuration(styles, '--sky-global-duration-short'),
       },
       height: {
         min: minHeight,
@@ -345,6 +357,23 @@ function readNumber(
  */
 function remToPx(rem: string, rootFontSize: number): number {
   return Number.parseFloat(rem) * rootFontSize;
+}
+
+/**
+ * Reads a CSS duration token as milliseconds. `@skyux/theme` authors the token
+ * as `150ms`, as `1ms` under `prefers-reduced-motion`, or as `0s` when
+ * `sky-animations-disabled` suppresses motion. An unresolved token falls back
+ * to `0` rather than `NaN`, which would break the animation loop.
+ */
+function readDuration(styles: CSSStyleDeclaration, property: string): number {
+  const raw = readString(styles, property);
+  const value = Number.parseFloat(raw);
+
+  if (Number.isNaN(value)) {
+    return 0;
+  }
+
+  return raw.endsWith('ms') ? value : value * 1000;
 }
 
 /**

--- a/libs/components/charts/src/lib/shared/fixtures/theme-styles-fixture.ts
+++ b/libs/components/charts/src/lib/shared/fixtures/theme-styles-fixture.ts
@@ -19,6 +19,9 @@ export function createThemeStylesFixture(
       deemphasizedColor: '#222222',
       lineHeight: 1.5,
     },
+    motion: {
+      duration: 150,
+    },
     height: {
       min: 180,
       max: 400,


### PR DESCRIPTION
:cherries: Cherry picked from #4755 [ci: disable animations for charts screenshots](https://github.com/blackbaud/skyux/pull/4755)

[AB#4103357](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/4103357) 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Chart animations now use the duration and easing configured by the active theme.
  - Animation is disabled when the theme specifies a zero duration.
  - Theme duration values support milliseconds and seconds.

- **Bug Fixes**
  - Unresolved or invalid animation durations now safely default to zero.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->