### PR TITLE
chore: update library resources (#4763)

### DIFF
--- a/libs/components/datetime/src/assets/locales/resources_es.json
+++ b/libs/components/datetime/src/assets/locales/resources_es.json
@@ -53,7 +53,7 @@
   },
   "skyux_date_range_picker_end_date_before_start_date_error_label_text": {
     "_description": "Mensaje de error del selector del rango de fechas cuando la fecha de finalización es anterior a la fecha de inicio.",
-    "message": "Cambie el rango de fechas para que la fecha de finalización sea anterior a la fecha de inicio."
+    "message": "Cambie el rango de fechas para que la fecha de finalización no sea anterior a la fecha de inicio."
   },
   "skyux_date_range_picker_format_label_specific_range": {
     "_description": "Etiqueta de la opción de tipo de formato \"Rango específico\" del campo de selección del componente de selección del rango de fechas.",

--- a/libs/components/datetime/src/lib/modules/shared/sky-datetime-resources.module.ts
+++ b/libs/components/datetime/src/lib/modules/shared/sky-datetime-resources.module.ts
@@ -141,7 +141,7 @@ const RESOURCES: Record<string, SkyLibResources> = {
     },
     skyux_date_range_picker_end_date_before_start_date_error_label_text: {
       message:
-        'Cambie el rango de fechas para que la fecha de finalización sea anterior a la fecha de inicio.',
+        'Cambie el rango de fechas para que la fecha de finalización no sea anterior a la fecha de inicio.',
     },
     skyux_date_range_picker_format_label_specific_range: {
       message: 'Rango específico',

--- a/libs/components/lookup/src/assets/locales/resources_es.json
+++ b/libs/components/lookup/src/assets/locales/resources_es.json
@@ -53,7 +53,7 @@
   },
   "skyux_lookup_show_more_select_all_button_aria_label": {
     "_description": "Texto de la etiqueta ARIA del botón Seleccionar todo en la barra de herramientas de selección múltiple Mostrar más de la búsqueda",
-    "message": "Seleccionar los {0}"
+    "message": "Seleccionar todos los {0}"
   },
   "skyux_lookup_show_more_select_all_button_title": {
     "_description": "Texto del botón Seleccionar todo en la barra de herramientas de selección múltiple Mostrar más de la búsqueda",
@@ -61,7 +61,7 @@
   },
   "skyux_lookup_show_more_clear_all_button_aria_label": {
     "_description": "Texto de la etiqueta ARIA del botón Seleccionar todo en la barra de herramientas de selección múltiple Mostrar más de la búsqueda",
-    "message": "Borrar los {0} seleccionados"
+    "message": "Borrar todos los {0} seleccionados"
   },
   "skyux_lookup_show_more_clear_all_button_title": {
     "_description": "Texto del botón Borrar todo en la barra de herramientas de selección múltiple Mostrar más de la búsqueda",

--- a/libs/components/lookup/src/lib/modules/shared/sky-lookup-resources.module.ts
+++ b/libs/components/lookup/src/lib/modules/shared/sky-lookup-resources.module.ts
@@ -85,13 +85,13 @@ const RESOURCES: Record<string, SkyLibResources> = {
         'Se muestran {1} elementos, de los cuales {0} están seleccionados.',
     },
     skyux_lookup_show_more_select_all_button_aria_label: {
-      message: 'Seleccionar los {0}',
+      message: 'Seleccionar todos los {0}',
     },
     skyux_lookup_show_more_select_all_button_title: {
       message: 'Seleccionar todo',
     },
     skyux_lookup_show_more_clear_all_button_aria_label: {
-      message: 'Borrar los {0} seleccionados',
+      message: 'Borrar todos los {0} seleccionados',
     },
     skyux_lookup_show_more_clear_all_button_title: { message: 'Borrar todo' },
     skyux_lookup_show_more_show_selected_option_title: {

--- a/libs/components/phone-field/src/assets/locales/resources_es.json
+++ b/libs/components/phone-field/src/assets/locales/resources_es.json
@@ -17,7 +17,7 @@
   },
   "skyux_phone_field_country_selected_label": {
     "_description": "Texto del lector de pantalla del componente de campo de teléfono para indicar el país seleccionado.",
-    "message": "Actualmente está seleccionado(a) {0}."
+    "message": "País seleccionado actualmente: {0}."
   },
   "skyux_phone_field_format_hint_text": {
     "_description": "Texto de ayuda para el formato de número de teléfono establecido actualmente en el campo de teléfono.",

--- a/libs/components/phone-field/src/lib/modules/shared/sky-phone-field-resources.module.ts
+++ b/libs/components/phone-field/src/lib/modules/shared/sky-phone-field-resources.module.ts
@@ -40,7 +40,7 @@ const RESOURCES: Record<string, SkyLibResources> = {
     skyux_phone_field_country_search_placeholder: { message: 'Buscar un país' },
     skyux_phone_field_country_select_label: { message: 'Elegir país.' },
     skyux_phone_field_country_selected_label: {
-      message: 'Actualmente está seleccionado(a) {0}.',
+      message: 'País seleccionado actualmente: {0}.',
     },
     skyux_phone_field_format_hint_text: { message: 'Ejemplo: {0}.' },
   },

--- a/libs/components/text-editor/src/assets/locales/resources_es.json
+++ b/libs/components/text-editor/src/assets/locales/resources_es.json
@@ -60,7 +60,7 @@
     "message": "Copiar"
   },
   "skyux_text_editor_edit_menu_action_copy_key_shortcut": {
-    "_description": "Texto para el acceso rápido de \"Cortar\" del menú Editar",
+    "_description": "Texto para el acceso rápido de \"Copiar\" del menú Editar",
     "message": "Ctrl+C"
   },
   "skyux_text_editor_edit_menu_action_paste_label": {


### PR DESCRIPTION
:cherries: Cherry picked from #4763 [chore: update library resources](https://github.com/blackbaud/skyux/pull/4763)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected Spanish date-range validation text to clarify that the end date cannot precede the start date.
  - Improved Spanish accessibility labels for lookup actions, including select-all and clear-all controls.
  - Updated the Spanish phone-field label to clearly identify the currently selected country.
  - Corrected the Spanish text describing the Copy keyboard shortcut in the text editor.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->