### PR TITLE
chore: release 14.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
 
+## [14.20.2](https://github.com/blackbaud/skyux/compare/14.20.1...14.20.2) (2026-09-10)
+
+
+### Bug Fixes
+
+* input components native controls match color scheme ([#4769](https://github.com/blackbaud/skyux/issues/4769)) ([4593389](https://github.com/blackbaud/skyux/commit/4593389c831da5252f321364d1cedd82293b5cb2))
+
 ## [14.20.1](https://github.com/blackbaud/skyux/compare/14.20.0...14.20.1) (2026-09-09)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "skyux",
-  "version": "14.20.1",
+  "version": "14.20.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "skyux",
-      "version": "14.20.1",
+      "version": "14.20.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skyux",
-  "version": "14.20.1",
+  "version": "14.20.2",
   "license": "MIT",
   "scripts": {
     "ng": "nx",


### PR DESCRIPTION
## [14.21.0](https://github.com/blackbaud/skyux/compare/14.20.1...14.21.0) (2026-09-17)


### Features

* **components/icon:** resolve dark mode icon variants ([#4791](https://github.com/blackbaud/skyux/issues/4791)) ([5ca104d](https://github.com/blackbaud/skyux/commit/5ca104dd57786af8449d26369a47afb7c91540e5))


### Bug Fixes

* **components/colorpicker:** reset an originally-empty field to empty and pristine ([#4794](https://github.com/blackbaud/skyux/issues/4794)) ([906ca8e](https://github.com/blackbaud/skyux/commit/906ca8e7f4b4c0368f29c1c721e4d6cb9be6c330)), closes [AB#4109461](https://dev.azure.com/blackbaud/Products/_workitems/edit/4109461)
* **components/toast:** links don't change color on hover ([#4787](https://github.com/blackbaud/skyux/issues/4787)) ([3a4cdaa](https://github.com/blackbaud/skyux/commit/3a4cdaa2a04f87909006ac1049fc3c32d7f67848))
* input components native controls match color scheme ([#4769](https://github.com/blackbaud/skyux/issues/4769)) ([4593389](https://github.com/blackbaud/skyux/commit/4593389c831da5252f321364d1cedd82293b5cb2))
* update design tokens for color fixes ([#4800](https://github.com/blackbaud/skyux/issues/4800)) ([57a82c8](https://github.com/blackbaud/skyux/commit/57a82c82fb19a130b9f6797f56886e858bf33fda))