### PR TITLE
chore: release 15.0.0-alpha.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Bug Fixes
 
+* **components/forms:** recalculate selection box heights when the grid becomes visible ([#4770](https://github.com/blackbaud/skyux/issues/4770)) ([#4777](https://github.com/blackbaud/skyux/issues/4777)) ([495f139](https://github.com/blackbaud/skyux/commit/495f13918f67eae2b6c996f7d35eeb078d880d07)), closes [AB#4108383](https://dev.azure.com/blackbaud/Products/_workitems/edit/4108383)
 * **components/text-editor:** ensure editor area is always white ([#4756](https://github.com/blackbaud/skyux/issues/4756)) ([#4760](https://github.com/blackbaud/skyux/issues/4760)) ([fb2ff0d](https://github.com/blackbaud/skyux/commit/fb2ff0d2f7ccaf3ea8b46d4956d73ddbc94df26b))
 * **sdk/skyux-stylelint:** no-deprecated-sky-scss-variables fix should handle scss namespacing ([#4758](https://github.com/blackbaud/skyux/issues/4758)) ([5ea208c](https://github.com/blackbaud/skyux/commit/5ea208cd864d63927447dfc6024616316873570c)), closes [AB#4113536](https://dev.azure.com/blackbaud/Products/_workitems/edit/4113536)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Bug Fixes
 
 * **components/text-editor:** ensure editor area is always white ([#4756](https://github.com/blackbaud/skyux/issues/4756)) ([#4760](https://github.com/blackbaud/skyux/issues/4760)) ([fb2ff0d](https://github.com/blackbaud/skyux/commit/fb2ff0d2f7ccaf3ea8b46d4956d73ddbc94df26b))
+* **sdk/skyux-stylelint:** no-deprecated-sky-scss-variables fix should handle scss namespacing ([#4758](https://github.com/blackbaud/skyux/issues/4758)) ([5ea208c](https://github.com/blackbaud/skyux/commit/5ea208cd864d63927447dfc6024616316873570c)), closes [AB#4113536](https://dev.azure.com/blackbaud/Products/_workitems/edit/4113536)
 
 ## [15.0.0-alpha.12](https://github.com/blackbaud/skyux/compare/15.0.0-alpha.11...15.0.0-alpha.12) (2026-09-09)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
 
+## [15.0.0-alpha.13](https://github.com/blackbaud/skyux/compare/15.0.0-alpha.12...15.0.0-alpha.13) (2026-09-09)
+
+
+### Bug Fixes
+
+* **components/text-editor:** ensure editor area is always white ([#4756](https://github.com/blackbaud/skyux/issues/4756)) ([#4760](https://github.com/blackbaud/skyux/issues/4760)) ([fb2ff0d](https://github.com/blackbaud/skyux/commit/fb2ff0d2f7ccaf3ea8b46d4956d73ddbc94df26b))
+
 ## [15.0.0-alpha.12](https://github.com/blackbaud/skyux/compare/15.0.0-alpha.11...15.0.0-alpha.12) (2026-09-09)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "skyux",
-  "version": "15.0.0-alpha.12",
+  "version": "15.0.0-alpha.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "skyux",
-      "version": "15.0.0-alpha.12",
+      "version": "15.0.0-alpha.13",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skyux",
-  "version": "15.0.0-alpha.12",
+  "version": "15.0.0-alpha.13",
   "license": "MIT",
   "scripts": {
     "ng": "nx",


### PR DESCRIPTION
## [15.0.0-alpha.13](https://github.com/blackbaud/skyux/compare/15.0.0-alpha.12...15.0.0-alpha.13) (2026-09-09)


### Bug Fixes

* **components/forms:** recalculate selection box heights when the grid becomes visible ([#4770](https://github.com/blackbaud/skyux/issues/4770)) ([#4777](https://github.com/blackbaud/skyux/issues/4777)) ([495f139](https://github.com/blackbaud/skyux/commit/495f13918f67eae2b6c996f7d35eeb078d880d07)), closes [AB#4108383](https://dev.azure.com/blackbaud/Products/_workitems/edit/4108383)
* **components/text-editor:** ensure editor area is always white ([#4756](https://github.com/blackbaud/skyux/issues/4756)) ([#4760](https://github.com/blackbaud/skyux/issues/4760)) ([fb2ff0d](https://github.com/blackbaud/skyux/commit/fb2ff0d2f7ccaf3ea8b46d4956d73ddbc94df26b))
* **sdk/skyux-stylelint:** no-deprecated-sky-scss-variables fix should handle scss namespacing ([#4758](https://github.com/blackbaud/skyux/issues/4758)) ([5ea208c](https://github.com/blackbaud/skyux/commit/5ea208cd864d63927447dfc6024616316873570c)), closes [AB#4113536](https://dev.azure.com/blackbaud/Products/_workitems/edit/4113536)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed form selection-box heights when grids become visible.
  - Corrected the text-editor background styling.
  - Improved SCSS namespacing in the Stylelint rule.

- **Release**
  - Updated the package to version 15.0.0-alpha.13.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->