### PR TITLE
fix: input components native controls match color scheme (#4769)

### DIFF
--- a/apps/e2e/forms-storybook-e2e/src/e2e/input-box.component.cy.ts
+++ b/apps/e2e/forms-storybook-e2e/src/e2e/input-box.component.cy.ts
@@ -84,6 +84,19 @@ describe('forms-storybook - input box', () => {
         );
       });
 
+      it('should properly focus a number input box', () => {
+        cy.skyReady('app-input-box', [], ['#input-box-number'])
+          .get('#input-box-number input')
+          .click();
+        cy.skyVisualTest(
+          `inputboxcomponent-inputbox--input-box-${theme}-number-focus`,
+          {
+            overwrite: true,
+          },
+          '#input-box-number',
+        );
+      });
+
       it('should properly focus a input box with buttons', () => {
         cy.skyReady('app-input-box', [], ['#input-box-button-multiple'])
           .get('#input-box-button-multiple input')

--- a/apps/e2e/forms-storybook/src/app/input-box/input-box.component.html
+++ b/apps/e2e/forms-storybook/src/app/input-box/input-box.component.html
@@ -287,6 +287,54 @@ Value</textarea>
   </sky-input-box>
 </div>
 
+<div class="sky-padding-even-md" id="input-box-number">
+  <sky-input-box stacked="true" labelText="Number">
+    <input type="number" value="8675309" />
+  </sky-input-box>
+</div>
+
+<div class="sky-padding-even-md" id="input-box-number-disabled">
+  <sky-input-box stacked="true" labelText="Number" [disabled]="true">
+    <input type="number" value="8675309" disabled />
+  </sky-input-box>
+</div>
+
+<div class="sky-padding-even-md" id="input-box-email">
+  <sky-input-box stacked="true" labelText="Email">
+    <input type="email" value="no-reply@blackbaud.com" />
+  </sky-input-box>
+</div>
+
+<div class="sky-padding-even-md" id="input-box-email-disabled">
+  <sky-input-box stacked="true" labelText="Email" [disabled]="true">
+    <input type="email" value="no-reply@blackbaud.com" disabled />
+  </sky-input-box>
+</div>
+
+<div class="sky-padding-even-md" id="input-box-password">
+  <sky-input-box stacked="true" labelText="Password">
+    <input type="password" value="testpass" />
+  </sky-input-box>
+</div>
+
+<div class="sky-padding-even-md" id="input-box-password-disabled">
+  <sky-input-box stacked="true" labelText="Password" [disabled]="true">
+    <input type="password" value="testpass" disabled />
+  </sky-input-box>
+</div>
+
+<div class="sky-padding-even-md" id="input-box-tel">
+  <sky-input-box stacked="true" labelText="Telephone">
+    <input type="tel" value="8675309" />
+  </sky-input-box>
+</div>
+
+<div class="sky-padding-even-md" id="input-box-tel-disabled">
+  <sky-input-box stacked="true" labelText="Telephone" [disabled]="true">
+    <input type="tel" value="8675309" disabled />
+  </sky-input-box>
+</div>
+
 <div class="sky-padding-even-md" id="input-box-select">
   <sky-input-box stacked="true">
     <label class="sky-control-label" [for]="inputBoxSelect.id"> Select </label>

--- a/libs/components/packages/package.json
+++ b/libs/components/packages/package.json
@@ -105,7 +105,7 @@
     "typescript": "^6.0.3"
   },
   "dependencies": {
-    "@blackbaud/skyux-design-tokens": "7.0.0-alpha.10",
+    "@blackbaud/skyux-design-tokens": "7.0.0-alpha.11",
     "fs-extra": "11.3.6",
     "jsonc-parser": "3.3.1",
     "parse5": "7.3.0",

--- a/libs/components/theme/package.json
+++ b/libs/components/theme/package.json
@@ -20,7 +20,7 @@
     "@angular/core": "^22.1.2"
   },
   "dependencies": {
-    "@blackbaud/skyux-design-tokens": "7.0.0-alpha.10",
+    "@blackbaud/skyux-design-tokens": "7.0.0-alpha.11",
     "fontfaceobserver": "2.3.0",
     "tslib": "^2.8.1"
   },

--- a/libs/components/theme/src/lib/styles/themes/modern/_forms.scss
+++ b/libs/components/theme/src/lib/styles/themes/modern/_forms.scss
@@ -4,6 +4,7 @@
 .sky-theme-modern {
   .sky-form-control {
     font-size: var(--sky-font-size-body-m);
+    color-scheme: var(--sky-color_scheme);
   }
 
   .sky-error-label {

--- a/libs/sdk/skyux-eslint/package.json
+++ b/libs/sdk/skyux-eslint/package.json
@@ -33,7 +33,7 @@
     "@typescript-eslint/utils": "^8.67.0"
   },
   "dependencies": {
-    "@blackbaud/skyux-design-tokens": "7.0.0-alpha.10",
+    "@blackbaud/skyux-design-tokens": "7.0.0-alpha.11",
     "@skyux-sdk/eslint-schematics": "0.0.0-PLACEHOLDER",
     "@skyux/manifest": "0.0.0-PLACEHOLDER",
     "tslib": "^2.8.1"

--- a/libs/sdk/skyux-stylelint/package.json
+++ b/libs/sdk/skyux-stylelint/package.json
@@ -23,7 +23,7 @@
     "stylelint": "^17.14.1"
   },
   "dependencies": {
-    "@blackbaud/skyux-design-tokens": "7.0.0-alpha.10",
+    "@blackbaud/skyux-design-tokens": "7.0.0-alpha.11",
     "tslib": "^2.8.1"
   },
   "type": "module",

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@angular/platform-browser-dynamic": "22.1.2",
         "@angular/router": "22.1.2",
         "@blackbaud/angular-tree-component": "1.0.0",
-        "@blackbaud/skyux-design-tokens": "7.0.0-alpha.10",
+        "@blackbaud/skyux-design-tokens": "7.0.0-alpha.11",
         "@eslint/js": "9.39.5",
         "@nx/angular": "23.1.1",
         "@skyux/icons": "11.4.0",
@@ -6030,9 +6030,9 @@
       }
     },
     "node_modules/@blackbaud/skyux-design-tokens": {
-      "version": "7.0.0-alpha.10",
-      "resolved": "https://registry.npmjs.org/@blackbaud/skyux-design-tokens/-/skyux-design-tokens-7.0.0-alpha.10.tgz",
-      "integrity": "sha512-Be7MJnbEGiiytSIn5//YAKshDN9zQ76+7RTNP8r/+FgAFnL6CxL39AEvmNeAuRu6xGWsrnwgXhNNJ4Kup0EiIw==",
+      "version": "7.0.0-alpha.11",
+      "resolved": "https://registry.npmjs.org/@blackbaud/skyux-design-tokens/-/skyux-design-tokens-7.0.0-alpha.11.tgz",
+      "integrity": "sha512-YuIYwniGFk+aYc4KSXnsGrbRIlLvMaAaSDzGGPtKe7ioFf1AezyMd+XGllBZ5glDF+ps/K3akJ4yf1Xsc/9y5g==",
       "license": "MIT",
       "engines": {
         "node": ">= 4.2.1",

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "@angular/platform-browser-dynamic": "22.1.2",
     "@angular/router": "22.1.2",
     "@blackbaud/angular-tree-component": "1.0.0",
-    "@blackbaud/skyux-design-tokens": "7.0.0-alpha.10",
+    "@blackbaud/skyux-design-tokens": "7.0.0-alpha.11",
     "@eslint/js": "9.39.5",
     "@nx/angular": "23.1.1",
     "@skyux/icons": "11.4.0",


### PR DESCRIPTION
Cherry-picks #4769 into `main`. The original cherry-pick attempt failed due to a `@blackbaud/skyux-design-tokens` version conflict between `main` (`7.0.0-alpha.10`) and `14.x.x` (`6.11.0`).

## Resolution
- Kept `main`'s dependency versions everywhere, pinning `@blackbaud/skyux-design-tokens` to `7.0.0-alpha.11` (rather than reverting to `6.11.0` or keeping `7.0.0-alpha.10`).
- Regenerated `package-lock.json` against that version.

## Test plan
- [x] CI build/lint/test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Storybook examples for number, email, password, and telephone input types, including enabled and disabled states.
  - Updated modern theme form controls to follow the configured color scheme.

- **Bug Fixes**
  - Improved visual validation for focused number inputs.

- **Chores**
  - Updated the design token package to version 7.0.0-alpha.11.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->