### PR TITLE
fix(components/forms): recalculate selection box heights when the grid becomes visible (#4770)

### DIFF
--- a/libs/components/forms/src/lib/modules/selection-box/selection-box-grid.component.spec.ts
+++ b/libs/components/forms/src/lib/modules/selection-box/selection-box-grid.component.spec.ts
@@ -1,7 +1,11 @@
 import { ElementRef } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { SkyAppTestUtility, expect, expectAsync } from '@skyux-sdk/testing';
-import { SkyCoreAdapterService, SkyMediaBreakpoints } from '@skyux/core';
+import { expect, expectAsync } from '@skyux-sdk/testing';
+import {
+  SkyCoreAdapterService,
+  SkyMediaBreakpoints,
+  SkyResizeObserverService,
+} from '@skyux/core';
 import {
   SkyTheme,
   SkyThemeMode,
@@ -10,7 +14,7 @@ import {
   SkyThemeSettingsChange,
 } from '@skyux/theme';
 
-import { BehaviorSubject } from 'rxjs';
+import { BehaviorSubject, Subject } from 'rxjs';
 
 import { SkySelectionBoxFixturesModule } from './fixtures/selection-box-fixtures.module';
 import { SelectionBoxGridTestComponent } from './fixtures/selection-box-grid.component.fixture';
@@ -42,9 +46,11 @@ describe('Selection box grid component', () => {
   let mockThemeSvc: {
     settingsChange: BehaviorSubject<SkyThemeSettingsChange>;
   };
+  let mockResize: Subject<void>;
   let setResponsiveClassSpy: jasmine.Spy;
 
   beforeEach(() => {
+    mockResize = new Subject<void>();
     mockThemeSvc = {
       settingsChange: new BehaviorSubject<SkyThemeSettingsChange>({
         currentSettings: new SkyThemeSettings(
@@ -66,6 +72,12 @@ describe('Selection box grid component', () => {
         {
           provide: SkyThemeService,
           useValue: mockThemeSvc,
+        },
+        {
+          provide: SkyResizeObserverService,
+          useValue: {
+            observe: (): Subject<void> => mockResize,
+          },
         },
       ],
     }).createComponent(SelectionBoxGridTestComponent);
@@ -117,20 +129,6 @@ describe('Selection box grid component', () => {
     for (const selectionBox of Array.from(selectionBoxes)) {
       expect(selectionBox.getBoundingClientRect().height).toEqual(newHeight);
     }
-  });
-
-  it(`should update CSS responsive classes on window resize`, () => {
-    spyOn(
-      SkySelectionBoxAdapterService.prototype,
-      'getParentWidth',
-    ).and.returnValue(300);
-    setResponsiveClassSpy.calls.reset();
-    expect(setResponsiveClassSpy).not.toHaveBeenCalled();
-
-    SkyAppTestUtility.fireDomEvent(window, 'resize');
-    fixture.detectChanges();
-
-    expect(setResponsiveClassSpy).toHaveBeenCalledTimes(1);
   });
 
   it('should set responsive CSS class to large', () => {
@@ -191,6 +189,24 @@ describe('Selection box grid component', () => {
     fixture.detectChanges();
     await fixture.whenStable();
     await waitForMutationObserver();
+    expect(resetHeightSpy).toHaveBeenCalledTimes(1);
+    expect(syncMaxHeightSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('should recalculate heights when the grid is resized', () => {
+    const resetHeightSpy = spyOn(
+      SkyCoreAdapterService.prototype,
+      'resetHeight',
+    );
+    const syncMaxHeightSpy = spyOn(
+      SkyCoreAdapterService.prototype,
+      'syncMaxHeight',
+    );
+
+    // A grid hidden from the layout (e.g. on an inactive tab) has no measurable
+    // height until it is displayed, which surfaces as a resize.
+    mockResize.next();
+
     expect(resetHeightSpy).toHaveBeenCalledTimes(1);
     expect(syncMaxHeightSpy).toHaveBeenCalledTimes(1);
   });

--- a/libs/components/forms/src/lib/modules/selection-box/selection-box-grid.component.ts
+++ b/libs/components/forms/src/lib/modules/selection-box/selection-box-grid.component.ts
@@ -3,7 +3,6 @@ import {
   Component,
   ContentChildren,
   ElementRef,
-  HostListener,
   Input,
   NgZone,
   OnDestroy,
@@ -13,10 +12,14 @@ import {
   ViewEncapsulation,
   inject,
 } from '@angular/core';
-import { SkyCoreAdapterService, SkyMutationObserverService } from '@skyux/core';
+import {
+  SkyCoreAdapterService,
+  SkyMutationObserverService,
+  SkyResizeObserverService,
+} from '@skyux/core';
 import { SkyThemeService } from '@skyux/theme';
 
-import { Subject } from 'rxjs';
+import { Subject, Subscription } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 
 import { SkySelectionBoxAdapterService } from './selection-box-adapter.service';
@@ -67,9 +70,11 @@ export class SkySelectionBoxGridComponent implements OnDestroy, OnInit {
   public set containerElementRef(value: ElementRef | undefined) {
     this.#_containerElementRef = value;
     this.#destroyMutationObserver();
+    this.#destroyResizeObserver();
     if (value) {
       this.#updateBreakpointClass();
       this.#initMutationObserver();
+      this.#initResizeObserver(value);
     }
   }
 
@@ -78,6 +83,7 @@ export class SkySelectionBoxGridComponent implements OnDestroy, OnInit {
   }
 
   #mutationObserver: MutationObserver | undefined;
+  #resizeSubscription: Subscription | undefined;
 
   #ngUnsubscribe = new Subject<void>();
 
@@ -90,6 +96,7 @@ export class SkySelectionBoxGridComponent implements OnDestroy, OnInit {
   readonly #hostElRef = inject(ElementRef);
   readonly #mutationObserverSvc = inject(SkyMutationObserverService);
   readonly #ngZone = inject(NgZone);
+  readonly #resizeObserverSvc = inject(SkyResizeObserverService);
   readonly #themeSvc = inject(SkyThemeService, { optional: true });
 
   public ngOnInit(): void {
@@ -108,11 +115,7 @@ export class SkySelectionBoxGridComponent implements OnDestroy, OnInit {
     this.#ngUnsubscribe.complete();
 
     this.#destroyMutationObserver();
-  }
-
-  @HostListener('window:resize')
-  public onWindowResize(): void {
-    this.#updateBreakpointClass();
+    this.#destroyResizeObserver();
   }
 
   #initMutationObserver(): void {
@@ -142,6 +145,19 @@ export class SkySelectionBoxGridComponent implements OnDestroy, OnInit {
       this.#mutationObserver.disconnect();
       this.#mutationObserver = undefined;
     }
+  }
+
+  #initResizeObserver(containerElementRef: ElementRef): void {
+    this.#resizeSubscription = this.#resizeObserverSvc
+      .observe(containerElementRef)
+      .subscribe(() => {
+        this.#updateBreakpointClass();
+      });
+  }
+
+  #destroyResizeObserver(): void {
+    this.#resizeSubscription?.unsubscribe();
+    this.#resizeSubscription = undefined;
   }
 
   #updateBreakpointClass(): void {


### PR DESCRIPTION
:cherries: Cherry picked from #4770 [fix(components/forms): recalculate selection box heights when the grid becomes visible](https://github.com/blackbaud/skyux/pull/4770)

[AB#4108383](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/4108383) 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved selection-box grid layout updates when its container changes size.
  - Grid heights now recalculate reliably during dynamic resizing, including when the container is replaced.
  - Improved cleanup of resize monitoring when the component is removed or no longer in use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->